### PR TITLE
fix!: restrict access to some methods of PM

### DIFF
--- a/misc/share/dbus-1/system.d/org.deepin.linglong.PackageManager1.conf
+++ b/misc/share/dbus-1/system.d/org.deepin.linglong.PackageManager1.conf
@@ -6,12 +6,25 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 <!-- -*- XML -*- -->
 <!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
-  <!-- Only @LINGLONG_USERNAME@ can own the service -->
+  <!-- Only @LINGLONG_USERNAME@ can own the service. Allow to invoke all methods -->
   <policy user="@LINGLONG_USERNAME@">
     <allow own="org.deepin.linglong.PackageManager1"/>
+    <allow send_destination="org.deepin.linglong.PackageManager1"/>
+    <allow receive_sender="org.deepin.linglong.PackageManager1"/>
   </policy>
-  <!-- Allow anyone to invoke methods on the interfaces -->
+  <!-- Allow anyone to invoke method Search, other methods should be rejected -->
   <policy context="default">
     <allow send_destination="org.deepin.linglong.PackageManager1"/>
+    <allow receive_sender="org.deepin.linglong.PackageManager1"/>
+
+    <deny send_destination="org.deepin.linglong.PackageManager1"
+          send_interface="org.deepin.linglong.PackageManager1" send_member="*"/>
+    <allow send_destination="org.deepin.linglong.PackageManager1"
+          send_interface="org.deepin.linglong.PackageManager1" send_member="Search"/>
+  </policy>
+  <!-- Allow root to invoke all methods -->
+  <policy user="root">
+  <allow send_destination="org.deepin.linglong.PackageManager1"/>
+  <allow receive_sender="org.deepin.linglong.PackageManager1"/>
   </policy>
 </busconfig>


### PR DESCRIPTION
* Add some rules to the dbus conf of PM: For deepin-linglong and root, allow to call any method. For other users, they should not call any method instead of Search.
* Capture the error of dbus reply which from PM, if the error type is 'AccessDenied' notify pepole and return.

Log: