### PR TITLE
fix: upgrade exception when all packages are up to date

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -1314,6 +1314,11 @@ int Cli::upgrade()
         }
     }
 
+    if (fuzzyRefs.empty()) {
+        this->printer.printReply({ .code = 0, .message = "All software packages are up to date." });
+        return 0;
+    }
+
     api::types::v1::PackageManager1UpdateParameters params;
     for (const auto &fuzzyRef : fuzzyRefs) {
         api::types::v1::PackageManager1Package package;


### PR DESCRIPTION
When all packages are up to date, the upgrade command does not automatically end

Issue: https://github.com/OpenAtom-Linyaps/linyaps/issues/1024