### PR TITLE
feat: skip debug files when stripping symbols

### DIFF
--- a/misc/libexec/linglong/builder/helper/symbols-strip.sh
+++ b/misc/libexec/linglong/builder/helper/symbols-strip.sh
@@ -8,19 +8,26 @@ prefix="$PREFIX"
 
 tmpFile=$(mktemp)
 
-find "$prefix" -type f > "$tmpFile"
+find "$prefix" -type f >"$tmpFile"
 
 while read -r filepath; do
-    if file "$filepath" | grep -q 'not stripped'; then
+        fileinfo=$(file "$filepath")
+        # skip stripped
+        if ! echo "$fileinfo" | grep -q 'not stripped'; then
+                continue
+        fi
+        # skip debug
+        if echo "$fileinfo" | grep -q 'with debug_info'; then
+                continue
+        fi
         # https://sourceware.org/gdb/current/onlinedocs/gdb.html/Separate-Debug-Files.html
         buildID=$(readelf -n "$filepath" | grep 'Build ID' | awk '{print $NF}')
         debugIDFile="$prefix/lib/debug/.build-id/${buildID:0:2}/${buildID:2}.debug"
         mkdir -p "$(dirname "$debugIDFile")"
         eu-strip "$filepath" -f "$debugIDFile"
-        echo "striped $filepath to $debugIDFile" 
+        echo "striped $filepath to $debugIDFile"
 
         debugFile="$prefix/lib/debug/$filepath.debug"
         mkdir -p "$(dirname "$debugFile")"
         ln -s "$debugIDFile" "$debugFile"
-    fi
-done < "$tmpFile"
+done <"$tmpFile"


### PR DESCRIPTION
剥离调试符号时应跳过已存在的debug文件, 这些文件可能是跟随deb导入的