### PR TITLE
fix(config): failed to install uab mime-type file

### DIFF
--- a/debian/linglong-bin.install
+++ b/debian/linglong-bin.install
@@ -22,5 +22,5 @@ usr/share/bash-completion/completions/ll-cli
 usr/share/dbus-1/system-services/org.deepin.linglong.PackageManager1.service
 usr/share/dbus-1/system.d/org.deepin.linglong.PackageManager1.conf
 usr/share/linglong/config.yaml
-usr/share/mime/packages/deepin-linglong.xml
+usr/share/mime/packages/vnd.linyaps.uab.xml
 usr/share/polkit-1/actions/org.deepin.linglong.PackageManager1.policy

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -41,7 +41,7 @@ configure_files(
   share/dbus-1/system-services/org.deepin.linglong.PackageManager1.service
   share/linglong/builder/templates/example.yaml
   share/linglong/config.yaml
-  share/mime/packages/deepin-linglong.xml
+  share/mime/packages/vnd.linyaps.uab.xml
   share/polkit-1/actions/org.deepin.linglong.PackageManager1.policy)
 
 # bash-completion


### PR DESCRIPTION
deepin-linglong.xml rename vnd.linyaps.uab.xml, install file name should be modified synchronously.