### PR TITLE
fix: should not use std::map<Reference>

### DIFF
--- a/libs/linglong/src/linglong/package/reference.cpp
+++ b/libs/linglong/src/linglong/package/reference.cpp
@@ -109,12 +109,15 @@ QString Reference::toString() const noexcept
     return QString("%1:%2/%3/%4").arg(channel, id, version.toString(), arch.toString());
 }
 
-bool operator<(const Reference &lhs, const Reference &rhs) noexcept
+bool operator!=(const Reference &lhs, const Reference &rhs) noexcept
 {
-    if (lhs.channel == rhs.channel && lhs.id == rhs.id && lhs.arch == rhs.arch)
-        return lhs.version < rhs.version;
+    return lhs.channel != rhs.channel || lhs.id != rhs.id || lhs.version != rhs.version
+      || lhs.arch != rhs.arch;
+}
 
-    return lhs.toString() < rhs.toString();
+bool operator==(const Reference &lhs, const Reference &rhs) noexcept
+{
+    return !(lhs != rhs);
 }
 
 QVariantMap Reference::toVariantMap(const Reference &ref) noexcept

--- a/libs/linglong/src/linglong/package/reference.h
+++ b/libs/linglong/src/linglong/package/reference.h
@@ -34,7 +34,8 @@ public:
     Architecture arch;
 
     [[nodiscard]] QString toString() const noexcept;
-     friend bool operator<(const Reference& lhs, const Reference& rhs) noexcept;
+    friend bool operator!=(const Reference &lhs, const Reference &rhs) noexcept;
+    friend bool operator==(const Reference &lhs, const Reference &rhs) noexcept;
 
 private:
     Reference(const QString &channel,
@@ -44,3 +45,18 @@ private:
 };
 
 } // namespace linglong::package
+
+// Note: declare here, so we can use std::unordered_map<Reference, ...> in other place
+template<>
+struct std::hash<linglong::package::Reference>
+{
+    size_t operator()(const linglong::package::Reference &ref) const noexcept
+    {
+        size_t hash = 0;
+        hash ^= std::hash<QString>{}(ref.channel);
+        hash ^= std::hash<QString>{}(ref.id) << 1;
+        hash ^= std::hash<QString>{}(ref.version.toString()) << 2;
+        hash ^= std::hash<QString>{}(ref.arch.toString()) << 3;
+        return hash;
+    }
+};

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -1089,7 +1089,7 @@ PackageManager::Prune(std::vector<api::types::v1::PackageInfoV2> &removed) noexc
         return LINGLONG_ERR(pkgsInfo);
     }
 
-    std::map<package::Reference, int> target;
+    std::unordered_map<package::Reference, int> target;
     for (const auto &info : *pkgsInfo) {
         if (info.packageInfoV2Module != "binary") {
             continue;


### PR DESCRIPTION
* Use std::unordered_map<Reference>.
* Overload operators '==' and '!=' and specialization of std::hash in Reference.

Log:"