### PR TITLE
fix: systemd service file not revised correctly

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -860,8 +860,10 @@ set -e
             return LINGLONG_ERR("link entries share to files share: failed");
         }
         if (binaryFiles.exists("lib/systemd/user")) {
+            // 配置放到share/systemd/user或lib/systemd/user对systemd来说基本等价
+            // 但玲珑仅将share导出到XDG_DATA_DIR，所以要将lib/systemd/user的内容复制到share/systemd/user
             if (!binaryEntries.mkpath("share/systemd/user")) {
-                return LINGLONG_ERR("mkpath files/share/systemd/user: failed");
+                qWarning() << "mkpath files/share/systemd/user: failed";
             }
             auto ret = copyDir(binaryFiles.filePath("lib/systemd/user"),
                                binaryEntries.absoluteFilePath("share/systemd/user"));

--- a/misc/libexec/linglong/app-conf-generator
+++ b/misc/libexec/linglong/app-conf-generator
@@ -20,8 +20,9 @@ ExecReplace() {
                         sed -i "/\[Desktop Entry\]/a X-linglong=${appId}" ${path}
                         sed -i "/TryExec=*/c TryExec=ll-cli" ${path}
                 fi
-                startByLinglong="ll-cli run ${appId} -- "
-                sed -i "s/^\(Exec=\)\(.*\)/\1${startByLinglong}\2/" $path
+                startByLinglong="/usr/bin/ll-cli run ${appId} -- "
+                sed -i "s#^\(Exec[[:space:]]*=\)\(.*\)#\1${startByLinglong}\2#" $path
+                sed -i "s#^\(ExecStart[[:space:]]*=\)\(.*\)#\1${startByLinglong}\2#" $path
         done
 }
 
@@ -49,12 +50,11 @@ ContextMenuGenerator() {
 
 main() {
         appId=$1
-        appEntriesPath=$2
+        appFilesPath=$2
 
-        desktopPath="${appEntriesPath}/share/applications"
-        systemdServicePath="${appEntriesPath}/share/systemd/user"
-        dbusServicePath="${appEntriesPath}/share/dbus-1/services"
-        contextMenuPath="${appEntriesPath}/share/applications/context-menus"
+        desktopPath="${appFilesPath}/share/applications"
+        dbusServicePath="${appFilesPath}/share/dbus-1/services"
+        contextMenuPath="${appFilesPath}/share/applications/context-menus"
 
         if [ -d "${desktopPath}" ]; then
                 DesktopGenerator ${desktopPath}
@@ -62,8 +62,11 @@ main() {
         if [ -d "${dbusServicePath}" ]; then
                 DBusServiceGenerator ${dbusServicePath}
         fi
-        if [ -d "${systemdServicePath}" ]; then
-                SystemdServiceGenerator ${systemdServicePath}
+        if [ -d "${appFilesPath}/lib/systemd/user" ]; then
+                SystemdServiceGenerator "${appFilesPath}/lib/systemd/user"
+        fi
+        if [ -d "${appFilesPath}/share/systemd/user" ]; then
+                SystemdServiceGenerator "${appFilesPath}/share/systemd/user"
         fi
         if [ -d "${contextMenuPath}" ]; then
                 ContextMenuGenerator ${contextMenuPath}


### PR DESCRIPTION
玲珑在构建后会使用app-conf-generator脚本修改应用的desktop, service等文件 在Exec字段添加ll-cli run实现通过玲珑启动应用, 减少应用开发者工作量
修复了在错误的share/systemd目录查找service，改为在lib/systemd目录查找 share/systemd目录是在执行完app-conf-generator后才从lib/systemd复制的 复制的原因是因为entries是指向share的软链接, systemd需要在entries中才会生效

Log: