### PR TITLE
fix: check dbus error after read/write the Property of PM

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -85,6 +85,7 @@ private:
     [[nodiscard]] utils::error::Result<std::vector<api::types::v1::CliContainer>>
     getCurrentContainers() const noexcept;
     int installFromFile(const QFileInfo &fileInfo, const api::types::v1::CommonOptions &options);
+    int setRepoConfig(const QVariantMap &config);
     utils::error::Result<void> runningAsRoot();
 
 private Q_SLOTS:

--- a/misc/share/dbus-1/system.d/org.deepin.linglong.PackageManager1.conf
+++ b/misc/share/dbus-1/system.d/org.deepin.linglong.PackageManager1.conf
@@ -14,8 +14,6 @@ SPDX-License-Identifier: LGPL-3.0-or-later
   </policy>
   
   <policy context="default">
-    <!-- FIXME: deny everything here, but the method Set(org.freedesktop.DBus.Properties) 
-      did not because we have allowed the method Get/GetAll -->
     <deny send_destination="org.deepin.linglong.PackageManager1"/>
 
     <!-- Completely open to anyone: org.freedesktop.DBus.* interfaces -->


### PR DESCRIPTION
Configuration() and setConfiguration() could be failed. Due to the limit of dbus permission policy, we should call runningAsRoot() before setConfiguration().

Log: