### PR TITLE
Revert "chore: bump version to 1.6.3-1"

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,14 +1,3 @@
-linglong (1.6.3-1) unstable; urgency=medium
-
-  * feat: add task queue to package manager
-  * refactor: use libcurl to replace QT NetworkManager
-  * feat: optimization reference export
-  * fix(box): default to follow symbol link when parse mount source
-  * fix(box): adjust 'nosymfollow' priority to highest
-  * fix: using queues to control install order
-
- -- dengbo <dengbo@deepin.org>  Fri, 27 Sep 2024 17:29:36 +0800
-
 linglong (1.5.6-1) unstable; urgency=medium
 
   * fix: layer size error when export layer repeatedly


### PR DESCRIPTION
This reverts commit 866d6c18978e605e33101b766880a6ac75ee0c2a.