### PR TITLE
feat: filter search results to show only latest versions by default

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -205,6 +205,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
                         .repoOptions = {},
                         .commands = {},
                         .showDevel = false,
+                        .showAll = false,
                         .showUpgradeList = false,
                         .forceOpt = false,
                         .confirmOpt = false };
@@ -390,6 +391,7 @@ ll-cli search . --type=runtime)"));
       ->capture_default_str()
       ->check(validatorString);
     cliSearch->add_flag("--dev", options.showDevel, _("include develop application in result"));
+    cliSearch->add_flag("--all", options.showAll, _("Show all results"));
 
     // add sub command list
     auto *cliList =

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -40,6 +40,7 @@ struct CliOptions
     RepoOptions repoOptions;
     std::vector<std::string> commands;
     bool showDevel;
+    bool showAll;
     bool showUpgradeList;
     bool forceOpt;
     bool confirmOpt;
@@ -93,6 +94,8 @@ private:
     static std::string mappingUrl(const std::string &url) noexcept;
     static void filterPackageInfosFromType(std::vector<api::types::v1::PackageInfoV2> &list,
                                            const std::string &type) noexcept;
+    static utils::error::Result<void>
+    filterPackageInfosFromVersion(std::vector<api::types::v1::PackageInfoV2> &list) noexcept;
     void printProgress() noexcept;
     [[nodiscard]] utils::error::Result<std::vector<api::types::v1::CliContainer>>
     getCurrentContainers() const noexcept;


### PR DESCRIPTION
Added a new `--all` flag to the search command to display all versions of packages. By default, search results will only show the latest version of each package.