### PR TITLE
fix(uab): build failed below GCC 12

### DIFF
--- a/libs/linglong/src/linglong/package/uab_packager.h
+++ b/libs/linglong/src/linglong/package/uab_packager.h
@@ -78,7 +78,7 @@ private:
     [[nodiscard]] utils::error::Result<void> packBundle() noexcept;
     [[nodiscard]] utils::error::Result<void> prepareBundle(const QDir &bundleDir) noexcept;
     [[nodiscard]] utils::error::Result<void> packMetaInfo() noexcept;
-    [[nodiscard]] utils::error::Result<std::pair<bool, std::unordered_set<std::filesystem::path>>>
+    [[nodiscard]] utils::error::Result<std::pair<bool, std::unordered_set<std::string>>>
     filteringFiles(const LayerDir &layer) const noexcept;
 
     elfHelper uab;


### PR DESCRIPTION
The std::hash specialization for std::filesystem::path has only been added as resolution of LWG issue 3657 into the standard draft.

This issue has been fixed in GCC 12:
https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=e3c5e8360b4e4799e1e2daf74282629248690f23.

So use std::unordered_set<std::string> instead of
std::unordered_set<std::filesystem::path> for compatibility with lower version of GCC.