### PR TITLE
fix(box): adjust 'nosymfollow' priority to highest

### DIFF
--- a/apps/ll-box/src/util/filesystem.h
+++ b/apps/ll-box/src/util/filesystem.h
@@ -78,11 +78,14 @@ public:
         return 0;
     }
 
-    void touch()
+    bool touch() const
     {
         if (!exists(this->string())) {
-            std::ofstream(this->string());
+            auto newFile = std::ofstream(this->string());
+            return newFile.is_open();
         }
+
+        return true;
     }
 
     int touch_symlink(const std::string &target) const


### PR DESCRIPTION
when declare option 'copy-symlink' and 'nosymfollow' at the same time, box will apply 'nosymfollow' and ignore 'copy-symlink'.