### PR TITLE
fix: debug symbols not stripped from build artifacts

### DIFF
--- a/misc/libexec/linglong/builder/helper/symbols-strip.sh
+++ b/misc/libexec/linglong/builder/helper/symbols-strip.sh
@@ -16,8 +16,8 @@ while read -r filepath; do
         if ! echo "$fileinfo" | grep -q 'not stripped'; then
                 continue
         fi
-        # skip debug
-        if echo "$fileinfo" | grep -q 'with debug_info'; then
+        # skip debug file
+        if [[ "$filepath" == *.debug ]]; then
                 continue
         fi
         # https://sourceware.org/gdb/current/onlinedocs/gdb.html/Separate-Debug-Files.html


### PR DESCRIPTION
之前在剥离调试符号的脚本中尝试跳过被剥离的调试符号文件,
但因判断条件错误, 导致未剥离调试符号的二进制文件也被跳过