### PR TITLE
chore: suppress error while executing systemd-generator

### DIFF
--- a/misc/lib/systemd/user-generators/linglong-user-systemd-generator
+++ b/misc/lib/systemd/user-generators/linglong-user-systemd-generator
@@ -6,4 +6,4 @@
 
 # https://www.freedesktop.org/software/systemd/man/latest/systemd.generator.html
 late="$3"
-cp -rs @LINGLONG_ROOT@/entries/lib/systemd/user/* "$late/"
+cp -rs @LINGLONG_ROOT@/entries/lib/systemd/user/* "${late}/" || true


### PR DESCRIPTION
file or directory may not exist