### PR TITLE
fix: failed to umount layer dir

### DIFF
--- a/libs/linglong/src/linglong/package/layer_packager.cpp
+++ b/libs/linglong/src/linglong/package/layer_packager.cpp
@@ -30,17 +30,6 @@ LayerPackager::LayerPackager(const QDir &workDir)
 
 LayerPackager::~LayerPackager()
 {
-    for (const auto &info : this->workDir.entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot)) {
-        if (!info.isDir()) {
-            continue;
-        }
-
-        auto ret = utils::command::Exec("umount", { info.absoluteFilePath() });
-        if (!ret) {
-            qCritical() << ret.error();
-        }
-    }
-
     if (this->workDir.removeRecursively()) {
         return;
     }

--- a/libs/linglong/src/linglong/package/uab_file.cpp
+++ b/libs/linglong/src/linglong/package/uab_file.cpp
@@ -64,7 +64,7 @@ utils::error::Result<std::shared_ptr<UABFile>> UABFile::loadFromFile(const QStri
 UABFile::~UABFile()
 {
     if (!mountPoint.empty()) {
-        auto ret = utils::command::Exec("umount", { mountPoint.c_str() });
+        auto ret = utils::command::Exec("fusermount", { "-z", "-u", mountPoint.c_str() });
         if (!ret) {
             qCritical() << "failed to umount " << mountPoint.c_str()
                         << ", please umount it manually";

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -646,7 +646,7 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
 
           auto unmountLayer = utils::finally::finally([mountPoint = layerDir->absolutePath()] {
               if (QFileInfo::exists(mountPoint)) {
-                  auto ret = utils::command::Exec("umount", { mountPoint });
+                  auto ret = utils::command::Exec("fusermount", { "-z", "-u", mountPoint });
                   if (!ret) {
                       qCritical() << "failed to umount " << mountPoint
                                   << ", please umount it manually";

--- a/libs/utils/src/linglong/utils/overlayfs.cpp
+++ b/libs/utils/src/linglong/utils/overlayfs.cpp
@@ -20,7 +20,7 @@ OverlayFS::OverlayFS(QString lowerdir, QString upperdir, QString workdir, QStrin
 
 OverlayFS::~OverlayFS()
 {
-    auto res = utils::command::Exec("umount", QStringList() << merged_);
+    auto res = utils::command::Exec("fusermount", { "-z", "-u", merged_ });
     if (!res) {
         qWarning() << QString("failed to umount %1 ").arg(merged_) << res.error();
     }
@@ -43,7 +43,7 @@ bool OverlayFS::mount()
         return false;
     }
 
-    utils::command::Exec("umount", QStringList() << merged_);
+    utils::command::Exec("fusermount", { "-z", "-u", merged_ });
 
     auto ret = utils::command::Exec("fuse-overlayfs",
             QStringList() <<
@@ -60,7 +60,7 @@ bool OverlayFS::mount()
 
 void OverlayFS::unmount(bool clean)
 {
-    auto res = utils::command::Exec("umount", QStringList() << merged_);
+    auto res = utils::command::Exec("fusermount", { "-z", "-u", merged_ });
     if (!res) {
         qWarning() << QString("failed to umount %1 ").arg(merged_) << res.error();
     }


### PR DESCRIPTION
Layer dir has been umount in
https://github.com/OpenAtom-Linyaps/linyaps/blob/619a93ea5ca8f9b7293e4dbff8b953f6b0ea7cb9/libs/linglong/src/linglong/package_manager/package_manager.cpp#L649, so do not need to umount again in LayerPackager destructor.