### PR TITLE
feat: add deepin-manual to export paths

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -861,6 +861,7 @@ set -e
             "share/plugins",      // Copy plugins conf，The configuration files provided by some
                                   // applications maybe used by the host dde-file-manager.
             "share/systemd",      // copy systemd service files
+            "share/deepin-manual" // copy deepin-manual files
         };
 
         QDir binaryFiles = this->workingDir.absoluteFilePath("linglong/output/binary/files");
@@ -1248,8 +1249,8 @@ utils::error::Result<void> Builder::run(const QStringList &modules,
     // mergedDir 会自动在释放时删除临时目录，所以要用变量保留住
     utils::error::Result<std::shared_ptr<package::LayerDir>> mergedDir;
     if (modules.size() > 1) {
-        qDebug() << "create temp merge dir." << "ref: " << curRef->toString()
-                 << "modules: " << modules;
+        qDebug() << "create temp merge dir."
+                 << "ref: " << curRef->toString() << "modules: " << modules;
         mergedDir = this->repo.getMergedModuleDir(*curRef, modules);
         if (!mergedDir.has_value()) {
             return LINGLONG_ERR(mergedDir);

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -1407,7 +1407,8 @@ void OSTreeRepo::exportReference(const package::Reference &ref) noexcept
         "metainfo",     // Copy appdata/metainfo files
         "plugins", // Copy plugins conf，The configuration files provided by some applications maybe
                    // used by the host dde-file-manager.
-        "systemd", // copy systemd service files
+        "systemd",      // copy systemd service files
+        "deepin-manual" // copy deepin-manual files
     };
 
     for (const auto &path : exportPaths) {
@@ -1663,8 +1664,9 @@ std::vector<std::string> OSTreeRepo::getModuleList(const package::Reference &ref
     return modules;
 }
 
-auto OSTreeRepo::getMergedModuleDir(const package::Reference &ref, bool fallbackLayerDir)
-  const noexcept -> utils::error::Result<package::LayerDir>
+auto OSTreeRepo::getMergedModuleDir(const package::Reference &ref,
+                                    bool fallbackLayerDir) const noexcept
+  -> utils::error::Result<package::LayerDir>
 {
     LINGLONG_TRACE("get merge dir from ref " + ref.toString());
     qDebug() << "getMergedModuleDir" << ref.toString();
@@ -1701,8 +1703,9 @@ auto OSTreeRepo::getMergedModuleDir(const package::Reference &ref, bool fallback
     return LINGLONG_ERR("merged doesn't exist");
 }
 
-auto OSTreeRepo::getMergedModuleDir(const package::Reference &ref, const QStringList &loadModules)
-  const noexcept -> utils::error::Result<std::shared_ptr<package::LayerDir>>
+auto OSTreeRepo::getMergedModuleDir(const package::Reference &ref,
+                                    const QStringList &loadModules) const noexcept
+  -> utils::error::Result<std::shared_ptr<package::LayerDir>>
 {
     LINGLONG_TRACE("merge modules");
     QDir mergedDir = this->repoDir.absoluteFilePath("merged");


### PR DESCRIPTION
deepin-manual path should be exported,
self-developed applications will installed files that will be accessed by the help manual.