### PR TITLE
feat: use getLayerDir when exporting

### DIFF
--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -1778,7 +1778,7 @@ OSTreeRepo::exportEntries(const std::filesystem::path &rootEntriesDir,
                           const api::types::v1::RepositoryCacheLayersItem &item) noexcept
 {
     LINGLONG_TRACE(QString("export %1").arg(item.info.id.c_str()));
-    auto layerDir = getMergedModuleDir(item);
+    auto layerDir = getLayerDir(item);
     if (!layerDir.has_value()) {
         return LINGLONG_ERR("get layer dir", layerDir);
     }


### PR DESCRIPTION
导出entires时不需要获取modules目录