### PR TITLE
fix: correct path deduplication while fixmount

### DIFF
--- a/libs/linglong/src/linglong/runtime/container_builder.cpp
+++ b/libs/linglong/src/linglong/runtime/container_builder.cpp
@@ -265,15 +265,9 @@ auto fixMount(ocppi::runtime::config::types::Config config) noexcept
             continue;
         }
 
-        for (auto it = tmpfsPath.cbegin(); it != tmpfsPath.cend(); ++it) {
-            if (existsPath == *it) {
+        for (const auto &it : tmpfsPath) {
+            if (existsPath == it) {
                 newTmp = false;
-                continue;
-            }
-
-            if (auto common = commonParent(existsPath, *it); common > originalRootPath) {
-                newTmp = false;
-                tmpfsPath.replace(it - tmpfsPath.cbegin(), common);
                 break;
             }
         }

--- a/release.bash
+++ b/release.bash
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 set -e
 
 # 定义 CMakeLists.txt 文件路径


### PR DESCRIPTION
only need to skip strictly equivalent path