### PR TITLE
fix(repo): ll-cli search result is abnormal

### DIFF
--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -1253,6 +1253,7 @@ OSTreeRepo::listRemote(const package::FuzzyReference &fuzzyRef) const noexcept
           .description = item->description,
           .id = item->app_id,
           .kind = item->kind,
+          .packageInfoV2Module = item->module,
           .name = item->name,
           .runtime = item->runtime,
           .size = item->size,


### PR DESCRIPTION
PackageInfoV2 packageInfoV2Module is not assignment when construction PackageInfoV2.

Log: fix ll-cli search abnormally