### PR TITLE
fix: relative symlinks to directories from becoming empty folders

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -85,12 +85,10 @@ utils::error::Result<void> inline copyDir(const QString &src, const QString &dst
         };
     }
 
-    QFileInfoList list = srcDir.entryInfoList();
+    QFileInfoList list =
+      srcDir.entryInfoList(QDir::System | QDir::AllEntries | QDir::NoDotAndDotDot);
 
     for (const auto &info : list) {
-        if (info.fileName() == "." || info.fileName() == "..") {
-            continue;
-        }
         if (info.isDir() && !info.isSymLink()) {
             // 穿件文件夹，递归调用
             auto ret = copyDir(info.filePath(), dst + "/" + info.fileName());


### PR DESCRIPTION
When copying relative symlinks pointing to existing directories, they were incorrectly turned into empty folders.

Issue: https://github.com/OpenAtom-Linyaps/linyaps/issues/1039

![image](https://github.com/user-attachments/assets/241d2581-3959-4924-a3c4-169a18ab2814)
