### PR TITLE
fix(builder):example can not build in loong64 arch

### DIFF
--- a/misc/share/linglong/builder/templates/example.yaml
+++ b/misc/share/linglong/builder/templates/example.yaml
@@ -10,11 +10,11 @@ package:
 
 command: [echo, -e, hello world] #the commands that your application need to run.
 
-base: org.deepin.foundation/20.0.0 #set the base environment, this can be changed.
+base: org.deepin.base/23.1.0 #set the base environment, this can be changed.
 
 #set the runtime environment if you need, a example of setting deepin runtime is as follows.
 #runtime:
-#org.deepin.Runtime/23.0.1
+#org.deepin.runtime.dtk/23.1.0
 
 #set the source if you need, a simple example of git is as follows.
 #sources:


### PR DESCRIPTION
org.deepin.foundation do not have loong64 arch, so use org.deepin.base.

Bug: https://pms.uniontech.com/bug-view-284713.html