### PR TITLE
fix(ll-builder): some minor bugs

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -547,14 +547,15 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     if (buildRepo->parsed()) {
         if (buildRepoShow->parsed()) {
             const auto &cfg = repo.getConfig();
-            auto &output = std::cout;
-            output << "version: " << cfg.version << "\ndefaultRepo: " << cfg.defaultRepo
-                   << "\nrepos:\n"
-                   << "name\turl\n";
-            std::for_each(cfg.repos.cbegin(), cfg.repos.cend(), [](const auto &pair) {
-                const auto &[name, url] = pair;
-                std::cout << name << '\t' << url << "\n";
-            });
+            // Note: keep the same format as ll-cli repo
+            std::cout << "Default: " << cfg.defaultRepo << std::endl;
+            std::cout << std::left << std::setw(11) << "Name";
+            std::cout << "Url" << std::endl;
+            for (const auto &r : cfg.repos) {
+                std::cout << std::left << std::setw(10) << r.first << " " << r.second
+                          << std::endl;
+            }
+            return 0;
         }
 
         auto newCfg = repo.getConfig();
@@ -744,20 +745,8 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     }
 
     if (buildImport->parsed()) {
-        auto project =
-          linglong::utils::serialize::LoadYAMLFile<linglong::api::types::v1::BuilderProject>(
-            QDir().absoluteFilePath("linglong.yaml"));
-        if (!project) {
-            qCritical() << project.error();
-            return -1;
-        }
-
-        linglong::builder::Builder builder(*project,
-                                           QDir::current(),
-                                           repo,
-                                           *containerBuilder,
-                                           *builderCfg);
-        auto result = builder.importLayer(QString::fromStdString(layerFile));
+        auto result =
+          linglong::builder::Builder::importLayer(repo, QString::fromStdString(layerFile));
         if (!result) {
             qCritical() << result.error();
             return -1;

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -1196,7 +1196,7 @@ linglong::utils::error::Result<void> Builder::push(const std::string &module,
     return repo.pushToRemote(repoName, repoUrl, *ref, module);
 }
 
-utils::error::Result<void> Builder::importLayer(const QString &path)
+utils::error::Result<void> Builder::importLayer(repo::OSTreeRepo &ostree, const QString &path)
 {
     LINGLONG_TRACE("import layer");
 
@@ -1212,7 +1212,7 @@ utils::error::Result<void> Builder::importLayer(const QString &path)
         return LINGLONG_ERR(layerDir);
     }
 
-    auto result = this->repo.importLayerDir(*layerDir);
+    auto result = ostree.importLayerDir(*layerDir);
     if (!result) {
         return LINGLONG_ERR(result);
     }

--- a/libs/linglong/src/linglong/builder/linglong_builder.h
+++ b/libs/linglong/src/linglong/builder/linglong_builder.h
@@ -64,7 +64,8 @@ public:
 
     auto import() -> utils::error::Result<void>;
 
-    auto importLayer(const QString &path) -> utils::error::Result<void>;
+    static auto importLayer(repo::OSTreeRepo &repo, const QString &path)
+      -> utils::error::Result<void>;
 
     auto run(const QStringList &modules, const QStringList &args, const bool &debug)
       -> utils::error::Result<void>;


### PR DESCRIPTION
* We should keep the output format of 'll-builder repo show' as ll-cli.
* 'll-builder repo show' should return after print info. 
* 'linglong.yaml' is not necessary to 'll-builder import.

Log: