### PR TITLE
chore: adjust the builder output format

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -238,7 +238,7 @@ utils::error::Result<package::Reference> pullDependency(const package::FuzzyRefe
         auto percentage = (uint)((((double)fetched) / requested) * 100);
         auto progress = QString("(%1/%2 %3%)").arg(fetched).arg(requested).arg(percentage);
         printReplacedText(QString("%1%2%3%4 %5")
-                            .arg(ref->id, -25)                        // NOLINT
+                            .arg(ref->id, -35)                        // NOLINT
                             .arg(ref->version.toString(), -15)        // NOLINT
                             .arg(QString::fromStdString(module), -15) // NOLINT
                             .arg("downloading")
@@ -248,7 +248,7 @@ utils::error::Result<package::Reference> pullDependency(const package::FuzzyRefe
     };
     QObject::connect(&tmpTask, &service::PackageTask::PartChanged, partChanged);
     printReplacedText(QString("%1%2%3%4 %5")
-                        .arg(ref->id, -25)                        // NOLINT
+                        .arg(ref->id, -35)                        // NOLINT
                         .arg(ref->version.toString(), -15)        // NOLINT
                         .arg(QString::fromStdString(module), -15) // NOLINT
                         .arg("waiting")
@@ -553,7 +553,7 @@ utils::error::Result<void> Builder::build(const QStringList &args) noexcept
     /*** Pull Depend Stage ***/
     printMessage("[Processing Dependency]");
     printMessage(QString("%1%2%3%4")
-                   .arg("Package", -25) // NOLINT
+                   .arg("Package", -35) // NOLINT
                    .arg("Version", -15) // NOLINT
                    .arg("Module", -15)  // NOLINT
                    .arg("Status")
@@ -569,7 +569,7 @@ utils::error::Result<void> Builder::build(const QStringList &args) noexcept
         return LINGLONG_ERR("pull base binary", baseRef);
     }
     printReplacedText(QString("%1%2%3%4")
-                        .arg(baseRef->id, -25)                 // NOLINT
+                        .arg(baseRef->id, -35)                 // NOLINT
                         .arg(baseRef->version.toString(), -15) // NOLINT
                         .arg("binary", -15)                    // NOLINT
                         .arg("complete\n")
@@ -584,7 +584,7 @@ utils::error::Result<void> Builder::build(const QStringList &args) noexcept
         return LINGLONG_ERR(ret);
     }
     printReplacedText(QString("%1%2%3%4")
-                        .arg(baseRef->id, -25)                 // NOLINT
+                        .arg(baseRef->id, -35)                 // NOLINT
                         .arg(baseRef->version.toString(), -15) // NOLINT
                         .arg("develop", -15)                   // NOLINT
                         .arg("complete\n")
@@ -615,7 +615,7 @@ utils::error::Result<void> Builder::build(const QStringList &args) noexcept
             return LINGLONG_ERR("pull runtime", runtimeRet);
         }
         printReplacedText(QString("%1%2%3%4")
-                            .arg(runtimeRet->id, -25)                 // NOLINT
+                            .arg(runtimeRet->id, -35)                 // NOLINT
                             .arg(runtimeRet->version.toString(), -15) // NOLINT
                             .arg("binary", -15)                       // NOLINT
                             .arg("complete\n")
@@ -631,7 +631,7 @@ utils::error::Result<void> Builder::build(const QStringList &args) noexcept
             return LINGLONG_ERR(ret);
         }
         printReplacedText(QString("%1%2%3%4")
-                            .arg(runtimeRet->id, -25)                 // NOLINT
+                            .arg(runtimeRet->id, -35)                 // NOLINT
                             .arg(runtimeRet->version.toString(), -15) // NOLINT
                             .arg("develop", -15)                      // NOLINT
                             .arg("complete\n")


### PR DESCRIPTION
Increase the width of the packge under the builder Processing Dependency.

避免包名和版本挤在一起