### PR TITLE
feat: support don't export the develop module

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -286,7 +286,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
 
     // build export
     bool layerMode = false;
-    linglong::builder::ExportOption ExportOption{ .exportDevelop = false, .exportI18n = true };
+    linglong::builder::ExportOption ExportOption{ .exportI18n = true };
     auto *buildExport = commandParser.add_subcommand("export", _("Export to linyaps layer or uab"));
     buildExport->usage(_("Usage: ll-builder export [OPTIONS]"));
 
@@ -311,6 +311,8 @@ You can report bugs to the linyaps team under this project: https://github.com/O
       ->type_name("FILE")
       ->check(CLI::ExistingFile)
       ->excludes(layerFlag, fullOpt);
+    buildExport->add_flag("--no-develop", ExportOption.noExportDevelop, _("Don't export the develop module"))
+        ->needs(layerFlag);
 
     // build push
     std::string pushModule;
@@ -814,7 +816,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
             if (!ExportOption.compressor.empty()) {
                 compressor = ExportOption.compressor.c_str();
             }
-            auto result = builder.exportLayer(QDir::currentPath(), compressor);
+            auto result = builder.exportLayer(QDir::currentPath(), compressor, ExportOption.noExportDevelop);
             if (!result) {
                 qCritical() << result.error();
                 return -1;

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -1438,7 +1438,8 @@ utils::error::Result<void> Builder::exportUAB(const QString &destination,
 }
 
 utils::error::Result<void> Builder::exportLayer(const QString &destination,
-                                                const QString &compressor)
+                                                const QString &compressor,
+                                                const bool &noExportDevelop)
 {
     LINGLONG_TRACE("export layer file");
 
@@ -1461,6 +1462,10 @@ utils::error::Result<void> Builder::exportLayer(const QString &destination,
         pkger.setCompressor(compressor);
     }
     for (const auto &module : modules) {
+        if (noExportDevelop && module == "develop") {
+            continue;
+        }
+        
         auto layerDir = this->repo.getLayerDir(*ref, module);
         if (!layerDir) {
             qCritical().nospace() << "resolve layer " << ref->toString() << "/" << module.c_str()

--- a/libs/linglong/src/linglong/builder/linglong_builder.h
+++ b/libs/linglong/src/linglong/builder/linglong_builder.h
@@ -21,7 +21,7 @@ struct ExportOption
     std::string iconPath;
     std::string loader;
     std::string compressor;
-    bool exportDevelop{ false };
+    bool noExportDevelop{ false };
     bool exportI18n{ false };
     bool full{ false };
 };
@@ -63,7 +63,7 @@ public:
 
     auto exportUAB(const QString &destination, const ExportOption &option)
       -> utils::error::Result<void>;
-    auto exportLayer(const QString &destination, const QString &compressor)
+    auto exportLayer(const QString &destination, const QString &compressor, const bool &noExportDevelop)
       -> utils::error::Result<void>;
 
     static auto extractLayer(const QString &layerPath, const QString &destination)


### PR DESCRIPTION
When exporting layer, add --no-develop to avoid exporting the develop module.