### PR TITLE
feat: do not use bash to execute ldconfig

### DIFF
--- a/apps/generators/40-host-ipc/src/main.cpp
+++ b/apps/generators/40-host-ipc/src/main.cpp
@@ -247,6 +247,13 @@ int main()
             localtimePath = "/run/host/rootfs" + absoluteTarget;
         }
     }
+    // 为 /run/linglong/etc/ld.so.cache 创建父目录
+    mounts.push_back({
+      { "destination", "/run/linglong/etc" },
+      { "options", nlohmann::json::array({ "nodev", "nosuid", "mode=700" }) },
+      { "source", "tmpfs" },
+      { "type", "tmpfs" },
+    });
 
     auto pwd = std::filesystem::current_path();
     // [name, destination, target]

--- a/misc/lib/linglong/container/config.json
+++ b/misc/lib/linglong/container/config.json
@@ -26,11 +26,11 @@
     "hooks": {
         "startContainer": [
             {
-                "path": "/bin/bash",
+                "path": "/sbin/ldconfig",
                 "args": [
-                    "/bin/bash",
-                    "-c",
-                    "mkdir -p /run/linglong/etc && /sbin/ldconfig -C /run/linglong/etc/ld.so.cache"
+                    "/sbin/ldconfig",
+                    "-C",
+                    "/run/linglong/etc/ld.so.cache"
                 ]
             }
         ]


### PR DESCRIPTION
在制作flatpak的base时发现, flatpak的动态链接器 (ld-linux-x86-64.so.2)
只包含了/usr/lib/x86_64-linux-gnu这一个动态库搜索路径, 导致bash在运行ldconfig之前是无法启动的
所以在容器钩子中不再通过bash运行ldconfig而是直接启动ldconfig, 以兼容复杂的base环境

note: org.gnome.Platform/x86_64/43 和 org.kde.Platform/x86_64/5.15-23.08 都有这个问题


Log: