### PR TITLE
fix: media not mounted normally when run app

### DIFF
--- a/apps/generators/20-devices/src/main.cpp
+++ b/apps/generators/20-devices/src/main.cpp
@@ -74,7 +74,7 @@ int main()
         mounts.push_back({ { "source", "/media" },
                            { "type", "bind" },
                            { "destination", "/media" },
-                           { "options", { "rbind", "rshared" } } });
+                           { "options", { "rbind", "rshared", "copy-symlink" } } });
     }
 
     std::cout << content.dump() << std::endl;


### PR DESCRIPTION
Mounts options need to add copy-symlink when /media is a symlink.

Log: fix /media not mounted normally when run app