### PR TITLE
fix: ll-builder failed to extract layer

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -497,20 +497,7 @@ int main(int argc, char **argv)
                   parser.showHelp(-1);
               }
 
-              auto project =
-                linglong::utils::serialize::LoadYAMLFile<linglong::api::types::v1::BuilderProject>(
-                  QDir().absoluteFilePath("linglong.yaml"));
-              if (!project) {
-                  qCritical() << project.error();
-                  return -1;
-              }
-
-              linglong::builder::Builder builder(*project,
-                                                 QDir::current(),
-                                                 repo,
-                                                 *containerBuidler,
-                                                 *builderCfg);
-              auto result = builder.extractLayer(layerPath, destination);
+              auto result = linglong::builder::Builder::extractLayer(layerPath, destination);
               if (!result) {
                   qCritical() << result.error();
                   return -1;

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -781,7 +781,7 @@ set -e
                         .arg("committing")
                         .toStdString(),
                       2);
-    qDebug() << "import binrary to layers";
+    qDebug() << "import binary to layers";
     package::LayerDir binaryOutputLayerDir = binaryOutput.absoluteFilePath("..");
     result = this->repo.remove(*ref);
     if (!result) {


### PR DESCRIPTION
ll-builder extract do not need constructing an build instance, it is a static function, calling directly.

Log: fix ll-builder extract can not use normally