### PR TITLE
fix: getRemoteModuleList for incompatibility with runtime modules

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -121,7 +121,7 @@ void ensureDirectory(const std::filesystem::path &dir)
         }
 
         if (!std::filesystem::create_directory(dir, ec)) {
-            qCritical() << "failed to create directory:" << ec.message().c_str();
+            qCritical() << "failed to create directory :" << dir.c_str() << ec.message().c_str();
             QCoreApplication::exit(ec.value());
             std::abort();
         }
@@ -307,10 +307,7 @@ ll-cli run org.deepin.demo -- bash -x /path/to/bash/script)"));
                      ->group(CliAppManagingGroup)
                      ->fallthrough();
     cliKill->usage(_("Usage: ll-cli kill [OPTIONS] APP"));
-    cliKill
-      ->add_option("APP",
-                   options.appid,
-                   _("Specify the running application"))
+    cliKill->add_option("APP", options.appid, _("Specify the running application"))
       ->required()
       ->check(validatorString);
 

--- a/tools/test-linglong.sh
+++ b/tools/test-linglong.sh
@@ -88,5 +88,5 @@ ll-cli list | grep org.dde.calendar | grep -vq unuse
 # 最新版本没有lang-ja模块，升级后删除lang-ja模块，保留其他模块
 ll-cli upgrade org.dde.calendar
 ll-cli list | grep org.dde.calendar | grep -q binary
+ll-cli list | grep org.dde.calendar | grep -q develop
 ll-cli list | grep org.dde.calendar | grep -vq lang-ja
-ll-cli list | grep org.dde.calendar | grep -vq unuse


### PR DESCRIPTION
获取远程模块列表时, 应该考虑兼容旧版本的runtime modules
优化安装和升级流程, 只安装单个模块时, 不需要提前获取远程模块列表