### PR TITLE
fix: ldd-check should run ldconfig first

### DIFF
--- a/misc/libexec/linglong/builder/helper/ldd-check.sh
+++ b/misc/libexec/linglong/builder/helper/ldd-check.sh
@@ -109,7 +109,10 @@ main() {
         fi
 
         logDbg "start checking..."
-
+        # 更新ld.so.cache
+        if [ -n "$LINGLONG_LD_SO_CACHE" ]; then
+                ldconfig -C "$LINGLONG_LD_SO_CACHE"
+        fi
         # Check the needed dynamic libraries for the specified binaries
         checkDepensLibs "${arg1}"
 


### PR DESCRIPTION
ldd-check在检查之前应该刷新ldconfig缓存,
否则无法找到应用构建生成的so文件