### PR TITLE
fix: preserve packages with different modules while filtering by version

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -2224,10 +2224,15 @@ Cli::filterPackageInfosFromVersion(std::vector<api::types::v1::PackageInfoV2> &l
     LINGLONG_TRACE("filter package infos from version");
 
     std::unordered_map<std::string, api::types::v1::PackageInfoV2> temp;
+
     for (const auto &info : list) {
-        auto it = temp.find(info.id);
+        auto key = QString("%1-%2")
+                     .arg(QString::fromStdString(info.id))
+                     .arg(QString::fromStdString(info.packageInfoV2Module))
+                     .toStdString();
+        auto it = temp.find(key);
         if (it == temp.end()) {
-            temp[info.id] = info;
+            temp[key] = info;
             continue;
         }
 
@@ -2241,13 +2246,15 @@ Cli::filterPackageInfosFromVersion(std::vector<api::types::v1::PackageInfoV2> &l
         }
 
         if (*oldVersion < *newVersion) {
-            temp[info.id] = info;
+            temp[key] = info;
         }
     }
+
     list.clear();
     std::transform(temp.begin(), temp.end(), std::back_inserter(list), [](const auto &pair) {
         return pair.second;
     });
+
     return LINGLONG_OK;
 }
 


### PR DESCRIPTION
Previously, packages with the same id but different module values were incorrectly treated as the same package, causing some to be lost. This fix ensures that (id, module) is used as the unique key, preserving all distinct packages while still filtering by version.