### PR TITLE
feat: change the mount options of rootfs

### DIFF
--- a/misc/lib/linglong/container/config.d/25-host-rootfs.json
+++ b/misc/lib/linglong/container/config.d/25-host-rootfs.json
@@ -8,11 +8,7 @@
                 "destination": "/run/host",
                 "type": "tmpfs",
                 "source": "tmpfs",
-                "options": [
-                    "nodev",
-                    "nosuid",
-                    "mode=700"
-                ]
+                "options": ["nodev", "nosuid", "mode=700"]
             }
         },
         {
@@ -22,10 +18,7 @@
                 "destination": "/run/host/rootfs",
                 "type": "bind",
                 "source": "/",
-                "options": [
-                    "rbind",
-                    "ro"
-                ]
+                "options": ["rbind"]
             }
         }
     ]


### PR DESCRIPTION
Modify the mount permissions of a root filesystem, so that it allows applications to read and write files to the host file system. 

For example, deepin calendar needs to create a systemd timer in the ~/.cache/systemd directory, but ~/.cache directory is overlay by linglong, you can use /run/hosts/rootfs/home/xxx/.cache/systemd.

Bug: https://pms.uniontech.com/bug-view-271647.html