### PR TITLE
fix: fix compiler error

### DIFF
--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -26,7 +26,7 @@
 
 #include <gio/gio.h>
 #include <glib.h>
-#include <nlohmann/json_fwd.hpp>
+#include <nlohmann/json.hpp>
 #include <ostree-repo.h>
 
 #include <QCryptographicHash>


### PR DESCRIPTION
fix compiler error when use nlohmann from CPM