### PR TITLE
feat: add priority to the repo config

### DIFF
--- a/api/schema/v1.json
+++ b/api/schema/v1.json
@@ -563,7 +563,8 @@
       "type": "object",
       "required": [
         "name",
-        "url"
+        "url",
+        "priority"
       ],
       "properties": {
         "name": {
@@ -577,6 +578,10 @@
         "alias": {
           "type": "string",
           "description": "alias of repo name"
+        },
+        "priority": {
+          "type": "integer",
+          "description": "priority of repo"
         }
       }
     },

--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -451,6 +451,7 @@ $defs:
     required:
       - name
       - url
+      - priority
     properties:
       name:
         type: string
@@ -461,6 +462,9 @@ $defs:
       alias:
         type: string
         description: alias of repo name
+      priority:
+        type: integer
+        description: priority of repo
   LayerInfo:
     description: Meta information on the head of layer file.
     type: object

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -482,6 +482,18 @@ ll-cli list --upgradable
     cliRepo->add_subcommand("show", _("Show repository information"))
       ->usage(_("Usage: ll-cli repo show [OPTIONS]"));
 
+    // add repo sub command set-priority
+    auto *repoSetPriority =
+      cliRepo->add_subcommand("set-priority", _("Set the priority of the repo"));
+    repoSetPriority->usage(_("Usage: ll-cli repo set-priority ALIAS PRIORITY"));
+    repoSetPriority->add_option("ALIAS", options.repoOptions.repoAlias, _("Alias of the repo name"))
+      ->required()
+      ->check(validatorString);
+    repoSetPriority
+      ->add_option("PRIORITY", options.repoOptions.repoPriority, _("Priority of the repo"))
+      ->required()
+      ->check(validatorString);
+
     // add sub command info
     auto *cliInfo =
       commandParser

--- a/libs/api/src/linglong/api/types/v1/Generators.hpp
+++ b/libs/api/src/linglong/api/types/v1/Generators.hpp
@@ -894,6 +894,7 @@ j["packages"] = x.packages;
 inline void from_json(const json & j, Repo& x) {
 x.alias = get_stack_optional<std::string>(j, "alias");
 x.name = j.at("name").get<std::string>();
+x.priority = j.at("priority").get<int64_t>();
 x.url = j.at("url").get<std::string>();
 }
 
@@ -903,6 +904,7 @@ if (x.alias) {
 j["alias"] = x.alias;
 }
 j["name"] = x.name;
+j["priority"] = x.priority;
 j["url"] = x.url;
 }
 

--- a/libs/api/src/linglong/api/types/v1/Repo.hpp
+++ b/libs/api/src/linglong/api/types/v1/Repo.hpp
@@ -40,6 +40,10 @@ std::optional<std::string> alias;
 */
 std::string name;
 /**
+* priority of repo
+*/
+int64_t priority;
+/**
 * repo url
 */
 std::string url;

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -26,6 +26,7 @@ struct RepoOptions
     std::string repoName;
     std::string repoUrl;
     std::optional<std::string> repoAlias;
+    std::int64_t repoPriority{ 0 };
 };
 
 struct CliOptions

--- a/libs/linglong/src/linglong/cli/cli_printer.cpp
+++ b/libs/linglong/src/linglong/cli/cli_printer.cpp
@@ -172,11 +172,21 @@ void CLIPrinter::printRepoConfig(const api::types::v1::RepoConfigV2 &repoInfo)
     for (const auto &repo : repoInfo.repos) {
         maxUrlLength = std::max(maxUrlLength, repo.url.size());
     }
-    std::cout << std::left << std::setw(11) << "Name";
-    std::cout << std::setw(maxUrlLength + 2) << "Url" << std::setw(11) << "Alias" << std::endl;
-    for (const auto &repo : repoInfo.repos) {
+    std::cout << std::left << std::setw(11) << _("Name");
+    std::cout << std::setw(maxUrlLength + 2) << _("Url") << std::setw(11) << _("Alias")
+              << std::setw(10) << _("Priority") << std::endl;
+
+    auto repos = repoInfo.repos;
+    // 按照优先级从高到低排序
+    std::sort(repos.begin(),
+              repos.end(),
+              [](const api::types::v1::Repo &a, const api::types::v1::Repo &b) {
+                  return a.priority > b.priority;
+              });
+    for (const auto &repo : repos) {
         std::cout << std::left << std::setw(11) << repo.name << std::setw(maxUrlLength + 2)
-                  << repo.url << std::setw(11) << repo.alias.value_or(repo.name) << std::endl;
+                  << repo.url << std::setw(11) << repo.alias.value_or(repo.name) << std::setw(10)
+                  << repo.priority << std::endl;
     }
 }
 

--- a/libs/linglong/src/linglong/repo/config.h
+++ b/libs/linglong/src/linglong/repo/config.h
@@ -18,7 +18,10 @@ utils::error::Result<api::types::v1::RepoConfigV2> loadConfig(const QString &fil
 utils::error::Result<api::types::v1::RepoConfigV2> loadConfig(const QStringList &files) noexcept;
 utils::error::Result<void> saveConfig(const api::types::v1::RepoConfigV2 &cfg,
                                       const QString &path) noexcept;
+int64_t getRepoMinPriority(const api::types::v1::RepoConfigV2 &cfg) noexcept;
+int64_t getRepoMaxPriority(const api::types::v1::RepoConfigV2 &cfg) noexcept;
 api::types::v1::Repo getDefaultRepo(const api::types::v1::RepoConfigV2 &cfg) noexcept;
+
 api::types::v1::RepoConfigV2 convertToV2(const api::types::v1::RepoConfig &cfg) noexcept;
 
 } // namespace linglong::repo

--- a/misc/share/linglong/config.yaml
+++ b/misc/share/linglong/config.yaml
@@ -7,3 +7,4 @@ defaultRepo: stable
 repos:
   - name: stable
     url: https://mirror-repo-linglong.deepin.com
+    priority: 0


### PR DESCRIPTION
The default priority for the stable repository is 0. 
When adding a new repository, its priority will be set to the current minimum priority minus 100. 
If the new repository is set as the default repository, its priority will be set to the current maximum priority plus 100. 
Added the set-priority subcommand to allow manual specification of priorities (duplicates are not allowed).