### PR TITLE
feat: optimized cli error messages

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -27,7 +27,6 @@
 #include <QtGlobal>
 
 #include <algorithm>
-#include <cstddef>
 #include <functional>
 #include <memory>
 #include <thread>

--- a/apps/ll-package-manager/src/main.cpp
+++ b/apps/ll-package-manager/src/main.cpp
@@ -156,6 +156,8 @@ void withoutDBusDaemon(ocppi::cli::CLI &cli)
 
 auto main(int argc, char *argv[]) -> int
 {
+    bindtextdomain(PACKAGE_LOCALE_DOMAIN, PACKAGE_LOCALE_DIR);
+    textdomain(PACKAGE_LOCALE_DOMAIN);
     QCoreApplication app(argc, argv);
 
     applicationInitialize();

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -24,6 +24,7 @@
 #include "linglong/repo/config.h"
 #include "linglong/runtime/container_builder.h"
 #include "linglong/utils/configure.h"
+#include "linglong/utils/error/details/error_impl.h"
 #include "linglong/utils/error/error.h"
 #include "linglong/utils/finally/finally.h"
 #include "linglong/utils/gettext.h"
@@ -1384,7 +1385,7 @@ int Cli::search([[maybe_unused]] CLI::App *subcommand)
                 // Note: should check return code of PackageManager1SearchResult
                 if (result->code != 0) {
                     this->printer.printErr(
-                      LINGLONG_ERRV("\n" + QString::fromStdString(result->message), result->code));
+                      LINGLONG_ERRV(QString::fromStdString(result->message), result->code));
                     loop.exit(result->code);
                     return;
                 }
@@ -1945,7 +1946,7 @@ int Cli::info([[maybe_unused]] CLI::App *subcommand)
                                           { .forceRemote = false, .fallbackToRemote = false });
         if (!ref) {
             qDebug() << ref.error();
-            this->printer.printErr(LINGLONG_ERRV("Can not find such application."));
+            this->printer.printErr(LINGLONG_ERRV("Cannot find such application."));
             return -1;
         }
 
@@ -1999,7 +2000,7 @@ int Cli::content([[maybe_unused]] CLI::App *subcommand)
                                                { .forceRemote = false, .fallbackToRemote = false });
     if (!ref) {
         qDebug() << ref.error();
-        this->printer.printErr(LINGLONG_ERRV("Can not find such application."));
+        this->printer.printErr(LINGLONG_ERRV("Cannot find such application."));
         return -1;
     }
 
@@ -2215,6 +2216,10 @@ utils::error::Result<void> Cli::runningAsRoot(const QList<QString> &args)
 
     const char *pkexecBin = "pkexec";
     QStringList argv{ pkexecBin };
+    // 如果有设置LINGLONG_VERBOSE_MESSAGE环境变量，通过env传递过去
+    if (linglong::utils::error::isVerboseMessageEnabled()) {
+        argv << "env" << "LINGLONG_VERBOSE_MESSAGE=true";
+    }
     argv.append(args);
     qDebug() << "run with pkexec:" << argv;
     std::vector<char *> targetArgv;
@@ -2642,7 +2647,7 @@ int Cli::dir([[maybe_unused]] CLI::App *subcommand)
                                                { .forceRemote = false, .fallbackToRemote = false });
     if (!ref) {
         qDebug() << ref.error();
-        this->printer.printErr(LINGLONG_ERRV("Can not find such application."));
+        this->printer.printErr(LINGLONG_ERRV("Cannot find such application."));
         return -1;
     }
 

--- a/libs/linglong/src/linglong/cli/cli_printer.cpp
+++ b/libs/linglong/src/linglong/cli/cli_printer.cpp
@@ -9,6 +9,7 @@
 #include "linglong/api/types/v1/Generators.hpp"
 #include "linglong/api/types/v1/State.hpp"
 #include "linglong/package/reference.h"
+#include "linglong/utils/error/details/error_impl.h"
 #include "linglong/utils/gettext.h"
 
 #include <QJsonArray>
@@ -32,8 +33,12 @@ std::wstring subwstr(std::wstring wstr, int width)
 
 void CLIPrinter::printErr(const utils::error::Error &err)
 {
-    std::cout << "Error: CODE=" << err.code() << std::endl
-              << err.message().toStdString() << std::endl;
+    if (linglong::utils::error::isVerboseMessageEnabled()) {
+        std::cout << "Error: CODE=" << err.code() << std::endl
+                  << err.message().toStdString() << std::endl;
+    } else {
+        std::cout << err.message().toStdString() << std::endl;
+    }
 }
 
 void CLIPrinter::printPruneResult(const std::vector<api::types::v1::PackageInfoV2> &list)
@@ -160,8 +165,12 @@ void CLIPrinter::printContainers(const std::vector<api::types::v1::CliContainer>
 
 void CLIPrinter::printReply(const api::types::v1::CommonResult &reply)
 {
-    std::cout << "code: " << reply.code << std::endl;
-    std::cout << "message:" << std::endl << reply.message << std::endl;
+    if (linglong::utils::error::isVerboseMessageEnabled()) {
+        std::cout << "code: " << reply.code << std::endl;
+        std::cout << "message:" << std::endl << reply.message << std::endl;
+    } else {
+        std::cout << reply.message << std::endl;
+    }
 }
 
 void CLIPrinter::printRepoConfig(const api::types::v1::RepoConfigV2 &repoInfo)

--- a/libs/linglong/src/linglong/package/fuzzy_reference.cpp
+++ b/libs/linglong/src/linglong/package/fuzzy_reference.cpp
@@ -96,4 +96,20 @@ QString FuzzyReference::toString() const noexcept
            this->arch ? this->arch->toString() : "unknown");
 }
 
+QString FuzzyReference::toErrString() const noexcept
+{
+    QString errString;
+    if (channel) {
+        errString += this->channel.value() + ":";
+    }
+    errString += this->id;
+    if (version) {
+        errString += "/" + version.value().toString();
+    }
+    if (arch) {
+        errString += "/" + arch.value().toString();
+    }
+    return errString;
+}
+
 } // namespace linglong::package

--- a/libs/linglong/src/linglong/package/fuzzy_reference.h
+++ b/libs/linglong/src/linglong/package/fuzzy_reference.h
@@ -31,6 +31,7 @@ public:
     std::optional<Architecture> arch;
 
     QString toString() const noexcept;
+    QString toErrString() const noexcept;
 
 private:
     explicit FuzzyReference(const std::optional<QString> &channel,

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -170,7 +170,7 @@ void progress_changed(OstreeAsyncProgress *progress, gpointer user_data)
 
         if (data->caught_error) {
             data->taskContext->reportError(
-              LINGLONG_ERRV("Caught error during pulling data, waiting for outstanding task"));
+              LINGLONG_ERRV(_("Caught error during pulling data, waiting for outstanding task")));
             return;
         }
 
@@ -205,7 +205,7 @@ void progress_changed(OstreeAsyncProgress *progress, gpointer user_data)
             data->last_was_metadata = true;
         }
 
-        data->status = "Downloading metadata";
+        data->status = _("Downloading metadata");
         new_progress = 0;
         if (data->progress > 0) {
             new_progress = (data->fetched * 5.0) / data->requested;
@@ -213,7 +213,7 @@ void progress_changed(OstreeAsyncProgress *progress, gpointer user_data)
     } else {
         if (data->total_delta_parts > 0) {
             total = data->total_delta_part_size - data->fetched_delta_part_size;
-            data->status = "Downloading delta part";
+            data->status = _("Downloading delta part");
         } else {
             auto average_object_size{ 1.0 };
             if (data->fetched > 0) {
@@ -221,7 +221,7 @@ void progress_changed(OstreeAsyncProgress *progress, gpointer user_data)
             }
 
             total = average_object_size * data->requested;
-            data->status = "Downloading files";
+            data->status = _("Downloading files");
         }
     }
     Q_EMIT data->taskContext->PartChanged(data->fetched, data->requested);

--- a/libs/utils/src/linglong/utils/command/env.h
+++ b/libs/utils/src/linglong/utils/command/env.h
@@ -12,7 +12,7 @@
 
 namespace linglong::utils::command {
 
-error::Result<QString> Exec(QString command, QStringList args);
+linglong::utils::error::Result<QString> Exec(QString command, QStringList args);
 QStringList getUserEnv(const QStringList &filters);
 extern const QStringList envList;
 

--- a/libs/utils/src/linglong/utils/error/details/error_impl.h
+++ b/libs/utils/src/linglong/utils/error/details/error_impl.h
@@ -15,6 +15,10 @@
 #include <memory>
 #include <utility>
 
+namespace linglong::utils::error {
+extern bool isVerboseMessageEnabled();
+}
+
 namespace linglong::utils::error::details {
 
 class ErrorImpl
@@ -42,7 +46,12 @@ public:
             if (!msg.isEmpty()) {
                 msg += "\n";
             }
-            msg += QString("%1:%2 %4").arg(err->context.file).arg(err->context.line).arg(err->msg);
+            if (linglong::utils::error::isVerboseMessageEnabled()) {
+                msg +=
+                  QString("%1:%2 %3").arg(err->context.file).arg(err->context.line).arg(err->msg);
+            } else {
+                msg += err->msg;
+            }
         }
         return msg;
     }

--- a/libs/utils/src/linglong/utils/error/error.cpp
+++ b/libs/utils/src/linglong/utils/error/error.cpp
@@ -5,3 +5,16 @@
  */
 
 #include "linglong/utils/error/error.h"
+
+namespace linglong::utils::error {
+
+bool isVerboseMessageEnabled()
+{
+    static bool cached = []() {
+        const char *verboseEnv = std::getenv("LINGLONG_VERBOSE_MESSAGE");
+        return (verboseEnv != nullptr && QString(verboseEnv).toLower() == "true");
+    }();
+    return cached;
+}
+
+} // namespace linglong::utils::error

--- a/libs/utils/src/linglong/utils/error/error.h
+++ b/libs/utils/src/linglong/utils/error/error.h
@@ -25,6 +25,10 @@
 
 namespace linglong::utils::error {
 
+#define TRACE_MSG(trace_msg, msg) ((trace_msg).isEmpty() ? (msg) : (trace_msg) + ": " + (msg))
+
+bool isVerboseMessageEnabled();
+
 class Error
 {
 public:
@@ -43,12 +47,13 @@ public:
     Err(const char *file, int line, const QString &trace_msg, const QString &msg, int code = -1)
       -> Error
     {
-        return Error(std::make_unique<details::ErrorImpl>(file,
-                                                          line,
-                                                          "default",
-                                                          code,
-                                                          trace_msg + ": " + msg,
-                                                          nullptr));
+        return Error(
+          std::make_unique<linglong::utils::error::details::ErrorImpl>(file,
+                                                                       line,
+                                                                       "default",
+                                                                       code,
+                                                                       TRACE_MSG(trace_msg, msg),
+                                                                       nullptr));
     }
 
     static auto Err(const char *file,
@@ -57,32 +62,32 @@ public:
                     const QString &msg,
                     const QFile &qfile) -> Error
     {
-        return Error(
-          std::make_unique<details::ErrorImpl>(file,
-                                               line,
-                                               "default",
-                                               qfile.error(),
-                                               trace_msg + ": " + msg + ": " + qfile.errorString(),
-                                               nullptr));
+        return Error(std::make_unique<linglong::utils::error::details::ErrorImpl>(
+          file,
+          line,
+          "default",
+          qfile.error(),
+          TRACE_MSG(trace_msg, msg + ": " + qfile.errorString()),
+          nullptr));
     }
 
     static auto Err(const char *file, int line, const QString &trace_msg, const QFile &qfile)
       -> Error
     {
-        return Error(std::make_unique<details::ErrorImpl>(file,
-                                                          line,
-                                                          "default",
-                                                          qfile.error(),
-                                                          trace_msg + ": " + qfile.fileName() + ": "
-                                                            + qfile.errorString(),
-                                                          nullptr));
+        return Error(std::make_unique<linglong::utils::error::details::ErrorImpl>(
+          file,
+          line,
+          "default",
+          qfile.error(),
+          TRACE_MSG(trace_msg, qfile.fileName() + ": " + qfile.errorString()),
+          nullptr));
     }
 
     static auto
     Err(const char *file, int line, const QString &trace_msg, std::exception_ptr err, int code = -1)
       -> Error
     {
-        QString what = trace_msg + ": ";
+        QString what = TRACE_MSG(trace_msg, "");
         try {
             std::rethrow_exception(std::move(err));
         } catch (const std::exception &e) {
@@ -91,8 +96,12 @@ public:
             what += "unknown";
         }
 
-        return Error(
-          std::make_unique<details::ErrorImpl>(file, line, "default", code, what, nullptr));
+        return Error(std::make_unique<linglong::utils::error::details::ErrorImpl>(file,
+                                                                                  line,
+                                                                                  "default",
+                                                                                  code,
+                                                                                  what,
+                                                                                  nullptr));
     }
 
     static auto Err(const char *file,
@@ -102,7 +111,7 @@ public:
                     std::exception_ptr err,
                     int code = -1) -> Error
     {
-        QString what = trace_msg + ": " + msg + ": ";
+        QString what = TRACE_MSG(trace_msg, msg + ": ");
         try {
             std::rethrow_exception(std::move(err));
         } catch (const std::exception &e) {
@@ -111,19 +120,24 @@ public:
             what += "unknown";
         }
 
-        return Error(
-          std::make_unique<details::ErrorImpl>(file, line, "default", code, what, nullptr));
+        return Error(std::make_unique<linglong::utils::error::details::ErrorImpl>(file,
+                                                                                  line,
+                                                                                  "default",
+                                                                                  code,
+                                                                                  what,
+                                                                                  nullptr));
     }
 
     static auto Err(const char *file, int line, const QString &trace_msg, const std::exception &e)
       -> Error
     {
-        return Error(std::make_unique<details::ErrorImpl>(file,
-                                                          line,
-                                                          "default",
-                                                          -1,
-                                                          trace_msg + ": " + e.what(),
-                                                          nullptr));
+        return Error(std::make_unique<linglong::utils::error::details::ErrorImpl>(
+          file,
+          line,
+          "default",
+          -1,
+          TRACE_MSG(trace_msg, e.what()),
+          nullptr));
     }
 
     static auto Err(const char *file,
@@ -133,10 +147,14 @@ public:
                     const std::exception &e,
                     int code = -1) -> Error
     {
-        QString what = trace_msg + ": " + msg + ": " + e.what();
+        QString what = TRACE_MSG(trace_msg, msg + ": " + e.what());
 
-        return Error(
-          std::make_unique<details::ErrorImpl>(file, line, "default", code, what, nullptr));
+        return Error(std::make_unique<linglong::utils::error::details::ErrorImpl>(file,
+                                                                                  line,
+                                                                                  "default",
+                                                                                  code,
+                                                                                  what,
+                                                                                  nullptr));
     }
 
     static auto Err(const char *file,
@@ -189,12 +207,13 @@ public:
     {
         Q_ASSERT(!cause.has_value());
 
-        return Error(std::make_unique<details::ErrorImpl>(file,
-                                                          line,
-                                                          "default",
-                                                          cause.error().code(),
-                                                          trace_msg + ": " + msg,
-                                                          std::move(cause.error().pImpl)));
+        return Error(std::make_unique<linglong::utils::error::details::ErrorImpl>(
+          file,
+          line,
+          "default",
+          cause.error().code(),
+          TRACE_MSG(trace_msg, msg),
+          std::move(cause.error().pImpl)));
     }
 
     template<typename Value>
@@ -205,35 +224,38 @@ public:
     {
         Q_ASSERT(!cause.has_value());
 
-        return Error(std::make_unique<details::ErrorImpl>(file,
-                                                          line,
-                                                          "default",
-                                                          cause.error().code(),
-                                                          trace_msg,
-                                                          std::move(cause.error().pImpl)));
+        return Error(std::make_unique<linglong::utils::error::details::ErrorImpl>(
+          file,
+          line,
+          "default",
+          cause.error().code(),
+          trace_msg,
+          std::move(cause.error().pImpl)));
     }
 
     static auto
     Err(const char *file, int line, const QString &trace_msg, const QString &msg, Error &&cause)
       -> Error
     {
-        return Error(std::make_unique<details::ErrorImpl>(file,
-                                                          line,
-                                                          "default",
-                                                          cause.code(),
-                                                          trace_msg + ": " + msg,
-                                                          std::move(cause.pImpl)));
+        return Error(
+          std::make_unique<linglong::utils::error::details::ErrorImpl>(file,
+                                                                       line,
+                                                                       "default",
+                                                                       cause.code(),
+                                                                       TRACE_MSG(trace_msg, msg),
+                                                                       std::move(cause.pImpl)));
     }
 
     static auto Err(const char *file, int line, const QString &trace_msg, Error &&cause) -> Error
     {
 
-        return Error(std::make_unique<details::ErrorImpl>(file,
-                                                          line,
-                                                          "default",
-                                                          cause.code(),
-                                                          trace_msg,
-                                                          std::move(cause.pImpl)));
+        return Error(
+          std::make_unique<linglong::utils::error::details::ErrorImpl>(file,
+                                                                       line,
+                                                                       "default",
+                                                                       cause.code(),
+                                                                       trace_msg,
+                                                                       std::move(cause.pImpl)));
     }
 
     template<typename Value>
@@ -261,12 +283,12 @@ public:
     }
 
 private:
-    explicit Error(std::unique_ptr<details::ErrorImpl> pImpl)
+    explicit Error(std::unique_ptr<linglong::utils::error::details::ErrorImpl> pImpl)
         : pImpl(std::move(pImpl))
     {
     }
 
-    std::unique_ptr<details::ErrorImpl> pImpl;
+    std::unique_ptr<linglong::utils::error::details::ErrorImpl> pImpl;
 };
 
 template<typename Value>
@@ -275,7 +297,14 @@ using Result = tl::expected<Value, Error>;
 } // namespace linglong::utils::error
 
 // Use this macro to define trace message at the begining of function
-#define LINGLONG_TRACE(message) QString linglong_trace_message = message;
+#define LINGLONG_TRACE(message)                                  \
+    QString linglong_trace_message = [](auto msg) -> QString {   \
+        if (linglong::utils::error::isVerboseMessageEnabled()) { \
+            return QString(msg);                                 \
+        } else {                                                 \
+            return QString{};                                    \
+        }                                                        \
+    }(message);
 
 // Use this macro to create new error or wrap an existing error
 // LINGLONG_ERR(message, code =-1)

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -47,9 +47,11 @@ if(GETTEXT_FOUND)
   get_real_target_name(TARGET linglong::ll-cli)
   get_real_target_name(BUILD_TARGET linglong::ll-builder)
   get_real_target_name(DIALOG linglong::ll-dialog)
+  get_real_target_name(PACKAGE_MANAGER linglong::ll-package-manager)
   add_dependencies("${TARGET}" process-pot-file)
   add_dependencies("${BUILD_TARGET}" process-pot-file)
   add_dependencies("${DIALOG}" process-pot-file)
+  add_dependencies("${PACKAGE_MANAGER}" process-pot-file)
 
   # Custom targets for updating translation files NOTE: these targets will
   # update files in the source tree

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -12,3 +12,7 @@ apps/ll-builder/src/main.cpp
 # ll-dialog
 apps/ll-dialog/src/permissionDialog.cpp
 apps/ll-dialog/src/cache_dialog.cpp
+
+# ll-package-manager
+libs/linglong/src/linglong/package_manager/package_manager.cpp
+libs/linglong/src/linglong/repo/ostree_repo.cpp

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-20 14:54+0800\n"
+"POT-Creation-Date: 2025-03-27 18:02+0800\n"
 "PO-Revision-Date: 2025-01-07 17:11+0800\n"
 "Last-Translator: deepiner, 2024\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,17 +17,17 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:56
+#: ../libs/linglong/src/linglong/cli/cli.cpp:58
 msgid "Permission deny, please check whether you are running as root."
 msgstr "Permission deny, please check whether you are running as root."
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2579
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2571
 msgid ""
 "The cache generation failed, please uninstall and reinstall the application."
 msgstr ""
 "The cache generation failed, please uninstall and reinstall the application."
 
-#: ../apps/ll-cli/src/main.cpp:158
+#: ../apps/ll-cli/src/main.cpp:147
 msgid ""
 "linyaps CLI\n"
 "A CLI program to run application and manage application and runtime\n"
@@ -35,19 +35,19 @@ msgstr ""
 "linyaps CLI\n"
 "A CLI program to run application and manage application and runtime\n"
 
-#: ../apps/ll-cli/src/main.cpp:165 ../apps/ll-builder/src/main.cpp:172
+#: ../apps/ll-cli/src/main.cpp:159 ../apps/ll-builder/src/main.cpp:172
 msgid "Print this help message and exit"
 msgstr "Print this help message and exit"
 
-#: ../apps/ll-cli/src/main.cpp:166 ../apps/ll-builder/src/main.cpp:173
+#: ../apps/ll-cli/src/main.cpp:160 ../apps/ll-builder/src/main.cpp:173
 msgid "Expand all help"
 msgstr "Expand all help"
 
-#: ../apps/ll-cli/src/main.cpp:167
+#: ../apps/ll-cli/src/main.cpp:161
 msgid "Usage: ll-cli [OPTIONS] [SUBCOMMAND]"
 msgstr "Usage: ll-cli [OPTIONS] [SUBCOMMAND]"
 
-#: ../apps/ll-cli/src/main.cpp:168
+#: ../apps/ll-cli/src/main.cpp:162
 msgid ""
 "If you found any problems during use,\n"
 "You can report bugs to the linyaps team under this project: https://github."
@@ -57,11 +57,12 @@ msgstr ""
 "You can report bugs to the linyaps team under this project: https://github."
 "com/OpenAtom-Linyaps/linyaps/issues"
 
-#: ../apps/ll-cli/src/main.cpp:178 ../apps/ll-builder/src/main.cpp:194
+#. add flags
+#: ../apps/ll-cli/src/main.cpp:169 ../apps/ll-builder/src/main.cpp:194
 msgid "Show version"
 msgstr "Show version"
 
-#: ../apps/ll-cli/src/main.cpp:182
+#: ../apps/ll-cli/src/main.cpp:173
 msgid ""
 "Use peer to peer DBus, this is used only in case that DBus daemon is not "
 "available"
@@ -69,43 +70,43 @@ msgstr ""
 "Use peer to peer DBus, this is used only in case that DBus daemon is not "
 "available"
 
-#: ../apps/ll-cli/src/main.cpp:185
+#: ../apps/ll-cli/src/main.cpp:177
 msgid "Use json format to output result"
 msgstr "Use json format to output result"
 
-#: ../apps/ll-cli/src/main.cpp:191 ../apps/ll-cli/src/main.cpp:525
+#: ../apps/ll-cli/src/main.cpp:184 ../apps/ll-cli/src/main.cpp:535
 #: ../apps/ll-builder/src/main.cpp:185
 msgid "Input parameter is empty, please input valid parameter instead"
 msgstr "Input parameter is empty, please input valid parameter instead"
 
 #. groups
-#: ../apps/ll-cli/src/main.cpp:214
+#: ../apps/ll-cli/src/main.cpp:207
 msgid "Managing installed applications and runtimes"
 msgstr "Managing installed applications and runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:215
+#: ../apps/ll-cli/src/main.cpp:208
 msgid "Managing running applications"
 msgstr "Managing running applications"
 
-#: ../apps/ll-cli/src/main.cpp:216
+#: ../apps/ll-cli/src/main.cpp:209
 msgid "Finding applications and runtimes"
 msgstr "Finding applications and runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:217
+#: ../apps/ll-cli/src/main.cpp:210
 msgid "Managing remote repositories"
 msgstr "Managing remote repositories"
 
 #. add sub command run
-#: ../apps/ll-cli/src/main.cpp:220
+#: ../apps/ll-cli/src/main.cpp:213
 msgid "Run an application"
 msgstr "Run an application"
 
 #. add sub command run options
-#: ../apps/ll-cli/src/main.cpp:225
+#: ../apps/ll-cli/src/main.cpp:218
 msgid "Specify the application ID"
 msgstr "Specify the application ID"
 
-#: ../apps/ll-cli/src/main.cpp:228
+#: ../apps/ll-cli/src/main.cpp:221
 msgid ""
 "Usage: ll-cli run [OPTIONS] APP [COMMAND...]\n"
 "\n"
@@ -127,70 +128,70 @@ msgstr ""
 "ll-cli run org.deepin.demo -- bash\n"
 "ll-cli run org.deepin.demo -- bash -x /path/to/bash/script"
 
-#: ../apps/ll-cli/src/main.cpp:238
+#: ../apps/ll-cli/src/main.cpp:231
 msgid "Pass file to applications running in a sandbox"
 msgstr "Pass file to applications running in a sandbox"
 
-#: ../apps/ll-cli/src/main.cpp:242
+#: ../apps/ll-cli/src/main.cpp:235
 msgid "Pass url to applications running in a sandbox"
 msgstr "Pass url to applications running in a sandbox"
 
-#: ../apps/ll-cli/src/main.cpp:245 ../apps/ll-cli/src/main.cpp:267
-#: ../apps/ll-cli/src/main.cpp:284
+#: ../apps/ll-cli/src/main.cpp:238 ../apps/ll-cli/src/main.cpp:260
+#: ../apps/ll-cli/src/main.cpp:277
 msgid "Run commands in a running sandbox"
 msgstr "Run commands in a running sandbox"
 
 #. add sub command ps
-#: ../apps/ll-cli/src/main.cpp:248
+#: ../apps/ll-cli/src/main.cpp:241
 msgid "List running applications"
 msgstr "List running applications"
 
-#: ../apps/ll-cli/src/main.cpp:251
+#: ../apps/ll-cli/src/main.cpp:244
 msgid "Usage: ll-cli ps [OPTIONS]"
 msgstr "Usage: ll-cli ps [OPTIONS]"
 
-#: ../apps/ll-cli/src/main.cpp:255
+#: ../apps/ll-cli/src/main.cpp:248
 msgid "Execute commands in the currently running sandbox"
 msgstr "Execute commands in the currently running sandbox"
 
-#: ../apps/ll-cli/src/main.cpp:261 ../apps/ll-cli/src/main.cpp:279
+#: ../apps/ll-cli/src/main.cpp:254 ../apps/ll-cli/src/main.cpp:272
 msgid "Specify the application running instance(you can get it by ps command)"
 msgstr "Specify the application running instance(you can get it by ps command)"
 
-#: ../apps/ll-cli/src/main.cpp:264 ../apps/ll-cli/src/main.cpp:281
+#: ../apps/ll-cli/src/main.cpp:257 ../apps/ll-cli/src/main.cpp:274
 msgid "Specify working directory"
 msgstr "Specify working directory"
 
-#: ../apps/ll-cli/src/main.cpp:272
+#: ../apps/ll-cli/src/main.cpp:265
 msgid "Enter the namespace where the application is running"
 msgstr "Enter the namespace where the application is running"
 
-#: ../apps/ll-cli/src/main.cpp:275
+#: ../apps/ll-cli/src/main.cpp:268
 msgid "Usage: ll-cli enter [OPTIONS] INSTANCE [COMMAND...]"
 msgstr "Usage: ll-cli enter [OPTIONS] INSTANCE [COMMAND...]"
 
 #. add sub command kill
-#: ../apps/ll-cli/src/main.cpp:287
+#: ../apps/ll-cli/src/main.cpp:280
 msgid "Stop running applications"
 msgstr "Stop running applications"
 
-#: ../apps/ll-cli/src/main.cpp:290
+#: ../apps/ll-cli/src/main.cpp:283
 msgid "Usage: ll-cli kill [OPTIONS] APP"
 msgstr "Usage: ll-cli kill [OPTIONS] APP"
 
-#: ../apps/ll-cli/src/main.cpp:294
+#: ../apps/ll-cli/src/main.cpp:287
 msgid "Specify the signal to send to the application"
 msgstr "Specify the signal to send to the application"
 
-#: ../apps/ll-cli/src/main.cpp:296
+#: ../apps/ll-cli/src/main.cpp:289
 msgid "Specify the running application"
 msgstr "Specify the running application"
 
-#: ../apps/ll-cli/src/main.cpp:302
+#: ../apps/ll-cli/src/main.cpp:295
 msgid "Installing an application or runtime"
 msgstr "Installing an application or runtime"
 
-#: ../apps/ll-cli/src/main.cpp:305
+#: ../apps/ll-cli/src/main.cpp:298
 msgid ""
 "Usage: ll-cli install [OPTIONS] APP\n"
 "\n"
@@ -226,47 +227,56 @@ msgstr ""
 "ll-cli install stable:org.deepin.demo/0.0.0.1/x86_64\n"
 "    "
 
-#: ../apps/ll-cli/src/main.cpp:324
+#: ../apps/ll-cli/src/main.cpp:317
 msgid "Specify the application ID, and it can also be a .uab or .layer file"
 msgstr "Specify the application ID, and it can also be a .uab or .layer file"
 
-#: ../apps/ll-cli/src/main.cpp:327
+#: ../apps/ll-cli/src/main.cpp:320
 msgid "Install a specify module"
 msgstr "Install a specify module"
 
-#: ../apps/ll-cli/src/main.cpp:330
+#: ../apps/ll-cli/src/main.cpp:323
 msgid "Force install the application"
 msgstr "Force install the application"
 
-#: ../apps/ll-cli/src/main.cpp:331
+#: ../apps/ll-cli/src/main.cpp:324
 msgid "Automatically answer yes to all questions"
 msgstr "Automatically answer yes to all questions"
 
-#: ../apps/ll-cli/src/main.cpp:339
+#: ../apps/ll-cli/src/main.cpp:330
 msgid "Uninstall the application or runtimes"
 msgstr "Uninstall the application or runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:342
+#: ../apps/ll-cli/src/main.cpp:333
 msgid "Usage: ll-cli uninstall [OPTIONS] APP"
 msgstr "Usage: ll-cli uninstall [OPTIONS] APP"
 
-#: ../apps/ll-cli/src/main.cpp:343
+#: ../apps/ll-cli/src/main.cpp:334
 msgid "Specify the applications ID"
 msgstr "Specify the applications ID"
 
-#: ../apps/ll-cli/src/main.cpp:346
+#: ../apps/ll-cli/src/main.cpp:337
 msgid "Uninstall a specify module"
 msgstr "Uninstall a specify module"
 
-#: ../apps/ll-cli/src/main.cpp:354
+#. below options are used for compatibility with old ll-cli
+#: ../apps/ll-cli/src/main.cpp:342
+msgid "Remove all unused modules"
+msgstr "Remove all unused modules"
+
+#: ../apps/ll-cli/src/main.cpp:346
+msgid "Uninstall all modules"
+msgstr "Uninstall all modules"
+
+#: ../apps/ll-cli/src/main.cpp:352
 msgid "Upgrade the application or runtimes"
 msgstr "Upgrade the application or runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:357
+#: ../apps/ll-cli/src/main.cpp:355
 msgid "Usage: ll-cli upgrade [OPTIONS] [APP]"
 msgstr "Usage: ll-cli upgrade [OPTIONS] [APP]"
 
-#: ../apps/ll-cli/src/main.cpp:361
+#: ../apps/ll-cli/src/main.cpp:359
 msgid ""
 "Specify the application ID.If it not be specified, all applications will be "
 "upgraded"
@@ -274,7 +284,7 @@ msgstr ""
 "Specify the application ID.If it not be specified, all applications will be "
 "upgraded"
 
-#: ../apps/ll-cli/src/main.cpp:368
+#: ../apps/ll-cli/src/main.cpp:366
 msgid ""
 "Search the applications/runtimes containing the specified text from the "
 "remote repository"
@@ -282,7 +292,7 @@ msgstr ""
 "Search the applications/runtimes containing the specified text from the "
 "remote repository"
 
-#: ../apps/ll-cli/src/main.cpp:372
+#: ../apps/ll-cli/src/main.cpp:370
 msgid ""
 "Usage: ll-cli search [OPTIONS] KEYWORDS\n"
 "\n"
@@ -308,28 +318,28 @@ msgstr ""
 "# find all off runtime of remote\n"
 "ll-cli search . --type=runtime"
 
-#: ../apps/ll-cli/src/main.cpp:383
+#: ../apps/ll-cli/src/main.cpp:381
 msgid "Specify the Keywords"
 msgstr "Specify the Keywords"
 
-#: ../apps/ll-cli/src/main.cpp:389 ../apps/ll-cli/src/main.cpp:414
+#: ../apps/ll-cli/src/main.cpp:387 ../apps/ll-cli/src/main.cpp:412
 msgid "Filter result with specify type. One of \"runtime\", \"app\" or \"all\""
 msgstr ""
 "Filter result with specify type. One of \"runtime\", \"app\" or \"all\""
 
-#: ../apps/ll-cli/src/main.cpp:393
+#: ../apps/ll-cli/src/main.cpp:391
 msgid "include develop application in result"
 msgstr "include develop application in result"
 
-#: ../apps/ll-cli/src/main.cpp:394
+#: ../apps/ll-cli/src/main.cpp:392
 msgid "Show all results"
 msgstr "Show all results"
 
-#: ../apps/ll-cli/src/main.cpp:398
+#: ../apps/ll-cli/src/main.cpp:396
 msgid "List installed applications or runtimes"
 msgstr "List installed applications or runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:401
+#: ../apps/ll-cli/src/main.cpp:399
 msgid ""
 "Usage: ll-cli list [OPTIONS]\n"
 "\n"
@@ -351,7 +361,7 @@ msgstr ""
 "# show the latest version list of the currently installed application(s)\n"
 "ll-cli list --upgradable\n"
 
-#: ../apps/ll-cli/src/main.cpp:420
+#: ../apps/ll-cli/src/main.cpp:418
 msgid ""
 "Show the list of latest version of the currently installed applications, it "
 "only works for app"
@@ -359,181 +369,219 @@ msgstr ""
 "Show the list of latest version of the currently installed applications, it "
 "only works for app"
 
-#: ../apps/ll-cli/src/main.cpp:427
+#: ../apps/ll-cli/src/main.cpp:425
 msgid "Display or modify information of the repository currently using"
 msgstr "Display or modify information of the repository currently using"
 
-#: ../apps/ll-cli/src/main.cpp:429
+#: ../apps/ll-cli/src/main.cpp:427
 msgid "Usage: ll-cli repo SUBCOMMAND [OPTIONS]"
 msgstr "Usage: ll-cli repo SUBCOMMAND [OPTIONS]"
 
 #. add repo sub command add
-#: ../apps/ll-cli/src/main.cpp:433 ../apps/ll-builder/src/main.cpp:356
+#: ../apps/ll-cli/src/main.cpp:431 ../apps/ll-builder/src/main.cpp:367
 msgid "Add a new repository"
 msgstr "Add a new repository"
 
-#: ../apps/ll-cli/src/main.cpp:434
+#: ../apps/ll-cli/src/main.cpp:432
 msgid "Usage: ll-cli repo add [OPTIONS] NAME URL"
 msgstr "Usage: ll-cli repo add [OPTIONS] NAME URL"
 
-#: ../apps/ll-cli/src/main.cpp:435 ../apps/ll-cli/src/main.cpp:448
-#: ../apps/ll-builder/src/main.cpp:358
+#: ../apps/ll-cli/src/main.cpp:433 ../apps/ll-cli/src/main.cpp:446
+#: ../apps/ll-builder/src/main.cpp:369
 msgid "Specify the repo name"
 msgstr "Specify the repo name"
 
-#: ../apps/ll-cli/src/main.cpp:438 ../apps/ll-cli/src/main.cpp:451
-#: ../apps/ll-cli/src/main.cpp:469 ../apps/ll-builder/src/main.cpp:361
-#: ../apps/ll-builder/src/main.cpp:381
+#: ../apps/ll-cli/src/main.cpp:436 ../apps/ll-cli/src/main.cpp:449
+#: ../apps/ll-cli/src/main.cpp:467 ../apps/ll-builder/src/main.cpp:372
+#: ../apps/ll-builder/src/main.cpp:392
 msgid "Url of the repository"
 msgstr "Url of the repository"
 
-#: ../apps/ll-cli/src/main.cpp:441 ../apps/ll-cli/src/main.cpp:458
-#: ../apps/ll-cli/src/main.cpp:466 ../apps/ll-cli/src/main.cpp:477
-#: ../apps/ll-builder/src/main.cpp:364 ../apps/ll-builder/src/main.cpp:371
-#: ../apps/ll-builder/src/main.cpp:378 ../apps/ll-builder/src/main.cpp:389
+#: ../apps/ll-cli/src/main.cpp:439 ../apps/ll-cli/src/main.cpp:456
+#: ../apps/ll-cli/src/main.cpp:464 ../apps/ll-cli/src/main.cpp:475
+#: ../apps/ll-cli/src/main.cpp:487 ../apps/ll-builder/src/main.cpp:375
+#: ../apps/ll-builder/src/main.cpp:382 ../apps/ll-builder/src/main.cpp:389
+#: ../apps/ll-builder/src/main.cpp:400
 msgid "Alias of the repo name"
 msgstr "Alias of the repo name"
 
-#: ../apps/ll-cli/src/main.cpp:447
+#: ../apps/ll-cli/src/main.cpp:445
 msgid "Modify repository URL"
 msgstr "Modify repository URL"
 
 #. add repo sub command remove
-#: ../apps/ll-cli/src/main.cpp:456 ../apps/ll-builder/src/main.cpp:369
+#: ../apps/ll-cli/src/main.cpp:454 ../apps/ll-builder/src/main.cpp:380
 msgid "Remove a repository"
 msgstr "Remove a repository"
 
-#: ../apps/ll-cli/src/main.cpp:457
+#: ../apps/ll-cli/src/main.cpp:455
 msgid "Usage: ll-cli repo remove [OPTIONS] NAME"
 msgstr "Usage: ll-cli repo remove [OPTIONS] NAME"
 
 #. add repo sub command update
 #. TODO: add --repo and --url options
 #. add repo sub command update
-#: ../apps/ll-cli/src/main.cpp:464 ../apps/ll-builder/src/main.cpp:376
+#: ../apps/ll-cli/src/main.cpp:462 ../apps/ll-builder/src/main.cpp:387
 msgid "Update the repository URL"
 msgstr "Update the repository URL"
 
-#: ../apps/ll-cli/src/main.cpp:465
+#: ../apps/ll-cli/src/main.cpp:463
 msgid "Usage: ll-cli repo update [OPTIONS] NAME URL"
 msgstr "Usage: ll-cli repo update [OPTIONS] NAME URL"
 
-#: ../apps/ll-cli/src/main.cpp:475 ../apps/ll-builder/src/main.cpp:387
+#: ../apps/ll-cli/src/main.cpp:473 ../apps/ll-builder/src/main.cpp:398
 msgid "Set a default repository name"
 msgstr "Set a default repository name"
 
-#: ../apps/ll-cli/src/main.cpp:476
+#: ../apps/ll-cli/src/main.cpp:474
 msgid "Usage: ll-cli repo set-default [OPTIONS] NAME"
 msgstr "Usage: ll-cli repo set-default [OPTIONS] NAME"
 
 #. add repo sub command show
-#: ../apps/ll-cli/src/main.cpp:482 ../apps/ll-builder/src/main.cpp:394
+#: ../apps/ll-cli/src/main.cpp:480 ../apps/ll-builder/src/main.cpp:405
 msgid "Show repository information"
 msgstr "Show repository information"
 
-#: ../apps/ll-cli/src/main.cpp:483
+#: ../apps/ll-cli/src/main.cpp:481
 msgid "Usage: ll-cli repo show [OPTIONS]"
 msgstr "Usage: ll-cli repo show [OPTIONS]"
 
-#: ../apps/ll-cli/src/main.cpp:488
+#: ../apps/ll-cli/src/main.cpp:485
+msgid "Set the priority of the repo"
+msgstr "Set the priority of the repo"
+
+#: ../apps/ll-cli/src/main.cpp:486
+msgid "Usage: ll-cli repo set-priority ALIAS PRIORITY"
+msgstr "Usage: ll-cli repo set-priority ALIAS PRIORITY"
+
+#: ../apps/ll-cli/src/main.cpp:491
+msgid "Priority of the repo"
+msgstr "Priority of the repo"
+
+#: ../apps/ll-cli/src/main.cpp:498
 msgid "Display information about installed apps or runtimes"
 msgstr "Display information about installed apps or runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:491
+#: ../apps/ll-cli/src/main.cpp:501
 msgid "Usage: ll-cli info [OPTIONS] APP"
 msgstr "Usage: ll-cli info [OPTIONS] APP"
 
-#: ../apps/ll-cli/src/main.cpp:495
+#: ../apps/ll-cli/src/main.cpp:505
 msgid "Specify the application ID, and it can also be a .layer file"
 msgstr "Specify the application ID, and it can also be a .layer file"
 
-#: ../apps/ll-cli/src/main.cpp:502
+#: ../apps/ll-cli/src/main.cpp:512
 msgid "Display the exported files of installed application"
 msgstr "Display the exported files of installed application"
 
-#: ../apps/ll-cli/src/main.cpp:505
+#: ../apps/ll-cli/src/main.cpp:515
 msgid "Usage: ll-cli content [OPTIONS] APP"
 msgstr "Usage: ll-cli content [OPTIONS] APP"
 
-#: ../apps/ll-cli/src/main.cpp:506
+#: ../apps/ll-cli/src/main.cpp:516
 msgid "Specify the installed application ID"
 msgstr "Specify the installed application ID"
 
 #. add sub command prune
-#: ../apps/ll-cli/src/main.cpp:511
+#: ../apps/ll-cli/src/main.cpp:521
 msgid "Remove the unused base or runtime"
 msgstr "Remove the unused base or runtime"
 
-#: ../apps/ll-cli/src/main.cpp:513
+#: ../apps/ll-cli/src/main.cpp:523
 msgid "Usage: ll-cli prune [OPTIONS]"
 msgstr "Usage: ll-cli prune [OPTIONS]"
 
-#: ../apps/ll-cli/src/main.cpp:518
+#: ../apps/ll-cli/src/main.cpp:528
 msgid "Display the information of installed application"
 msgstr "Display the information of installed application"
 
-#: ../apps/ll-cli/src/main.cpp:520
+#: ../apps/ll-cli/src/main.cpp:530
 msgid "Usage: ll-cli inspect [OPTIONS]"
 msgstr "Usage: ll-cli inspect [OPTIONS]"
 
-#: ../apps/ll-cli/src/main.cpp:522
+#: ../apps/ll-cli/src/main.cpp:532
 msgid "Specify the process id"
 msgstr "Specify the process id"
 
-#: ../apps/ll-cli/src/main.cpp:531
+#: ../apps/ll-cli/src/main.cpp:541
 msgid "Invalid process id"
 msgstr "Invalid process id"
 
-#: ../apps/ll-cli/src/main.cpp:534
+#: ../apps/ll-cli/src/main.cpp:544
 msgid "Invalid pid format"
 msgstr "Invalid process id"
 
-#: ../apps/ll-cli/src/main.cpp:552
+#: ../apps/ll-cli/src/main.cpp:554
+msgid "Specify the installed app(base or runtime)"
+msgstr "Specify the installed app(base or runtime)"
+
+#: ../apps/ll-cli/src/main.cpp:565
 msgid "linyaps CLI version "
 msgstr "linyaps CLI version "
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:71
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:232
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:76
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:258
 msgid "ID"
 msgstr "ID"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:72
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:77
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:185
 msgid "Name"
 msgstr "Name"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:73
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:78
 msgid "Version"
 msgstr "Version"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:74
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:79
 msgid "Channel"
 msgstr "Channel"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:75
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:80
 msgid "Module"
 msgstr "Module"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:76
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:81
 msgid "Description"
 msgstr "Description"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:110
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:111
+msgid "No containers are running."
+msgstr "No containers are running."
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:115
 msgid "App"
 msgstr "App"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:111
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:116
 msgid "ContainerID"
 msgstr "ContainerID"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:112
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:117
 msgid "Pid"
 msgstr "Pid"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:233
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:186
+msgid "Url"
+msgstr "Url"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:187
+msgid "Alias"
+msgstr "Alias"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:188
+msgid "Priority"
+msgstr "Priority"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:246
+msgid "No apps available for update."
+msgstr "No apps available for update."
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:259
 msgid "Installed"
 msgstr "Installed"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:234
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:260
 msgid "New"
 msgstr "New"
 
@@ -580,7 +628,7 @@ msgid "Usage: ll-builder build [OPTIONS] [COMMAND...]"
 msgstr "Usage: ll-builder build [OPTIONS] [COMMAND...]"
 
 #: ../apps/ll-builder/src/main.cpp:215 ../apps/ll-builder/src/main.cpp:258
-#: ../apps/ll-builder/src/main.cpp:293 ../apps/ll-builder/src/main.cpp:309
+#: ../apps/ll-builder/src/main.cpp:293 ../apps/ll-builder/src/main.cpp:320
 msgid "File path of the linglong.yaml"
 msgstr "File path of the linglong.yaml"
 
@@ -677,104 +725,108 @@ msgstr "Export to linyaps layer or uab"
 msgid "Usage: ll-builder export [OPTIONS]"
 msgstr "Usage: ll-builder export [OPTIONS]"
 
-#: ../apps/ll-builder/src/main.cpp:297
+#: ../apps/ll-builder/src/main.cpp:303
 msgid "Uab icon (optional)"
 msgstr "Uab icon (optional)"
 
-#: ../apps/ll-builder/src/main.cpp:300
+#: ../apps/ll-builder/src/main.cpp:306
 msgid "Export uab fully"
 msgstr "Export uab fully"
 
-#: ../apps/ll-builder/src/main.cpp:301
+#: ../apps/ll-builder/src/main.cpp:307
 msgid "Export to linyaps layer file"
 msgstr "Export to linyaps layer file"
 
-#: ../apps/ll-builder/src/main.cpp:307
+#: ../apps/ll-builder/src/main.cpp:310
+msgid "Use custom loader"
+msgstr "Use custom loader"
+
+#: ../apps/ll-builder/src/main.cpp:318
 msgid "Push linyaps app to remote repo"
 msgstr "Push linyaps app to remote repo"
 
-#: ../apps/ll-builder/src/main.cpp:308
+#: ../apps/ll-builder/src/main.cpp:319
 msgid "Usage: ll-builder push [OPTIONS]"
 msgstr "Usage: ll-builder push [OPTIONS]"
 
-#: ../apps/ll-builder/src/main.cpp:313
+#: ../apps/ll-builder/src/main.cpp:324
 msgid "Remote repo url"
 msgstr "Remote repo url"
 
-#: ../apps/ll-builder/src/main.cpp:316
+#: ../apps/ll-builder/src/main.cpp:327
 msgid "Remote repo name"
 msgstr "Remote repo name"
 
-#: ../apps/ll-builder/src/main.cpp:319
+#: ../apps/ll-builder/src/main.cpp:330
 msgid "Push single module"
 msgstr "Push single module"
 
-#: ../apps/ll-builder/src/main.cpp:324
+#: ../apps/ll-builder/src/main.cpp:335
 msgid "Import linyaps layer to build repo"
 msgstr "Import linyaps layer to build repo"
 
-#: ../apps/ll-builder/src/main.cpp:325
+#: ../apps/ll-builder/src/main.cpp:336
 msgid "Usage: ll-builder import [OPTIONS] LAYER"
 msgstr "Usage: ll-builder import [OPTIONS] LAYER"
 
-#: ../apps/ll-builder/src/main.cpp:326 ../apps/ll-builder/src/main.cpp:345
+#: ../apps/ll-builder/src/main.cpp:337 ../apps/ll-builder/src/main.cpp:356
 msgid "Layer file path"
 msgstr "Layer file path"
 
-#: ../apps/ll-builder/src/main.cpp:334
+#: ../apps/ll-builder/src/main.cpp:345
 msgid "Import linyaps layer dir to build repo"
 msgstr "Import linyaps layer dir to build repo"
 
-#: ../apps/ll-builder/src/main.cpp:336
+#: ../apps/ll-builder/src/main.cpp:347
 msgid "Usage: ll-builder import-dir PATH"
 msgstr "Usage: ll-builder import-dir PATH"
 
-#: ../apps/ll-builder/src/main.cpp:337
+#: ../apps/ll-builder/src/main.cpp:348
 msgid "Layer dir path"
 msgstr "Layer dir path"
 
-#: ../apps/ll-builder/src/main.cpp:343
+#: ../apps/ll-builder/src/main.cpp:354
 msgid "Extract linyaps layer to dir"
 msgstr "Extract linyaps layer to dir"
 
-#: ../apps/ll-builder/src/main.cpp:344
+#: ../apps/ll-builder/src/main.cpp:355
 msgid "Usage: ll-builder extract [OPTIONS] LAYER DIR"
 msgstr "Usage: ll-builder extract [OPTIONS] LAYER DIR"
 
-#: ../apps/ll-builder/src/main.cpp:348
+#: ../apps/ll-builder/src/main.cpp:359
 msgid "Destination directory"
 msgstr "Destination directory"
 
 #. add build repo
-#: ../apps/ll-builder/src/main.cpp:351
+#: ../apps/ll-builder/src/main.cpp:362
 msgid "Display and manage repositories"
 msgstr "Display and manage repositories"
 
-#: ../apps/ll-builder/src/main.cpp:352
+#: ../apps/ll-builder/src/main.cpp:363
 msgid "Usage: ll-builder repo [OPTIONS] SUBCOMMAND"
 msgstr "Usage: ll-builder repo [OPTIONS] SUBCOMMAND"
 
-#: ../apps/ll-builder/src/main.cpp:357
+#: ../apps/ll-builder/src/main.cpp:368
 msgid "Usage: ll-builder repo add [OPTIONS] NAME URL"
 msgstr "Usage: ll-builder repo add [OPTIONS] NAME URL"
 
-#: ../apps/ll-builder/src/main.cpp:370
+#: ../apps/ll-builder/src/main.cpp:381
 msgid "Usage: ll-builder repo remove [OPTIONS] NAME"
 msgstr "Usage: ll-builder repo remove [OPTIONS] NAME"
 
-#: ../apps/ll-builder/src/main.cpp:377
+#: ../apps/ll-builder/src/main.cpp:388
 msgid "Usage: ll-builder repo update [OPTIONS] NAME URL"
 msgstr "Usage: ll-builder repo update [OPTIONS] NAME URL"
 
-#: ../apps/ll-builder/src/main.cpp:388
+#: ../apps/ll-builder/src/main.cpp:399
 msgid "Usage: ll-builder repo set-default [OPTIONS] NAME"
 msgstr "Usage: ll-builder repo set-default [OPTIONS] NAME"
 
-#: ../apps/ll-builder/src/main.cpp:395
+#: ../apps/ll-builder/src/main.cpp:406
 msgid "Usage: ll-builder repo show [OPTIONS]"
 msgstr "Usage: ll-builder repo show [OPTIONS]"
 
-#: ../apps/ll-builder/src/main.cpp:400
+#: ../apps/ll-builder/src/main.cpp:411
 msgid "linyaps build tool version "
 msgstr "linyaps build tool version "
 
@@ -799,3 +851,193 @@ msgstr "Linglong Package Manager"
 #: ../apps/ll-dialog/src/cache_dialog.cpp:54
 msgid "is starting"
 msgstr "is starting"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:526
+msgid "The current version does not support the develop module installation."
+msgstr "The current version does not support the develop module installation."
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:541
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:805
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1384
+msgid "app arch: %1 not match host architecture"
+msgstr "app arch: %1 not match host architecture"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:592
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:855
+msgid ""
+"The latest version has been installed. If you want to replace it, try using "
+"'ll-cli install %1 --force'"
+msgstr ""
+"The latest version has been installed. If you want to replace it, try using "
+"'ll-cli install %1 --force'"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:636
+msgid "installing layer"
+msgstr "installing layer"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:638
+msgid "preparing environment"
+msgstr "preparing environment"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:677
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:682
+msgid "install layer successfully"
+msgstr "install layer successfully"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:743
+msgid "queued to install from layer"
+msgstr "queued to install from layer"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:747
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1292
+msgid "%1 is now installing"
+msgstr "%1 is now installing"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:766
+msgid "couldn't pass uab verification"
+msgstr "couldn't pass uab verification"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:784
+msgid "couldn't find application layer in this uab"
+msgstr "couldn't find application layer in this uab"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:844
+msgid "%1 is already installed"
+msgstr "%1 is already installed"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:901
+msgid "installing uab"
+msgstr "installing uab"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:903
+msgid "prepare environment"
+msgstr "prepare environment"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:919
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:930
+msgid "the contents of this uab file are invalid"
+msgstr "the contents of this uab file are invalid"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:946
+msgid "get status of %1 failed: %2"
+msgstr "get status of %1 failed: %2"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:951
+msgid "layer directory %1 doesn't exist"
+msgstr "layer directory %1 doesn't exist"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1053
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1358
+msgid "Failed to generate some cache.\n"
+msgstr "Failed to generate some cache.\n"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1140
+msgid "cannot specify a version when installing a module"
+msgstr "cannot specify a version when installing a module"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1149
+msgid "to install the module, one must first install the app"
+msgstr "to install the module, one must first install the app"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1154
+msgid "module is already installed"
+msgstr "module is already installed"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1167
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1288
+msgid "queued to install from remote"
+msgstr "queued to install from remote"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1182
+msgid "%1 is already installed."
+msgstr "%1 is already installed."
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1222
+msgid ""
+"The latest version has been installed. If you want to replace it, try using "
+"'ll-cli install %1/%2 --force'"
+msgstr ""
+"The latest version has been installed. If you want to replace it, try using "
+"'ll-cli install %1/%2 --force'"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1267
+msgid "canceled"
+msgstr "canceled"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1302
+msgid "Installing %1"
+msgstr "installing %1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1314
+msgid "These modules do not exist remotely: %1"
+msgstr "These modules do not exist remotely: %1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1330
+msgid "processing after install"
+msgstr "processing after install"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1349
+msgid "Failed to remove old reference %1 after install %2 : %3"
+msgstr "Failed to remove old reference %1 after install %2 : %3"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1365
+msgid "Install %1 success"
+msgstr "Install %1 success"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1375
+msgid "Beginning to install"
+msgstr "Beginning to install"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1388
+msgid "Installing application %1"
+msgstr "Installing application %1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1429
+msgid "install failed"
+msgstr "install failed"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1897
+msgid "Installing runtime %1"
+msgstr "Installing runtime %1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1940
+msgid "Installing base "
+msgstr "Installing base "
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:173
+msgid "Caught error during pulling data, waiting for outstanding task"
+msgstr "Caught error during pulling data, waiting for outstanding task"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:208
+msgid "Downloading metadata"
+msgstr "Downloading metadata"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:216
+msgid "Downloading delta part"
+msgstr "Downloading delta part"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:224
+msgid "Downloading files"
+msgstr "Downloading files"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:482
+msgid "package not found: %1"
+msgstr "package not found: %1"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:1316
+msgid "Cannot find %1/%2 from remote repo"
+msgstr "Cannot find %1/%2 from remote repo"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:1480
+msgid ""
+"Failed to get response from remote server (network error or server "
+"unavailable)"
+msgstr ""
+"Failed to get response from remote server (network error or server "
+"unavailable)"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:1489
+msgid ""
+"Remote server returned error code: %1 (network error or server unavailable)"
+msgstr ""
+"Remote server returned error code: %1 (network error or server unavailable)"

--- a/po/en_US.po
+++ b/po/en_US.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-20 14:54+0800\n"
+"POT-Creation-Date: 2025-03-27 18:02+0800\n"
 "PO-Revision-Date: 2025-01-07 17:11+0800\n"
 "Last-Translator: deepiner, 2024\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,17 +17,17 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:56
+#: ../libs/linglong/src/linglong/cli/cli.cpp:58
 msgid "Permission deny, please check whether you are running as root."
 msgstr "Permission deny, please check whether you are running as root."
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2579
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2571
 msgid ""
 "The cache generation failed, please uninstall and reinstall the application."
 msgstr ""
 "The cache generation failed, please uninstall and reinstall the application."
 
-#: ../apps/ll-cli/src/main.cpp:158
+#: ../apps/ll-cli/src/main.cpp:147
 msgid ""
 "linyaps CLI\n"
 "A CLI program to run application and manage application and runtime\n"
@@ -35,19 +35,19 @@ msgstr ""
 "linyaps CLI\n"
 "A CLI program to run application and manage application and runtime\n"
 
-#: ../apps/ll-cli/src/main.cpp:165 ../apps/ll-builder/src/main.cpp:172
+#: ../apps/ll-cli/src/main.cpp:159 ../apps/ll-builder/src/main.cpp:172
 msgid "Print this help message and exit"
 msgstr "Print this help message and exit"
 
-#: ../apps/ll-cli/src/main.cpp:166 ../apps/ll-builder/src/main.cpp:173
+#: ../apps/ll-cli/src/main.cpp:160 ../apps/ll-builder/src/main.cpp:173
 msgid "Expand all help"
 msgstr "Expand all help"
 
-#: ../apps/ll-cli/src/main.cpp:167
+#: ../apps/ll-cli/src/main.cpp:161
 msgid "Usage: ll-cli [OPTIONS] [SUBCOMMAND]"
 msgstr "Usage: ll-cli [OPTIONS] [SUBCOMMAND]"
 
-#: ../apps/ll-cli/src/main.cpp:168
+#: ../apps/ll-cli/src/main.cpp:162
 msgid ""
 "If you found any problems during use,\n"
 "You can report bugs to the linyaps team under this project: https://github."
@@ -57,11 +57,12 @@ msgstr ""
 "You can report bugs to the linyaps team under this project: https://github."
 "com/OpenAtom-Linyaps/linyaps/issues"
 
-#: ../apps/ll-cli/src/main.cpp:178 ../apps/ll-builder/src/main.cpp:194
+#. add flags
+#: ../apps/ll-cli/src/main.cpp:169 ../apps/ll-builder/src/main.cpp:194
 msgid "Show version"
 msgstr "Show version"
 
-#: ../apps/ll-cli/src/main.cpp:182
+#: ../apps/ll-cli/src/main.cpp:173
 msgid ""
 "Use peer to peer DBus, this is used only in case that DBus daemon is not "
 "available"
@@ -69,43 +70,43 @@ msgstr ""
 "Use peer to peer DBus, this is used only in case that DBus daemon is not "
 "available"
 
-#: ../apps/ll-cli/src/main.cpp:185
+#: ../apps/ll-cli/src/main.cpp:177
 msgid "Use json format to output result"
 msgstr "Use json format to output result"
 
-#: ../apps/ll-cli/src/main.cpp:191 ../apps/ll-cli/src/main.cpp:525
+#: ../apps/ll-cli/src/main.cpp:184 ../apps/ll-cli/src/main.cpp:535
 #: ../apps/ll-builder/src/main.cpp:185
 msgid "Input parameter is empty, please input valid parameter instead"
 msgstr "Input parameter is empty, please input valid parameter instead"
 
 #. groups
-#: ../apps/ll-cli/src/main.cpp:214
+#: ../apps/ll-cli/src/main.cpp:207
 msgid "Managing installed applications and runtimes"
 msgstr "Managing installed applications and runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:215
+#: ../apps/ll-cli/src/main.cpp:208
 msgid "Managing running applications"
 msgstr "Managing running applications"
 
-#: ../apps/ll-cli/src/main.cpp:216
+#: ../apps/ll-cli/src/main.cpp:209
 msgid "Finding applications and runtimes"
 msgstr "Finding applications and runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:217
+#: ../apps/ll-cli/src/main.cpp:210
 msgid "Managing remote repositories"
 msgstr "Managing remote repositories"
 
 #. add sub command run
-#: ../apps/ll-cli/src/main.cpp:220
+#: ../apps/ll-cli/src/main.cpp:213
 msgid "Run an application"
 msgstr "Run an application"
 
 #. add sub command run options
-#: ../apps/ll-cli/src/main.cpp:225
+#: ../apps/ll-cli/src/main.cpp:218
 msgid "Specify the application ID"
 msgstr "Specify the application ID"
 
-#: ../apps/ll-cli/src/main.cpp:228
+#: ../apps/ll-cli/src/main.cpp:221
 msgid ""
 "Usage: ll-cli run [OPTIONS] APP [COMMAND...]\n"
 "\n"
@@ -127,70 +128,70 @@ msgstr ""
 "ll-cli run org.deepin.demo -- bash\n"
 "ll-cli run org.deepin.demo -- bash -x /path/to/bash/script"
 
-#: ../apps/ll-cli/src/main.cpp:238
+#: ../apps/ll-cli/src/main.cpp:231
 msgid "Pass file to applications running in a sandbox"
 msgstr "Pass file to applications running in a sandbox"
 
-#: ../apps/ll-cli/src/main.cpp:242
+#: ../apps/ll-cli/src/main.cpp:235
 msgid "Pass url to applications running in a sandbox"
 msgstr "Pass url to applications running in a sandbox"
 
-#: ../apps/ll-cli/src/main.cpp:245 ../apps/ll-cli/src/main.cpp:267
-#: ../apps/ll-cli/src/main.cpp:284
+#: ../apps/ll-cli/src/main.cpp:238 ../apps/ll-cli/src/main.cpp:260
+#: ../apps/ll-cli/src/main.cpp:277
 msgid "Run commands in a running sandbox"
 msgstr "Run commands in a running sandbox"
 
 #. add sub command ps
-#: ../apps/ll-cli/src/main.cpp:248
+#: ../apps/ll-cli/src/main.cpp:241
 msgid "List running applications"
 msgstr "List running applications"
 
-#: ../apps/ll-cli/src/main.cpp:251
+#: ../apps/ll-cli/src/main.cpp:244
 msgid "Usage: ll-cli ps [OPTIONS]"
 msgstr "Usage: ll-cli ps [OPTIONS]"
 
-#: ../apps/ll-cli/src/main.cpp:255
+#: ../apps/ll-cli/src/main.cpp:248
 msgid "Execute commands in the currently running sandbox"
 msgstr "Execute commands in the currently running sandbox"
 
-#: ../apps/ll-cli/src/main.cpp:261 ../apps/ll-cli/src/main.cpp:279
+#: ../apps/ll-cli/src/main.cpp:254 ../apps/ll-cli/src/main.cpp:272
 msgid "Specify the application running instance(you can get it by ps command)"
 msgstr "Specify the application running instance(you can get it by ps command)"
 
-#: ../apps/ll-cli/src/main.cpp:264 ../apps/ll-cli/src/main.cpp:281
+#: ../apps/ll-cli/src/main.cpp:257 ../apps/ll-cli/src/main.cpp:274
 msgid "Specify working directory"
 msgstr "Specify working directory"
 
-#: ../apps/ll-cli/src/main.cpp:272
+#: ../apps/ll-cli/src/main.cpp:265
 msgid "Enter the namespace where the application is running"
 msgstr "Enter the namespace where the application is running"
 
-#: ../apps/ll-cli/src/main.cpp:275
+#: ../apps/ll-cli/src/main.cpp:268
 msgid "Usage: ll-cli enter [OPTIONS] INSTANCE [COMMAND...]"
 msgstr "Usage: ll-cli enter [OPTIONS] INSTANCE [COMMAND...]"
 
 #. add sub command kill
-#: ../apps/ll-cli/src/main.cpp:287
+#: ../apps/ll-cli/src/main.cpp:280
 msgid "Stop running applications"
 msgstr "Stop running applications"
 
-#: ../apps/ll-cli/src/main.cpp:290
+#: ../apps/ll-cli/src/main.cpp:283
 msgid "Usage: ll-cli kill [OPTIONS] APP"
 msgstr "Usage: ll-cli kill [OPTIONS] APP"
 
-#: ../apps/ll-cli/src/main.cpp:294
+#: ../apps/ll-cli/src/main.cpp:287
 msgid "Specify the signal to send to the application"
 msgstr "Specify the signal to send to the application"
 
-#: ../apps/ll-cli/src/main.cpp:296
+#: ../apps/ll-cli/src/main.cpp:289
 msgid "Specify the running application"
 msgstr "Specify the running application"
 
-#: ../apps/ll-cli/src/main.cpp:302
+#: ../apps/ll-cli/src/main.cpp:295
 msgid "Installing an application or runtime"
 msgstr "Installing an application or runtime"
 
-#: ../apps/ll-cli/src/main.cpp:305
+#: ../apps/ll-cli/src/main.cpp:298
 msgid ""
 "Usage: ll-cli install [OPTIONS] APP\n"
 "\n"
@@ -226,47 +227,56 @@ msgstr ""
 "ll-cli install stable:org.deepin.demo/0.0.0.1/x86_64\n"
 "    "
 
-#: ../apps/ll-cli/src/main.cpp:324
+#: ../apps/ll-cli/src/main.cpp:317
 msgid "Specify the application ID, and it can also be a .uab or .layer file"
 msgstr "Specify the application ID, and it can also be a .uab or .layer file"
 
-#: ../apps/ll-cli/src/main.cpp:327
+#: ../apps/ll-cli/src/main.cpp:320
 msgid "Install a specify module"
 msgstr "Install a specify module"
 
-#: ../apps/ll-cli/src/main.cpp:330
+#: ../apps/ll-cli/src/main.cpp:323
 msgid "Force install the application"
 msgstr "Force install the application"
 
-#: ../apps/ll-cli/src/main.cpp:331
+#: ../apps/ll-cli/src/main.cpp:324
 msgid "Automatically answer yes to all questions"
 msgstr "Automatically answer yes to all questions"
 
-#: ../apps/ll-cli/src/main.cpp:339
+#: ../apps/ll-cli/src/main.cpp:330
 msgid "Uninstall the application or runtimes"
 msgstr "Uninstall the application or runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:342
+#: ../apps/ll-cli/src/main.cpp:333
 msgid "Usage: ll-cli uninstall [OPTIONS] APP"
 msgstr "Usage: ll-cli uninstall [OPTIONS] APP"
 
-#: ../apps/ll-cli/src/main.cpp:343
+#: ../apps/ll-cli/src/main.cpp:334
 msgid "Specify the applications ID"
 msgstr "Specify the applications ID"
 
-#: ../apps/ll-cli/src/main.cpp:346
+#: ../apps/ll-cli/src/main.cpp:337
 msgid "Uninstall a specify module"
 msgstr "Uninstall a specify module"
 
-#: ../apps/ll-cli/src/main.cpp:354
+#. below options are used for compatibility with old ll-cli
+#: ../apps/ll-cli/src/main.cpp:342
+msgid "Remove all unused modules"
+msgstr "Remove all unused modules"
+
+#: ../apps/ll-cli/src/main.cpp:346
+msgid "Uninstall all modules"
+msgstr "Uninstall all modules"
+
+#: ../apps/ll-cli/src/main.cpp:352
 msgid "Upgrade the application or runtimes"
 msgstr "Upgrade the application or runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:357
+#: ../apps/ll-cli/src/main.cpp:355
 msgid "Usage: ll-cli upgrade [OPTIONS] [APP]"
 msgstr "Usage: ll-cli upgrade [OPTIONS] [APP]"
 
-#: ../apps/ll-cli/src/main.cpp:361
+#: ../apps/ll-cli/src/main.cpp:359
 msgid ""
 "Specify the application ID.If it not be specified, all applications will be "
 "upgraded"
@@ -274,7 +284,7 @@ msgstr ""
 "Specify the application ID.If it not be specified, all applications will be "
 "upgraded"
 
-#: ../apps/ll-cli/src/main.cpp:368
+#: ../apps/ll-cli/src/main.cpp:366
 msgid ""
 "Search the applications/runtimes containing the specified text from the "
 "remote repository"
@@ -282,7 +292,7 @@ msgstr ""
 "Search the applications/runtimes containing the specified text from the "
 "remote repository"
 
-#: ../apps/ll-cli/src/main.cpp:372
+#: ../apps/ll-cli/src/main.cpp:370
 msgid ""
 "Usage: ll-cli search [OPTIONS] KEYWORDS\n"
 "\n"
@@ -308,28 +318,28 @@ msgstr ""
 "# find all off runtime of remote\n"
 "ll-cli search . --type=runtime"
 
-#: ../apps/ll-cli/src/main.cpp:383
+#: ../apps/ll-cli/src/main.cpp:381
 msgid "Specify the Keywords"
 msgstr "Specify the Keywords"
 
-#: ../apps/ll-cli/src/main.cpp:389 ../apps/ll-cli/src/main.cpp:414
+#: ../apps/ll-cli/src/main.cpp:387 ../apps/ll-cli/src/main.cpp:412
 msgid "Filter result with specify type. One of \"runtime\", \"app\" or \"all\""
 msgstr ""
 "Filter result with specify type. One of \"runtime\", \"app\" or \"all\""
 
-#: ../apps/ll-cli/src/main.cpp:393
+#: ../apps/ll-cli/src/main.cpp:391
 msgid "include develop application in result"
 msgstr "include develop application in result"
 
-#: ../apps/ll-cli/src/main.cpp:394
+#: ../apps/ll-cli/src/main.cpp:392
 msgid "Show all results"
 msgstr "Show all results"
 
-#: ../apps/ll-cli/src/main.cpp:398
+#: ../apps/ll-cli/src/main.cpp:396
 msgid "List installed applications or runtimes"
 msgstr "List installed applications or runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:401
+#: ../apps/ll-cli/src/main.cpp:399
 msgid ""
 "Usage: ll-cli list [OPTIONS]\n"
 "\n"
@@ -351,7 +361,7 @@ msgstr ""
 "# show the latest version list of the currently installed application(s)\n"
 "ll-cli list --upgradable\n"
 
-#: ../apps/ll-cli/src/main.cpp:420
+#: ../apps/ll-cli/src/main.cpp:418
 msgid ""
 "Show the list of latest version of the currently installed applications, it "
 "only works for app"
@@ -359,181 +369,219 @@ msgstr ""
 "Show the list of latest version of the currently installed applications, it "
 "only works for app"
 
-#: ../apps/ll-cli/src/main.cpp:427
+#: ../apps/ll-cli/src/main.cpp:425
 msgid "Display or modify information of the repository currently using"
 msgstr "Display or modify information of the repository currently using"
 
-#: ../apps/ll-cli/src/main.cpp:429
+#: ../apps/ll-cli/src/main.cpp:427
 msgid "Usage: ll-cli repo SUBCOMMAND [OPTIONS]"
 msgstr "Usage: ll-cli repo SUBCOMMAND [OPTIONS]"
 
 #. add repo sub command add
-#: ../apps/ll-cli/src/main.cpp:433 ../apps/ll-builder/src/main.cpp:356
+#: ../apps/ll-cli/src/main.cpp:431 ../apps/ll-builder/src/main.cpp:367
 msgid "Add a new repository"
 msgstr "Add a new repository"
 
-#: ../apps/ll-cli/src/main.cpp:434
+#: ../apps/ll-cli/src/main.cpp:432
 msgid "Usage: ll-cli repo add [OPTIONS] NAME URL"
 msgstr "Usage: ll-cli repo add [OPTIONS] NAME URL"
 
-#: ../apps/ll-cli/src/main.cpp:435 ../apps/ll-cli/src/main.cpp:448
-#: ../apps/ll-builder/src/main.cpp:358
+#: ../apps/ll-cli/src/main.cpp:433 ../apps/ll-cli/src/main.cpp:446
+#: ../apps/ll-builder/src/main.cpp:369
 msgid "Specify the repo name"
 msgstr "Specify the repo name"
 
-#: ../apps/ll-cli/src/main.cpp:438 ../apps/ll-cli/src/main.cpp:451
-#: ../apps/ll-cli/src/main.cpp:469 ../apps/ll-builder/src/main.cpp:361
-#: ../apps/ll-builder/src/main.cpp:381
+#: ../apps/ll-cli/src/main.cpp:436 ../apps/ll-cli/src/main.cpp:449
+#: ../apps/ll-cli/src/main.cpp:467 ../apps/ll-builder/src/main.cpp:372
+#: ../apps/ll-builder/src/main.cpp:392
 msgid "Url of the repository"
 msgstr "Url of the repository"
 
-#: ../apps/ll-cli/src/main.cpp:441 ../apps/ll-cli/src/main.cpp:458
-#: ../apps/ll-cli/src/main.cpp:466 ../apps/ll-cli/src/main.cpp:477
-#: ../apps/ll-builder/src/main.cpp:364 ../apps/ll-builder/src/main.cpp:371
-#: ../apps/ll-builder/src/main.cpp:378 ../apps/ll-builder/src/main.cpp:389
+#: ../apps/ll-cli/src/main.cpp:439 ../apps/ll-cli/src/main.cpp:456
+#: ../apps/ll-cli/src/main.cpp:464 ../apps/ll-cli/src/main.cpp:475
+#: ../apps/ll-cli/src/main.cpp:487 ../apps/ll-builder/src/main.cpp:375
+#: ../apps/ll-builder/src/main.cpp:382 ../apps/ll-builder/src/main.cpp:389
+#: ../apps/ll-builder/src/main.cpp:400
 msgid "Alias of the repo name"
 msgstr "Alias of the repo name"
 
-#: ../apps/ll-cli/src/main.cpp:447
+#: ../apps/ll-cli/src/main.cpp:445
 msgid "Modify repository URL"
 msgstr "Modify repository URL"
 
 #. add repo sub command remove
-#: ../apps/ll-cli/src/main.cpp:456 ../apps/ll-builder/src/main.cpp:369
+#: ../apps/ll-cli/src/main.cpp:454 ../apps/ll-builder/src/main.cpp:380
 msgid "Remove a repository"
 msgstr "Remove a repository"
 
-#: ../apps/ll-cli/src/main.cpp:457
+#: ../apps/ll-cli/src/main.cpp:455
 msgid "Usage: ll-cli repo remove [OPTIONS] NAME"
 msgstr "Usage: ll-cli repo remove [OPTIONS] NAME"
 
 #. add repo sub command update
 #. TODO: add --repo and --url options
 #. add repo sub command update
-#: ../apps/ll-cli/src/main.cpp:464 ../apps/ll-builder/src/main.cpp:376
+#: ../apps/ll-cli/src/main.cpp:462 ../apps/ll-builder/src/main.cpp:387
 msgid "Update the repository URL"
 msgstr "Update the repository URL"
 
-#: ../apps/ll-cli/src/main.cpp:465
+#: ../apps/ll-cli/src/main.cpp:463
 msgid "Usage: ll-cli repo update [OPTIONS] NAME URL"
 msgstr "Usage: ll-cli repo update [OPTIONS] NAME URL"
 
-#: ../apps/ll-cli/src/main.cpp:475 ../apps/ll-builder/src/main.cpp:387
+#: ../apps/ll-cli/src/main.cpp:473 ../apps/ll-builder/src/main.cpp:398
 msgid "Set a default repository name"
 msgstr "Set a default repository name"
 
-#: ../apps/ll-cli/src/main.cpp:476
+#: ../apps/ll-cli/src/main.cpp:474
 msgid "Usage: ll-cli repo set-default [OPTIONS] NAME"
 msgstr "Usage: ll-cli repo set-default [OPTIONS] NAME"
 
 #. add repo sub command show
-#: ../apps/ll-cli/src/main.cpp:482 ../apps/ll-builder/src/main.cpp:394
+#: ../apps/ll-cli/src/main.cpp:480 ../apps/ll-builder/src/main.cpp:405
 msgid "Show repository information"
 msgstr "Show repository information"
 
-#: ../apps/ll-cli/src/main.cpp:483
+#: ../apps/ll-cli/src/main.cpp:481
 msgid "Usage: ll-cli repo show [OPTIONS]"
 msgstr "Usage: ll-cli repo show [OPTIONS]"
 
-#: ../apps/ll-cli/src/main.cpp:488
+#: ../apps/ll-cli/src/main.cpp:485
+msgid "Set the priority of the repo"
+msgstr "Set the priority of the repo"
+
+#: ../apps/ll-cli/src/main.cpp:486
+msgid "Usage: ll-cli repo set-priority ALIAS PRIORITY"
+msgstr "Usage: ll-cli repo set-priority ALIAS PRIORITY"
+
+#: ../apps/ll-cli/src/main.cpp:491
+msgid "Priority of the repo"
+msgstr "Priority of the repo"
+
+#: ../apps/ll-cli/src/main.cpp:498
 msgid "Display information about installed apps or runtimes"
 msgstr "Display information about installed apps or runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:491
+#: ../apps/ll-cli/src/main.cpp:501
 msgid "Usage: ll-cli info [OPTIONS] APP"
 msgstr "Usage: ll-cli info [OPTIONS] APP"
 
-#: ../apps/ll-cli/src/main.cpp:495
+#: ../apps/ll-cli/src/main.cpp:505
 msgid "Specify the application ID, and it can also be a .layer file"
 msgstr "Specify the application ID, and it can also be a .layer file"
 
-#: ../apps/ll-cli/src/main.cpp:502
+#: ../apps/ll-cli/src/main.cpp:512
 msgid "Display the exported files of installed application"
 msgstr "Display the exported files of installed application"
 
-#: ../apps/ll-cli/src/main.cpp:505
+#: ../apps/ll-cli/src/main.cpp:515
 msgid "Usage: ll-cli content [OPTIONS] APP"
 msgstr "Usage: ll-cli content [OPTIONS] APP"
 
-#: ../apps/ll-cli/src/main.cpp:506
+#: ../apps/ll-cli/src/main.cpp:516
 msgid "Specify the installed application ID"
 msgstr "Specify the installed application ID"
 
 #. add sub command prune
-#: ../apps/ll-cli/src/main.cpp:511
+#: ../apps/ll-cli/src/main.cpp:521
 msgid "Remove the unused base or runtime"
 msgstr "Remove the unused base or runtime"
 
-#: ../apps/ll-cli/src/main.cpp:513
+#: ../apps/ll-cli/src/main.cpp:523
 msgid "Usage: ll-cli prune [OPTIONS]"
 msgstr "Usage: ll-cli prune [OPTIONS]"
 
-#: ../apps/ll-cli/src/main.cpp:518
+#: ../apps/ll-cli/src/main.cpp:528
 msgid "Display the information of installed application"
 msgstr "Display the information of installed application"
 
-#: ../apps/ll-cli/src/main.cpp:520
+#: ../apps/ll-cli/src/main.cpp:530
 msgid "Usage: ll-cli inspect [OPTIONS]"
 msgstr "Usage: ll-cli inspect [OPTIONS]"
 
-#: ../apps/ll-cli/src/main.cpp:522
+#: ../apps/ll-cli/src/main.cpp:532
 msgid "Specify the process id"
 msgstr "Specify the process id"
 
-#: ../apps/ll-cli/src/main.cpp:531
+#: ../apps/ll-cli/src/main.cpp:541
 msgid "Invalid process id"
 msgstr "Invalid process id"
 
-#: ../apps/ll-cli/src/main.cpp:534
+#: ../apps/ll-cli/src/main.cpp:544
 msgid "Invalid pid format"
 msgstr "Invalid pid format"
 
-#: ../apps/ll-cli/src/main.cpp:552
+#: ../apps/ll-cli/src/main.cpp:554
+msgid "Specify the installed app(base or runtime)"
+msgstr "Specify the installed app(base or runtime)"
+
+#: ../apps/ll-cli/src/main.cpp:565
 msgid "linyaps CLI version "
 msgstr "linyaps CLI version "
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:71
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:232
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:76
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:258
 msgid "ID"
 msgstr "ID"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:72
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:77
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:185
 msgid "Name"
 msgstr "Name"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:73
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:78
 msgid "Version"
 msgstr "version"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:74
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:79
 msgid "Channel"
 msgstr "Channel"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:75
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:80
 msgid "Module"
 msgstr "Module"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:76
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:81
 msgid "Description"
 msgstr "Description"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:110
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:111
+msgid "No containers are running."
+msgstr "No containers are running."
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:115
 msgid "App"
 msgstr "App"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:111
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:116
 msgid "ContainerID"
 msgstr "ContainerID"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:112
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:117
 msgid "Pid"
 msgstr "Pid"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:233
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:186
+msgid "Url"
+msgstr "Url"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:187
+msgid "Alias"
+msgstr "Alias"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:188
+msgid "Priority"
+msgstr "Priority"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:246
+msgid "No apps available for update."
+msgstr "No apps available for update."
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:259
 msgid "Installed"
 msgstr "Installed"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:234
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:260
 msgid "New"
 msgstr "New"
 
@@ -580,7 +628,7 @@ msgid "Usage: ll-builder build [OPTIONS] [COMMAND...]"
 msgstr "Usage: ll-builder build [OPTIONS] [COMMAND...]"
 
 #: ../apps/ll-builder/src/main.cpp:215 ../apps/ll-builder/src/main.cpp:258
-#: ../apps/ll-builder/src/main.cpp:293 ../apps/ll-builder/src/main.cpp:309
+#: ../apps/ll-builder/src/main.cpp:293 ../apps/ll-builder/src/main.cpp:320
 msgid "File path of the linglong.yaml"
 msgstr "File path of the linglong.yaml"
 
@@ -677,104 +725,108 @@ msgstr "Export to linyaps layer or uab"
 msgid "Usage: ll-builder export [OPTIONS]"
 msgstr "Usage: ll-builder export [OPTIONS]"
 
-#: ../apps/ll-builder/src/main.cpp:297
+#: ../apps/ll-builder/src/main.cpp:303
 msgid "Uab icon (optional)"
 msgstr "Uab icon (optional)"
 
-#: ../apps/ll-builder/src/main.cpp:300
+#: ../apps/ll-builder/src/main.cpp:306
 msgid "Export uab fully"
 msgstr "Export uab fully"
 
-#: ../apps/ll-builder/src/main.cpp:301
+#: ../apps/ll-builder/src/main.cpp:307
 msgid "Export to linyaps layer file"
 msgstr "Export to linyaps layer file"
 
-#: ../apps/ll-builder/src/main.cpp:307
+#: ../apps/ll-builder/src/main.cpp:310
+msgid "Use custom loader"
+msgstr "Use custom loader"
+
+#: ../apps/ll-builder/src/main.cpp:318
 msgid "Push linyaps app to remote repo"
 msgstr "Push linyaps app to remote repo"
 
-#: ../apps/ll-builder/src/main.cpp:308
+#: ../apps/ll-builder/src/main.cpp:319
 msgid "Usage: ll-builder push [OPTIONS]"
 msgstr "Usage: ll-builder push [OPTIONS]"
 
-#: ../apps/ll-builder/src/main.cpp:313
+#: ../apps/ll-builder/src/main.cpp:324
 msgid "Remote repo url"
 msgstr "Remote repo url"
 
-#: ../apps/ll-builder/src/main.cpp:316
+#: ../apps/ll-builder/src/main.cpp:327
 msgid "Remote repo name"
 msgstr "Remote repo name"
 
-#: ../apps/ll-builder/src/main.cpp:319
+#: ../apps/ll-builder/src/main.cpp:330
 msgid "Push single module"
 msgstr "Push single module"
 
-#: ../apps/ll-builder/src/main.cpp:324
+#: ../apps/ll-builder/src/main.cpp:335
 msgid "Import linyaps layer to build repo"
 msgstr "Import linyaps layer to build repo"
 
-#: ../apps/ll-builder/src/main.cpp:325
+#: ../apps/ll-builder/src/main.cpp:336
 msgid "Usage: ll-builder import [OPTIONS] LAYER"
 msgstr "Usage: ll-builder import [OPTIONS] LAYER"
 
-#: ../apps/ll-builder/src/main.cpp:326 ../apps/ll-builder/src/main.cpp:345
+#: ../apps/ll-builder/src/main.cpp:337 ../apps/ll-builder/src/main.cpp:356
 msgid "Layer file path"
 msgstr "Layer file path"
 
-#: ../apps/ll-builder/src/main.cpp:334
+#: ../apps/ll-builder/src/main.cpp:345
 msgid "Import linyaps layer dir to build repo"
 msgstr "Import linyaps layer dir to build repo"
 
-#: ../apps/ll-builder/src/main.cpp:336
+#: ../apps/ll-builder/src/main.cpp:347
 msgid "Usage: ll-builder import-dir PATH"
 msgstr "Usage: ll-builder import-dir PATH"
 
-#: ../apps/ll-builder/src/main.cpp:337
+#: ../apps/ll-builder/src/main.cpp:348
 msgid "Layer dir path"
 msgstr "Layer dir path"
 
-#: ../apps/ll-builder/src/main.cpp:343
+#: ../apps/ll-builder/src/main.cpp:354
 msgid "Extract linyaps layer to dir"
 msgstr "Extract linyaps layer to dir"
 
-#: ../apps/ll-builder/src/main.cpp:344
+#: ../apps/ll-builder/src/main.cpp:355
 msgid "Usage: ll-builder extract [OPTIONS] LAYER DIR"
 msgstr "Usage: ll-builder extract [OPTIONS] LAYER DIR"
 
-#: ../apps/ll-builder/src/main.cpp:348
+#: ../apps/ll-builder/src/main.cpp:359
 msgid "Destination directory"
 msgstr "Destination directory"
 
 #. add build repo
-#: ../apps/ll-builder/src/main.cpp:351
+#: ../apps/ll-builder/src/main.cpp:362
 msgid "Display and manage repositories"
 msgstr "Display and manage repositories"
 
-#: ../apps/ll-builder/src/main.cpp:352
+#: ../apps/ll-builder/src/main.cpp:363
 msgid "Usage: ll-builder repo [OPTIONS] SUBCOMMAND"
 msgstr "Usage: ll-builder repo [OPTIONS] SUBCOMMAND"
 
-#: ../apps/ll-builder/src/main.cpp:357
+#: ../apps/ll-builder/src/main.cpp:368
 msgid "Usage: ll-builder repo add [OPTIONS] NAME URL"
 msgstr "Usage: ll-builder repo add [OPTIONS] NAME URL"
 
-#: ../apps/ll-builder/src/main.cpp:370
+#: ../apps/ll-builder/src/main.cpp:381
 msgid "Usage: ll-builder repo remove [OPTIONS] NAME"
 msgstr "Usage: ll-builder repo remove [OPTIONS] NAME"
 
-#: ../apps/ll-builder/src/main.cpp:377
+#: ../apps/ll-builder/src/main.cpp:388
 msgid "Usage: ll-builder repo update [OPTIONS] NAME URL"
 msgstr "Usage: ll-builder repo update [OPTIONS] NAME URL"
 
-#: ../apps/ll-builder/src/main.cpp:388
+#: ../apps/ll-builder/src/main.cpp:399
 msgid "Usage: ll-builder repo set-default [OPTIONS] NAME"
 msgstr "Usage: ll-builder repo set-default [OPTIONS] NAME"
 
-#: ../apps/ll-builder/src/main.cpp:395
+#: ../apps/ll-builder/src/main.cpp:406
 msgid "Usage: ll-builder repo show [OPTIONS]"
 msgstr "Usage: ll-builder repo show [OPTIONS]"
 
-#: ../apps/ll-builder/src/main.cpp:400
+#: ../apps/ll-builder/src/main.cpp:411
 msgid "linyaps build tool version "
 msgstr "linyaps build tool version "
 
@@ -799,3 +851,193 @@ msgstr "Linglong Package Manager"
 #: ../apps/ll-dialog/src/cache_dialog.cpp:54
 msgid "is starting"
 msgstr "is starting"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:526
+msgid "The current version does not support the develop module installation."
+msgstr "The current version does not support the develop module installation."
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:541
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:805
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1384
+msgid "app arch: %1 not match host architecture"
+msgstr "app arch: %1 not match host architecture"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:592
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:855
+msgid ""
+"The latest version has been installed. If you want to replace it, try using "
+"'ll-cli install %1 --force'"
+msgstr ""
+"The latest version has been installed. If you want to replace it, try using "
+"'ll-cli install %1 --force'"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:636
+msgid "installing layer"
+msgstr "installing layer"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:638
+msgid "preparing environment"
+msgstr "preparing environment"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:677
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:682
+msgid "install layer successfully"
+msgstr "install layer successfully"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:743
+msgid "queued to install from layer"
+msgstr "queued to install from layer"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:747
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1292
+msgid "%1 is now installing"
+msgstr "%1 is now installing"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:766
+msgid "couldn't pass uab verification"
+msgstr "couldn't pass uab verification"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:784
+msgid "couldn't find application layer in this uab"
+msgstr "couldn't find application layer in this uab"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:844
+msgid "%1 is already installed"
+msgstr "%1 is already installed"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:901
+msgid "installing uab"
+msgstr "installing uab"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:903
+msgid "prepare environment"
+msgstr "prepare environment"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:919
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:930
+msgid "the contents of this uab file are invalid"
+msgstr "the contents of this uab file are invalid"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:946
+msgid "get status of %1 failed: %2"
+msgstr "get status of %1 failed: %2"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:951
+msgid "layer directory %1 doesn't exist"
+msgstr "layer directory %1 doesn't exist"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1053
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1358
+msgid "Failed to generate some cache.\n"
+msgstr "Failed to generate some cache.\n"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1140
+msgid "cannot specify a version when installing a module"
+msgstr "cannot specify a version when installing a module"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1149
+msgid "to install the module, one must first install the app"
+msgstr "to install the module, one must first install the app"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1154
+msgid "module is already installed"
+msgstr "module is already installed"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1167
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1288
+msgid "queued to install from remote"
+msgstr "queued to install from remote"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1182
+msgid "%1 is already installed."
+msgstr "%1 is already installed."
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1222
+msgid ""
+"The latest version has been installed. If you want to replace it, try using "
+"'ll-cli install %1/%2 --force'"
+msgstr ""
+"The latest version has been installed. If you want to replace it, try using "
+"'ll-cli install %1/%2 --force'"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1267
+msgid "canceled"
+msgstr "canceled"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1302
+msgid "Installing %1"
+msgstr "Installing %1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1314
+msgid "These modules do not exist remotely: %1"
+msgstr "These modules do not exist remotely: %1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1330
+msgid "processing after install"
+msgstr "processing after install"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1349
+msgid "Failed to remove old reference %1 after install %2 : %3"
+msgstr "Failed to remove old reference %1 after install %2 : %3"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1365
+msgid "Install %1 success"
+msgstr "Install %1 success"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1375
+msgid "Beginning to install"
+msgstr "Beginning to install"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1388
+msgid "Installing application %1"
+msgstr "Installing application %1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1429
+msgid "install failed"
+msgstr "install failed"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1897
+msgid "Installing runtime %1"
+msgstr "Installing runtime %1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1940
+msgid "Installing base "
+msgstr "Installing base "
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:173
+msgid "Caught error during pulling data, waiting for outstanding task"
+msgstr "Caught error during pulling data, waiting for outstanding task"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:208
+msgid "Downloading metadata"
+msgstr "Downloading metadata"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:216
+msgid "Downloading delta part"
+msgstr "Downloading delta part"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:224
+msgid "Downloading files"
+msgstr "Downloading files"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:482
+msgid "package not found: %1"
+msgstr "package not found: %1"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:1316
+msgid "Cannot find %1/%2 from remote repo"
+msgstr "Cannot find %1/%2 from remote repo"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:1480
+msgid ""
+"Failed to get response from remote server (network error or server "
+"unavailable)"
+msgstr ""
+"Failed to get response from remote server (network error or server "
+"unavailable)"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:1489
+msgid ""
+"Remote server returned error code: %1 (network error or server unavailable)"
+msgstr ""
+"Remote server returned error code: %1 (network error or server unavailable)"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-20 14:54+0800\n"
+"POT-Creation-Date: 2025-03-27 18:02+0800\n"
 "PO-Revision-Date: 2025-01-07 17:11+0800\n"
 "Last-Translator: deepiner, 2024\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,18 +17,18 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:56
+#: ../libs/linglong/src/linglong/cli/cli.cpp:58
 msgid "Permission deny, please check whether you are running as root."
 msgstr "Permiso denegado, por favor verifica si estás ejecutando como root."
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2579
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2571
 msgid ""
 "The cache generation failed, please uninstall and reinstall the application."
 msgstr ""
 "La generación de la caché falló, por favor desinstala y reinstala la "
 "aplicación."
 
-#: ../apps/ll-cli/src/main.cpp:158
+#: ../apps/ll-cli/src/main.cpp:147
 msgid ""
 "linyaps CLI\n"
 "A CLI program to run application and manage application and runtime\n"
@@ -37,19 +37,19 @@ msgstr ""
 "Un programa CLI para ejecutar aplicaciones y gestionar aplicaciones y "
 "entornos de ejecución\n"
 
-#: ../apps/ll-cli/src/main.cpp:165 ../apps/ll-builder/src/main.cpp:172
+#: ../apps/ll-cli/src/main.cpp:159 ../apps/ll-builder/src/main.cpp:172
 msgid "Print this help message and exit"
 msgstr "Imprimir este mensaje de ayuda y salir"
 
-#: ../apps/ll-cli/src/main.cpp:166 ../apps/ll-builder/src/main.cpp:173
+#: ../apps/ll-cli/src/main.cpp:160 ../apps/ll-builder/src/main.cpp:173
 msgid "Expand all help"
 msgstr "Expandir toda la ayuda"
 
-#: ../apps/ll-cli/src/main.cpp:167
+#: ../apps/ll-cli/src/main.cpp:161
 msgid "Usage: ll-cli [OPTIONS] [SUBCOMMAND]"
 msgstr "Uso: ll-cli [OPCIONES] [SUBCOMANDO]"
 
-#: ../apps/ll-cli/src/main.cpp:168
+#: ../apps/ll-cli/src/main.cpp:162
 msgid ""
 "If you found any problems during use,\n"
 "You can report bugs to the linyaps team under this project: https://github."
@@ -59,11 +59,12 @@ msgstr ""
 "puedes reportar errores al equipo de linyaps en este proyecto: https://"
 "github.com/OpenAtom-Linyaps/linyaps/issues"
 
-#: ../apps/ll-cli/src/main.cpp:178 ../apps/ll-builder/src/main.cpp:194
+#. add flags
+#: ../apps/ll-cli/src/main.cpp:169 ../apps/ll-builder/src/main.cpp:194
 msgid "Show version"
 msgstr "Mostrar versión"
 
-#: ../apps/ll-cli/src/main.cpp:182
+#: ../apps/ll-cli/src/main.cpp:173
 msgid ""
 "Use peer to peer DBus, this is used only in case that DBus daemon is not "
 "available"
@@ -71,44 +72,44 @@ msgstr ""
 "Usar DBus de igual a igual, esto solo se usa en caso de que el demonio de "
 "DBus no esté disponible"
 
-#: ../apps/ll-cli/src/main.cpp:185
+#: ../apps/ll-cli/src/main.cpp:177
 msgid "Use json format to output result"
 msgstr "Usar formato json para mostrar el resultado"
 
-#: ../apps/ll-cli/src/main.cpp:191 ../apps/ll-cli/src/main.cpp:525
+#: ../apps/ll-cli/src/main.cpp:184 ../apps/ll-cli/src/main.cpp:535
 #: ../apps/ll-builder/src/main.cpp:185
 msgid "Input parameter is empty, please input valid parameter instead"
 msgstr ""
 "El parámetro de entrada está vacío, por favor ingrese un parámetro válido."
 
 #. groups
-#: ../apps/ll-cli/src/main.cpp:214
+#: ../apps/ll-cli/src/main.cpp:207
 msgid "Managing installed applications and runtimes"
 msgstr "Gestionar aplicaciones instaladas y tiempos de ejecución"
 
-#: ../apps/ll-cli/src/main.cpp:215
+#: ../apps/ll-cli/src/main.cpp:208
 msgid "Managing running applications"
 msgstr "Gestionar aplicaciones en ejecución"
 
-#: ../apps/ll-cli/src/main.cpp:216
+#: ../apps/ll-cli/src/main.cpp:209
 msgid "Finding applications and runtimes"
 msgstr "Buscar aplicaciones y tiempos de ejecución"
 
-#: ../apps/ll-cli/src/main.cpp:217
+#: ../apps/ll-cli/src/main.cpp:210
 msgid "Managing remote repositories"
 msgstr "Gestionar repositorios remotos"
 
 #. add sub command run
-#: ../apps/ll-cli/src/main.cpp:220
+#: ../apps/ll-cli/src/main.cpp:213
 msgid "Run an application"
 msgstr "Ejecutar una aplicación"
 
 #. add sub command run options
-#: ../apps/ll-cli/src/main.cpp:225
+#: ../apps/ll-cli/src/main.cpp:218
 msgid "Specify the application ID"
 msgstr "Especificar el ID de la aplicación"
 
-#: ../apps/ll-cli/src/main.cpp:228
+#: ../apps/ll-cli/src/main.cpp:221
 msgid ""
 "Usage: ll-cli run [OPTIONS] APP [COMMAND...]\n"
 "\n"
@@ -130,72 +131,72 @@ msgstr ""
 "ll-cli run org.deepin.demo -- bash\n"
 "ll-cli run org.deepin.demo -- bash -x /path/to/bash/script"
 
-#: ../apps/ll-cli/src/main.cpp:238
+#: ../apps/ll-cli/src/main.cpp:231
 msgid "Pass file to applications running in a sandbox"
 msgstr "Pasar archivo a las aplicaciones que se ejecutan en un entorno aislado"
 
-#: ../apps/ll-cli/src/main.cpp:242
+#: ../apps/ll-cli/src/main.cpp:235
 msgid "Pass url to applications running in a sandbox"
 msgstr "Pasar URL a las aplicaciones que se ejecutan en un entorno aislado"
 
-#: ../apps/ll-cli/src/main.cpp:245 ../apps/ll-cli/src/main.cpp:267
-#: ../apps/ll-cli/src/main.cpp:284
+#: ../apps/ll-cli/src/main.cpp:238 ../apps/ll-cli/src/main.cpp:260
+#: ../apps/ll-cli/src/main.cpp:277
 msgid "Run commands in a running sandbox"
 msgstr "Ejecutar comandos en un entorno aislado en ejecución"
 
 #. add sub command ps
-#: ../apps/ll-cli/src/main.cpp:248
+#: ../apps/ll-cli/src/main.cpp:241
 msgid "List running applications"
 msgstr "Listar aplicaciones en ejecución"
 
-#: ../apps/ll-cli/src/main.cpp:251
+#: ../apps/ll-cli/src/main.cpp:244
 msgid "Usage: ll-cli ps [OPTIONS]"
 msgstr "Uso: ll-cli ps [OPCIONES]"
 
-#: ../apps/ll-cli/src/main.cpp:255
+#: ../apps/ll-cli/src/main.cpp:248
 msgid "Execute commands in the currently running sandbox"
 msgstr "Ejecutar comandos en el entorno aislado actualmente en ejecución"
 
-#: ../apps/ll-cli/src/main.cpp:261 ../apps/ll-cli/src/main.cpp:279
+#: ../apps/ll-cli/src/main.cpp:254 ../apps/ll-cli/src/main.cpp:272
 msgid "Specify the application running instance(you can get it by ps command)"
 msgstr ""
 "Especifique la instancia de la aplicación en ejecución (puede obtenerla con "
 "el comando ps)"
 
-#: ../apps/ll-cli/src/main.cpp:264 ../apps/ll-cli/src/main.cpp:281
+#: ../apps/ll-cli/src/main.cpp:257 ../apps/ll-cli/src/main.cpp:274
 msgid "Specify working directory"
 msgstr "Especificar el directorio de trabajo"
 
-#: ../apps/ll-cli/src/main.cpp:272
+#: ../apps/ll-cli/src/main.cpp:265
 msgid "Enter the namespace where the application is running"
 msgstr "Entrar en el espacio de nombres donde se está ejecutando la aplicación"
 
-#: ../apps/ll-cli/src/main.cpp:275
+#: ../apps/ll-cli/src/main.cpp:268
 msgid "Usage: ll-cli enter [OPTIONS] INSTANCE [COMMAND...]"
 msgstr "Uso: ll-cli enter [OPCIONES] INSTANCE [COMANDO...]"
 
 #. add sub command kill
-#: ../apps/ll-cli/src/main.cpp:287
+#: ../apps/ll-cli/src/main.cpp:280
 msgid "Stop running applications"
 msgstr "Detener aplicaciones en ejecución"
 
-#: ../apps/ll-cli/src/main.cpp:290
+#: ../apps/ll-cli/src/main.cpp:283
 msgid "Usage: ll-cli kill [OPTIONS] APP"
 msgstr "Uso: ll-cli kill [OPCIONES] APP"
 
-#: ../apps/ll-cli/src/main.cpp:294
+#: ../apps/ll-cli/src/main.cpp:287
 msgid "Specify the signal to send to the application"
 msgstr "Especificar el ID de la aplicación instalada"
 
-#: ../apps/ll-cli/src/main.cpp:296
+#: ../apps/ll-cli/src/main.cpp:289
 msgid "Specify the running application"
 msgstr "Especifique la aplicación en ejecución"
 
-#: ../apps/ll-cli/src/main.cpp:302
+#: ../apps/ll-cli/src/main.cpp:295
 msgid "Installing an application or runtime"
 msgstr "Instalando una aplicación o tiempo de ejecución"
 
-#: ../apps/ll-cli/src/main.cpp:305
+#: ../apps/ll-cli/src/main.cpp:298
 msgid ""
 "Usage: ll-cli install [OPTIONS] APP\n"
 "\n"
@@ -231,49 +232,58 @@ msgstr ""
 "ll-cli install stable:org.deepin.demo/0.0.0.1/x86_64\n"
 "    "
 
-#: ../apps/ll-cli/src/main.cpp:324
+#: ../apps/ll-cli/src/main.cpp:317
 msgid "Specify the application ID, and it can also be a .uab or .layer file"
 msgstr ""
 "Especificar el ID de la aplicación, también puede ser un archivo .uab o ."
 "layer"
 
-#: ../apps/ll-cli/src/main.cpp:327
+#: ../apps/ll-cli/src/main.cpp:320
 msgid "Install a specify module"
 msgstr "Instalar un módulo especificado"
 
-#: ../apps/ll-cli/src/main.cpp:330
+#: ../apps/ll-cli/src/main.cpp:323
 msgid "Force install the application"
 msgstr "Forzar la instalación de la aplicación"
 
-#: ../apps/ll-cli/src/main.cpp:331
+#: ../apps/ll-cli/src/main.cpp:324
 msgid "Automatically answer yes to all questions"
 msgstr "Responder automáticamente sí a todas las preguntas"
 
-#: ../apps/ll-cli/src/main.cpp:339
+#: ../apps/ll-cli/src/main.cpp:330
 msgid "Uninstall the application or runtimes"
 msgstr "Desinstalar la aplicación o entornos de ejecución"
 
-#: ../apps/ll-cli/src/main.cpp:342
+#: ../apps/ll-cli/src/main.cpp:333
 msgid "Usage: ll-cli uninstall [OPTIONS] APP"
 msgstr "Uso: ll-cli uninstall [OPCIONES] APP"
 
-#: ../apps/ll-cli/src/main.cpp:343
+#: ../apps/ll-cli/src/main.cpp:334
 msgid "Specify the applications ID"
 msgstr "Especificar el ID de las aplicaciones"
 
-#: ../apps/ll-cli/src/main.cpp:346
+#: ../apps/ll-cli/src/main.cpp:337
 msgid "Uninstall a specify module"
 msgstr "Desinstalar un módulo especificado"
 
-#: ../apps/ll-cli/src/main.cpp:354
+#. below options are used for compatibility with old ll-cli
+#: ../apps/ll-cli/src/main.cpp:342
+msgid "Remove all unused modules"
+msgstr "Eliminar todos los módulos no utilizados"
+
+#: ../apps/ll-cli/src/main.cpp:346
+msgid "Uninstall all modules"
+msgstr "Desinstalar todos los módulos"
+
+#: ../apps/ll-cli/src/main.cpp:352
 msgid "Upgrade the application or runtimes"
 msgstr "Actualizar la aplicación o entornos de ejecución"
 
-#: ../apps/ll-cli/src/main.cpp:357
+#: ../apps/ll-cli/src/main.cpp:355
 msgid "Usage: ll-cli upgrade [OPTIONS] [APP]"
 msgstr "Uso: ll-cli upgrade [OPCIONES] [APP]"
 
-#: ../apps/ll-cli/src/main.cpp:361
+#: ../apps/ll-cli/src/main.cpp:359
 msgid ""
 "Specify the application ID.If it not be specified, all applications will be "
 "upgraded"
@@ -281,7 +291,7 @@ msgstr ""
 "Especificar el ID de la aplicación. Si no se especifica, se actualizarán "
 "todas las aplicaciones"
 
-#: ../apps/ll-cli/src/main.cpp:368
+#: ../apps/ll-cli/src/main.cpp:366
 msgid ""
 "Search the applications/runtimes containing the specified text from the "
 "remote repository"
@@ -289,7 +299,7 @@ msgstr ""
 "Buscar las aplicaciones/entornos de ejecución que contengan el texto "
 "especificado desde el repositorio remoto"
 
-#: ../apps/ll-cli/src/main.cpp:372
+#: ../apps/ll-cli/src/main.cpp:370
 msgid ""
 "Usage: ll-cli search [OPTIONS] KEYWORDS\n"
 "\n"
@@ -315,29 +325,29 @@ msgstr ""
 "# encontrar todos los entornos de ejecución remotos\n"
 "ll-cli search . --type=runtime"
 
-#: ../apps/ll-cli/src/main.cpp:383
+#: ../apps/ll-cli/src/main.cpp:381
 msgid "Specify the Keywords"
 msgstr "Especificar las Palabras Clave"
 
-#: ../apps/ll-cli/src/main.cpp:389 ../apps/ll-cli/src/main.cpp:414
+#: ../apps/ll-cli/src/main.cpp:387 ../apps/ll-cli/src/main.cpp:412
 msgid "Filter result with specify type. One of \"runtime\", \"app\" or \"all\""
 msgstr ""
 "Filtrar resultado con tipo especificado. Uno de \"runtime\", \"app\" o "
 "\"all\""
 
-#: ../apps/ll-cli/src/main.cpp:393
+#: ../apps/ll-cli/src/main.cpp:391
 msgid "include develop application in result"
 msgstr "incluir aplicación en desarrollo en el resultado"
 
-#: ../apps/ll-cli/src/main.cpp:394
+#: ../apps/ll-cli/src/main.cpp:392
 msgid "Show all results"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:398
+#: ../apps/ll-cli/src/main.cpp:396
 msgid "List installed applications or runtimes"
 msgstr "Listar aplicaciones o entornos de ejecución instalados"
 
-#: ../apps/ll-cli/src/main.cpp:401
+#: ../apps/ll-cli/src/main.cpp:399
 msgid ""
 "Usage: ll-cli list [OPTIONS]\n"
 "\n"
@@ -360,7 +370,7 @@ msgstr ""
 "instaladas\n"
 "ll-cli list --upgradable\n"
 
-#: ../apps/ll-cli/src/main.cpp:420
+#: ../apps/ll-cli/src/main.cpp:418
 msgid ""
 "Show the list of latest version of the currently installed applications, it "
 "only works for app"
@@ -368,183 +378,221 @@ msgstr ""
 "Mostrar la lista de la última versión de las aplicaciones actualmente "
 "instaladas, solo funciona para aplicaciones"
 
-#: ../apps/ll-cli/src/main.cpp:427
+#: ../apps/ll-cli/src/main.cpp:425
 msgid "Display or modify information of the repository currently using"
 msgstr "Mostrar o modificar la información del repositorio actualmente en uso"
 
-#: ../apps/ll-cli/src/main.cpp:429
+#: ../apps/ll-cli/src/main.cpp:427
 msgid "Usage: ll-cli repo SUBCOMMAND [OPTIONS]"
 msgstr "Uso: ll-cli repo SUBCOMANDO [OPCIONES]"
 
 #. add repo sub command add
-#: ../apps/ll-cli/src/main.cpp:433 ../apps/ll-builder/src/main.cpp:356
+#: ../apps/ll-cli/src/main.cpp:431 ../apps/ll-builder/src/main.cpp:367
 msgid "Add a new repository"
 msgstr "Agregar un nuevo repositorio"
 
-#: ../apps/ll-cli/src/main.cpp:434
+#: ../apps/ll-cli/src/main.cpp:432
 msgid "Usage: ll-cli repo add [OPTIONS] NAME URL"
 msgstr "Uso: ll-cli repo add [OPCIONES] NOMBRE URL"
 
-#: ../apps/ll-cli/src/main.cpp:435 ../apps/ll-cli/src/main.cpp:448
-#: ../apps/ll-builder/src/main.cpp:358
+#: ../apps/ll-cli/src/main.cpp:433 ../apps/ll-cli/src/main.cpp:446
+#: ../apps/ll-builder/src/main.cpp:369
 msgid "Specify the repo name"
 msgstr "Especificar el nombre del repositorio"
 
-#: ../apps/ll-cli/src/main.cpp:438 ../apps/ll-cli/src/main.cpp:451
-#: ../apps/ll-cli/src/main.cpp:469 ../apps/ll-builder/src/main.cpp:361
-#: ../apps/ll-builder/src/main.cpp:381
+#: ../apps/ll-cli/src/main.cpp:436 ../apps/ll-cli/src/main.cpp:449
+#: ../apps/ll-cli/src/main.cpp:467 ../apps/ll-builder/src/main.cpp:372
+#: ../apps/ll-builder/src/main.cpp:392
 msgid "Url of the repository"
 msgstr "URL del repositorio"
 
-#: ../apps/ll-cli/src/main.cpp:441 ../apps/ll-cli/src/main.cpp:458
-#: ../apps/ll-cli/src/main.cpp:466 ../apps/ll-cli/src/main.cpp:477
-#: ../apps/ll-builder/src/main.cpp:364 ../apps/ll-builder/src/main.cpp:371
-#: ../apps/ll-builder/src/main.cpp:378 ../apps/ll-builder/src/main.cpp:389
+#: ../apps/ll-cli/src/main.cpp:439 ../apps/ll-cli/src/main.cpp:456
+#: ../apps/ll-cli/src/main.cpp:464 ../apps/ll-cli/src/main.cpp:475
+#: ../apps/ll-cli/src/main.cpp:487 ../apps/ll-builder/src/main.cpp:375
+#: ../apps/ll-builder/src/main.cpp:382 ../apps/ll-builder/src/main.cpp:389
+#: ../apps/ll-builder/src/main.cpp:400
 msgid "Alias of the repo name"
 msgstr "Especificar el nombre del repositorio"
 
-#: ../apps/ll-cli/src/main.cpp:447
+#: ../apps/ll-cli/src/main.cpp:445
 msgid "Modify repository URL"
 msgstr "Modificar la URL del repositorio"
 
 #. add repo sub command remove
-#: ../apps/ll-cli/src/main.cpp:456 ../apps/ll-builder/src/main.cpp:369
+#: ../apps/ll-cli/src/main.cpp:454 ../apps/ll-builder/src/main.cpp:380
 msgid "Remove a repository"
 msgstr "Eliminar un repositorio"
 
-#: ../apps/ll-cli/src/main.cpp:457
+#: ../apps/ll-cli/src/main.cpp:455
 msgid "Usage: ll-cli repo remove [OPTIONS] NAME"
 msgstr "Uso: ll-cli repo remove [OPCIONES] NOMBRE"
 
 #. add repo sub command update
 #. TODO: add --repo and --url options
 #. add repo sub command update
-#: ../apps/ll-cli/src/main.cpp:464 ../apps/ll-builder/src/main.cpp:376
+#: ../apps/ll-cli/src/main.cpp:462 ../apps/ll-builder/src/main.cpp:387
 msgid "Update the repository URL"
 msgstr "Actualizar la URL del repositorio"
 
-#: ../apps/ll-cli/src/main.cpp:465
+#: ../apps/ll-cli/src/main.cpp:463
 msgid "Usage: ll-cli repo update [OPTIONS] NAME URL"
 msgstr "Uso: ll-cli repo update [OPCIONES] NOMBRE URL"
 
-#: ../apps/ll-cli/src/main.cpp:475 ../apps/ll-builder/src/main.cpp:387
+#: ../apps/ll-cli/src/main.cpp:473 ../apps/ll-builder/src/main.cpp:398
 msgid "Set a default repository name"
 msgstr "Establecer un nombre de repositorio predeterminado"
 
-#: ../apps/ll-cli/src/main.cpp:476
+#: ../apps/ll-cli/src/main.cpp:474
 msgid "Usage: ll-cli repo set-default [OPTIONS] NAME"
 msgstr "Uso: ll-cli repo set-default [OPCIONES] NOMBRE"
 
 #. add repo sub command show
-#: ../apps/ll-cli/src/main.cpp:482 ../apps/ll-builder/src/main.cpp:394
+#: ../apps/ll-cli/src/main.cpp:480 ../apps/ll-builder/src/main.cpp:405
 msgid "Show repository information"
 msgstr "Mostrar información del repositorio"
 
-#: ../apps/ll-cli/src/main.cpp:483
+#: ../apps/ll-cli/src/main.cpp:481
 msgid "Usage: ll-cli repo show [OPTIONS]"
 msgstr "Uso: ll-cli repo show [OPCIONES]"
 
-#: ../apps/ll-cli/src/main.cpp:488
+#: ../apps/ll-cli/src/main.cpp:485
+msgid "Set the priority of the repo"
+msgstr "Establecer la prioridad del repositorio"
+
+#: ../apps/ll-cli/src/main.cpp:486
+msgid "Usage: ll-cli repo set-priority ALIAS PRIORITY"
+msgstr "Uso: ll-cli repo set-priority ALIAS PRIORITY"
+
+#: ../apps/ll-cli/src/main.cpp:491
+msgid "Priority of the repo"
+msgstr "Prioridad del repositorio"
+
+#: ../apps/ll-cli/src/main.cpp:498
 msgid "Display information about installed apps or runtimes"
 msgstr ""
 "Mostrar información sobre aplicaciones o entornos de ejecución instalados"
 
-#: ../apps/ll-cli/src/main.cpp:491
+#: ../apps/ll-cli/src/main.cpp:501
 msgid "Usage: ll-cli info [OPTIONS] APP"
 msgstr "Uso: ll-cli info [OPCIONES] APP"
 
-#: ../apps/ll-cli/src/main.cpp:495
+#: ../apps/ll-cli/src/main.cpp:505
 msgid "Specify the application ID, and it can also be a .layer file"
 msgstr ""
 "Especificar el ID de la aplicación, también puede ser un archivo .layer"
 
-#: ../apps/ll-cli/src/main.cpp:502
+#: ../apps/ll-cli/src/main.cpp:512
 msgid "Display the exported files of installed application"
 msgstr "Mostrar los archivos exportados de la aplicación instalada"
 
-#: ../apps/ll-cli/src/main.cpp:505
+#: ../apps/ll-cli/src/main.cpp:515
 msgid "Usage: ll-cli content [OPTIONS] APP"
 msgstr "Uso: ll-cli content [OPCIONES] APP"
 
-#: ../apps/ll-cli/src/main.cpp:506
+#: ../apps/ll-cli/src/main.cpp:516
 msgid "Specify the installed application ID"
 msgstr "Especificar el ID de la aplicación instalada"
 
 #. add sub command prune
-#: ../apps/ll-cli/src/main.cpp:511
+#: ../apps/ll-cli/src/main.cpp:521
 msgid "Remove the unused base or runtime"
 msgstr "Eliminar la base o el entorno de ejecución no utilizado"
 
-#: ../apps/ll-cli/src/main.cpp:513
+#: ../apps/ll-cli/src/main.cpp:523
 msgid "Usage: ll-cli prune [OPTIONS]"
 msgstr "Uso: ll-cli prune [OPCIONES]"
 
-#: ../apps/ll-cli/src/main.cpp:518
+#: ../apps/ll-cli/src/main.cpp:528
 msgid "Display the information of installed application"
 msgstr "Mostrar la información de la aplicación instalada."
 
-#: ../apps/ll-cli/src/main.cpp:520
+#: ../apps/ll-cli/src/main.cpp:530
 msgid "Usage: ll-cli inspect [OPTIONS]"
 msgstr "Uso: ll-cli inspect [OPCIONES]"
 
-#: ../apps/ll-cli/src/main.cpp:522
+#: ../apps/ll-cli/src/main.cpp:532
 msgid "Specify the process id"
 msgstr "Especifica el ID del proceso"
 
-#: ../apps/ll-cli/src/main.cpp:531
+#: ../apps/ll-cli/src/main.cpp:541
 msgid "Invalid process id"
 msgstr "ID de proceso no válido"
 
-#: ../apps/ll-cli/src/main.cpp:534
+#: ../apps/ll-cli/src/main.cpp:544
 msgid "Invalid pid format"
 msgstr "Formato de PID no válido"
 
-#: ../apps/ll-cli/src/main.cpp:552
+#: ../apps/ll-cli/src/main.cpp:554
+msgid "Specify the installed app(base or runtime)"
+msgstr "Especificar la aplicación instalada (base o runtime)"
+
+#: ../apps/ll-cli/src/main.cpp:565
 msgid "linyaps CLI version "
 msgstr "versión de linyaps CLI "
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:71
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:232
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:76
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:258
 msgid "ID"
 msgstr "ID"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:72
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:77
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:185
 msgid "Name"
 msgstr "Nombre"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:73
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:78
 msgid "Version"
 msgstr "Versión"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:74
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:79
 msgid "Channel"
 msgstr "Canal"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:75
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:80
 msgid "Module"
 msgstr "Módulo"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:76
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:81
 msgid "Description"
 msgstr "Descripción"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:110
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:111
+msgid "No containers are running."
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:115
 msgid "App"
 msgstr "App"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:111
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:116
 msgid "ContainerID"
 msgstr "ContainerID"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:112
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:117
 msgid "Pid"
 msgstr "Pid"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:233
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:186
+msgid "Url"
+msgstr "Url"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:187
+msgid "Alias"
+msgstr "Alias"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:188
+msgid "Priority"
+msgstr "Prioridad"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:246
+msgid "No apps available for update."
+msgstr "No hay aplicaciones disponibles para actualizar."
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:259
 msgid "Installed"
 msgstr "Instalado"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:234
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:260
 msgid "New"
 msgstr "Nuevo"
 
@@ -591,7 +639,7 @@ msgid "Usage: ll-builder build [OPTIONS] [COMMAND...]"
 msgstr "Uso: ll-builder build [OPCIONES] [COMANDO...]"
 
 #: ../apps/ll-builder/src/main.cpp:215 ../apps/ll-builder/src/main.cpp:258
-#: ../apps/ll-builder/src/main.cpp:293 ../apps/ll-builder/src/main.cpp:309
+#: ../apps/ll-builder/src/main.cpp:293 ../apps/ll-builder/src/main.cpp:320
 msgid "File path of the linglong.yaml"
 msgstr "Ruta del archivo de linglong.yaml"
 
@@ -692,104 +740,108 @@ msgstr "Exportar a la capa o uab de linyaps"
 msgid "Usage: ll-builder export [OPTIONS]"
 msgstr "Uso: ll-builder export [OPCIONES]"
 
-#: ../apps/ll-builder/src/main.cpp:297
+#: ../apps/ll-builder/src/main.cpp:303
 msgid "Uab icon (optional)"
 msgstr "Icono de uab (opcional)"
 
-#: ../apps/ll-builder/src/main.cpp:300
+#: ../apps/ll-builder/src/main.cpp:306
 msgid "Export uab fully"
 msgstr "UAB de exportación"
 
-#: ../apps/ll-builder/src/main.cpp:301
+#: ../apps/ll-builder/src/main.cpp:307
 msgid "Export to linyaps layer file"
 msgstr "Exportar al archivo de capa de linyaps"
 
-#: ../apps/ll-builder/src/main.cpp:307
+#: ../apps/ll-builder/src/main.cpp:310
+msgid "Use custom loader"
+msgstr "Usar cargador personalizado"
+
+#: ../apps/ll-builder/src/main.cpp:318
 msgid "Push linyaps app to remote repo"
 msgstr "Enviar la aplicación linyaps al repositorio remoto"
 
-#: ../apps/ll-builder/src/main.cpp:308
+#: ../apps/ll-builder/src/main.cpp:319
 msgid "Usage: ll-builder push [OPTIONS]"
 msgstr "Uso: ll-builder push [OPCIONES]"
 
-#: ../apps/ll-builder/src/main.cpp:313
+#: ../apps/ll-builder/src/main.cpp:324
 msgid "Remote repo url"
 msgstr "URL del repositorio remoto"
 
-#: ../apps/ll-builder/src/main.cpp:316
+#: ../apps/ll-builder/src/main.cpp:327
 msgid "Remote repo name"
 msgstr "Nombre del repositorio remoto"
 
-#: ../apps/ll-builder/src/main.cpp:319
+#: ../apps/ll-builder/src/main.cpp:330
 msgid "Push single module"
 msgstr "Enviar módulo único"
 
-#: ../apps/ll-builder/src/main.cpp:324
+#: ../apps/ll-builder/src/main.cpp:335
 msgid "Import linyaps layer to build repo"
 msgstr "Importar la capa de linyaps para construir el repositorio"
 
-#: ../apps/ll-builder/src/main.cpp:325
+#: ../apps/ll-builder/src/main.cpp:336
 msgid "Usage: ll-builder import [OPTIONS] LAYER"
 msgstr "Uso: ll-builder import [OPCIONES] CAPA"
 
-#: ../apps/ll-builder/src/main.cpp:326 ../apps/ll-builder/src/main.cpp:345
+#: ../apps/ll-builder/src/main.cpp:337 ../apps/ll-builder/src/main.cpp:356
 msgid "Layer file path"
 msgstr "Ruta del archivo de la capa"
 
-#: ../apps/ll-builder/src/main.cpp:334
+#: ../apps/ll-builder/src/main.cpp:345
 msgid "Import linyaps layer dir to build repo"
 msgstr "Importar directorio de capa linyaps al repositorio de compilación"
 
-#: ../apps/ll-builder/src/main.cpp:336
+#: ../apps/ll-builder/src/main.cpp:347
 msgid "Usage: ll-builder import-dir PATH"
 msgstr "Uso: ll-builder import-dir PATH"
 
-#: ../apps/ll-builder/src/main.cpp:337
+#: ../apps/ll-builder/src/main.cpp:348
 msgid "Layer dir path"
 msgstr "Ruta del directorio de capa"
 
-#: ../apps/ll-builder/src/main.cpp:343
+#: ../apps/ll-builder/src/main.cpp:354
 msgid "Extract linyaps layer to dir"
 msgstr "Extraer la capa de linyaps al directorio"
 
-#: ../apps/ll-builder/src/main.cpp:344
+#: ../apps/ll-builder/src/main.cpp:355
 msgid "Usage: ll-builder extract [OPTIONS] LAYER DIR"
 msgstr "Uso: ll-builder extract [OPCIONES] CAPA DIR"
 
-#: ../apps/ll-builder/src/main.cpp:348
+#: ../apps/ll-builder/src/main.cpp:359
 msgid "Destination directory"
 msgstr "Directorio de destino"
 
 #. add build repo
-#: ../apps/ll-builder/src/main.cpp:351
+#: ../apps/ll-builder/src/main.cpp:362
 msgid "Display and manage repositories"
 msgstr "Mostrar y gestionar repositorios"
 
-#: ../apps/ll-builder/src/main.cpp:352
+#: ../apps/ll-builder/src/main.cpp:363
 msgid "Usage: ll-builder repo [OPTIONS] SUBCOMMAND"
 msgstr "Uso: ll-builder repo [OPCIONES] SUBCOMANDO"
 
-#: ../apps/ll-builder/src/main.cpp:357
+#: ../apps/ll-builder/src/main.cpp:368
 msgid "Usage: ll-builder repo add [OPTIONS] NAME URL"
 msgstr "Uso: ll-builder repo add [OPCIONES] NOMBRE URL"
 
-#: ../apps/ll-builder/src/main.cpp:370
+#: ../apps/ll-builder/src/main.cpp:381
 msgid "Usage: ll-builder repo remove [OPTIONS] NAME"
 msgstr "Uso: ll-builder repo remove [OPCIONES] NOMBRE"
 
-#: ../apps/ll-builder/src/main.cpp:377
+#: ../apps/ll-builder/src/main.cpp:388
 msgid "Usage: ll-builder repo update [OPTIONS] NAME URL"
 msgstr "Uso: ll-builder repo update [OPCIONES] NOMBRE URL"
 
-#: ../apps/ll-builder/src/main.cpp:388
+#: ../apps/ll-builder/src/main.cpp:399
 msgid "Usage: ll-builder repo set-default [OPTIONS] NAME"
 msgstr "Uso: ll-builder repo set-default [OPCIONES] NOMBRE"
 
-#: ../apps/ll-builder/src/main.cpp:395
+#: ../apps/ll-builder/src/main.cpp:406
 msgid "Usage: ll-builder repo show [OPTIONS]"
 msgstr "Uso: ll-builder repo show [OPCIONES]"
 
-#: ../apps/ll-builder/src/main.cpp:400
+#: ../apps/ll-builder/src/main.cpp:411
 msgid "linyaps build tool version "
 msgstr "versión de la herramienta de construcción de linyaps "
 
@@ -814,3 +866,195 @@ msgstr "Administrador de paquetes Linglong"
 #: ../apps/ll-dialog/src/cache_dialog.cpp:54
 msgid "is starting"
 msgstr "A partir de"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:526
+msgid "The current version does not support the develop module installation."
+msgstr "La versión actual no admite la instalación del módulo de desarrollo."
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:541
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:805
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1384
+msgid "app arch: %1 not match host architecture"
+msgstr ""
+"arquitectura de la aplicación: %1 no coincide con la arquitectura del host"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:592
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:855
+msgid ""
+"The latest version has been installed. If you want to replace it, try using "
+"'ll-cli install %1 --force'"
+msgstr ""
+"Ya está instalada la última versión. Si deseas reemplazarla, intenta usar "
+"'ll-cli install %1 --force'"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:636
+msgid "installing layer"
+msgstr "instalando capa"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:638
+msgid "preparing environment"
+msgstr "preparando entorno"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:677
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:682
+msgid "install layer successfully"
+msgstr "capa instalada correctamente"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:743
+msgid "queued to install from layer"
+msgstr "en cola para instalación desde capa"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:747
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1292
+msgid "%1 is now installing"
+msgstr "%1 se está instalando"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:766
+msgid "couldn't pass uab verification"
+msgstr "no se pudo pasar la verificación UAB"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:784
+msgid "couldn't find application layer in this uab"
+msgstr "no se encontró la capa de aplicación en este UAB"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:844
+msgid "%1 is already installed"
+msgstr "%1 ya está instalado"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:901
+msgid "installing uab"
+msgstr "instalando UAB"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:903
+msgid "prepare environment"
+msgstr "preparar entorno"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:919
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:930
+msgid "the contents of this uab file are invalid"
+msgstr "el contenido de este archivo UAB no es válido"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:946
+msgid "get status of %1 failed: %2"
+msgstr "falló al obtener el estado de %1: %2"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:951
+msgid "layer directory %1 doesn't exist"
+msgstr "el directorio de capa %1 no existe"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1053
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1358
+msgid "Failed to generate some cache.\n"
+msgstr "Error al generar caché.\n"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1140
+msgid "cannot specify a version when installing a module"
+msgstr "no se puede especificar una versión al instalar un módulo"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1149
+msgid "to install the module, one must first install the app"
+msgstr "para instalar el módulo, primero se debe instalar la aplicación"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1154
+msgid "module is already installed"
+msgstr "el módulo ya está instalado"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1167
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1288
+msgid "queued to install from remote"
+msgstr "en cola para instalación remota"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1182
+msgid "%1 is already installed."
+msgstr "%1 ya está instalado."
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1222
+msgid ""
+"The latest version has been installed. If you want to replace it, try using "
+"'ll-cli install %1/%2 --force'"
+msgstr ""
+"Ya está instalada la última versión. Si deseas reemplazarla, intenta usar "
+"'ll-cli install %1/%2 --force'"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1267
+msgid "canceled"
+msgstr "cancelado"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1302
+msgid "Installing %1"
+msgstr "Instalando %1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1314
+msgid "These modules do not exist remotely: %1"
+msgstr "Estos módulos no existen de forma remota: %1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1330
+msgid "processing after install"
+msgstr "procesando posterior a la instalación"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1349
+msgid "Failed to remove old reference %1 after install %2 : %3"
+msgstr "Error al eliminar la referencia antigua %1 después de instalar %2: %3"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1365
+msgid "Install %1 success"
+msgstr "Instalación de %1 exitosa"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1375
+msgid "Beginning to install"
+msgstr "Comenzando la instalación"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1388
+msgid "Installing application %1"
+msgstr "Instalando aplicación %1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1429
+msgid "install failed"
+msgstr "instalación fallida"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1897
+msgid "Installing runtime %1"
+msgstr "Instalando entorno de ejecución %1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1940
+msgid "Installing base "
+msgstr "Instalando base"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:173
+msgid "Caught error during pulling data, waiting for outstanding task"
+msgstr "Error al obtener datos, esperando tareas pendientes"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:208
+msgid "Downloading metadata"
+msgstr "Descargando metadatos"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:216
+msgid "Downloading delta part"
+msgstr "Descargando partes delta"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:224
+msgid "Downloading files"
+msgstr "Descargando archivos"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:482
+msgid "package not found: %1"
+msgstr "paquete no encontrado: %1"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:1316
+msgid "Cannot find %1/%2 from remote repo"
+msgstr "No se encontró %1/%2 en el repositorio remoto"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:1480
+msgid ""
+"Failed to get response from remote server (network error or server "
+"unavailable)"
+msgstr ""
+"No se pudo obtener respuesta del servidor remoto (error de red o servidor no "
+"disponible)"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:1489
+msgid ""
+"Remote server returned error code: %1 (network error or server unavailable)"
+msgstr ""
+"El servidor remoto devolvió el código de error: %1 (error de red o servidor "
+"no disponible)"

--- a/po/linyaps.pot
+++ b/po/linyaps.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-20 14:54+0800\n"
+"POT-Creation-Date: 2025-03-27 18:02+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,87 +17,88 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:56
+#: ../libs/linglong/src/linglong/cli/cli.cpp:58
 msgid "Permission deny, please check whether you are running as root."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2579
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2571
 msgid ""
 "The cache generation failed, please uninstall and reinstall the application."
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:158
+#: ../apps/ll-cli/src/main.cpp:147
 msgid ""
 "linyaps CLI\n"
 "A CLI program to run application and manage application and runtime\n"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:165 ../apps/ll-builder/src/main.cpp:172
+#: ../apps/ll-cli/src/main.cpp:159 ../apps/ll-builder/src/main.cpp:172
 msgid "Print this help message and exit"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:166 ../apps/ll-builder/src/main.cpp:173
+#: ../apps/ll-cli/src/main.cpp:160 ../apps/ll-builder/src/main.cpp:173
 msgid "Expand all help"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:167
+#: ../apps/ll-cli/src/main.cpp:161
 msgid "Usage: ll-cli [OPTIONS] [SUBCOMMAND]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:168
+#: ../apps/ll-cli/src/main.cpp:162
 msgid ""
 "If you found any problems during use,\n"
 "You can report bugs to the linyaps team under this project: https://github."
 "com/OpenAtom-Linyaps/linyaps/issues"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:178 ../apps/ll-builder/src/main.cpp:194
+#. add flags
+#: ../apps/ll-cli/src/main.cpp:169 ../apps/ll-builder/src/main.cpp:194
 msgid "Show version"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:182
+#: ../apps/ll-cli/src/main.cpp:173
 msgid ""
 "Use peer to peer DBus, this is used only in case that DBus daemon is not "
 "available"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:185
+#: ../apps/ll-cli/src/main.cpp:177
 msgid "Use json format to output result"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:191 ../apps/ll-cli/src/main.cpp:525
+#: ../apps/ll-cli/src/main.cpp:184 ../apps/ll-cli/src/main.cpp:535
 #: ../apps/ll-builder/src/main.cpp:185
 msgid "Input parameter is empty, please input valid parameter instead"
 msgstr ""
 
 #. groups
-#: ../apps/ll-cli/src/main.cpp:214
+#: ../apps/ll-cli/src/main.cpp:207
 msgid "Managing installed applications and runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:215
+#: ../apps/ll-cli/src/main.cpp:208
 msgid "Managing running applications"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:216
+#: ../apps/ll-cli/src/main.cpp:209
 msgid "Finding applications and runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:217
+#: ../apps/ll-cli/src/main.cpp:210
 msgid "Managing remote repositories"
 msgstr ""
 
 #. add sub command run
-#: ../apps/ll-cli/src/main.cpp:220
+#: ../apps/ll-cli/src/main.cpp:213
 msgid "Run an application"
 msgstr ""
 
 #. add sub command run options
-#: ../apps/ll-cli/src/main.cpp:225
+#: ../apps/ll-cli/src/main.cpp:218
 msgid "Specify the application ID"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:228
+#: ../apps/ll-cli/src/main.cpp:221
 msgid ""
 "Usage: ll-cli run [OPTIONS] APP [COMMAND...]\n"
 "\n"
@@ -110,70 +111,70 @@ msgid ""
 "ll-cli run org.deepin.demo -- bash -x /path/to/bash/script"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:238
+#: ../apps/ll-cli/src/main.cpp:231
 msgid "Pass file to applications running in a sandbox"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:242
+#: ../apps/ll-cli/src/main.cpp:235
 msgid "Pass url to applications running in a sandbox"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:245 ../apps/ll-cli/src/main.cpp:267
-#: ../apps/ll-cli/src/main.cpp:284
+#: ../apps/ll-cli/src/main.cpp:238 ../apps/ll-cli/src/main.cpp:260
+#: ../apps/ll-cli/src/main.cpp:277
 msgid "Run commands in a running sandbox"
 msgstr ""
 
 #. add sub command ps
-#: ../apps/ll-cli/src/main.cpp:248
+#: ../apps/ll-cli/src/main.cpp:241
 msgid "List running applications"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:251
+#: ../apps/ll-cli/src/main.cpp:244
 msgid "Usage: ll-cli ps [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:255
+#: ../apps/ll-cli/src/main.cpp:248
 msgid "Execute commands in the currently running sandbox"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:261 ../apps/ll-cli/src/main.cpp:279
+#: ../apps/ll-cli/src/main.cpp:254 ../apps/ll-cli/src/main.cpp:272
 msgid "Specify the application running instance(you can get it by ps command)"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:264 ../apps/ll-cli/src/main.cpp:281
+#: ../apps/ll-cli/src/main.cpp:257 ../apps/ll-cli/src/main.cpp:274
 msgid "Specify working directory"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:272
+#: ../apps/ll-cli/src/main.cpp:265
 msgid "Enter the namespace where the application is running"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:275
+#: ../apps/ll-cli/src/main.cpp:268
 msgid "Usage: ll-cli enter [OPTIONS] INSTANCE [COMMAND...]"
 msgstr ""
 
 #. add sub command kill
-#: ../apps/ll-cli/src/main.cpp:287
+#: ../apps/ll-cli/src/main.cpp:280
 msgid "Stop running applications"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:290
+#: ../apps/ll-cli/src/main.cpp:283
 msgid "Usage: ll-cli kill [OPTIONS] APP"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:294
+#: ../apps/ll-cli/src/main.cpp:287
 msgid "Specify the signal to send to the application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:296
+#: ../apps/ll-cli/src/main.cpp:289
 msgid "Specify the running application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:302
+#: ../apps/ll-cli/src/main.cpp:295
 msgid "Installing an application or runtime"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:305
+#: ../apps/ll-cli/src/main.cpp:298
 msgid ""
 "Usage: ll-cli install [OPTIONS] APP\n"
 "\n"
@@ -193,59 +194,68 @@ msgid ""
 "    "
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:324
+#: ../apps/ll-cli/src/main.cpp:317
 msgid "Specify the application ID, and it can also be a .uab or .layer file"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:327
+#: ../apps/ll-cli/src/main.cpp:320
 msgid "Install a specify module"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:330
+#: ../apps/ll-cli/src/main.cpp:323
 msgid "Force install the application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:331
+#: ../apps/ll-cli/src/main.cpp:324
 msgid "Automatically answer yes to all questions"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:339
+#: ../apps/ll-cli/src/main.cpp:330
 msgid "Uninstall the application or runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:342
+#: ../apps/ll-cli/src/main.cpp:333
 msgid "Usage: ll-cli uninstall [OPTIONS] APP"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:343
+#: ../apps/ll-cli/src/main.cpp:334
 msgid "Specify the applications ID"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:346
+#: ../apps/ll-cli/src/main.cpp:337
 msgid "Uninstall a specify module"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:354
+#. below options are used for compatibility with old ll-cli
+#: ../apps/ll-cli/src/main.cpp:342
+msgid "Remove all unused modules"
+msgstr ""
+
+#: ../apps/ll-cli/src/main.cpp:346
+msgid "Uninstall all modules"
+msgstr ""
+
+#: ../apps/ll-cli/src/main.cpp:352
 msgid "Upgrade the application or runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:357
+#: ../apps/ll-cli/src/main.cpp:355
 msgid "Usage: ll-cli upgrade [OPTIONS] [APP]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:361
+#: ../apps/ll-cli/src/main.cpp:359
 msgid ""
 "Specify the application ID.If it not be specified, all applications will be "
 "upgraded"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:368
+#: ../apps/ll-cli/src/main.cpp:366
 msgid ""
 "Search the applications/runtimes containing the specified text from the "
 "remote repository"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:372
+#: ../apps/ll-cli/src/main.cpp:370
 msgid ""
 "Usage: ll-cli search [OPTIONS] KEYWORDS\n"
 "\n"
@@ -260,27 +270,27 @@ msgid ""
 "ll-cli search . --type=runtime"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:383
+#: ../apps/ll-cli/src/main.cpp:381
 msgid "Specify the Keywords"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:389 ../apps/ll-cli/src/main.cpp:414
+#: ../apps/ll-cli/src/main.cpp:387 ../apps/ll-cli/src/main.cpp:412
 msgid "Filter result with specify type. One of \"runtime\", \"app\" or \"all\""
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:393
+#: ../apps/ll-cli/src/main.cpp:391
 msgid "include develop application in result"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:394
+#: ../apps/ll-cli/src/main.cpp:392
 msgid "Show all results"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:398
+#: ../apps/ll-cli/src/main.cpp:396
 msgid "List installed applications or runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:401
+#: ../apps/ll-cli/src/main.cpp:399
 msgid ""
 "Usage: ll-cli list [OPTIONS]\n"
 "\n"
@@ -293,187 +303,225 @@ msgid ""
 "ll-cli list --upgradable\n"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:420
+#: ../apps/ll-cli/src/main.cpp:418
 msgid ""
 "Show the list of latest version of the currently installed applications, it "
 "only works for app"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:427
+#: ../apps/ll-cli/src/main.cpp:425
 msgid "Display or modify information of the repository currently using"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:429
+#: ../apps/ll-cli/src/main.cpp:427
 msgid "Usage: ll-cli repo SUBCOMMAND [OPTIONS]"
 msgstr ""
 
 #. add repo sub command add
-#: ../apps/ll-cli/src/main.cpp:433 ../apps/ll-builder/src/main.cpp:356
+#: ../apps/ll-cli/src/main.cpp:431 ../apps/ll-builder/src/main.cpp:367
 msgid "Add a new repository"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:434
+#: ../apps/ll-cli/src/main.cpp:432
 msgid "Usage: ll-cli repo add [OPTIONS] NAME URL"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:435 ../apps/ll-cli/src/main.cpp:448
-#: ../apps/ll-builder/src/main.cpp:358
+#: ../apps/ll-cli/src/main.cpp:433 ../apps/ll-cli/src/main.cpp:446
+#: ../apps/ll-builder/src/main.cpp:369
 msgid "Specify the repo name"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:438 ../apps/ll-cli/src/main.cpp:451
-#: ../apps/ll-cli/src/main.cpp:469 ../apps/ll-builder/src/main.cpp:361
-#: ../apps/ll-builder/src/main.cpp:381
+#: ../apps/ll-cli/src/main.cpp:436 ../apps/ll-cli/src/main.cpp:449
+#: ../apps/ll-cli/src/main.cpp:467 ../apps/ll-builder/src/main.cpp:372
+#: ../apps/ll-builder/src/main.cpp:392
 msgid "Url of the repository"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:441 ../apps/ll-cli/src/main.cpp:458
-#: ../apps/ll-cli/src/main.cpp:466 ../apps/ll-cli/src/main.cpp:477
-#: ../apps/ll-builder/src/main.cpp:364 ../apps/ll-builder/src/main.cpp:371
-#: ../apps/ll-builder/src/main.cpp:378 ../apps/ll-builder/src/main.cpp:389
+#: ../apps/ll-cli/src/main.cpp:439 ../apps/ll-cli/src/main.cpp:456
+#: ../apps/ll-cli/src/main.cpp:464 ../apps/ll-cli/src/main.cpp:475
+#: ../apps/ll-cli/src/main.cpp:487 ../apps/ll-builder/src/main.cpp:375
+#: ../apps/ll-builder/src/main.cpp:382 ../apps/ll-builder/src/main.cpp:389
+#: ../apps/ll-builder/src/main.cpp:400
 msgid "Alias of the repo name"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:447
+#: ../apps/ll-cli/src/main.cpp:445
 msgid "Modify repository URL"
 msgstr ""
 
 #. add repo sub command remove
-#: ../apps/ll-cli/src/main.cpp:456 ../apps/ll-builder/src/main.cpp:369
+#: ../apps/ll-cli/src/main.cpp:454 ../apps/ll-builder/src/main.cpp:380
 msgid "Remove a repository"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:457
+#: ../apps/ll-cli/src/main.cpp:455
 msgid "Usage: ll-cli repo remove [OPTIONS] NAME"
 msgstr ""
 
 #. add repo sub command update
 #. TODO: add --repo and --url options
 #. add repo sub command update
-#: ../apps/ll-cli/src/main.cpp:464 ../apps/ll-builder/src/main.cpp:376
+#: ../apps/ll-cli/src/main.cpp:462 ../apps/ll-builder/src/main.cpp:387
 msgid "Update the repository URL"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:465
+#: ../apps/ll-cli/src/main.cpp:463
 msgid "Usage: ll-cli repo update [OPTIONS] NAME URL"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:475 ../apps/ll-builder/src/main.cpp:387
+#: ../apps/ll-cli/src/main.cpp:473 ../apps/ll-builder/src/main.cpp:398
 msgid "Set a default repository name"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:476
+#: ../apps/ll-cli/src/main.cpp:474
 msgid "Usage: ll-cli repo set-default [OPTIONS] NAME"
 msgstr ""
 
 #. add repo sub command show
-#: ../apps/ll-cli/src/main.cpp:482 ../apps/ll-builder/src/main.cpp:394
+#: ../apps/ll-cli/src/main.cpp:480 ../apps/ll-builder/src/main.cpp:405
 msgid "Show repository information"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:483
+#: ../apps/ll-cli/src/main.cpp:481
 msgid "Usage: ll-cli repo show [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:488
-msgid "Display information about installed apps or runtimes"
+#: ../apps/ll-cli/src/main.cpp:485
+msgid "Set the priority of the repo"
+msgstr ""
+
+#: ../apps/ll-cli/src/main.cpp:486
+msgid "Usage: ll-cli repo set-priority ALIAS PRIORITY"
 msgstr ""
 
 #: ../apps/ll-cli/src/main.cpp:491
+msgid "Priority of the repo"
+msgstr ""
+
+#: ../apps/ll-cli/src/main.cpp:498
+msgid "Display information about installed apps or runtimes"
+msgstr ""
+
+#: ../apps/ll-cli/src/main.cpp:501
 msgid "Usage: ll-cli info [OPTIONS] APP"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:495
+#: ../apps/ll-cli/src/main.cpp:505
 msgid "Specify the application ID, and it can also be a .layer file"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:502
+#: ../apps/ll-cli/src/main.cpp:512
 msgid "Display the exported files of installed application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:505
+#: ../apps/ll-cli/src/main.cpp:515
 msgid "Usage: ll-cli content [OPTIONS] APP"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:506
+#: ../apps/ll-cli/src/main.cpp:516
 msgid "Specify the installed application ID"
 msgstr ""
 
 #. add sub command prune
-#: ../apps/ll-cli/src/main.cpp:511
+#: ../apps/ll-cli/src/main.cpp:521
 msgid "Remove the unused base or runtime"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:513
+#: ../apps/ll-cli/src/main.cpp:523
 msgid "Usage: ll-cli prune [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:518
+#: ../apps/ll-cli/src/main.cpp:528
 msgid "Display the information of installed application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:520
+#: ../apps/ll-cli/src/main.cpp:530
 msgid "Usage: ll-cli inspect [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:522
+#: ../apps/ll-cli/src/main.cpp:532
 msgid "Specify the process id"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:531
+#: ../apps/ll-cli/src/main.cpp:541
 msgid "Invalid process id"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:534
+#: ../apps/ll-cli/src/main.cpp:544
 msgid "Invalid pid format"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:552
+#: ../apps/ll-cli/src/main.cpp:554
+msgid "Specify the installed app(base or runtime)"
+msgstr ""
+
+#: ../apps/ll-cli/src/main.cpp:565
 msgid "linyaps CLI version "
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:71
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:232
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:76
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:258
 msgid "ID"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:72
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:77
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:185
 msgid "Name"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:73
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:78
 msgid "Version"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:74
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:79
 msgid "Channel"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:75
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:80
 msgid "Module"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:76
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:81
 msgid "Description"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:110
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:111
+msgid "No containers are running."
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:115
 msgid "App"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:111
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:116
 msgid "ContainerID"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:112
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:117
 msgid "Pid"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:233
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:186
+msgid "Url"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:187
+msgid "Alias"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:188
+msgid "Priority"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:246
+msgid "No apps available for update."
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:259
 msgid "Installed"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:234
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:260
 msgid "New"
 msgstr ""
 
@@ -515,7 +563,7 @@ msgid "Usage: ll-builder build [OPTIONS] [COMMAND...]"
 msgstr ""
 
 #: ../apps/ll-builder/src/main.cpp:215 ../apps/ll-builder/src/main.cpp:258
-#: ../apps/ll-builder/src/main.cpp:293 ../apps/ll-builder/src/main.cpp:309
+#: ../apps/ll-builder/src/main.cpp:293 ../apps/ll-builder/src/main.cpp:320
 msgid "File path of the linglong.yaml"
 msgstr ""
 
@@ -609,104 +657,108 @@ msgstr ""
 msgid "Usage: ll-builder export [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:297
+#: ../apps/ll-builder/src/main.cpp:303
 msgid "Uab icon (optional)"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:300
+#: ../apps/ll-builder/src/main.cpp:306
 msgid "Export uab fully"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:301
+#: ../apps/ll-builder/src/main.cpp:307
 msgid "Export to linyaps layer file"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:307
+#: ../apps/ll-builder/src/main.cpp:310
+msgid "Use custom loader"
+msgstr ""
+
+#: ../apps/ll-builder/src/main.cpp:318
 msgid "Push linyaps app to remote repo"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:308
+#: ../apps/ll-builder/src/main.cpp:319
 msgid "Usage: ll-builder push [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:313
+#: ../apps/ll-builder/src/main.cpp:324
 msgid "Remote repo url"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:316
+#: ../apps/ll-builder/src/main.cpp:327
 msgid "Remote repo name"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:319
+#: ../apps/ll-builder/src/main.cpp:330
 msgid "Push single module"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:324
+#: ../apps/ll-builder/src/main.cpp:335
 msgid "Import linyaps layer to build repo"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:325
+#: ../apps/ll-builder/src/main.cpp:336
 msgid "Usage: ll-builder import [OPTIONS] LAYER"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:326 ../apps/ll-builder/src/main.cpp:345
+#: ../apps/ll-builder/src/main.cpp:337 ../apps/ll-builder/src/main.cpp:356
 msgid "Layer file path"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:334
+#: ../apps/ll-builder/src/main.cpp:345
 msgid "Import linyaps layer dir to build repo"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:336
+#: ../apps/ll-builder/src/main.cpp:347
 msgid "Usage: ll-builder import-dir PATH"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:337
+#: ../apps/ll-builder/src/main.cpp:348
 msgid "Layer dir path"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:343
+#: ../apps/ll-builder/src/main.cpp:354
 msgid "Extract linyaps layer to dir"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:344
+#: ../apps/ll-builder/src/main.cpp:355
 msgid "Usage: ll-builder extract [OPTIONS] LAYER DIR"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:348
+#: ../apps/ll-builder/src/main.cpp:359
 msgid "Destination directory"
 msgstr ""
 
 #. add build repo
-#: ../apps/ll-builder/src/main.cpp:351
+#: ../apps/ll-builder/src/main.cpp:362
 msgid "Display and manage repositories"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:352
+#: ../apps/ll-builder/src/main.cpp:363
 msgid "Usage: ll-builder repo [OPTIONS] SUBCOMMAND"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:357
+#: ../apps/ll-builder/src/main.cpp:368
 msgid "Usage: ll-builder repo add [OPTIONS] NAME URL"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:370
+#: ../apps/ll-builder/src/main.cpp:381
 msgid "Usage: ll-builder repo remove [OPTIONS] NAME"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:377
+#: ../apps/ll-builder/src/main.cpp:388
 msgid "Usage: ll-builder repo update [OPTIONS] NAME URL"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:388
+#: ../apps/ll-builder/src/main.cpp:399
 msgid "Usage: ll-builder repo set-default [OPTIONS] NAME"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:395
+#: ../apps/ll-builder/src/main.cpp:406
 msgid "Usage: ll-builder repo show [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:400
+#: ../apps/ll-builder/src/main.cpp:411
 msgid "linyaps build tool version "
 msgstr ""
 
@@ -730,4 +782,187 @@ msgstr ""
 
 #: ../apps/ll-dialog/src/cache_dialog.cpp:54
 msgid "is starting"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:526
+msgid "The current version does not support the develop module installation."
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:541
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:805
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1384
+msgid "app arch: %1 not match host architecture"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:592
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:855
+msgid ""
+"The latest version has been installed. If you want to replace it, try using "
+"'ll-cli install %1 --force'"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:636
+msgid "installing layer"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:638
+msgid "preparing environment"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:677
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:682
+msgid "install layer successfully"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:743
+msgid "queued to install from layer"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:747
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1292
+msgid "%1 is now installing"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:766
+msgid "couldn't pass uab verification"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:784
+msgid "couldn't find application layer in this uab"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:844
+msgid "%1 is already installed"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:901
+msgid "installing uab"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:903
+msgid "prepare environment"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:919
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:930
+msgid "the contents of this uab file are invalid"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:946
+msgid "get status of %1 failed: %2"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:951
+msgid "layer directory %1 doesn't exist"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1053
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1358
+msgid "Failed to generate some cache.\n"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1140
+msgid "cannot specify a version when installing a module"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1149
+msgid "to install the module, one must first install the app"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1154
+msgid "module is already installed"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1167
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1288
+msgid "queued to install from remote"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1182
+msgid "%1 is already installed."
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1222
+msgid ""
+"The latest version has been installed. If you want to replace it, try using "
+"'ll-cli install %1/%2 --force'"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1267
+msgid "canceled"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1302
+msgid "Installing %1"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1314
+msgid "These modules do not exist remotely: %1"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1330
+msgid "processing after install"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1349
+msgid "Failed to remove old reference %1 after install %2 : %3"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1365
+msgid "Install %1 success"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1375
+msgid "Beginning to install"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1388
+msgid "Installing application %1"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1429
+msgid "install failed"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1897
+msgid "Installing runtime %1"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1940
+msgid "Installing base "
+msgstr ""
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:173
+msgid "Caught error during pulling data, waiting for outstanding task"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:208
+msgid "Downloading metadata"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:216
+msgid "Downloading delta part"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:224
+msgid "Downloading files"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:482
+msgid "package not found: %1"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:1316
+msgid "Cannot find %1/%2 from remote repo"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:1480
+msgid ""
+"Failed to get response from remote server (network error or server "
+"unavailable)"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:1489
+msgid ""
+"Remote server returned error code: %1 (network error or server unavailable)"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,25 +8,25 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-20 14:54+0800\n"
+"POT-Creation-Date: 2025-03-27 18:02+0800\n"
 "PO-Revision-Date: 2025-01-07 17:11+0800\n"
 "Last-Translator:  deepiner, 2024\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Content-Transfer-Encyoding: 8bit\n"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:56
+#: ../libs/linglong/src/linglong/cli/cli.cpp:58
 msgid "Permission deny, please check whether you are running as root."
 msgstr "权限被拒绝，请检查是否以 root 身份运行。"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2579
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2571
 msgid ""
 "The cache generation failed, please uninstall and reinstall the application."
 msgstr "缓存生成失败，请卸载并重新安装该应用程序。"
 
-#: ../apps/ll-cli/src/main.cpp:158
+#: ../apps/ll-cli/src/main.cpp:147
 msgid ""
 "linyaps CLI\n"
 "A CLI program to run application and manage application and runtime\n"
@@ -34,19 +34,19 @@ msgstr ""
 "如意玲珑 CLI\n"
 "一个用于运行应用程序和管理应用程序和运行时的命令行工具\n"
 
-#: ../apps/ll-cli/src/main.cpp:165 ../apps/ll-builder/src/main.cpp:172
+#: ../apps/ll-cli/src/main.cpp:159 ../apps/ll-builder/src/main.cpp:172
 msgid "Print this help message and exit"
 msgstr "打印帮助信息并退出"
 
-#: ../apps/ll-cli/src/main.cpp:166 ../apps/ll-builder/src/main.cpp:173
+#: ../apps/ll-cli/src/main.cpp:160 ../apps/ll-builder/src/main.cpp:173
 msgid "Expand all help"
 msgstr "展开所有帮助"
 
-#: ../apps/ll-cli/src/main.cpp:167
+#: ../apps/ll-cli/src/main.cpp:161
 msgid "Usage: ll-cli [OPTIONS] [SUBCOMMAND]"
 msgstr "用法: ll-cli [选项] [子命令]"
 
-#: ../apps/ll-cli/src/main.cpp:168
+#: ../apps/ll-cli/src/main.cpp:162
 msgid ""
 "If you found any problems during use,\n"
 "You can report bugs to the linyaps team under this project: https://github."
@@ -56,53 +56,54 @@ msgstr ""
 "您可以通过此项目向如意玲珑项目团队报告错误：https://github.com/OpenAtom-"
 "Linyaps/linyaps/issues"
 
-#: ../apps/ll-cli/src/main.cpp:178 ../apps/ll-builder/src/main.cpp:194
+#. add flags
+#: ../apps/ll-cli/src/main.cpp:169 ../apps/ll-builder/src/main.cpp:194
 msgid "Show version"
 msgstr "显示版本"
 
-#: ../apps/ll-cli/src/main.cpp:182
+#: ../apps/ll-cli/src/main.cpp:173
 msgid ""
 "Use peer to peer DBus, this is used only in case that DBus daemon is not "
 "available"
 msgstr "使用点对点 DBus，仅在 DBus 守护程序不可用时使用"
 
-#: ../apps/ll-cli/src/main.cpp:185
+#: ../apps/ll-cli/src/main.cpp:177
 msgid "Use json format to output result"
 msgstr "使用json格式输出结果"
 
-#: ../apps/ll-cli/src/main.cpp:191 ../apps/ll-cli/src/main.cpp:525
+#: ../apps/ll-cli/src/main.cpp:184 ../apps/ll-cli/src/main.cpp:535
 #: ../apps/ll-builder/src/main.cpp:185
 msgid "Input parameter is empty, please input valid parameter instead"
 msgstr "输入参数为空，请输入有效参数"
 
 #. groups
-#: ../apps/ll-cli/src/main.cpp:214
+#: ../apps/ll-cli/src/main.cpp:207
 msgid "Managing installed applications and runtimes"
 msgstr "管理已安装的应用程序和运行时"
 
-#: ../apps/ll-cli/src/main.cpp:215
+#: ../apps/ll-cli/src/main.cpp:208
 msgid "Managing running applications"
 msgstr "管理正在运行的应用程序"
 
-#: ../apps/ll-cli/src/main.cpp:216
+#: ../apps/ll-cli/src/main.cpp:209
 msgid "Finding applications and runtimes"
 msgstr "查找应用程序和运行时"
 
-#: ../apps/ll-cli/src/main.cpp:217
+#: ../apps/ll-cli/src/main.cpp:210
 msgid "Managing remote repositories"
 msgstr "管理仓库"
 
 #. add sub command run
-#: ../apps/ll-cli/src/main.cpp:220
+#: ../apps/ll-cli/src/main.cpp:213
 msgid "Run an application"
 msgstr "运行应用程序"
 
 #. add sub command run options
-#: ../apps/ll-cli/src/main.cpp:225
+#: ../apps/ll-cli/src/main.cpp:218
 msgid "Specify the application ID"
 msgstr "指定应用程序名"
 
-#: ../apps/ll-cli/src/main.cpp:228
+#: ../apps/ll-cli/src/main.cpp:221
 msgid ""
 "Usage: ll-cli run [OPTIONS] APP [COMMAND...]\n"
 "\n"
@@ -124,70 +125,70 @@ msgstr ""
 "ll-cli run org.deepin.demo -- bash\n"
 "ll-cli run org.deepin.demo -- bash -x /path/to/bash/script"
 
-#: ../apps/ll-cli/src/main.cpp:238
+#: ../apps/ll-cli/src/main.cpp:231
 msgid "Pass file to applications running in a sandbox"
 msgstr "将文件传递到沙盒中运行的应用程序"
 
-#: ../apps/ll-cli/src/main.cpp:242
+#: ../apps/ll-cli/src/main.cpp:235
 msgid "Pass url to applications running in a sandbox"
 msgstr "将URL传递到沙盒中运行的应用程序"
 
-#: ../apps/ll-cli/src/main.cpp:245 ../apps/ll-cli/src/main.cpp:267
-#: ../apps/ll-cli/src/main.cpp:284
+#: ../apps/ll-cli/src/main.cpp:238 ../apps/ll-cli/src/main.cpp:260
+#: ../apps/ll-cli/src/main.cpp:277
 msgid "Run commands in a running sandbox"
 msgstr "在正在运行的沙盒中运行命令"
 
 #. add sub command ps
-#: ../apps/ll-cli/src/main.cpp:248
+#: ../apps/ll-cli/src/main.cpp:241
 msgid "List running applications"
 msgstr "列出正在运行的应用程序"
 
-#: ../apps/ll-cli/src/main.cpp:251
+#: ../apps/ll-cli/src/main.cpp:244
 msgid "Usage: ll-cli ps [OPTIONS]"
 msgstr "用法: ll-cli ps [选项]"
 
-#: ../apps/ll-cli/src/main.cpp:255
+#: ../apps/ll-cli/src/main.cpp:248
 msgid "Execute commands in the currently running sandbox"
 msgstr "在当前运行的沙盒中执行命令。"
 
-#: ../apps/ll-cli/src/main.cpp:261 ../apps/ll-cli/src/main.cpp:279
+#: ../apps/ll-cli/src/main.cpp:254 ../apps/ll-cli/src/main.cpp:272
 msgid "Specify the application running instance(you can get it by ps command)"
 msgstr "指定正在运行的应用程序实例（可以通过 ps 命令获取）"
 
-#: ../apps/ll-cli/src/main.cpp:264 ../apps/ll-cli/src/main.cpp:281
+#: ../apps/ll-cli/src/main.cpp:257 ../apps/ll-cli/src/main.cpp:274
 msgid "Specify working directory"
 msgstr "指定工作目录"
 
-#: ../apps/ll-cli/src/main.cpp:272
+#: ../apps/ll-cli/src/main.cpp:265
 msgid "Enter the namespace where the application is running"
 msgstr "进入应用程序正在运行的命名空间"
 
-#: ../apps/ll-cli/src/main.cpp:275
+#: ../apps/ll-cli/src/main.cpp:268
 msgid "Usage: ll-cli enter [OPTIONS] INSTANCE [COMMAND...]"
 msgstr "用法: ll-cli enter [选项] 实例 [命令...]"
 
 #. add sub command kill
-#: ../apps/ll-cli/src/main.cpp:287
+#: ../apps/ll-cli/src/main.cpp:280
 msgid "Stop running applications"
 msgstr "停止运行的应用程序"
 
-#: ../apps/ll-cli/src/main.cpp:290
+#: ../apps/ll-cli/src/main.cpp:283
 msgid "Usage: ll-cli kill [OPTIONS] APP"
 msgstr "用法: ll-cli kill [选项] 应用"
 
-#: ../apps/ll-cli/src/main.cpp:294
+#: ../apps/ll-cli/src/main.cpp:287
 msgid "Specify the signal to send to the application"
 msgstr "指定已安装应用程序名"
 
-#: ../apps/ll-cli/src/main.cpp:296
+#: ../apps/ll-cli/src/main.cpp:289
 msgid "Specify the running application"
 msgstr "指定正在运行的应用程序名"
 
-#: ../apps/ll-cli/src/main.cpp:302
+#: ../apps/ll-cli/src/main.cpp:295
 msgid "Installing an application or runtime"
 msgstr "安装应用程序或运行时"
 
-#: ../apps/ll-cli/src/main.cpp:305
+#: ../apps/ll-cli/src/main.cpp:298
 msgid ""
 "Usage: ll-cli install [OPTIONS] APP\n"
 "\n"
@@ -223,59 +224,68 @@ msgstr ""
 "ll-cli install stable:org.deepin.demo/0.0.0.1/x86_64\n"
 "    "
 
-#: ../apps/ll-cli/src/main.cpp:324
+#: ../apps/ll-cli/src/main.cpp:317
 msgid "Specify the application ID, and it can also be a .uab or .layer file"
 msgstr "指定应用名，也可以是 .uab 或 .layer 文件"
 
-#: ../apps/ll-cli/src/main.cpp:327
+#: ../apps/ll-cli/src/main.cpp:320
 msgid "Install a specify module"
 msgstr "安装指定模块"
 
-#: ../apps/ll-cli/src/main.cpp:330
+#: ../apps/ll-cli/src/main.cpp:323
 msgid "Force install the application"
 msgstr "强制安装指定版本的应用程序"
 
-#: ../apps/ll-cli/src/main.cpp:331
+#: ../apps/ll-cli/src/main.cpp:324
 msgid "Automatically answer yes to all questions"
 msgstr "自动对所有问题回答是"
 
-#: ../apps/ll-cli/src/main.cpp:339
+#: ../apps/ll-cli/src/main.cpp:330
 msgid "Uninstall the application or runtimes"
 msgstr "卸载应用程序或运行时"
 
-#: ../apps/ll-cli/src/main.cpp:342
+#: ../apps/ll-cli/src/main.cpp:333
 msgid "Usage: ll-cli uninstall [OPTIONS] APP"
 msgstr "用法: ll-cli uninstall [选项] 应用"
 
-#: ../apps/ll-cli/src/main.cpp:343
+#: ../apps/ll-cli/src/main.cpp:334
 msgid "Specify the applications ID"
 msgstr "指定应用程序名"
 
-#: ../apps/ll-cli/src/main.cpp:346
+#: ../apps/ll-cli/src/main.cpp:337
 msgid "Uninstall a specify module"
 msgstr "卸载指定模块"
 
-#: ../apps/ll-cli/src/main.cpp:354
+#. below options are used for compatibility with old ll-cli
+#: ../apps/ll-cli/src/main.cpp:342
+msgid "Remove all unused modules"
+msgstr "移除所有不使用的模块"
+
+#: ../apps/ll-cli/src/main.cpp:346
+msgid "Uninstall all modules"
+msgstr "卸载所有模块"
+
+#: ../apps/ll-cli/src/main.cpp:352
 msgid "Upgrade the application or runtimes"
 msgstr "升级应用程序或运行时"
 
-#: ../apps/ll-cli/src/main.cpp:357
+#: ../apps/ll-cli/src/main.cpp:355
 msgid "Usage: ll-cli upgrade [OPTIONS] [APP]"
 msgstr "用法: ll-cli upgrade [选项] [应用]"
 
-#: ../apps/ll-cli/src/main.cpp:361
+#: ../apps/ll-cli/src/main.cpp:359
 msgid ""
 "Specify the application ID.If it not be specified, all applications will be "
 "upgraded"
 msgstr "指定应用程序名。如果未指定，将升级所有可升级的应用程序"
 
-#: ../apps/ll-cli/src/main.cpp:368
+#: ../apps/ll-cli/src/main.cpp:366
 msgid ""
 "Search the applications/runtimes containing the specified text from the "
 "remote repository"
 msgstr "从远程仓库中搜索包含指定关键词的应用程序/运行时"
 
-#: ../apps/ll-cli/src/main.cpp:372
+#: ../apps/ll-cli/src/main.cpp:370
 msgid ""
 "Usage: ll-cli search [OPTIONS] KEYWORDS\n"
 "\n"
@@ -301,27 +311,27 @@ msgstr ""
 "# 从远程仓库搜索所有运行时\n"
 "ll-cli search . --type=runtime"
 
-#: ../apps/ll-cli/src/main.cpp:383
+#: ../apps/ll-cli/src/main.cpp:381
 msgid "Specify the Keywords"
 msgstr "指定搜索关键词"
 
-#: ../apps/ll-cli/src/main.cpp:389 ../apps/ll-cli/src/main.cpp:414
+#: ../apps/ll-cli/src/main.cpp:387 ../apps/ll-cli/src/main.cpp:412
 msgid "Filter result with specify type. One of \"runtime\", \"app\" or \"all\""
 msgstr "使用指定类型过滤结果。“runtime”、“app”或“all”之一"
 
-#: ../apps/ll-cli/src/main.cpp:393
+#: ../apps/ll-cli/src/main.cpp:391
 msgid "include develop application in result"
 msgstr "搜索结果中包括应用调试包"
 
-#: ../apps/ll-cli/src/main.cpp:394
+#: ../apps/ll-cli/src/main.cpp:392
 msgid "Show all results"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:398
+#: ../apps/ll-cli/src/main.cpp:396
 msgid "List installed applications or runtimes"
 msgstr "列出已安装的应用程序或运行时"
 
-#: ../apps/ll-cli/src/main.cpp:401
+#: ../apps/ll-cli/src/main.cpp:399
 msgid ""
 "Usage: ll-cli list [OPTIONS]\n"
 "\n"
@@ -343,187 +353,225 @@ msgstr ""
 "# 显示当前已安装应用程序的最新版本列表\n"
 "ll-cli list --upgradable\n"
 
-#: ../apps/ll-cli/src/main.cpp:420
+#: ../apps/ll-cli/src/main.cpp:418
 msgid ""
 "Show the list of latest version of the currently installed applications, it "
 "only works for app"
 msgstr "显示当前已安装应用程序的最新版本列表，仅适用于应用程序"
 
-#: ../apps/ll-cli/src/main.cpp:427
+#: ../apps/ll-cli/src/main.cpp:425
 msgid "Display or modify information of the repository currently using"
 msgstr "显示或修改当前使用的仓库信息"
 
-#: ../apps/ll-cli/src/main.cpp:429
+#: ../apps/ll-cli/src/main.cpp:427
 msgid "Usage: ll-cli repo SUBCOMMAND [OPTIONS]"
 msgstr "用法: ll-cli repo [选项] 子命令"
 
 #. add repo sub command add
-#: ../apps/ll-cli/src/main.cpp:433 ../apps/ll-builder/src/main.cpp:356
+#: ../apps/ll-cli/src/main.cpp:431 ../apps/ll-builder/src/main.cpp:367
 msgid "Add a new repository"
 msgstr "添加新的仓库"
 
-#: ../apps/ll-cli/src/main.cpp:434
+#: ../apps/ll-cli/src/main.cpp:432
 msgid "Usage: ll-cli repo add [OPTIONS] NAME URL"
 msgstr "用法: ll-cli repo add [选项] 名称 URL"
 
-#: ../apps/ll-cli/src/main.cpp:435 ../apps/ll-cli/src/main.cpp:448
-#: ../apps/ll-builder/src/main.cpp:358
+#: ../apps/ll-cli/src/main.cpp:433 ../apps/ll-cli/src/main.cpp:446
+#: ../apps/ll-builder/src/main.cpp:369
 msgid "Specify the repo name"
 msgstr "指定仓库名称"
 
-#: ../apps/ll-cli/src/main.cpp:438 ../apps/ll-cli/src/main.cpp:451
-#: ../apps/ll-cli/src/main.cpp:469 ../apps/ll-builder/src/main.cpp:361
-#: ../apps/ll-builder/src/main.cpp:381
+#: ../apps/ll-cli/src/main.cpp:436 ../apps/ll-cli/src/main.cpp:449
+#: ../apps/ll-cli/src/main.cpp:467 ../apps/ll-builder/src/main.cpp:372
+#: ../apps/ll-builder/src/main.cpp:392
 msgid "Url of the repository"
 msgstr "仓库URL"
 
-#: ../apps/ll-cli/src/main.cpp:441 ../apps/ll-cli/src/main.cpp:458
-#: ../apps/ll-cli/src/main.cpp:466 ../apps/ll-cli/src/main.cpp:477
-#: ../apps/ll-builder/src/main.cpp:364 ../apps/ll-builder/src/main.cpp:371
-#: ../apps/ll-builder/src/main.cpp:378 ../apps/ll-builder/src/main.cpp:389
+#: ../apps/ll-cli/src/main.cpp:439 ../apps/ll-cli/src/main.cpp:456
+#: ../apps/ll-cli/src/main.cpp:464 ../apps/ll-cli/src/main.cpp:475
+#: ../apps/ll-cli/src/main.cpp:487 ../apps/ll-builder/src/main.cpp:375
+#: ../apps/ll-builder/src/main.cpp:382 ../apps/ll-builder/src/main.cpp:389
+#: ../apps/ll-builder/src/main.cpp:400
 msgid "Alias of the repo name"
 msgstr "仓库别名"
 
-#: ../apps/ll-cli/src/main.cpp:447
+#: ../apps/ll-cli/src/main.cpp:445
 msgid "Modify repository URL"
 msgstr "修改仓库URL"
 
 #. add repo sub command remove
-#: ../apps/ll-cli/src/main.cpp:456 ../apps/ll-builder/src/main.cpp:369
+#: ../apps/ll-cli/src/main.cpp:454 ../apps/ll-builder/src/main.cpp:380
 msgid "Remove a repository"
 msgstr "移除仓库"
 
-#: ../apps/ll-cli/src/main.cpp:457
+#: ../apps/ll-cli/src/main.cpp:455
 msgid "Usage: ll-cli repo remove [OPTIONS] NAME"
 msgstr "用法: ll-cli repo remove [选项] 名称"
 
 #. add repo sub command update
 #. TODO: add --repo and --url options
 #. add repo sub command update
-#: ../apps/ll-cli/src/main.cpp:464 ../apps/ll-builder/src/main.cpp:376
+#: ../apps/ll-cli/src/main.cpp:462 ../apps/ll-builder/src/main.cpp:387
 msgid "Update the repository URL"
 msgstr "更新仓库URL"
 
-#: ../apps/ll-cli/src/main.cpp:465
+#: ../apps/ll-cli/src/main.cpp:463
 msgid "Usage: ll-cli repo update [OPTIONS] NAME URL"
 msgstr "用法: ll-cli repo update [选项] 名称 URL"
 
-#: ../apps/ll-cli/src/main.cpp:475 ../apps/ll-builder/src/main.cpp:387
+#: ../apps/ll-cli/src/main.cpp:473 ../apps/ll-builder/src/main.cpp:398
 msgid "Set a default repository name"
 msgstr "设置默认仓库名称"
 
-#: ../apps/ll-cli/src/main.cpp:476
+#: ../apps/ll-cli/src/main.cpp:474
 msgid "Usage: ll-cli repo set-default [OPTIONS] NAME"
 msgstr "用法: ll-cli repo set-default [选项] 名称"
 
 #. add repo sub command show
-#: ../apps/ll-cli/src/main.cpp:482 ../apps/ll-builder/src/main.cpp:394
+#: ../apps/ll-cli/src/main.cpp:480 ../apps/ll-builder/src/main.cpp:405
 msgid "Show repository information"
 msgstr "显示仓库信息"
 
-#: ../apps/ll-cli/src/main.cpp:483
+#: ../apps/ll-cli/src/main.cpp:481
 msgid "Usage: ll-cli repo show [OPTIONS]"
 msgstr "用法: ll-cli repo show [选项]"
 
-#: ../apps/ll-cli/src/main.cpp:488
+#: ../apps/ll-cli/src/main.cpp:485
+msgid "Set the priority of the repo"
+msgstr "设置仓库的优先级"
+
+#: ../apps/ll-cli/src/main.cpp:486
+msgid "Usage: ll-cli repo set-priority ALIAS PRIORITY"
+msgstr "用法: ll-cli repo set-priority ALIAS PRIORITY"
+
+#: ../apps/ll-cli/src/main.cpp:491
+msgid "Priority of the repo"
+msgstr "仓库优先级"
+
+#: ../apps/ll-cli/src/main.cpp:498
 msgid "Display information about installed apps or runtimes"
 msgstr "显示已安装的应用程序或运行时的信息"
 
-#: ../apps/ll-cli/src/main.cpp:491
+#: ../apps/ll-cli/src/main.cpp:501
 msgid "Usage: ll-cli info [OPTIONS] APP"
 msgstr "用法: ll-cli info [选项] 应用"
 
-#: ../apps/ll-cli/src/main.cpp:495
+#: ../apps/ll-cli/src/main.cpp:505
 msgid "Specify the application ID, and it can also be a .layer file"
 msgstr "指定应用程序名，也可以是如意玲珑.layer文件"
 
-#: ../apps/ll-cli/src/main.cpp:502
+#: ../apps/ll-cli/src/main.cpp:512
 msgid "Display the exported files of installed application"
 msgstr "显示已安装应用导出的文件"
 
-#: ../apps/ll-cli/src/main.cpp:505
+#: ../apps/ll-cli/src/main.cpp:515
 msgid "Usage: ll-cli content [OPTIONS] APP"
 msgstr "用法: ll-cli content [选项] 应用"
 
-#: ../apps/ll-cli/src/main.cpp:506
+#: ../apps/ll-cli/src/main.cpp:516
 msgid "Specify the installed application ID"
 msgstr "指定已安装应用程序名"
 
 #. add sub command prune
-#: ../apps/ll-cli/src/main.cpp:511
+#: ../apps/ll-cli/src/main.cpp:521
 msgid "Remove the unused base or runtime"
 msgstr "移除未使用的最小系统或运行时"
 
-#: ../apps/ll-cli/src/main.cpp:513
+#: ../apps/ll-cli/src/main.cpp:523
 msgid "Usage: ll-cli prune [OPTIONS]"
 msgstr "用法: ll-cli prune [选项]"
 
-#: ../apps/ll-cli/src/main.cpp:518
+#: ../apps/ll-cli/src/main.cpp:528
 msgid "Display the information of installed application"
 msgstr "显示已安装应用导出的文件"
 
-#: ../apps/ll-cli/src/main.cpp:520
+#: ../apps/ll-cli/src/main.cpp:530
 msgid "Usage: ll-cli inspect [OPTIONS]"
 msgstr "用法: ll-cli inspect [选项]"
 
-#: ../apps/ll-cli/src/main.cpp:522
+#: ../apps/ll-cli/src/main.cpp:532
 msgid "Specify the process id"
 msgstr "指定进程id"
 
-#: ../apps/ll-cli/src/main.cpp:531
+#: ../apps/ll-cli/src/main.cpp:541
 msgid "Invalid process id"
 msgstr "无效的进程id"
 
-#: ../apps/ll-cli/src/main.cpp:534
+#: ../apps/ll-cli/src/main.cpp:544
 msgid "Invalid pid format"
 msgstr "无效的pid格式"
 
-#: ../apps/ll-cli/src/main.cpp:552
+#: ../apps/ll-cli/src/main.cpp:554
+msgid "Specify the installed app(base or runtime)"
+msgstr "指定已安装应用程序名(base或runtime)"
+
+#: ../apps/ll-cli/src/main.cpp:565
 msgid "linyaps CLI version "
 msgstr "如意玲珑CLI版本 "
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:71
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:232
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:76
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:258
 msgid "ID"
 msgstr "ID"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:72
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:77
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:185
 msgid "Name"
 msgstr "名称"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:73
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:78
 msgid "Version"
 msgstr "版本"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:74
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:79
 msgid "Channel"
 msgstr "渠道"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:75
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:80
 msgid "Module"
 msgstr "模块"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:76
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:81
 msgid "Description"
 msgstr "描述"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:110
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:111
+msgid "No containers are running."
+msgstr "没有正在运行的容器"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:115
 msgid "App"
 msgstr "应用"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:111
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:116
 msgid "ContainerID"
 msgstr "容器ID"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:112
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:117
 msgid "Pid"
 msgstr "进程ID"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:233
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:186
+msgid "Url"
+msgstr "地址"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:187
+msgid "Alias"
+msgstr "别名"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:188
+msgid "Priority"
+msgstr "优先级"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:246
+msgid "No apps available for update."
+msgstr "没有可更新的应用"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:259
 msgid "Installed"
 msgstr "已安装"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:234
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:260
 msgid "New"
 msgstr "新版本"
 
@@ -570,7 +618,7 @@ msgid "Usage: ll-builder build [OPTIONS] [COMMAND...]"
 msgstr "用法: ll-builder build [选项] [命令...]"
 
 #: ../apps/ll-builder/src/main.cpp:215 ../apps/ll-builder/src/main.cpp:258
-#: ../apps/ll-builder/src/main.cpp:293 ../apps/ll-builder/src/main.cpp:309
+#: ../apps/ll-builder/src/main.cpp:293 ../apps/ll-builder/src/main.cpp:320
 msgid "File path of the linglong.yaml"
 msgstr "linglong.yaml的文件路径"
 
@@ -664,104 +712,108 @@ msgstr "导出如意玲珑layer或uab"
 msgid "Usage: ll-builder export [OPTIONS]"
 msgstr "用法: ll-builder export [选项]"
 
-#: ../apps/ll-builder/src/main.cpp:297
+#: ../apps/ll-builder/src/main.cpp:303
 msgid "Uab icon (optional)"
 msgstr "Uab图标（可选）"
 
-#: ../apps/ll-builder/src/main.cpp:300
+#: ../apps/ll-builder/src/main.cpp:306
 msgid "Export uab fully"
 msgstr "全量导出uab"
 
-#: ../apps/ll-builder/src/main.cpp:301
+#: ../apps/ll-builder/src/main.cpp:307
 msgid "Export to linyaps layer file"
 msgstr "导出如意玲珑layer文件"
 
-#: ../apps/ll-builder/src/main.cpp:307
+#: ../apps/ll-builder/src/main.cpp:310
+msgid "Use custom loader"
+msgstr "使用自定义的loader"
+
+#: ../apps/ll-builder/src/main.cpp:318
 msgid "Push linyaps app to remote repo"
 msgstr "推送如意玲珑应用到远程仓库"
 
-#: ../apps/ll-builder/src/main.cpp:308
+#: ../apps/ll-builder/src/main.cpp:319
 msgid "Usage: ll-builder push [OPTIONS]"
 msgstr "用法: ll-builder push [选项]"
 
-#: ../apps/ll-builder/src/main.cpp:313
+#: ../apps/ll-builder/src/main.cpp:324
 msgid "Remote repo url"
 msgstr "远程仓库URL"
 
-#: ../apps/ll-builder/src/main.cpp:316
+#: ../apps/ll-builder/src/main.cpp:327
 msgid "Remote repo name"
 msgstr "远程仓库名"
 
-#: ../apps/ll-builder/src/main.cpp:319
+#: ../apps/ll-builder/src/main.cpp:330
 msgid "Push single module"
 msgstr "推送单个模块"
 
-#: ../apps/ll-builder/src/main.cpp:324
+#: ../apps/ll-builder/src/main.cpp:335
 msgid "Import linyaps layer to build repo"
 msgstr "导入如意玲珑layer文件到构建仓库"
 
-#: ../apps/ll-builder/src/main.cpp:325
+#: ../apps/ll-builder/src/main.cpp:336
 msgid "Usage: ll-builder import [OPTIONS] LAYER"
 msgstr "用法: ll-builder import [选项] LAYER文件"
 
-#: ../apps/ll-builder/src/main.cpp:326 ../apps/ll-builder/src/main.cpp:345
+#: ../apps/ll-builder/src/main.cpp:337 ../apps/ll-builder/src/main.cpp:356
 msgid "Layer file path"
 msgstr "layer文件路径"
 
-#: ../apps/ll-builder/src/main.cpp:334
+#: ../apps/ll-builder/src/main.cpp:345
 msgid "Import linyaps layer dir to build repo"
 msgstr "导入如意玲珑layer目录到构建仓库"
 
-#: ../apps/ll-builder/src/main.cpp:336
+#: ../apps/ll-builder/src/main.cpp:347
 msgid "Usage: ll-builder import-dir PATH"
 msgstr "用法: ll-builder import-dir PATH"
 
-#: ../apps/ll-builder/src/main.cpp:337
+#: ../apps/ll-builder/src/main.cpp:348
 msgid "Layer dir path"
 msgstr "layer目录路径"
 
-#: ../apps/ll-builder/src/main.cpp:343
+#: ../apps/ll-builder/src/main.cpp:354
 msgid "Extract linyaps layer to dir"
 msgstr "将如意玲珑layer文件解压到目录"
 
-#: ../apps/ll-builder/src/main.cpp:344
+#: ../apps/ll-builder/src/main.cpp:355
 msgid "Usage: ll-builder extract [OPTIONS] LAYER DIR"
 msgstr "用法: ll-builder extract [选项] LAYER文件 目录"
 
-#: ../apps/ll-builder/src/main.cpp:348
+#: ../apps/ll-builder/src/main.cpp:359
 msgid "Destination directory"
 msgstr "目标目录"
 
 #. add build repo
-#: ../apps/ll-builder/src/main.cpp:351
+#: ../apps/ll-builder/src/main.cpp:362
 msgid "Display and manage repositories"
 msgstr "显示和管理仓库"
 
-#: ../apps/ll-builder/src/main.cpp:352
+#: ../apps/ll-builder/src/main.cpp:363
 msgid "Usage: ll-builder repo [OPTIONS] SUBCOMMAND"
 msgstr "用法: ll-builder repo [选项] 子命令"
 
-#: ../apps/ll-builder/src/main.cpp:357
+#: ../apps/ll-builder/src/main.cpp:368
 msgid "Usage: ll-builder repo add [OPTIONS] NAME URL"
 msgstr "用法: ll-builder repo add [选项] 名称 URL"
 
-#: ../apps/ll-builder/src/main.cpp:370
+#: ../apps/ll-builder/src/main.cpp:381
 msgid "Usage: ll-builder repo remove [OPTIONS] NAME"
 msgstr "用法: ll-builder repo remove [选项] 名称"
 
-#: ../apps/ll-builder/src/main.cpp:377
+#: ../apps/ll-builder/src/main.cpp:388
 msgid "Usage: ll-builder repo update [OPTIONS] NAME URL"
 msgstr "用法: ll-builder repo update [选项] 名称 URL"
 
-#: ../apps/ll-builder/src/main.cpp:388
+#: ../apps/ll-builder/src/main.cpp:399
 msgid "Usage: ll-builder repo set-default [OPTIONS] NAME"
 msgstr "用法: ll-builder repo set-default [选项] 名称"
 
-#: ../apps/ll-builder/src/main.cpp:395
+#: ../apps/ll-builder/src/main.cpp:406
 msgid "Usage: ll-builder repo show [OPTIONS]"
 msgstr "用法: ll-builder repo show [选项]"
 
-#: ../apps/ll-builder/src/main.cpp:400
+#: ../apps/ll-builder/src/main.cpp:411
 msgid "linyaps build tool version "
 msgstr "如意玲珑构建工具版本"
 
@@ -786,3 +838,187 @@ msgstr "玲珑软件包管理器"
 #: ../apps/ll-dialog/src/cache_dialog.cpp:54
 msgid "is starting"
 msgstr "正在启动"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:526
+msgid "The current version does not support the develop module installation."
+msgstr "当前版本不支持开发模块安装"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:541
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:805
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1384
+msgid "app arch: %1 not match host architecture"
+msgstr "应用架构 %1 与主机架构不匹配"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:592
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:855
+msgid ""
+"The latest version has been installed. If you want to replace it, try using "
+"'ll-cli install %1 --force'"
+msgstr "已安装最新版本。如需覆盖安装，请尝试使用命令'll-cli install %1 --force"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:636
+msgid "installing layer"
+msgstr "正在安装layer"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:638
+msgid "preparing environment"
+msgstr "准备环境中"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:677
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:682
+msgid "install layer successfully"
+msgstr "layer安装成功"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:743
+msgid "queued to install from layer"
+msgstr "layer已排队安装"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:747
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1292
+msgid "%1 is now installing"
+msgstr "正在安装 %1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:766
+msgid "couldn't pass uab verification"
+msgstr "无法通过UAB验证"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:784
+msgid "couldn't find application layer in this uab"
+msgstr "在此UAB中找不到layer"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:844
+msgid "%1 is already installed"
+msgstr "%1 已安装"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:901
+msgid "installing uab"
+msgstr "正在安装UAB"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:903
+msgid "prepare environment"
+msgstr "准备环境中"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:919
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:930
+msgid "the contents of this uab file are invalid"
+msgstr "此UAB文件内容无效"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:946
+msgid "get status of %1 failed: %2"
+msgstr "获取 %1 状态失败: %2"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:951
+msgid "layer directory %1 doesn't exist"
+msgstr "layer目录 %1 不存在"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1053
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1358
+msgid "Failed to generate some cache.\n"
+msgstr "生成缓存失败\n"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1140
+msgid "cannot specify a version when installing a module"
+msgstr "安装模块时不能指定版本"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1149
+msgid "to install the module, one must first install the app"
+msgstr "要安装模块，必须先安装应用程序"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1154
+msgid "module is already installed"
+msgstr "模块已安装"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1167
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1288
+msgid "queued to install from remote"
+msgstr "已加入远程安装队列"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1182
+msgid "%1 is already installed."
+msgstr "%1 已安装"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1222
+msgid ""
+"The latest version has been installed. If you want to replace it, try using "
+"'ll-cli install %1/%2 --force'"
+msgstr ""
+"已安装最新版本。如需覆盖安装，请尝试使用'll-cli install %1/%2 --force'命令"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1267
+msgid "canceled"
+msgstr "已取消"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1302
+msgid "Installing %1"
+msgstr "正在安装 %1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1314
+msgid "These modules do not exist remotely: %1"
+msgstr "这些模块不存在于远程仓库：%1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1330
+msgid "processing after install"
+msgstr "安装后处理中"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1349
+msgid "Failed to remove old reference %1 after install %2 : %3"
+msgstr "安装 %2 后删除旧引用 %1 失败：%3"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1365
+msgid "Install %1 success"
+msgstr "%1 安装成功"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1375
+msgid "Beginning to install"
+msgstr "开始安装"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1388
+msgid "Installing application %1"
+msgstr "正在安装应用程序 %1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1429
+msgid "install failed"
+msgstr "安装失败"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1897
+msgid "Installing runtime %1"
+msgstr "正在安装runtime %1"
+
+#: ../libs/linglong/src/linglong/package_manager/package_manager.cpp:1940
+msgid "Installing base "
+msgstr "正在安装base "
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:173
+msgid "Caught error during pulling data, waiting for outstanding task"
+msgstr "拉取数据时发生错误，正在等待未完成的任务"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:208
+msgid "Downloading metadata"
+msgstr "正在下载元数据"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:216
+msgid "Downloading delta part"
+msgstr "正在下载增量部分"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:224
+msgid "Downloading files"
+msgstr "正在下载文件"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:482
+msgid "package not found: %1"
+msgstr "未找到软件包：%1"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:1316
+msgid "Cannot find %1/%2 from remote repo"
+msgstr "无法从远程仓库找到 %1/%2"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:1480
+msgid ""
+"Failed to get response from remote server (network error or server "
+"unavailable)"
+msgstr "获取远程服务器响应失败（网络错误或服务不可用）"
+
+#: ../libs/linglong/src/linglong/repo/ostree_repo.cpp:1489
+msgid ""
+"Remote server returned error code: %1 (network error or server unavailable)"
+msgstr "获取远程服务器响应失败 %1（网络错误或服务不可用）"

--- a/tools/update-translation.sh
+++ b/tools/update-translation.sh
@@ -1,0 +1,9 @@
+#!/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+cmake -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_UAB=ON -DSTATIC_BOX=ON -B build
+cmake --build build --target pot
+cmake --build build --target po


### PR DESCRIPTION
By default, only simple error messages are displayed.
If you need to display detailed information, you can pass the `LINGLONG_VERBOSE_MESSAGE=true` environment variable to the cli and PM.

pm的一些错误信息做了国际化
