### PR TITLE
fix: ll-builder build command parameter error

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -199,9 +199,9 @@ You can report bugs to the linyaps team under this project: https://github.com/O
       ->check(validatorString);
 
     // add builder build
-    bool buildOffline = false, fullDevelopModule = false, skipFetchSource = false,
-         skipPullDepend = false, skipCheckOutput = false, buildSkipFetchSource = false,
-         skipStripSymbols = false, skipCommitOutput = false, buildSkipRunContainer = false;
+    bool buildOffline = false, buildFullDevelopModule = false, buildSkipFetchSource = false,
+         buildSkipPullDepend = false, buildSkipCheckOutput = false, buildSkipStripSymbols = false,
+         buildSkipCommitOutput = false, buildSkipRunContainer = false;
     std::string filePath{ "./linglong.yaml" }, arch;
     // group empty will hide command
     std::string hiddenGroup = "";
@@ -230,15 +230,19 @@ You can report bugs to the linyaps team under this project: https://github.com/O
                              "--skip-pull-depend will be set"));
     buildBuilder
       ->add_flag("--full-develop-module",
-                 fullDevelopModule,
+                 buildFullDevelopModule,
                  _("Build full develop packages, runtime requires"))
       ->group(hiddenGroup);
-    buildBuilder->add_flag("--skip-fetch-source", skipFetchSource, _("Skip fetch sources"));
-    buildBuilder->add_flag("--skip-pull-depend", skipPullDepend, _("Skip pull dependency"));
+    buildBuilder->add_flag("--skip-fetch-source", buildSkipFetchSource, _("Skip fetch sources"));
+    buildBuilder->add_flag("--skip-pull-depend", buildSkipPullDepend, _("Skip pull dependency"));
     buildBuilder->add_flag("--skip-run-container", buildSkipRunContainer, _("Skip run container"));
-    buildBuilder->add_flag("--skip-commit-output", skipCommitOutput, _("Skip commit build output"));
-    buildBuilder->add_flag("--skip-output-check", skipCheckOutput, _("Skip output check"));
-    buildBuilder->add_flag("--skip-strip-symbols", skipStripSymbols, _("Skip strip debug symbols"));
+    buildBuilder->add_flag("--skip-commit-output",
+                           buildSkipCommitOutput,
+                           _("Skip commit build output"));
+    buildBuilder->add_flag("--skip-output-check", buildSkipCheckOutput, _("Skip output check"));
+    buildBuilder->add_flag("--skip-strip-symbols",
+                           buildSkipStripSymbols,
+                           _("Skip strip debug symbols"));
 
     // add builder run
     bool debugMode = false;
@@ -500,48 +504,22 @@ You can report bugs to the linyaps team under this project: https://github.com/O
             cfg.arch = arch->toString().toStdString();
             builder.setConfig(cfg);
         }
-
-        if (buildSkipFetchSource) {
-            auto cfg = builder.getConfig();
-            options.skipFetchSource = true;
-        }
-
-        if (skipPullDepend) {
-            auto cfg = builder.getConfig();
-            options.skipPullDepend = true;
-        }
-
+        options.skipFetchSource = buildSkipFetchSource;
+        options.skipPullDepend = buildSkipPullDepend;
+        options.skipCommitOutput = buildSkipCommitOutput;
+        options.skipCheckOutput = buildSkipCheckOutput;
+        options.skipStripSymbols = buildSkipStripSymbols;
+        options.fullDevelop = buildFullDevelopModule;
         if (buildSkipRunContainer) {
-            auto cfg = builder.getConfig();
+            options.skipCommitOutput = true;
             options.skipRunContainer = true;
-            options.skipCommitOutput = true;
         }
-
-        if (skipCommitOutput) {
-            auto cfg = builder.getConfig();
-            options.skipCommitOutput = true;
-        }
-
         if (buildOffline) {
             auto cfg = builder.getConfig();
             options.skipFetchSource = true;
             options.skipPullDepend = true;
             cfg.offline = true;
             builder.setConfig(cfg);
-        }
-
-        if (skipCheckOutput) {
-            auto cfg = builder.getConfig();
-            options.skipCheckOutput = true;
-        }
-
-        if (skipStripSymbols) {
-            auto cfg = builder.getConfig();
-            options.skipStripSymbols = true;
-        }
-
-        if (fullDevelopModule) {
-            options.fullDevelop = true;
         }
 
         builder.setBuildOptions(options);

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -895,7 +895,8 @@ utils::error::Result<void> OSTreeRepo::pushToRemote(const std::string &remoteRep
     }
     auto signRes = std::shared_ptr<sign_in_200_response_t>(signResRaw, sign_in_200_response_free);
     if (signRes->code != 200) {
-        return LINGLONG_ERR(QString("sign error(%1): %2").arg(auth.username).arg(signRes->msg));
+        auto msg = signRes->msg ? signRes->msg : "cannot send request to remote server";
+        return LINGLONG_ERR(QString("sign error(%1): %2").arg(auth.username).arg(msg));
     }
     auto *token = signRes->data->token;
     // 创建上传任务
@@ -911,7 +912,8 @@ utils::error::Result<void> OSTreeRepo::pushToRemote(const std::string &remoteRep
       std::shared_ptr<new_upload_task_id_200_response_t>(newTaskResRaw,
                                                          new_upload_task_id_200_response_free);
     if (newTaskRes->code != 200) {
-        return LINGLONG_ERR(QString("create task error: %1").arg(newTaskRes->msg));
+        auto msg = newTaskRes->msg ? newTaskRes->msg : "cannot send request to remote server";
+        return LINGLONG_ERR(QString("create task error: %1").arg(msg));
     }
     auto *taskID = newTaskRes->data->id;
 
@@ -944,8 +946,8 @@ utils::error::Result<void> OSTreeRepo::pushToRemote(const std::string &remoteRep
       std::shared_ptr<api_upload_task_file_resp_t>(uploadTaskResRaw,
                                                    api_upload_task_file_resp_free);
     if (uploadTaskRes->code != 200) {
-        return LINGLONG_ERR(
-          QString("upload file error(%1): %2").arg(taskID).arg(uploadTaskRes->msg));
+        auto msg = uploadTaskRes->msg ? uploadTaskRes->msg : "cannot send request to remote server";
+        return LINGLONG_ERR(QString("upload file error(%1): %2").arg(taskID).arg(msg));
     }
     // 查询任务状态
     while (true) {
@@ -958,8 +960,8 @@ utils::error::Result<void> OSTreeRepo::pushToRemote(const std::string &remoteRep
           std::shared_ptr<upload_task_info_200_response_t>(uploadInfoRaw,
                                                            upload_task_info_200_response_free);
         if (uploadInfo->code != 200) {
-            return LINGLONG_ERR(
-              QString("get upload info error(%1): %2").arg(taskID).arg(uploadInfo->msg));
+            auto msg = uploadInfo->msg ? uploadInfo->msg : "cannot send request to remote server";
+            return LINGLONG_ERR(QString("get upload info error(%1): %2").arg(taskID).arg(msg));
         }
         qInfo() << "pushing" << reference.toString() << module.c_str()
                 << "status:" << uploadInfo->data->status;
@@ -1277,7 +1279,8 @@ OSTreeRepo::listRemote(const package::FuzzyReference &fuzzyRef) const noexcept
         return LINGLONG_ERR("cannot send request to remote server");
     }
     if (res->code != 200) {
-        return LINGLONG_ERR(res->msg);
+        auto msg = res->msg ? res->msg : "cannot send request to remote server";
+        return LINGLONG_ERR(msg);
     }
     if (!res->data) {
         return {};


### PR DESCRIPTION
ll-builder build的命令参数有重复的变量, 导致部分参数不生效
网络库在断网时没有返回准确的错误信息