### PR TITLE
fix: failed to install runtime or base layer

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -209,10 +209,13 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd) 
               return;
           }
 
-          pullDependency(taskRef, *info, isDevelop);
-          if (taskRef.currentStatus() == InstallTask::Failed
-              || taskRef.currentStatus() == InstallTask::Canceled) {
-              return;
+          if (info->kind == "app") {
+              pullDependency(taskRef, *info, isDevelop);
+
+              if (taskRef.currentStatus() == InstallTask::Failed
+                  || taskRef.currentStatus() == InstallTask::Canceled) {
+                  return;
+              }
           }
 
           auto result = this->repo.importLayerDir(*layerDir);


### PR DESCRIPTION
Only need to pull dependencies when installing app, but not when installing runtime or base.

Log: fixed runtime or base layer can not install normally