### PR TITLE
fix: no desktop in launcher after install app

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -6,6 +6,7 @@
 
 #include "linglong/cli/cli.h"
 
+#include "linglong/api/dbus/v1/dbus_peer.h"
 #include "linglong/api/types/v1/InteractionReply.hpp"
 #include "linglong/api/types/v1/InteractionRequest.hpp"
 #include "linglong/api/types/v1/PackageManager1InstallParameters.hpp"
@@ -958,6 +959,7 @@ int Cli::installFromFile(const QFileInfo &fileInfo, const api::types::v1::Common
         return -1;
     }
 
+    updateAM();
     return this->lastState == linglong::api::types::v1::State::Succeed ? 0 : -1;
 }
 
@@ -1092,6 +1094,7 @@ int Cli::install()
     }
     loop.exec();
 
+    updateAM();
     return this->lastState == linglong::api::types::v1::State::Succeed ? 0 : -1;
 }
 
@@ -1201,6 +1204,7 @@ int Cli::upgrade()
     }
     loop.exec();
 
+    updateAM();
     if (this->lastState != linglong::api::types::v1::State::Succeed) {
         return -1;
     }
@@ -1479,6 +1483,7 @@ int Cli::uninstall()
     }
     loop.exec();
 
+    updateAM();
     return this->lastState == linglong::api::types::v1::State::Succeed ? 0 : -1;
 }
 
@@ -2351,5 +2356,26 @@ Cli::ensureCache(const package::Reference &ref,
     }
 
     return appCache;
+}
+
+void Cli::updateAM() noexcept
+{
+    // NOTE: make sure AM refresh the cache of desktop 
+    if ((QSysInfo::productType() == "Deepin" || QSysInfo::productType() == "deepin")
+        && this->lastState == linglong::api::types::v1::State::Succeed) {
+        QDBusConnection conn = QDBusConnection::systemBus();
+        if (!conn.isConnected()) {
+            qWarning() << "Failed to connect to the system bus";
+        }
+
+        auto peer = linglong::api::dbus::v1::DBusPeer("org.desktopspec.ApplicationUpdateNotifier1",
+                                                      "/org/desktopspec/ApplicationUpdateNotifier1",
+                                                      conn);
+        auto reply = peer.Ping();
+        reply.waitForFinished();
+        if (!reply.isValid()) {
+            qWarning() << "Failed to ping org.desktopspec.ApplicationUpdateNotifier1" << reply.error();
+        }
+    }
 }
 } // namespace linglong::cli

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -99,6 +99,7 @@ private:
     ensureCache(const package::Reference &ref,
                 const api::types::v1::RepositoryCacheLayersItem &appLayerItem) noexcept;
     QDBusReply<QString> authorization();
+    void updateAM() noexcept;
 
 private Q_SLOTS:
     // maybe use in the future


### PR DESCRIPTION
Bring updateAM() back and call another service which in system bus. 
Service name is org.desktopspec.ApplicationUpdateNotifier1.

Log: