### PR TITLE
fix: failed to convert appimage in arm arch

### DIFF
--- a/misc/share/linglong/builder/templates/appimage-local.yaml
+++ b/misc/share/linglong/builder/templates/appimage-local.yaml
@@ -9,7 +9,7 @@ package:
     {{{DESCRIPTION}}}
 
 command: ['{{{COMMAND}}}'] #the commands that your application need to run.
-base: org.deepin.foundation/23.0.0 #set the base environment, this can be changed.
+base: org.deepin.foundation/20.0.0 #set the base environment, this can be changed.
 
 build: |
   APPIMAGE=$(find . -regex '.*\.AppImage\|.*\appimage' -exec basename {} \;)

--- a/misc/share/linglong/builder/templates/appimage-url.yaml
+++ b/misc/share/linglong/builder/templates/appimage-url.yaml
@@ -9,7 +9,7 @@ package:
     {{{DESCRIPTION}}}
 
 command: ['{{{COMMAND}}}'] #the commands that your application need to run.
-base: org.deepin.foundation/23.0.0 #set the base environment, this can be changed.
+base: org.deepin.foundation/20.0.0 #set the base environment, this can be changed.
 
 sources:
   - kind: file


### PR DESCRIPTION
there is no arm arch foundation on 23, so use 20.

Log:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Changes**
	- Downgraded the base environment from `org.deepin.foundation/23.0.0` to `org.deepin.foundation/20.0.0` in both the `appimage-local` and `appimage-url` configuration files, which may affect application compatibility and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->