### PR TITLE
feat: compatibility with older versions of pkexec

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -85,6 +85,7 @@ private:
     int installFromFile(const QFileInfo &fileInfo, const api::types::v1::CommonOptions &options);
     int setRepoConfig(const QVariantMap &config);
     utils::error::Result<void> runningAsRoot();
+    utils::error::Result<void> runningAsRoot(const QList<QString> &args);
     utils::error::Result<std::vector<api::types::v1::UpgradeListResult>>
     listUpgradable(const std::vector<api::types::v1::PackageInfoV2> &pkgs);
     utils::error::Result<std::vector<api::types::v1::UpgradeListResult>>


### PR DESCRIPTION
旧版本pkexec没有keep-cwd选项, 为兼容旧版本pkexec,
将相对路径的layer文件转为绝对路径