### PR TITLE
feat: support base custom application installation location

### DIFF
--- a/api/schema/v1.json
+++ b/api/schema/v1.json
@@ -615,6 +615,10 @@
         "compatible_version": {
           "type": "string",
           "description": "record linyaps package is compatible with linyaps component version"
+        },
+        "app_prefix": {
+          "type": "string",
+          "description": "application install location. The field is intended solely for the use of the base, indicating the installation path of applications built using that base."
         }
       }
     },

--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -495,6 +495,9 @@ $defs:
       compatible_version:
         type: string
         description: record linyaps package is compatible with linyaps component version
+      app_prefix:
+        type: string
+        description: application install location. The field is intended solely for the use of the base, indicating the installation path of applications built using that base.
   PackageInfo:
     title: PackageInfo
     description: this is the each item output of ll-cli list --json

--- a/apps/generators/05-initialize/src/main.cpp
+++ b/apps/generators/05-initialize/src/main.cpp
@@ -58,10 +58,8 @@ int main()
         });
 
         mounts.push_back(
-          { { "destination",
-              std::filesystem::path("/opt/apps") / annotations["org.deepin.linglong.appID"]
-                / "files" },
-            { "options", nlohmann::json::array({ "rbind", "rw" }) },
+          { { "destination", annotations["org.deepin.linglong.appPrefix"] },
+            { "options", nlohmann::json::array({ "rbind", "ro" }) },
             { "source",
               std::filesystem::path(annotations["org.deepin.linglong.appDir"].get<std::string>())
                 / "files" },

--- a/apps/generators/25-host-env/src/main.cpp
+++ b/apps/generators/25-host-env/src/main.cpp
@@ -6,6 +6,7 @@
 
 #include <filesystem>
 #include <iostream>
+#include <string>
 
 extern char **environ;
 
@@ -79,9 +80,11 @@ int main()
     }
 
     auto annotations = content.at("annotations");
-    env.push_back("LINGLONG_APPID="
-                  + annotations.at("org.deepin.linglong.appID").get<std::string>());
-
+    auto appID = annotations.at("org.deepin.linglong.appID").get<std::string>();
+    // appPrefix
+    auto appPrefix = annotations.at("org.deepin.linglong.appPrefix").get<std::string>();
+    env.push_back("LINGLONG_APPID=" + appID);
+    env.push_back("LINGLONG_APP_PREFIX=" + appPrefix);
     std::cout << content.dump() << std::endl;
     return 0;
 }

--- a/apps/uab/loader/src/main.cpp
+++ b/apps/uab/loader/src/main.cpp
@@ -641,6 +641,11 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
     auto appDir = std::filesystem::path{ layerFilesDir }.parent_path();
 
     annotations["org.deepin.linglong.appDir"] = appDir.string();
+    if (opts.appPrefix) {
+        annotations["org.deepin.linglong.appPrefix"] = *opts.appPrefix;
+    } else {
+        annotations["org.deepin.linglong.appPrefix"] = "/opt/apps/" + opts.appID + "/files";
+    }
     config.annotations = std::move(annotations);
 
     // replace commands

--- a/libs/api/src/linglong/api/types/v1/Generators.hpp
+++ b/libs/api/src/linglong/api/types/v1/Generators.hpp
@@ -567,6 +567,7 @@ j["version"] = x.version;
 }
 
 inline void from_json(const json & j, PackageInfoV2& x) {
+x.appPrefix = get_stack_optional<std::string>(j, "app_prefix");
 x.arch = j.at("arch").get<std::vector<std::string>>();
 x.base = j.at("base").get<std::string>();
 x.channel = j.at("channel").get<std::string>();
@@ -587,6 +588,9 @@ x.version = j.at("version").get<std::string>();
 
 inline void to_json(json & j, const PackageInfoV2 & x) {
 j = json::object();
+if (x.appPrefix) {
+j["app_prefix"] = x.appPrefix;
+}
 j["arch"] = x.arch;
 j["base"] = x.base;
 j["channel"] = x.channel;

--- a/libs/api/src/linglong/api/types/v1/PackageInfoV2.hpp
+++ b/libs/api/src/linglong/api/types/v1/PackageInfoV2.hpp
@@ -34,6 +34,11 @@ using nlohmann::json;
 */
 struct PackageInfoV2 {
 /**
+* application install location. The field is intended solely for the use of the base,
+* indicating the installation path of applications built using that base.
+*/
+std::optional<std::string> appPrefix;
+/**
 * arch of package info
 */
 std::vector<std::string> arch;

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -386,6 +386,7 @@ int Cli::run()
         this->printer.printErr(LINGLONG_ERRV(baseLayerDir));
         return -1;
     }
+    auto baseInfo = baseLayerDir->info();
 
     auto commands = options.commands;
     if (commands.empty()) {
@@ -539,6 +540,7 @@ int Cli::run()
       .runtimeDir = runtimeLayerDir,
       .baseDir = *baseLayerDir,
       .appDir = *appLayerDir,
+      .appPrefix = baseInfo->appPrefix,
       .patches = {},
       .mounts = std::move(applicationMounts),
       .masks = {},

--- a/libs/linglong/src/linglong/package/uab_packager.cpp
+++ b/libs/linglong/src/linglong/package/uab_packager.cpp
@@ -17,6 +17,7 @@
 #include <QStandardPaths>
 
 #include <fstream>
+#include <string>
 #include <unordered_set>
 #include <utility>
 
@@ -165,6 +166,12 @@ utils::error::Result<void> UABPackager::setIcon(const QFileInfo &newIcon) noexce
 
     icon = newIcon;
     return LINGLONG_OK;
+}
+
+// set app install dir, default is /opt/apps/$appid/files
+void UABPackager::setAppPrefix(const std::string &appPrefix) noexcept
+{
+    m_appPrefix = appPrefix;
 }
 
 utils::error::Result<void> UABPackager::appendLayer(const LayerDir &layer) noexcept
@@ -546,8 +553,13 @@ utils::error::Result<void> UABPackager::prepareBundle(const QDir &bundleDir) noe
     QTextStream stream{ &ldConf };
     stream << "/runtime/lib" << Qt::endl;
     stream << "/runtime/lib/" + arch->getTriplet() << Qt::endl;
-    stream << "/opt/apps/" + appID + "/files/lib" << Qt::endl;
-    stream << "/opt/apps/" + appID + "/files/lib/" + arch->getTriplet() << Qt::endl;
+    auto appPrefix = "/opt/apps/" + appID + "/files";
+    if (m_appPrefix) {
+        appPrefix = QString::fromStdString(*m_appPrefix);
+    }
+    stream << appPrefix + "/lib" << Qt::endl;
+    stream << appPrefix + "/lib/" + arch->getTriplet() << Qt::endl;
+
     stream.flush();
 
     // copy ll-box

--- a/libs/linglong/src/linglong/package/uab_packager.h
+++ b/libs/linglong/src/linglong/package/uab_packager.h
@@ -17,6 +17,7 @@
 #include <QUuid>
 
 #include <filesystem>
+#include <string>
 #include <unordered_set>
 
 namespace linglong::package {
@@ -68,6 +69,7 @@ public:
     UABPackager(UABPackager &&) = delete;
 
     utils::error::Result<void> setIcon(const QFileInfo &icon) noexcept;
+    void setAppPrefix(const std::string &appPrefix) noexcept;
     utils::error::Result<void> appendLayer(const LayerDir &layer) noexcept;
     utils::error::Result<void> pack(const QString &uabFilename) noexcept;
     utils::error::Result<void> exclude(const std::vector<std::string> &files) noexcept;
@@ -86,6 +88,7 @@ private:
     std::unordered_set<std::string> excludeFiles;
     std::unordered_set<std::string> includeFiles;
     std::optional<QFileInfo> icon{ std::nullopt };
+    std::optional<std::string> m_appPrefix;
     api::types::v1::UabMetaInfo meta;
     QDir buildDir;
 };

--- a/libs/linglong/src/linglong/runtime/container.cpp
+++ b/libs/linglong/src/linglong/runtime/container.cpp
@@ -151,10 +151,16 @@ Container::run(const ocppi::runtime::config::types::Process &process) noexcept
 
         ofs << "/runtime/lib" << std::endl;
         ofs << "/runtime/lib/" + arch->getTriplet().toStdString() << std::endl;
-        ofs << "/opt/apps/" + this->appID.toStdString() + "/files/lib" << std::endl;
-        ofs << "/opt/apps/" + this->appID.toStdString() + "/files/lib/"
-            + arch->getTriplet().toStdString()
-            << std::endl;
+
+        auto appPrefix = "/opt/apps/" + this->appID.toStdString() + "/files";
+        if (cfg.annotations) {
+            auto annotations = *cfg.annotations;
+            if (annotations.find("org.deepin.linglong.appPrefix") != annotations.end()) {
+                appPrefix = annotations["org.deepin.linglong.appPrefix"];
+            }
+        }
+        ofs << appPrefix + "/lib" << std::endl;
+        ofs << appPrefix + "/lib/" + arch->getTriplet().toStdString() << std::endl;
     }
     this->cfg.mounts->push_back(ocppi::runtime::config::types::Mount{
       .destination = "/etc/ld.so.conf.d/zz_deepin-linglong-app.conf",

--- a/libs/linglong/src/linglong/runtime/container_builder.cpp
+++ b/libs/linglong/src/linglong/runtime/container_builder.cpp
@@ -248,6 +248,12 @@ auto getOCIConfig(const ContainerOptions &opts) noexcept
     if (opts.appDir) {
         annotations["org.deepin.linglong.appDir"] = opts.appDir->absolutePath().toStdString();
     }
+    if (opts.appPrefix) {
+        annotations["org.deepin.linglong.appPrefix"] = *opts.appPrefix;
+    } else {
+        annotations["org.deepin.linglong.appPrefix"] =
+          "/opt/apps/" + opts.appID.toStdString() + "/files";
+    }
     config->annotations = std::move(annotations);
 
     QDir configDotDDir = QFileInfo(containerConfigFilePath).dir().filePath("config.d");

--- a/libs/linglong/src/linglong/runtime/container_builder.h
+++ b/libs/linglong/src/linglong/runtime/container_builder.h
@@ -21,9 +21,10 @@ struct ContainerOptions
     QString appID;
     QString containerID;
 
-    std::optional<QDir> runtimeDir; // mount to /runtime
-    QDir baseDir;                   // mount to /
-    std::optional<QDir> appDir;     // mount to /opt/apps/${info.appid}/files
+    std::optional<QDir> runtimeDir;       // mount to /runtime
+    QDir baseDir;                         // mount to /
+    std::optional<QDir> appDir;           // mount to /opt/apps/${info.appid}/files
+    std::optional<std::string> appPrefix; // if appPrefix exists, mount appDir to appPrefix
 
     std::vector<api::types::v1::OciConfigurationPatch> patches;
     std::vector<ocppi::runtime::config::types::Mount> mounts; // extra mounts


### PR DESCRIPTION
base可以通过app_home信息设置应用安装位置 如果base设置了app_home,
玲珑在构建时会将PREFIX设置成app_home指定的目录
在运行时也会将应用文件挂载成app_home指定的目录