### PR TITLE
fix: can't search after adding repo using alias

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -474,7 +474,7 @@ ll-cli list --upgradable
     auto *repoSetDefault =
       cliRepo->add_subcommand("set-default", _("Set a default repository name"));
     repoSetDefault->usage(_("Usage: ll-cli repo set-default [OPTIONS] NAME"));
-    repoSetDefault->add_option("NAME", options.repoOptions.repoName, _("Specify the repo name"))
+    repoSetDefault->add_option("Alias", options.repoOptions.repoAlias, _("Alias the repo name"))
       ->required()
       ->check(validatorString);
 
@@ -557,7 +557,8 @@ ll-cli list --upgradable
         qCritical() << config.error();
         return -1;
     }
-    linglong::repo::ClientFactory clientFactory(linglong::repo::getDefaultRepoUrl(*config));
+    const auto defaultRepo = linglong::repo::getDefaultRepo(*config);
+    linglong::repo::ClientFactory clientFactory(defaultRepo.url);
 
     auto ret = QMetaObject::invokeMethod(
       QCoreApplication::instance(),

--- a/apps/ll-package-manager/src/main.cpp
+++ b/apps/ll-package-manager/src/main.cpp
@@ -32,8 +32,9 @@ void withDBusDaemon(ocppi::cli::CLI &cli)
         QCoreApplication::exit(-1);
         return;
     }
-    std::string defaultRepoUrl = linglong::repo::getDefaultRepoUrl(*config);
-    auto *clientFactory = new linglong::repo::ClientFactory(defaultRepoUrl);
+    const auto defaultRepo = linglong::repo::getDefaultRepo(*config);
+    qWarning() << "server" << defaultRepo.url.c_str();
+    auto *clientFactory = new linglong::repo::ClientFactory(defaultRepo.url);
     clientFactory->setParent(QCoreApplication::instance());
 
     auto repoRoot = QDir(LINGLONG_ROOT);
@@ -99,8 +100,9 @@ void withoutDBusDaemon(ocppi::cli::CLI &cli)
         QCoreApplication::exit(-1);
         return;
     }
-    auto *clientFactory =
-      new linglong::repo::ClientFactory(linglong::repo::getDefaultRepoUrl(*config));
+
+    const auto defaultRepo = linglong::repo::getDefaultRepo(*config);
+    auto *clientFactory = new linglong::repo::ClientFactory(defaultRepo.url);
     clientFactory->setParent(QCoreApplication::instance());
 
     auto repoRoot = QDir(LINGLONG_ROOT);

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -455,7 +455,7 @@ utils::error::Result<void> Builder::build(const QStringList &args) noexcept
     std::string repoUrl;
     const auto &defaultRepo =
       std::find_if(repoCfg.repos.begin(), repoCfg.repos.end(), [&repoCfg](const auto &repo) {
-          return repo.alias == repoCfg.defaultRepo;
+          return repo.alias.value_or(repo.name) == repoCfg.defaultRepo;
       });
     repoUrl = defaultRepo->url;
     printMessage("Url: " + repoUrl, 2);

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -1861,19 +1861,6 @@ int Cli::repo(CLI::App *app)
             return EINVAL;
         }
 
-        if (!options.repoOptions.repoAlias.has_value()) {
-            bool exists =
-              std::any_of(cfgRef.repos.begin(), cfgRef.repos.end(), [&name](const auto &repo) {
-                  return repo.name == name;
-              });
-            if (exists) {
-                this->printer.printErr(
-                  LINGLONG_ERRV(QString{ "repo " } + name.c_str()
-                                + " already exist. please use --alias to set a alias."));
-                return -1;
-            }
-        }
-
         bool isExist =
           std::any_of(cfgRef.repos.begin(), cfgRef.repos.end(), [&alias](const auto &repo) {
               return repo.alias == alias;
@@ -1884,7 +1871,7 @@ int Cli::repo(CLI::App *app)
             return -1;
         }
         cfgRef.repos.push_back(api::types::v1::Repo{
-          .alias = alias,
+          .alias = options.repoOptions.repoAlias,
           .name = name,
           .url = url,
         });
@@ -1893,7 +1880,7 @@ int Cli::repo(CLI::App *app)
 
     auto existingRepo =
       std::find_if(cfgRef.repos.begin(), cfgRef.repos.end(), [&alias](const auto &repo) {
-          return repo.alias == alias;
+          return repo.alias.value_or(repo.name) == alias;
       });
 
     if (existingRepo == cfgRef.repos.end()) {

--- a/libs/linglong/src/linglong/cli/cli_printer.cpp
+++ b/libs/linglong/src/linglong/cli/cli_printer.cpp
@@ -145,7 +145,7 @@ void CLIPrinter::printRepoConfig(const api::types::v1::RepoConfigV2 &repoInfo)
     std::cout << std::setw(maxUrlLength + 2) << "Url" << std::setw(11) << "Alias" << std::endl;
     for (const auto &repo : repoInfo.repos) {
         std::cout << std::left << std::setw(11) << repo.name << std::setw(maxUrlLength + 2)
-                  << repo.url << std::setw(11) << repo.alias.value() << std::endl;
+                  << repo.url << std::setw(11) << repo.alias.value_or(repo.name) << std::endl;
     }
 }
 

--- a/libs/linglong/src/linglong/repo/config.cpp
+++ b/libs/linglong/src/linglong/repo/config.cpp
@@ -79,7 +79,7 @@ utils::error::Result<void> saveConfig(const api::types::v1::RepoConfigV2 &cfg,
     try {
         auto defaultRepoExists =
           std::any_of(cfg.repos.begin(), cfg.repos.end(), [&cfg](const auto &repo) {
-              return repo.alias == cfg.defaultRepo;
+              return repo.alias.value_or(repo.name) == cfg.defaultRepo;
           });
 
         if (!defaultRepoExists) {
@@ -100,14 +100,14 @@ utils::error::Result<void> saveConfig(const api::types::v1::RepoConfigV2 &cfg,
     }
 }
 
-std::string getDefaultRepoUrl(const api::types::v1::RepoConfigV2 &cfg) noexcept
+api::types::v1::Repo getDefaultRepo(const api::types::v1::RepoConfigV2 &cfg) noexcept
 {
     const auto &defaultRepo =
       std::find_if(cfg.repos.begin(), cfg.repos.end(), [&cfg](const auto &repo) {
-          return repo.alias == cfg.defaultRepo;
+          return repo.alias.value_or(repo.name) == cfg.defaultRepo;
       });
 
-    return defaultRepo->url;
+    return *defaultRepo;
 }
 
 api::types::v1::RepoConfigV2 convertToV2(const api::types::v1::RepoConfig &cfg) noexcept
@@ -119,7 +119,6 @@ api::types::v1::RepoConfigV2 convertToV2(const api::types::v1::RepoConfig &cfg) 
     for (const auto &[name, url] : cfg.repos) {
         api::types::v1::Repo repoV2;
         repoV2.name = name;
-        repoV2.alias = name;
         repoV2.url = url;
         configV2.repos.push_back(repoV2);
     }

--- a/libs/linglong/src/linglong/repo/config.h
+++ b/libs/linglong/src/linglong/repo/config.h
@@ -18,7 +18,7 @@ utils::error::Result<api::types::v1::RepoConfigV2> loadConfig(const QString &fil
 utils::error::Result<api::types::v1::RepoConfigV2> loadConfig(const QStringList &files) noexcept;
 utils::error::Result<void> saveConfig(const api::types::v1::RepoConfigV2 &cfg,
                                       const QString &path) noexcept;
-std::string getDefaultRepoUrl(const api::types::v1::RepoConfigV2 &cfg) noexcept;
+api::types::v1::Repo getDefaultRepo(const api::types::v1::RepoConfigV2 &cfg) noexcept;
 api::types::v1::RepoConfigV2 convertToV2(const api::types::v1::RepoConfig &cfg) noexcept;
 
 } // namespace linglong::repo


### PR DESCRIPTION
OSTree still uses defaultRepo, but defaultRepo has now become an alias.