### PR TITLE
fix: ll-cli outputs --help info instead of --help-all

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -539,6 +539,10 @@ ll-cli list --upgradable
 
     auto res = transformOldExec(argc, argv);
     std::reverse(res.begin(), res.end());
+    if (argc == 1) {
+        std::cout << commandParser.help() << std::endl;
+        return 0;
+    }
     CLI11_PARSE(commandParser, res);
 
     if (versionFlag) {


### PR DESCRIPTION
This commit ensures that `ll-cli` now outputs the standard `--help` information when no arguments are provided, aligning with common CLI conventions. 
The `--help-all` option remains available for users who need expanded details.