### PR TITLE
fix: failed to run linglong.sh

### DIFF
--- a/misc/script/linglong.sh
+++ b/misc/script/linglong.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
-source "@CMAKE_INSTALL_PREFIX@/lib/linglong/generate-xdg-data-dirs.sh"
+. "@CMAKE_INSTALL_PREFIX@/lib/linglong/generate-xdg-data-dirs.sh"
 
 export XDG_DATA_DIRS


### PR DESCRIPTION
Change 'source' to '.', because '#/usr/bin/env bash' is not work in /etc/profile.d(Default is 'sh') and source is not supported in 'sh'.

Log: