### PR TITLE
feat: not use the host machine PATH variable

### DIFF
--- a/apps/generators/25-host-env/src/main.cpp
+++ b/apps/generators/25-host-env/src/main.cpp
@@ -25,14 +25,13 @@ const std::vector<std::string> envList = {
     "CLUTTER_IM_MODULE",
     "QT4_IM_MODULE",
     "GTK_IM_MODULE",
-    "auto_proxy",   // 网络系统代理自动代理
-    "http_proxy",   // 网络系统代理手动http代理
-    "https_proxy",  // 网络系统代理手动https代理
-    "ftp_proxy",    // 网络系统代理手动ftp代理
-    "SOCKS_SERVER", // 网络系统代理手动socks代理
-    "no_proxy",     // 网络系统代理手动配置代理
-    "USER",         // wine应用会读取此环境变量
-    "PATH",
+    "auto_proxy",      // 网络系统代理自动代理
+    "http_proxy",      // 网络系统代理手动http代理
+    "https_proxy",     // 网络系统代理手动https代理
+    "ftp_proxy",       // 网络系统代理手动ftp代理
+    "SOCKS_SERVER",    // 网络系统代理手动socks代理
+    "no_proxy",        // 网络系统代理手动配置代理
+    "USER",            // wine应用会读取此环境变量
     "QT_IM_MODULE",    // 输入法
     "LINGLONG_ROOT",   // 玲珑安装位置
     "WAYLAND_DISPLAY", // 导入wayland相关环境变量

--- a/libs/utils/src/linglong/utils/command/env.cpp
+++ b/libs/utils/src/linglong/utils/command/env.cpp
@@ -35,7 +35,6 @@ const QStringList envList = {
     "SOCKS_SERVER", // 网络系统代理手动socks代理
     "no_proxy",     // 网络系统代理手动配置代理
     "USER",         // wine应用会读取此环境变量
-    "PATH",
     "HOME",
     "QT_IM_MODULE",    // 输入法
     "LINGLONG_ROOT",   // 玲珑安装位置


### PR DESCRIPTION
目前会通过profile.d/00env.sh将宿主机的PATH变量传递到容器中并覆盖profile文件设置的默认值

目前看来并没有好处, 反而会导致预料之外的问题, 比如在一些系统上PATH没有包含/bin目录, 但玲珑的base可能需要