### PR TITLE
fix: ostree config doesn't have the correct update

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -1841,8 +1841,8 @@ int Cli::repo(CLI::App *app)
         }
 
         // remove last slash
-        if (options.repoOptions.repoUrl.back() == '/') {
-            options.repoOptions.repoUrl.pop_back();
+        if (url.back() == '/') {
+            url.pop_back();
         }
     }
 


### PR DESCRIPTION
When adding and removing a repository, ostree's repo config isn't updated.