### PR TITLE
fix: some minor bugs of 'll-cli prune'

### DIFF
--- a/libs/linglong/src/linglong/cli/cli_printer.cpp
+++ b/libs/linglong/src/linglong/cli/cli_printer.cpp
@@ -36,11 +36,15 @@ void CLIPrinter::printErr(const utils::error::Error &err)
 
 void CLIPrinter::printPruneResult(const std::vector<api::types::v1::PackageInfoV2> &list)
 {
+    if(list.size() == 0) {
+        std::cout << "No unused base or runtime." << std::endl;
+    }
+    std::cout << "Unused base or runtime:" <<std::endl;
     for (const auto &info : list) {
         auto ref = package::Reference::fromPackageInfo(info);
         std::cout << ref->toString().toStdString() << std::endl;
     }
-    std::cout << list.size() << " unused layers have been removed." << std::endl;
+    std::cout << list.size() << " unused base or runtime have been removed." << std::endl;
 }
 
 void CLIPrinter::printPackages(const std::vector<api::types::v1::PackageInfoV2> &list)

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -1776,7 +1776,7 @@ PackageManager::Prune(std::vector<api::types::v1::PackageInfoV2> &removed) noexc
 
     std::unordered_map<package::Reference, int> target;
     for (const auto &info : *pkgsInfo) {
-        if (info.packageInfoV2Module != "binary") {
+        if (info.packageInfoV2Module != "binary" && info.packageInfoV2Module != "runtime") {
             continue;
         }
 


### PR DESCRIPTION
* Optimize output information of prune.
* If the module is runtime, it should be removed too.

Log: