### PR TITLE
fix: abnormal cursor size in wayland

### DIFF
--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/25_host_env.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/25_host_env.cpp
@@ -41,6 +41,7 @@ bool HostEnv::generate(ocppi::runtime::config::types::Config &config) const noex
         "XDG_SESSION_DESKTOP",
         "D_DISABLE_RT_SCREEN_SCALE",
         "XMODIFIERS",
+        "XCURSOR_SIZE", // 鼠标尺寸
         "DESKTOP_SESSION",
         "DEEPIN_WINE_SCALE",
         "XDG_CURRENT_DESKTOP",


### PR DESCRIPTION
DTK使用XCURSOR_SIZE环境变量设置鼠标尺寸
需要将该环境变量从宿主机传递到容器中