### PR TITLE
Do not control the "erofsfuse" dependency version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Deepin Packages Builder <packages@deepin.com>
 Build-Depends: cmake,
                debhelper-compat (= 12),
-               erofsfuse (>= 1.8.3),
+               erofsfuse,
                intltool,
                libcli11-dev (>= 2.4.1) | hello,
                libcurl4-openssl-dev,


### PR DESCRIPTION
erofsfuse这个依赖在玲珑上主要作用为导出uab,但玲珑已经默认关闭了在其他发行版上进行导出uab的功能,因此不需要进行版本控制,而且进行版本控制后会导致Ubuntu 24.04这样的发行版无法进行编译安装,我建议通过安装玲珑后读取erofsfuse动态库的so版本,高于1.8.3就对uab导出功能进行开放这样实现。