### PR TITLE
feat: ll-builder supports import directory

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -323,6 +323,16 @@ You can report bugs to the linyaps team under this project: https://github.com/O
       ->required()
       ->check(CLI::ExistingFile);
 
+    // add build importDir
+    std::string layerDir;
+    auto buildImportDir =
+      commandParser.add_subcommand("import-dir", _("Import linyaps layer dir to build repo"))
+        ->group(hiddenGroup);
+    buildImportDir->usage(_("Usage: ll-builder import-dir PATH"));
+    buildImportDir->add_option("PATH", layerDir, _("layer dir path"))
+      ->type_name("PATH")
+      ->required();
+
     // add build extract
     std::string dir;
     auto buildExtract = commandParser.add_subcommand("extract", _("Extract linyaps layer to dir"));
@@ -775,6 +785,16 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     if (buildImport->parsed()) {
         auto result =
           linglong::builder::Builder::importLayer(repo, QString::fromStdString(layerFile));
+        if (!result) {
+            qCritical() << result.error();
+            return -1;
+        }
+        return 0;
+    }
+
+    if (buildImportDir->parsed()) {
+        auto result =
+          linglong::builder::Builder::importLayer(repo, QString::fromStdString(layerDir));
         if (!result) {
             qCritical() << result.error();
             return -1;

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -1304,7 +1304,18 @@ linglong::utils::error::Result<void> Builder::push(const std::string &module,
 utils::error::Result<void> Builder::importLayer(repo::OSTreeRepo &ostree, const QString &path)
 {
     LINGLONG_TRACE("import layer");
-
+    if (std::filesystem::is_directory(path.toStdString())) {
+        auto layerDir = package::LayerDir(path);
+        auto info = layerDir.info();
+        if (!info) {
+            return LINGLONG_ERR(info);
+        }
+        auto result = ostree.importLayerDir(layerDir);
+        if (!result) {
+            return LINGLONG_ERR(result);
+        }
+        return LINGLONG_OK;
+    }
     auto layerFile = package::LayerFile::New(path);
     if (!layerFile) {
         return LINGLONG_ERR(layerFile);


### PR DESCRIPTION
ll-builder import命令支持传递目录, 这便于制作base和手动修改app