### PR TITLE
feat: `ll-cli ps` output to display only AppID in the App field

### DIFF
--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-19 15:42+0800\n"
+"POT-Creation-Date: 2025-02-19 17:26+0800\n"
 "PO-Revision-Date: 2025-01-07 17:11+0800\n"
 "Last-Translator: deepiner, 2024\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -493,7 +493,7 @@ msgid "linyaps CLI version "
 msgstr "linyaps CLI version "
 
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:83
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:225
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:238
 msgid "ID"
 msgstr "ID"
 
@@ -529,11 +529,11 @@ msgstr "ContainerID"
 msgid "Pid"
 msgstr "Pid"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:226
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:239
 msgid "Installed"
 msgstr "Installed"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:227
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:240
 msgid "New"
 msgstr "New"
 

--- a/po/en_US.po
+++ b/po/en_US.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-19 15:42+0800\n"
+"POT-Creation-Date: 2025-02-19 17:26+0800\n"
 "PO-Revision-Date: 2025-01-07 17:11+0800\n"
 "Last-Translator: deepiner, 2024\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -493,7 +493,7 @@ msgid "linyaps CLI version "
 msgstr "linyaps CLI version "
 
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:83
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:225
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:238
 msgid "ID"
 msgstr "ID"
 
@@ -529,11 +529,11 @@ msgstr "ContainerID"
 msgid "Pid"
 msgstr "Pid"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:226
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:239
 msgid "Installed"
 msgstr "Installed"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:227
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:240
 msgid "New"
 msgstr "New"
 

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-19 15:42+0800\n"
+"POT-Creation-Date: 2025-02-19 17:26+0800\n"
 "PO-Revision-Date: 2025-01-07 17:11+0800\n"
 "Last-Translator: deepiner, 2024\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -504,7 +504,7 @@ msgid "linyaps CLI version "
 msgstr "versión de linyaps CLI "
 
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:83
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:225
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:238
 msgid "ID"
 msgstr "ID"
 
@@ -540,11 +540,11 @@ msgstr "ContainerID"
 msgid "Pid"
 msgstr "Pid"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:226
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:239
 msgid "Installed"
 msgstr "Instalado"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:227
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:240
 msgid "New"
 msgstr "Nuevo"
 

--- a/po/linyaps.pot
+++ b/po/linyaps.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-19 15:42+0800\n"
+"POT-Creation-Date: 2025-02-19 17:26+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -433,7 +433,7 @@ msgid "linyaps CLI version "
 msgstr ""
 
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:83
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:225
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:238
 msgid "ID"
 msgstr ""
 
@@ -469,11 +469,11 @@ msgstr ""
 msgid "Pid"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:226
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:239
 msgid "Installed"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:227
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:240
 msgid "New"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-19 15:42+0800\n"
+"POT-Creation-Date: 2025-02-19 17:26+0800\n"
 "PO-Revision-Date: 2025-01-07 17:11+0800\n"
 "Last-Translator:  deepiner, 2024\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -483,7 +483,7 @@ msgid "linyaps CLI version "
 msgstr "如意玲珑CLI版本 "
 
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:83
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:225
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:238
 msgid "ID"
 msgstr "ID"
 
@@ -519,11 +519,11 @@ msgstr "容器ID"
 msgid "Pid"
 msgstr "进程ID"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:226
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:239
 msgid "Installed"
 msgstr "已安装"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:227
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:240
 msgid "New"
 msgstr "新版本"
 


### PR DESCRIPTION
Previously, the `App` field in the `ll-cli ps` command output displayed the full package name (e.g., `main:org.dde.calendar/5.14.7.3/x86_64`). This has been updated to display only the AppID portion (e.g., `org.dde.calendar`).