### PR TITLE
fix: the prefix of install file was not removed

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -813,7 +813,9 @@ set -e
             if (!configFile.open(QIODevice::ReadOnly)) {
                 return LINGLONG_ERR("open file", configFile);
             }
-            installRules.append(QString(configFile.readAll()).split('\n'));
+            for (auto &line : QString(configFile.readAll()).split('\n')) {
+                installRules.append(line.replace(installPrefix, ""));
+            }
             // remove empty or duplicate lines
             installRules.removeAll("");
             installRules.removeDuplicates();


### PR DESCRIPTION
在旧版本玲珑中, $appid.install用于裁剪binary体积, 记录的文件路径需要带着$PREFIX 在新版本玲珑中, 裁剪会自动添加$PREFIX, 但兼容$appid.install文件的逻辑未考虑去除PREFIX 导致使用$appid.install的应用构建有问题