### PR TITLE
refactor: improve error message and fix some error

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -785,10 +785,17 @@ set -e
                       2);
     qDebug() << "import binrary to layers";
     package::LayerDir binaryOutputLayerDir = binaryOutput.absoluteFilePath("..");
-    result = this->repo.remove(*ref);
-    if (!result) {
-        qWarning() << "remove" << ref->toString() << result.error().message();
+
+    // remove ref if exist
+    auto layerDir = this->repo.getLayerDir(*ref);
+    if (layerDir) {
+        auto result = this->repo.remove(*ref);
+        if (!result) {
+            return LINGLONG_ERR("failed to remove" + ref->toString() + ":"
+                                + result.error().message());
+        }
     }
+
     auto localLayer = this->repo.importLayerDir(binaryOutputLayerDir);
     if (!localLayer) {
         return LINGLONG_ERR(localLayer);
@@ -854,10 +861,8 @@ utils::error::Result<void> Builder::exportUAB(const QString &destination, const 
         packager.include(project.include.value());
     }
 
-    auto baseRef = pullDependency(QString::fromStdString(this->project.base),
-                                  this->repo,
-                                  "binary",
-                                  cfg.skipPullDepend.has_value() && *cfg.skipPullDepend);
+    auto baseRef =
+      pullDependency(QString::fromStdString(this->project.base), this->repo, "binary", false);
     if (!baseRef) {
         return LINGLONG_ERR(baseRef);
     }
@@ -871,7 +876,7 @@ utils::error::Result<void> Builder::exportUAB(const QString &destination, const 
         auto ref = pullDependency(QString::fromStdString(*this->project.runtime),
                                   this->repo,
                                   "binary",
-                                  cfg.skipPullDepend.has_value() && *cfg.skipPullDepend);
+                                  false);
         if (!ref) {
             return LINGLONG_ERR(ref);
         }

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -403,7 +403,7 @@ QVariantMap PackageManager::installFromUAB(const QDBusUnixFileDescriptor &fd) no
               }
 
               const auto &layerDir = package::LayerDir{ layerDirPath.absolutePath() };
-              std::string subRef;
+              std::optional<std::string> subRef{ std::nullopt };
               if (layer.minified) {
                   subRef = metaInfo.get().uuid;
               }
@@ -424,7 +424,7 @@ QVariantMap PackageManager::installFromUAB(const QDBusUnixFileDescriptor &fd) no
 
               bool isAppLayer = layer.info.kind == "app";
               if (isAppLayer) { // it's meaningless for app layer that declare minified is true
-                  subRef.clear();
+                  subRef = std::nullopt;
               }
 
               auto ret = this->repo.importLayerDir(layerDir, subRef);


### PR DESCRIPTION
 - two packages with the same version but different channels are not
 - use type 'std::optional<std::string>' for subRef of UAB