### PR TITLE
feat: copy linglong.yaml to output

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -762,6 +762,10 @@ set -e
     }
     infoFile.close();
 
+    qDebug() << "copy linglong.yaml to output";
+    QFile::copy(this->workingDir.absoluteFilePath("linglong.yaml"), this->workingDir.absoluteFilePath("linglong/output/binary/linglong.yaml"));
+    QFile::copy(this->workingDir.absoluteFilePath("linglong.yaml"), this->workingDir.absoluteFilePath("linglong/output/develop/linglong.yaml"));
+
     printMessage("[Commit Contents]");
     printMessage(QString("%1%2%3%4")
                    .arg("Package", -25) // NOLINT


### PR DESCRIPTION
ll-builder 构建出来的玲珑应用没有拷贝出 linglong.yaml，不方便后续应用维护以及复现打包过程。

Log: copy linglong.yaml