### PR TITLE
fix: no error messages when fetch fails

### DIFF
--- a/libs/utils/src/linglong/utils/command/env.cpp
+++ b/libs/utils/src/linglong/utils/command/env.cpp
@@ -67,6 +67,7 @@ linglong::utils::error::Result<QString> Exec(QString command, QStringList args)
     QProcess process;
     process.setProgram(command);
     process.setArguments(args);
+    process.setProcessChannelMode(QProcess::MergedChannels);
     process.start();
 
     if (!process.waitForFinished(-1)) {
@@ -74,7 +75,7 @@ linglong::utils::error::Result<QString> Exec(QString command, QStringList args)
     }
 
     if (process.exitCode() != 0) {
-        return LINGLONG_ERR(process.readAllStandardError(), process.exitCode());
+        return LINGLONG_ERR(process.readAllStandardOutput(), process.exitCode());
     }
 
     return process.readAllStandardOutput();


### PR DESCRIPTION
使用QProcess执行fetch-file-source脚本下载文件时, 如果文件哈希值错误,
脚本会使用echo返回错误信息, 但玲珑打印的stderr, 导致错误信息丢失
本次提交给QProcess设置mergedChannels, 能同时打印process的stdout和stderr