### PR TITLE
fix: Fix missing header

### DIFF
--- a/apps/ll-dialog/src/main.cpp
+++ b/apps/ll-dialog/src/main.cpp
@@ -4,6 +4,7 @@
 
 #include "cache_dialog.h"
 #include "linglong/utils/configure.h"
+#include "linglong/utils/gettext.h"
 #include "permissionDialog.h"
 #include "tl/expected.hpp"
 


### PR DESCRIPTION
Fix compiler error on deepin v20 from source:
error: ‘bindtextdomain’ was not declared in this scope
error: ‘textdomain’ was not declared in this scope