### PR TITLE
fix(cli): can not install or uninstall develop module

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -1276,7 +1276,14 @@ int Cli::uninstall()
         return -1;
     }
 
-    auto layerDir = this->repository.getLayerDir(*ref);
+    std::string module = "binary";
+    auto params = api::types::v1::PackageManager1UninstallParameters{};
+    if (!options.module.empty()) {
+        module = options.module;
+        params.package.packageManager1PackageModule = module;
+    }
+
+    auto layerDir = this->repository.getLayerDir(*ref, module);
     if (!layerDir) {
         this->printer.printErr(layerDir.error());
         return -1;
@@ -1294,7 +1301,6 @@ int Cli::uninstall()
         return -1;
     }
 
-    auto params = api::types::v1::PackageManager1UninstallParameters{};
     params.package.id = fuzzyRef->id.toStdString();
     if (fuzzyRef->channel) {
         params.package.channel = fuzzyRef->channel->toStdString();
@@ -1303,9 +1309,6 @@ int Cli::uninstall()
         params.package.version = fuzzyRef->version->toString().toStdString();
     }
 
-    if (!options.module.empty()) {
-        params.package.packageManager1PackageModule = options.module;
-    }
     auto pendingReply = this->pkgMan.Uninstall(utils::serialize::toQVariantMap(params));
     pendingReply.waitForFinished();
 

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -536,6 +536,13 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
 
     const auto &packageInfo = *packageInfoRet;
 
+    // FIXME: need to support install develop
+    if (packageInfo.packageInfoV2Module != "binary"
+        && packageInfo.packageInfoV2Module != "runtime") {
+        return toDBusReply(-1,
+                           "The current version does not support the develop module installation.");
+    }
+
     auto architectureRet = package::Architecture::parse(packageInfo.arch[0]);
     if (!architectureRet) {
         return toDBusReply(architectureRet);
@@ -689,6 +696,13 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
           auto result = this->repo.importLayerDir(*layerDir);
           if (!result) {
               taskRef.reportError(std::move(result).error());
+              return;
+          }
+
+          // develop module only need to import
+          if (module != "binary" && module != "runtime") {
+              taskRef.updateState(linglong::api::types::v1::State::Succeed,
+                                  "install layer successfully");
               return;
           }
 
@@ -1510,18 +1524,18 @@ void PackageManager::Uninstall(PackageTask &taskContext,
     taskContext.updateSubState(linglong::api::types::v1::SubState::PreAction,
                                "prepare uninstalling package");
 
-    std::vector<std::string> removedModules{ "binary" };
-    if (module == "binary") {
-        auto modules = this->repo.getModuleList(ref);
-        removedModules = std::move(modules);
-    }
-
+    std::vector<std::string> removedModules{ module };
     utils::Transaction transaction;
 
-    this->repo.unexportReference(ref);
-    transaction.addRollBack([this, &ref]() noexcept {
-        this->repo.exportReference(ref);
-    });
+    if (module == "binary" || module == "runtime") {
+        auto modules = this->repo.getModuleList(ref);
+        removedModules = std::move(modules);
+
+        this->repo.unexportReference(ref);
+        transaction.addRollBack([this, &ref]() noexcept {
+            this->repo.exportReference(ref);
+        });
+    }
 
     UninstallRef(taskContext, ref, removedModules);
     if (isTaskDone(taskContext.subState())) {
@@ -1739,7 +1753,7 @@ void PackageManager::pullDependency(PackageTask &taskContext,
                                     const api::types::v1::PackageInfoV2 &info,
                                     const std::string &module) noexcept
 {
-    if (info.kind != "app") {
+    if (info.kind != "app" || module != "binary" || module != "runtime") {
         return;
     }
 


### PR DESCRIPTION
1. Develop module can not be installed without binary module.
2. Develop module should be remove when run uninstall app.