### PR TITLE
fix: merge runtime module also

### DIFF
--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -2339,7 +2339,8 @@ utils::error::Result<void> OSTreeRepo::mergeModules() const noexcept
             commits.push_back(layer.commit);
             modules.push_back(layer.info.packageInfoV2Module);
             hash.addData(QString::fromStdString(layer.commit).toUtf8());
-            if (layer.info.packageInfoV2Module == "binary") {
+            if (layer.info.packageInfoV2Module == "binary"
+                || layer.info.packageInfoV2Module == "runtime") {
                 binaryCommit = layer.commit;
             }
         }


### PR DESCRIPTION
old runtime module is equal to binary module