### PR TITLE
fix: exporting systemd service may cause system error

### DIFF
--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -1829,23 +1829,23 @@ OSTreeRepo::exportEntries(const std::filesystem::path &rootEntriesDir,
         "share/dsg" // Copy dsg conf，the configuration file is used for self-developed
                     // applications.
     };
-    // 如果存在lib/systemd目录，则导出lib/systemd，否则导出share/systemd
-    exists = std::filesystem::exists(appEntriesDir / "lib/systemd", ec);
+    // 如果存在lib/systemd目录，优先导出lib/systemd，否则导出share/systemd（为兼容旧应用，新应用应该逐步将配置文件放在lib/systemd目录下）
+    exists = std::filesystem::exists(appEntriesDir / "lib/systemd/user", ec);
     if (ec) {
         return LINGLONG_ERR("Failed to check the existence of lib/systemd directory: {}", ec);
     }
     if (exists) {
-        exportPaths.push_back("lib/systemd");
+        exportPaths.push_back("lib/systemd/user");
     } else {
-        exportPaths.push_back("share/systemd");
+        exportPaths.push_back("share/systemd/user");
     }
     // 导出应用entries目录下的所有文件到玲珑仓库的entries目录下
     for (const auto &path : exportPaths) {
         auto source = appEntriesDir / path;
         auto destination = rootEntriesDir / path;
         // 将 share/systemd 目录下的文件导出到 lib/systemd 目录下
-        if (path == "share/systemd") {
-            destination = rootEntriesDir / "lib/systemd";
+        if (path == "share/systemd/user") {
+            destination = rootEntriesDir / "lib/systemd/user";
         }
         // 检查源目录是否存在，跳过不存在的目录
         exists = std::filesystem::exists(source, ec);


### PR DESCRIPTION
builder不再将systemd service导出到share目录,
避免因share优先级过高影响系统功能