### PR TITLE
fix: using queues to control install order

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.h
+++ b/libs/linglong/src/linglong/package_manager/package_manager.h
@@ -30,7 +30,6 @@ public:
     PackageManager(PackageManager &&) = delete;
     auto operator=(const PackageManager &) -> PackageManager & = delete;
     auto operator=(PackageManager &&) -> PackageManager & = delete;
-    void Install(InstallTask &taskContext, const package::Reference &ref, bool devel) noexcept;
     void Update(InstallTask &taskContext,
                 const package::Reference &ref,
                 const package::Reference &newRef,
@@ -40,14 +39,16 @@ public
     Q_SLOT : auto getConfiguration() const noexcept -> QVariantMap;
     auto setConfiguration(const QVariantMap &parameters) noexcept -> QVariantMap;
     auto Install(const QVariantMap &parameters) noexcept -> QVariantMap;
-    auto InstallFromFile(const QDBusUnixFileDescriptor &fd,
-                         const QString &fileType) noexcept -> QVariantMap;
+    void installRef(InstallTask &taskContext, const package::Reference &ref, bool devel) noexcept;
+    auto InstallFromFile(const QDBusUnixFileDescriptor &fd, const QString &fileType) noexcept
+      -> QVariantMap;
     auto Uninstall(const QVariantMap &parameters) noexcept -> QVariantMap;
     auto Update(const QVariantMap &parameters) noexcept -> QVariantMap;
     auto Search(const QVariantMap &parameters) noexcept -> QVariantMap;
     void CancelTask(const QString &taskID) noexcept;
 
 Q_SIGNALS:
+    void TaskListChanged(QString taskID);
     void TaskChanged(QString taskID, QString percentage, QString message, int status);
 
 private:
@@ -60,6 +61,8 @@ private:
                         bool develop) noexcept;
     linglong::repo::OSTreeRepo &repo; // NOLINT
     std::list<InstallTask> taskList;
+    // 正在运行的任务ID
+    QString runningTaskID;
 };
 
 } // namespace linglong::service

--- a/libs/linglong/src/linglong/package_manager/task.h
+++ b/libs/linglong/src/linglong/package_manager/task.h
@@ -14,6 +14,9 @@
 #include <QString>
 #include <QUuid>
 
+#include <functional>
+#include <optional>
+
 namespace linglong::service {
 
 class InstallTask : public QObject
@@ -73,6 +76,10 @@ public:
 
     [[nodiscard]] const QString &layer() const noexcept { return m_layer; }
 
+    auto getJob() { return m_job; }
+
+    void setJob(std::function<void()> job) { m_job = job; };
+
 Q_SIGNALS:
     void
     TaskChanged(QString taskID, QString percentage, QString message, Status status, QPrivateSignal);
@@ -88,7 +95,7 @@ private:
     QUuid m_taskID;
     QString m_layer;
     GCancellable *m_cancelFlag{ nullptr };
-
+    std::optional<std::function<void()>> m_job;
     inline static QMap<Status, double> partsMap{ { Queued, 0 },       { Canceled, 0 },
                                                  { preInstall, 10 },  { installRuntime, 20 },
                                                  { installBase, 20 }, { installApplication, 20 },


### PR DESCRIPTION
有用户反馈安装应用时会阻塞搜索命令的使用, 对此进行了排查
发现为修复同时执行多个安装任务导致manager异常退出的问题
在下载文件时使用g_main_context_new切换事件循环, 这会导致dbus服务无法处理调用, 同时也会导致下载进度无法通过dbus信号发出 本次改动去掉了g_main_context_new, 并通过taskRunning控制同时只执行一个安装任务 后续会将layer和uab的安装也加入到控制队列中
顺便修复因ostree_async_progress重用导致下载runtime不显示进度的问题