### PR TITLE
feat: disable ll-cli update ostree repo config

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -194,6 +194,8 @@ int main(int argc, char **argv)
           linglong::repo::ClientFactory clientFactory(config->repos[config->defaultRepo]);
           auto *repo = new linglong::repo::OSTreeRepo(QDir(LINGLONG_ROOT), *config, clientFactory);
           repo->setParent(QCoreApplication::instance());
+          // 禁止cli自动更新ostree仓库配置
+          repo->disableUpdateOstreeRepoConfig();
 
           auto ociRuntimeCLI = qgetenv("LINGLONG_OCI_RUNTIME");
           if (ociRuntimeCLI.isEmpty()) {

--- a/libs/linglong/src/linglong/repo/client_factory.h
+++ b/libs/linglong/src/linglong/repo/client_factory.h
@@ -9,7 +9,6 @@
 #include "ClientApi.h"
 
 #include <QObject>
-#include <QPoint>
 
 namespace linglong::repo {
 

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -31,6 +31,15 @@ struct clearReferenceOption
     bool fallbackToRemote = true;
 };
 
+struct OstreeRepoDeleter
+{
+    void operator()(OstreeRepo *repo)
+    {
+        qDebug() << "delete OstreeRepo" << repo;
+        g_clear_object(&repo);
+    }
+};
+
 class OSTreeRepo : public QObject
 {
     Q_OBJECT
@@ -133,23 +142,15 @@ public:
 private:
     api::types::v1::RepoConfig cfg;
 
-    struct OstreeRepoDeleter
-    {
-        void operator()(OstreeRepo *repo)
-        {
-            qDebug() << "delete OstreeRepo" << repo;
-            g_clear_object(&repo);
-        }
-    };
-
-    std::unique_ptr<OstreeRepo, OstreeRepoDeleter> ostreeRepo = nullptr;
     QDir repoDir;
     QDir ostreeRepoDir() const noexcept;
     QDir createLayerQDir(const package::Reference &ref,
                          const QString &module = "binary",
                          const QString &subRef = "") const noexcept;
+    utils::error::Result<OstreeRepo *> getOStreeRepo();
 
     ClientFactory &m_clientFactory;
+    std::unique_ptr<OstreeRepo, OstreeRepoDeleter> m_ostreeRepo = nullptr;
 };
 
 } // namespace linglong::repo

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -139,9 +139,11 @@ public:
     void unexportReference(const package::Reference &ref) noexcept;
     void updateSharedInfo() noexcept;
 
+    void disableUpdateOstreeRepoConfig() { this->autoUpdateOstreeRepoConfig = false; }
+
 private:
     api::types::v1::RepoConfig cfg;
-
+    bool autoUpdateOstreeRepoConfig = true;
     QDir repoDir;
     QDir ostreeRepoDir() const noexcept;
     QDir createLayerQDir(const package::Reference &ref,


### PR DESCRIPTION
禁止ll-cli自动更新ostree仓库的配置,
避免不小心使用sudo运行ll-cli后, 配置所属用户被更改