### PR TITLE
fix: ll-bulder build dependent on fuse-overlay

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -54,6 +54,7 @@ Package: linglong-builder
 Architecture: any
 Depends: erofs-utils,
          erofsfuse,
+         fuse-overlayfs,
          git,
          linglong-bin,
          linglong-box | crun,


### PR DESCRIPTION
Add Depends fuse-overlay