### PR TITLE
fix: always search module 'binary' at first

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -1393,7 +1393,7 @@ int Cli::list()
         this->printer.printPackages(*pkgs);
         return 0;
     }
-    
+
     auto upgradeList = this->listUpgradable(std::move(pkgs).value());
     if(!upgradeList) {
         this->printer.printErr(upgradeList.error());

--- a/libs/linglong/src/linglong/package_manager/package_task.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_task.cpp
@@ -149,7 +149,7 @@ void PackageTask::updateState(linglong::api::types::v1::State newState,
     // Every part is completed, it means succeed
     if (this->m_taskParts == this->m_refs.size()) {
         this->setProperty("State", static_cast<int>(linglong::api::types::v1::State::Succeed));
-        auto curState = state();
+        curState = state();
     }
 
     if (curState == linglong::api::types::v1::State::Canceled

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -1572,10 +1572,13 @@ OSTreeRepo::markDeleted(const package::Reference &ref,
 
 utils::error::Result<api::types::v1::RepositoryCacheLayersItem>
 OSTreeRepo::getLayerItem(const package::Reference &ref,
-                         const std::string &module,
+                         std::string module,
                          const std::optional<std::string> &subRef) const noexcept
 {
     LINGLONG_TRACE("get latest layer of " + ref.toString());
+    if (module == "runtime") {
+        module = "binary";
+    }
 
     repoCacheQuery query{ .id = ref.id.toStdString(),
                           .repo = std::nullopt,

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -114,7 +114,7 @@ public:
 
     [[nodiscard]] utils::error::Result<api::types::v1::RepositoryCacheLayersItem>
     getLayerItem(const package::Reference &ref,
-                 const std::string &module = "binary",
+                 std::string module = "binary",
                  const std::optional<std::string> &subRef = std::nullopt) const noexcept;
 
 private:


### PR DESCRIPTION
correct state missing