### PR TITLE
fix: dbus permission authentication is skipped

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -92,6 +92,7 @@ private:
     listUpgradable(const std::vector<api::types::v1::PackageInfoV2> &pkgs);
     utils::error::Result<std::vector<api::types::v1::UpgradeListResult>>
     listUpgradable(const std::string &type);
+    QDBusReply<QString> authorization();
 
 private Q_SLOTS:
     // maybe use in the future


### PR DESCRIPTION
The interface org.freedesktop.DBus.Introspectable can not be rejected in dbus(1.12.20.11-deepin1). We use org.deepin.linglong.PackageManager.Prune to identify permissions now.

Log: