### PR TITLE
feat(linglong_builder): add build option to skip ldd check

### DIFF
--- a/api/schema/v1.json
+++ b/api/schema/v1.json
@@ -401,6 +401,10 @@
           "type": "boolean",
           "description": "skip commit output when build"
         },
+        "skip_check_output": {
+          "type": "boolean",
+          "description": "skip check output when build"
+        },
         "arch": {
           "type": "string",
           "description": "arch of builder config"

--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -330,6 +330,9 @@ $defs:
       skip_commit_output:
         type: boolean
         description: skip commit output when build
+      skip_check_output:
+        type: boolean
+        description: skip check output when build
       arch:
         type: string
         description: arch of builder config

--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -452,6 +452,8 @@ int main(int argc, char **argv)
               auto buildSkipCommitOutput =
                 QCommandLineOption("skip-commit-output", "skip commit build output", "");
               auto buildArch = QCommandLineOption("arch", "set the build arch", "arch");
+              auto buildSkipOutputCheck =
+                QCommandLineOption("skip-output-check", "skip output check", "");
 
               parser.addOptions({ yamlFile,
                                   execVerbose,
@@ -460,7 +462,8 @@ int main(int argc, char **argv)
                                   buildSkipPullDepend,
                                   buildSkipRunContainer,
                                   buildSkipCommitOutput,
-                                  buildArch });
+                                  buildArch,
+                                  buildSkipOutputCheck });
 
               parser.addPositionalArgument("build", "build project", "build");
               parser.setApplicationDescription("linglong build command tools\n"
@@ -518,6 +521,12 @@ int main(int argc, char **argv)
                   cfg.skipFetchSource = true;
                   cfg.skipPullDepend = true;
                   cfg.offline = true;
+                  builder.setConfig(cfg);
+              }
+
+              if (parser.isSet(buildSkipOutputCheck)) {
+                  auto cfg = builder.getConfig();
+                  cfg.skipCheckOutput = true;
                   builder.setConfig(cfg);
               }
               auto allArgs = QCoreApplication::arguments();

--- a/libs/api/src/linglong/api/types/v1/BuilderConfig.hpp
+++ b/libs/api/src/linglong/api/types/v1/BuilderConfig.hpp
@@ -48,6 +48,10 @@ std::optional<bool> offline;
 */
 std::string repo;
 /**
+* skip check output when build
+*/
+std::optional<bool> skipCheckOutput;
+/**
 * skip commit output when build
 */
 std::optional<bool> skipCommitOutput;

--- a/libs/api/src/linglong/api/types/v1/Generators.hpp
+++ b/libs/api/src/linglong/api/types/v1/Generators.hpp
@@ -217,6 +217,7 @@ x.arch = get_stack_optional<std::string>(j, "arch");
 x.cache = get_stack_optional<std::string>(j, "cache");
 x.offline = get_stack_optional<bool>(j, "offline");
 x.repo = j.at("repo").get<std::string>();
+x.skipCheckOutput = get_stack_optional<bool>(j, "skip_check_output");
 x.skipCommitOutput = get_stack_optional<bool>(j, "skip_commit_output");
 x.skipFetchSource = get_stack_optional<bool>(j, "skip_fetch_source");
 x.skipPullDepend = get_stack_optional<bool>(j, "skip_pull_depend");
@@ -236,6 +237,9 @@ if (x.offline) {
 j["offline"] = x.offline;
 }
 j["repo"] = x.repo;
+if (x.skipCheckOutput) {
+j["skip_check_output"] = x.skipCheckOutput;
+}
 if (x.skipCommitOutput) {
 j["skip_commit_output"] = x.skipCommitOutput;
 }

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -606,7 +606,7 @@ set -e
     scriptContent.append(project.build);
     scriptContent.push_back('\n');
     // Do some checks after run container
-    if (this->project.package.kind == "app") {
+    if (!cfg.skipCheckOutput && this->project.package.kind == "app") {
         scriptContent.append("# POST BUILD PROCESS\n");
         scriptContent.append(LINGLONG_BUILDER_HELPER "/main-check.sh\n");
     }


### PR DESCRIPTION
Some appimage packages use libraries in packages(LD_LIBRARY_PATH), it will cause the ldd check fails. so add build option to skip ldd check.