### PR TITLE
fix: ll-box create mount point for nosymfollow

### DIFF
--- a/apps/ll-box/src/container/mount/host_mount.cpp
+++ b/apps/ll-box/src/container/mount/host_mount.cpp
@@ -100,6 +100,7 @@ public:
                 }
 
                 source = util::format("/proc/self/fd/%d", sourceFd);
+                host_dest_full_path.touch();
                 break;
             }
 


### PR DESCRIPTION
当前ll-box运行容器时会报错ld.so.cache target不存在, 但base里面是存在这个文件的 排查后发现当前的ld.so.cache有两个挂载项, 一个是fix mount创建的base文件挂载, 另一个是为支持ldconfig实现的软链接挂载 因为fixmount最后会检查target重复的挂载项, 并进行删除, 这导致第一个fix mount创建的挂载记录被删除, 支持ldconfig实现的软链接挂载没有了挂载点

现在为设置nosymfollow的挂载项预先创建挂载点(如果挂载点不存在的话), 这和其他挂载行为保持一致, 避免挂载点不存在时ll-box报错