### PR TITLE
fix: failed to install linglong layer file use ll-cli

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -20,6 +20,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include <QFileInfo>
+
 #include <iostream>
 
 using namespace linglong::utils::error;
@@ -430,9 +432,11 @@ int Cli::install(std::map<std::string, docopt::value> &args)
     LINGLONG_TRACE("command install");
 
     auto tier = args["TIER"].asString();
-    auto fuzzyRef = package::FuzzyReference::parse(QString::fromStdString(tier));
 
-    if (!fuzzyRef) {
+    QFileInfo file(QString::fromStdString(tier));
+
+    // 如果检测是layer文件，则直接安装
+    if (file.isFile() && file.suffix() == "layer") {
         const auto layerFile = package::LayerFile::New(QString::fromStdString(tier));
         if (!layerFile) {
             qCritical() << layerFile.error();
@@ -475,6 +479,7 @@ int Cli::install(std::map<std::string, docopt::value> &args)
     }
 
     api::types::v1::PackageManager1InstallParameters params;
+    auto fuzzyRef = package::FuzzyReference::parse(QString::fromStdString(tier));
     params.package.id = fuzzyRef->id.toStdString();
     if (fuzzyRef->channel) {
         params.package.channel = fuzzyRef->channel->toStdString();

--- a/libs/linglong/src/linglong/package/layer_file.cpp
+++ b/libs/linglong/src/linglong/package/layer_file.cpp
@@ -73,19 +73,21 @@ utils::error::Result<quint32> LayerFile::metaInfoLength()
 {
     LINGLONG_TRACE("read meta info length");
 
+    if (metaInfoLengthValue > 0) {
+        return metaInfoLengthValue;
+    }
+
     QDataStream layerDataStream(this);
 
     layerDataStream.startTransaction();
     layerDataStream.setByteOrder(QDataStream::LittleEndian);
-    layerDataStream.skipRawData(magicNumber.size());
-    quint32 metaInfoLength = 0;
-    layerDataStream >> metaInfoLength;
+    layerDataStream >> metaInfoLengthValue;
 
     if (!layerDataStream.commitTransaction()) {
         return LINGLONG_ERR("unknown error.");
     }
 
-    return metaInfoLength;
+    return metaInfoLengthValue;
 }
 
 utils::error::Result<quint32> LayerFile::binaryDataOffset() noexcept

--- a/libs/linglong/src/linglong/package/layer_file.h
+++ b/libs/linglong/src/linglong/package/layer_file.h
@@ -49,6 +49,7 @@ private:
     utils::error::Result<quint32> metaInfoLength();
 
     bool cleanup = false;
+    quint32 metaInfoLengthValue = 0;
 };
 
 } // namespace linglong::package

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -100,7 +100,7 @@ auto PackageManager::setConfiguration(const QVariantMap &parameters) noexcept ->
 auto PackageManager::InstallLayer(const QDBusUnixFileDescriptor &fd) noexcept -> QVariantMap
 {
     const auto layerFile =
-      package::LayerFile::New(QString("/proc/self/fd/%1").arg(fd.fileDescriptor()));
+      package::LayerFile::New(QString("/proc/%1/fd/%2").arg(getpid()).arg(fd.fileDescriptor()));
     if (!layerFile) {
         return toDBusReply(layerFile);
     }


### PR DESCRIPTION
1. if is linglong layer file, install it directly.
2. LayerFile has offset a magicNumber size(40) in Constructor, so we do not need to skip magicNumber before read meta info length.

Log: