### PR TITLE
fix: can not uninstall ref if layer dir is not exist

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -1283,19 +1283,13 @@ int Cli::uninstall()
         params.package.packageManager1PackageModule = module;
     }
 
-    auto layerDir = this->repository.getLayerDir(*ref, module);
-    if (!layerDir) {
-        this->printer.printErr(layerDir.error());
+    auto layerItem = this->repository.getLayerItem(*ref, module);
+    if (!layerItem) {
+        this->printer.printErr(layerItem.error());
         return -1;
     }
 
-    auto info = layerDir->info();
-    if (!info) {
-        this->printer.printErr(info.error());
-        return -1;
-    }
-
-    if (info->kind != "app") {
+    if (layerItem->info.kind != "app") {
         this->printer.printErr(
           LINGLONG_ERRV("This layer is not an application, please use 'll-cli prune'.", -1));
         return -1;

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -1046,14 +1046,16 @@ utils::error::Result<void> OSTreeRepo::remove(const package::Reference &ref,
     if (!layer) {
         return LINGLONG_ERR(layer);
     }
-    auto layerDir = this->getLayerDir(*layer);
-    if (!layerDir) {
-        return LINGLONG_ERR(layerDir);
-    }
 
     auto ret = this->removeOstreeRef(*layer);
     if (!ret) {
         return LINGLONG_ERR(ret);
+    }
+
+    auto layerDir = this->getLayerDir(*layer);
+    if (!layerDir) {
+        qWarning() << layerDir.error().message();
+        return LINGLONG_OK;
     }
 
     if (!layerDir->removeRecursively()) {


### PR DESCRIPTION
If the layer dir is not exists, we just need to give a warning instead of return with error.

Log: