### PR TITLE
fix: ll-builder cannot exit while pulling dependency

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_task.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_task.cpp
@@ -6,6 +6,7 @@
 
 #include "linglong/adaptors/task/task1.h"
 #include "linglong/utils/dbus/register.h"
+#include "linglong/utils/global/initialize.h"
 
 #include <QDebug>
 #include <QUuid>
@@ -56,6 +57,10 @@ PackageTask::PackageTask()
     : m_taskID(QUuid::createUuid())
     , m_cancelFlag(g_cancellable_new())
 {
+    connect(utils::global::GlobalTaskControl::instance(),
+            &utils::global::GlobalTaskControl::OnCancel,
+            this,
+            &PackageTask::Cancel);
 }
 
 PackageTask::PackageTask(QDBusConnection connection, QStringList refs, QObject *parent)
@@ -80,6 +85,11 @@ PackageTask::PackageTask(QDBusConnection connection, QStringList refs, QObject *
     const auto *interface = mo->classInfo(interfaceIndex).value();
     m_forwarder =
       new utils::dbus::PropertiesForwarder(connection, taskObjectPath(), interface, this);
+
+    connect(utils::global::GlobalTaskControl::instance(),
+            &utils::global::GlobalTaskControl::OnCancel,
+            this,
+            &PackageTask::Cancel);
 }
 
 PackageTask::~PackageTask()

--- a/libs/utils/src/linglong/utils/global/initialize.cpp
+++ b/libs/utils/src/linglong/utils/global/initialize.cpp
@@ -8,7 +8,9 @@
 
 #include "linglong/utils/configure.h"
 
+#include <qcoreapplication.h>
 #include <qloggingcategory.h>
+#include <qobjectdefs.h>
 #include <systemd/sd-journal.h>
 
 #include <QCoreApplication>
@@ -27,6 +29,7 @@ void catchUnixSignals(std::initializer_list<int> quitSignals)
     auto handler = [](int sig) -> void {
         qInfo().noquote() << QString("Quit the application by signal(%1).").arg(sig);
         QCoreApplication::quit();
+        GlobalTaskControl::cancel();
     };
 
     sigset_t blocking_mask;
@@ -133,6 +136,24 @@ void installMessageHandler()
 bool linglongInstalled()
 {
     return QCoreApplication::applicationDirPath() == BINDIR;
+}
+
+auto globalTaskControl = GlobalTaskControl{};
+
+const GlobalTaskControl *GlobalTaskControl::instance()
+{
+    return &globalTaskControl;
+}
+
+void GlobalTaskControl::cancel()
+{
+    globalTaskControl.cancelFlag.store(true);
+    Q_EMIT globalTaskControl.OnCancel();
+}
+
+bool GlobalTaskControl::canceled()
+{
+    return globalTaskControl.cancelFlag.load();
 }
 
 } // namespace linglong::utils::global

--- a/libs/utils/src/linglong/utils/global/initialize.h
+++ b/libs/utils/src/linglong/utils/global/initialize.h
@@ -6,10 +6,29 @@
 
 #pragma once
 
+#include <QObject>
+
+#include <atomic>
+
 namespace linglong::utils::global {
 
 void applicationInitialize(bool appForceStderrLogging = false);
 void installMessageHandler();
 bool linglongInstalled();
+void cancelAllTask() noexcept;
+
+class GlobalTaskControl : public QObject
+{
+    Q_OBJECT
+public:
+    static void cancel();
+    static bool canceled();
+    static const GlobalTaskControl *instance();
+Q_SIGNALS:
+    void OnCancel();
+
+private:
+    std::atomic<bool> cancelFlag = false;
+};
 
 } // namespace linglong::utils::global


### PR DESCRIPTION
修复builder在下载依赖时无法按Ctrl+C退出的问题
尝试使用QCoreApplication::aboutToQuit让任务停止没有效果, 所以使用了自定义的全局对象