### PR TITLE
feat: install packages by priority

### DIFF
--- a/api/schema/v1.json
+++ b/api/schema/v1.json
@@ -1014,6 +1014,10 @@
         "id": {
           "type": "string",
           "description": "id of package manager search"
+        },
+        "repo": {
+          "type": "string",
+          "description": "search packages in specified repo."
         }
       }
     },

--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -783,6 +783,9 @@ $defs:
       id:
         type: string
         description: id of package manager search
+      repo:
+        type: string
+        description: search packages in specified repo.
   PackageManager1JobInfo:
     type: object
     description: Get the job result using an ID

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -389,6 +389,9 @@ ll-cli search . --type=runtime)"));
       ->type_name("TYPE")
       ->capture_default_str()
       ->check(validatorString);
+    cliSearch->add_option("--repo", options.searchRepo, _("Search packages in specified repo."))
+      ->type_name("REPO")
+      ->check(validatorString);
     cliSearch->add_flag("--dev", options.showDevel, _("include develop application in result"));
     cliSearch->add_flag("--all", options.showAll, _("Show all results"));
 

--- a/libs/api/src/linglong/api/types/v1/Generators.hpp
+++ b/libs/api/src/linglong/api/types/v1/Generators.hpp
@@ -862,11 +862,15 @@ j["RemoteRef"] = x.remoteRef;
 
 inline void from_json(const json & j, PackageManager1SearchParameters& x) {
 x.id = j.at("id").get<std::string>();
+x.repo = get_stack_optional<std::string>(j, "repo");
 }
 
 inline void to_json(json & j, const PackageManager1SearchParameters & x) {
 j = json::object();
 j["id"] = x.id;
+if (x.repo) {
+j["repo"] = x.repo;
+}
 }
 
 inline void from_json(const json & j, PackageManager1SearchResult& x) {

--- a/libs/api/src/linglong/api/types/v1/PackageManager1SearchParameters.hpp
+++ b/libs/api/src/linglong/api/types/v1/PackageManager1SearchParameters.hpp
@@ -35,6 +35,10 @@ struct PackageManager1SearchParameters {
 * id of package manager search
 */
 std::string id;
+/**
+* search packages in specified repo.
+*/
+std::optional<std::string> repo;
 };
 }
 }

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -38,9 +38,9 @@
 #include <nlohmann/json.hpp>
 
 #include <QCryptographicHash>
+#include <QDBusReply>
 #include <QEventLoop>
 #include <QFileInfo>
-#include <QDBusReply>
 
 #include <charconv>
 #include <cstdlib>
@@ -1359,6 +1359,7 @@ int Cli::search([[maybe_unused]] CLI::App *subcommand)
 
     auto params = api::types::v1::PackageManager1SearchParameters{
         .id = options.appid,
+        .repo = options.searchRepo,
     };
 
     auto pendingReply = this->pkgMan.Search(utils::serialize::toQVariantMap(params));

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -39,6 +39,7 @@ struct CliOptions
     std::string module;
     std::string type;
     RepoOptions repoOptions;
+    std::optional<std::string> searchRepo;
     std::vector<std::string> commands;
     bool showDevel;
     bool showAll;

--- a/libs/linglong/src/linglong/package/reference.cpp
+++ b/libs/linglong/src/linglong/package/reference.cpp
@@ -83,9 +83,10 @@ Reference::fromPackageInfo(const api::types::v1::PackageInfoV2 &info) noexcept
 utils::error::Result<Reference> Reference::create(const QString &channel,
                                                   const QString &id,
                                                   const Version &version,
-                                                  const Architecture &arch) noexcept
+                                                  const Architecture &arch,
+                                                  const linglong::api::types::v1::Repo &repo) noexcept
 try {
-    return Reference(channel, id, version, arch);
+    return Reference(channel, id, version, arch,repo);
 } catch (const std::exception &e) {
     LINGLONG_TRACE("create reference");
     return LINGLONG_ERR("invalid reference", e);
@@ -94,11 +95,13 @@ try {
 Reference::Reference(const QString &channel,
                      const QString &id,
                      const Version &version,
-                     const Architecture &arch)
+                     const Architecture &arch,
+                     const linglong::api::types::v1::Repo &repo)
     : channel(channel)
     , id(id)
     , version(version)
     , arch(arch)
+    , repo(repo)
 {
     if (channel.isEmpty()) {
         throw std::runtime_error("empty channel");

--- a/libs/linglong/src/linglong/package/reference.h
+++ b/libs/linglong/src/linglong/package/reference.h
@@ -9,6 +9,7 @@
 #include "linglong/api/types/v1/PackageInfoV2.hpp"
 #include "linglong/package/architecture.h"
 #include "linglong/package/version.h"
+#include "linglong/api/types/v1/Repo.hpp"
 
 #include <QString>
 
@@ -22,7 +23,8 @@ public:
     static utils::error::Result<Reference> create(const QString &channel,
                                                   const QString &id,
                                                   const Version &version,
-                                                  const Architecture &architecture) noexcept;
+                                                  const Architecture &architecture,
+                                                  const linglong::api::types::v1::Repo &repo = {}) noexcept;
     static utils::error::Result<Reference>
     fromPackageInfo(const api::types::v1::PackageInfoV2 &info) noexcept;
     static QVariantMap toVariantMap(const Reference &ref) noexcept;
@@ -32,6 +34,7 @@ public:
     QString id;
     Version version;
     Architecture arch;
+    linglong::api::types::v1::Repo repo;
 
     [[nodiscard]] QString toString() const noexcept;
     friend bool operator!=(const Reference &lhs, const Reference &rhs) noexcept;
@@ -41,7 +44,8 @@ private:
     Reference(const QString &channel,
               const QString &id,
               const Version &version,
-              const Architecture &architecture);
+              const Architecture &architecture,
+              const api::types::v1::Repo &repo = {});
 };
 
 } // namespace linglong::package

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -44,7 +44,7 @@ public:
 
     ~OSTreeRepo() override;
 
-    [[nodiscard]] const api::types::v1::RepoConfigV2 &getConfig() const noexcept;
+    [[nodiscard]] const api::types::v1::RepoConfigV2 &getConfig() noexcept;
     utils::error::Result<void> setConfig(const api::types::v1::RepoConfigV2 &cfg) noexcept;
 
     utils::error::Result<package::LayerDir>
@@ -78,7 +78,8 @@ public:
     utils::error::Result<std::vector<api::types::v1::PackageInfoV2>>
     listLocalLatest() const noexcept;
     utils::error::Result<std::vector<api::types::v1::PackageInfoV2>>
-    listRemote(const package::FuzzyReference &fuzzyRef) const noexcept;
+    listRemote(const package::FuzzyReference &fuzzyRef,
+               const linglong::api::types::v1::Repo &repo = {}) const noexcept;
     [[nodiscard]] utils::error::Result<std::vector<api::types::v1::RepositoryCacheLayersItem>>
     listLocalBy(const linglong::repo::repoCacheQuery &query) const noexcept;
 


### PR DESCRIPTION
## 安装流程
- 优先搜索：默认仓库（优先级最高）
- 命中条件：找到目标软件包即停止搜索
- 备选策略：若未找到，按优先级降序搜索其他仓库
- 如果使用了--repo 只安装指定仓库的软件
## 依赖拉取
- 优先搜索：默认仓库
- 命中条件：找到base/runtime依赖即终止
- 备选策略：依赖缺失时按仓库优先级降序搜索
## 可升级列表
- 优先搜索：只搜索软件的来源仓库
- 命中条件：发现比本地版本更新的包即列出
## 升级操作
- 优先搜索：只搜索软件的来源仓库
- 命中条件：发现合格新版本立即升级
- 版本规则：
  - 应用包：允许跨版本升级（1.0→2.0）
  - 基础包：仅允许小版本升级（1.0→1.1）
## 搜索操作
- 优先搜索：列出所有仓库的软件包
- 命中条件：匹配到关键词立即返回结果
- 精确控制：
  - 支持--repo指定单一仓库