### PR TITLE
feat: skip the check when kind is runtime

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -486,8 +486,11 @@ set -e
 
     scriptContent.append(project.build);
     scriptContent.push_back('\n');
-    scriptContent.append("# POST BUILD PROCESS\n");
-    scriptContent.append(LINGLONG_BUILDER_HELPER "/main-check.sh\n");
+    // Do some checks after run container
+    if (this->project.package.kind == "app") {
+        scriptContent.append("# POST BUILD PROCESS\n");
+        scriptContent.append(LINGLONG_BUILDER_HELPER "/main-check.sh\n");
+    }
     auto writeBytes = scriptContent.size();
     auto bytesWrite = entry.write(scriptContent.c_str());
 


### PR DESCRIPTION
目前的检查脚本未对runtime做适配, 在构建runtime时会报错
kind等于runtime时先跳过检查, 未来可能会为runtime添加对应的检查脚本

Log: