### PR TITLE
fix: unable to run and build applications using crun

### DIFF
--- a/apps/generators/40-host-ipc/src/main.cpp
+++ b/apps/generators/40-host-ipc/src/main.cpp
@@ -274,7 +274,7 @@ int main()
         };
         mounts.push_back({
           { "destination", destination },
-          { "options", nlohmann::json::array({ "rbind", "ro", "nosymfollow" }) },
+          { "options", nlohmann::json::array({ "rbind", "ro", "nosymfollow", "copy-symlink" }) },
           { "source", linkfile.string() },
           { "type", "bind" },
         });


### PR DESCRIPTION
挂载软链接时添加copy-symlink参数,

修复使用crun作为运行时, 在执行build和run时报错的问题

Log: