### PR TITLE
Introduce ll-builder-utils to export UAB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,14 @@ if(NOT ("${LINGLONG_VERSION}" STREQUAL ""))
   set(PROJECT_VERSION ${LINGLONG_VERSION})
 endif()
 
-set(ENABLE_UAB
+set(ENABLE_LINGLONG_APP_BUILDER_UTILS
     OFF
-    CACHE BOOL "enable building UAB")
+    CACHE BOOL "enable build ll-builder-utils to linglong app")
+
+set(BUILD_LINGLONG_BUILDER_UTILS_IN_BOX
+    OFF
+    CACHE BOOL "build ll-builder-utils in box")
+
 set(ENABLE_LINGLONG_INSTALLER
     OFF
     CACHE BOOL "enable linglong installer")
@@ -163,6 +168,20 @@ endfunction()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# build ll-build-utils only
+if(BUILD_LINGLONG_BUILDER_UTILS_IN_BOX)
+    pfl_init(AUTO)
+    pfl_add_libraries(
+        LIBS
+        api
+        ocppi
+        oci-cfg-generators
+        APPS
+        ll-builder-utils
+        uab)
+    return()
+endif()
+
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
@@ -250,8 +269,11 @@ pfl_add_libraries(
   ll-cli
   ll-package-manager
   llpkg
-  uab
   ll-session-helper)
+
+if(ENABLE_LINGLONG_APP_BUILDER_UTILS)
+    add_subdirectory(apps/ll-builder-utils)
+endif()
 
 add_subdirectory(misc)
 add_subdirectory(po)

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -200,3 +200,9 @@ path = "apps/dumb-init/src/*"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "Yelp Inc."
 SPDX-License-Identifier = "MIT"
+
+[[annotations]]
+path = "apps/ll-builder-utils/patch/libfuse.patch"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "UnionTech Software Technology Co., Ltd."
+SPDX-License-Identifier = "LGPL-3.0-or-later"

--- a/apps/ll-builder-utils/CMakeLists.txt
+++ b/apps/ll-builder-utils/CMakeLists.txt
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+if(NOT BUILD_LINGLONG_BUILDER_UTILS_IN_BOX)
+    find_program(BUILDER ll-builder NO_CACHE REQUIRED)
+
+    message(STATUS "ll-builder: ${BUILDER}")
+
+    add_custom_target(ll-builder-utils
+        COMMAND ${BUILDER} build
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        )
+else()
+    message(STATUS "build ll-build-export")
+    install(FILES ll-builder-export TYPE BIN PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE WORLD_READ WORLD_EXECUTE)
+endif()

--- a/apps/ll-builder-utils/ll-builder-export
+++ b/apps/ll-builder-utils/ll-builder-export
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+#!/bin/bash
+
+# Usage: $0 [OPTIONS]
+# Options:
+# --get-header <target_path>   拷贝预置头文件到指定路径
+# --get-loader <target_path>  拷贝预置加载器到指定路径
+# --packdir <dir:output_path> 打包目录到压缩文件
+
+if [ $# -eq 0 ]; then
+    exit 0
+fi
+
+echo $PWD
+
+APPID="cn.org.linyaps.builder.utils"
+UAB_HEADER="/opt/apps/${APPID}/files/lib/linglong/builder/uab/uab-header"
+UAB_LOADER="/opt/apps/${APPID}/files/lib/linglong/builder/uab/uab-loader"
+
+# 参数解析
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --get-header)
+            if [ -z "$2" ]; then
+                echo "--get-header need output path" >&2
+                exit 1
+            fi
+            TARGET_HEADER="$2"
+            shift 2
+            ;;
+        --get-loader)
+            if [ -z "$2" ]; then
+                echo "-get-loader need output path" >&2
+                exit 1
+            fi
+            TARGET_LOADER="$2"
+            shift 2
+            ;;
+        --packdir)
+            if [ -z "$2" ]; then
+                echo "--packdir 需要打包参数" >&2
+                exit 1
+            fi
+            IFS=':' read -r PACK_DIR OUTPUT_FILE <<< "$2"
+            shift 2
+            ;;
+        -z)
+            if [ -n "$2" ]; then
+                COMPRESSOR=$2
+                shift 2
+            else
+                shift 1
+            fi
+            ;;
+        *)
+            exit 1
+            ;;
+    esac
+done
+
+# copy uab-header
+if [ -n "$TARGET_HEADER" ]; then
+    mkdir -p "$(dirname "$TARGET_HEADER")"
+    if ! cp -v "$UAB_HEADER" "$TARGET_HEADER"; then
+        echo "copy failed" >&2
+        exit 1
+    fi
+fi
+
+# copy uab-loader
+if [ -n "$TARGET_LOADER" ]; then
+    mkdir -p "$(dirname "$TARGET_LOADER")"
+    if ! cp -v "$UAB_LOADER" "$TARGET_LOADER"; then
+        echo "copy failed" >&2
+        exit 1
+    fi
+fi
+
+# make erofs image
+if [ -n "$PACK_DIR" ] && [ -n "$OUTPUT_FILE" ]; then
+    if [ ! -d "$PACK_DIR" ]; then
+        echo "$PACK_DIR not exist" >&2
+        exit 1
+    fi
+    mkdir -p "$(dirname "$OUTPUT_FILE")"
+    if [ -z ${COMPRESSOR} ]; then
+        mkfs.erofs -Efragments,dedupe,ztailpacking -C1048576 -b4096 ${OUTPUT_FILE} ${PACK_DIR}
+    else
+        mkfs.erofs -z ${COMPRESSOR} -Efragments,dedupe,ztailpacking -C1048576 -b4096 ${OUTPUT_FILE} ${PACK_DIR}
+    fi
+
+    if [ $? -ne 0 ]; then
+        echo "packdir failed"
+        exit 1
+    fi
+fi
+
+exit 0

--- a/apps/ll-builder-utils/patch/libfuse.patch
+++ b/apps/ll-builder-utils/patch/libfuse.patch
@@ -1,0 +1,134 @@
+diff --git a/lib/mount.c b/lib/mount.c
+index 6ed4444..b592ade 100644
+--- a/lib/mount.c
++++ b/lib/mount.c
+@@ -46,7 +46,6 @@
+ #define umount2(mnt, flags) unmount(mnt, (flags == 2) ? MNT_FORCE : 0)
+ #endif
+ 
+-#define FUSERMOUNT_PROG		"fusermount3"
+ #define FUSE_COMMFD_ENV		"_FUSE_COMMFD"
+ #define FUSE_COMMFD2_ENV	"_FUSE_COMMFD2"
+ 
+@@ -121,6 +120,34 @@ static const struct fuse_opt fuse_mount_opts[] = {
+ 	FUSE_OPT_END
+ };
+ 
++/**
++ * Returns FUSERMOUNT_PROG path from environment variable.
++ *
++ * If $FUSERMOUNT_PROG is not set, the program exits.
++ *
++ * Call with FUSERMOUNT_PROG_DEBUG=nonzerovalue to make the code print the value before evaluation.
++ */
++static const char *fusermountProg(void)
++{
++	static const char envVar[] = "FUSERMOUNT_PROG";
++	char *fusermountProg = getenv(envVar);
++
++	static const char debugEnvVarSuffix[] = "_DEBUG";
++	char debugEnvVar[sizeof(envVar) + sizeof(debugEnvVarSuffix) + 1];
++	sprintf(debugEnvVar, "%s%s", envVar, debugEnvVarSuffix);
++
++	if (fusermountProg == NULL) {
++		fprintf(stderr, "Error: $%s not set\n", envVar);
++		exit(1);
++	}
++
++	if (getenv(debugEnvVar) != NULL) {
++		fprintf(stderr, "$%s: %s\n", envVar, fusermountProg);
++	}
++
++	return fusermountProg;
++}
++
+ /*
+  * Running fusermount by calling 'posix_spawn'
+  *
+@@ -129,19 +156,12 @@ static const struct fuse_opt fuse_mount_opts[] = {
+ static int fusermount_posix_spawn(posix_spawn_file_actions_t *action,
+ 				  char const * const argv[], pid_t *out_pid)
+ {
+-	const char *full_path = FUSERMOUNT_DIR "/" FUSERMOUNT_PROG;
+ 	pid_t pid;
+ 
+ 	/* See man 7 environ for the global environ pointer */
+ 
+-	/* first try the install path */
+-	int status = posix_spawn(&pid, full_path,  action, NULL,
++	int status = posix_spawn(&pid, fusermountProg(),  action, NULL,
+ 				 (char * const *) argv, environ);
+-	if (status != 0) {
+-		/* if that fails, try a system install */
+-		status = posix_spawnp(&pid, FUSERMOUNT_PROG, action, NULL,
+-				      (char * const *) argv, environ);
+-	}
+ 
+ 	if (status != 0) {
+ 		fuse_log(FUSE_LOG_ERR,
+@@ -160,12 +180,12 @@ static int fusermount_posix_spawn(posix_spawn_file_actions_t *action,
+ 
+ void fuse_mount_version(void)
+ {
+-	char const *const argv[] = {FUSERMOUNT_PROG, "--version", NULL};
++	char const *const argv[] = {fusermountProg(), "--version", NULL};
+ 	int status = fusermount_posix_spawn(NULL, argv, NULL);
+ 
+ 	if(status != 0)
+ 		fuse_log(FUSE_LOG_ERR, "Running '%s --version' failed",
+-			 FUSERMOUNT_PROG);
++			 fusermountProg());
+ }
+ 
+ struct mount_flags {
+@@ -337,12 +357,12 @@ void fuse_kern_unmount(const char *mountpoint, int fd)
+ 		return;
+ 
+ 	char const * const argv[] =
+-		{ FUSERMOUNT_PROG, "--unmount", "--quiet", "--lazy",
++		{ fusermountProg(), "--unmount", "--quiet", "--lazy",
+ 				"--", mountpoint, NULL };
+ 	int status = fusermount_posix_spawn(NULL, argv, NULL);
+ 	if(status != 0) {
+ 		fuse_log(FUSE_LOG_ERR, "Spawning %s to unmount failed: %s",
+-			 FUSERMOUNT_PROG, strerror(-status));
++			 fusermountProg(), strerror(-status));
+ 		return;
+ 	}
+ }
+@@ -378,7 +398,7 @@ static int setup_auto_unmount(const char *mountpoint, int quiet)
+ 	setenv(FUSE_COMMFD2_ENV, arg_fd_entry, 1);
+ 
+ 	char const *const argv[] = {
+-		FUSERMOUNT_PROG,
++		fusermountProg(),
+ 		"--auto-unmount",
+ 		"--",
+ 		mountpoint,
+@@ -434,7 +454,7 @@ static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
+ 	res = socketpair(PF_UNIX, SOCK_STREAM, 0, fds);
+ 	if(res == -1) {
+ 		fuse_log(FUSE_LOG_ERR, "Running %s: socketpair() failed: %s\n",
+-			 FUSERMOUNT_PROG, strerror(errno));
++			 fusermountProg(), strerror(errno));
+ 		return -1;
+ 	}
+ 
+@@ -451,7 +471,7 @@ static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
+ 	setenv(FUSE_COMMFD2_ENV, arg_fd_entry, 1);
+ 
+ 	char const *const argv[] = {
+-		FUSERMOUNT_PROG,
++		fusermountProg(),
+ 		"-o", opts ? opts : "",
+ 		"--",
+ 		mountpoint,
+@@ -476,7 +496,7 @@ static int fuse_mount_fusermount(const char *mountpoint, struct mount_opts *mo,
+ 		close(fds[0]);
+ 		close(fds[1]);
+ 		fuse_log(FUSE_LOG_ERR, "posix_spawn(p)() for %s failed: %s",
+-			 FUSERMOUNT_PROG, strerror(-status));
++			 fusermountProg(), strerror(-status));
+ 		return -1;
+ 	}
+ 

--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -316,6 +316,8 @@ You can report bugs to the linyaps team under this project: https://github.com/O
       ->excludes(layerFlag, fullOpt);
     buildExport->add_flag("--no-develop", ExportOption.noExportDevelop, _("Don't export the develop module"))
         ->needs(layerFlag);
+    std::filesystem::path outputFile;
+    buildExport->add_option("-o, --output", outputFile, _("Output file"))->type_name("FILE");
 
     // build push
     std::string pushModule;
@@ -836,11 +838,10 @@ You can report bugs to the linyaps team under this project: https://github.com/O
 
         if (layerMode) {
             // layer 默认使用lzma有更高压缩率
-            QString compressor = "lzma";
-            if (!ExportOption.compressor.empty()) {
-                compressor = ExportOption.compressor.c_str();
+            if (ExportOption.compressor.empty()) {
+                ExportOption.compressor = "lzma";
             }
-            auto result = builder.exportLayer(compressor, ExportOption.noExportDevelop);
+            auto result = builder.exportLayer(ExportOption);
             if (!result) {
                 qCritical() << result.error();
                 return -1;
@@ -853,11 +854,10 @@ You can report bugs to the linyaps team under this project: https://github.com/O
             ExportOption.loader = appLoader;
         }
         // uab 默认使用lz4可以更快解压速度，避免影响应用自运行
-        QString compressor = "lz4";
-        if (!ExportOption.compressor.empty()) {
-            compressor = ExportOption.compressor.c_str();
+        if (ExportOption.compressor.empty()) {
+            ExportOption.compressor = "lz4";
         }
-        auto result = builder.exportUAB(ExportOption);
+        auto result = builder.exportUAB(ExportOption, outputFile);
         if (!result) {
             qCritical() << result.error();
             return -1;

--- a/apps/uab/CMakeLists.txt
+++ b/apps/uab/CMakeLists.txt
@@ -1,9 +1,5 @@
 # SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-if (NOT ${ENABLE_UAB})
-    return()
-endif()
-
 add_subdirectory(loader)
 add_subdirectory(header)

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -557,7 +557,8 @@ utils::error::Result<void> Builder::buildStageFetchSource() noexcept
 }
 
 utils::error::Result<package::Reference> Builder::clearDependency(const std::string &ref,
-                                                                  bool onlyLocal) noexcept
+                                                                  bool forceRemote,
+                                                                  bool fallbackToRemote) noexcept
 {
     LINGLONG_TRACE("clear dependency");
 
@@ -567,7 +568,8 @@ utils::error::Result<package::Reference> Builder::clearDependency(const std::str
     }
 
     auto res =
-      repo.clearReference(*fuzzyRef, { .forceRemote = !onlyLocal, .fallbackToRemote = false });
+      repo.clearReference(*fuzzyRef,
+                          { .forceRemote = forceRemote, .fallbackToRemote = fallbackToRemote });
     if (!res) {
         return LINGLONG_ERR(QString{"ref doesn't exist %1"}.arg(fuzzyRef->toString()));
     }
@@ -588,14 +590,14 @@ utils::error::Result<void> Builder::buildStagePullDependency() noexcept
                    .toStdString(),
                  2);
 
-    auto ref = clearDependency(this->project.base, this->buildOptions.skipPullDepend);
+    auto ref = clearDependency(this->project.base, !this->buildOptions.skipPullDepend, false);
     if (!ref) {
         return LINGLONG_ERR("base dependency error", ref);
     }
     baseRef = std::move(ref).value();
 
     if (this->project.runtime) {
-        ref = clearDependency(*this->project.runtime, this->buildOptions.skipPullDepend);
+        ref = clearDependency(*this->project.runtime, !this->buildOptions.skipPullDepend, false);
         if (!ref) {
             return LINGLONG_ERR("runtime dependency error", ref);
         }
@@ -676,7 +678,7 @@ utils::error::Result<void> Builder::buildStagePullDependency() noexcept
             return LINGLONG_ERR("failed to get runtime layer item", layerItem);
         }
 
-        auto ref = clearDependency(layerItem->info.base, true);
+        auto ref = clearDependency(layerItem->info.base, false, false);
         if (!ref || *ref != *baseRef) {
             return LINGLONG_ERR("base is not compatible with runtime ");
         }
@@ -1515,6 +1517,53 @@ utils::error::Result<void> Builder::exportUAB(const ExportOption &option,
 
     package::UABPackager packager{ workingDir };
 
+    // Try to use uab-header, uab-loader, and bundling logic from ll-builder-utils if available.
+    // Fallback to defaults if ll-builder-utils is not found or fails.
+    auto ref = clearDependency("cn.org.linyaps.builder.utils", false, true);
+    if (ref && pullDependency(*ref, this->repo, "binary")) {
+        auto res = run({ "binary" },
+                       { "/opt/apps/cn.org.linyaps.builder.utils/files/bin/ll-builder-export",
+                         "--get-header",
+                         "/project/uab-header",
+                         "--get-loader",
+                         "/project/uab-loader" },
+                       false,
+                       *ref);
+        if (res) {
+            std::error_code ec;
+            if (std::filesystem::exists(workingDir.absoluteFilePath("uab-header").toStdString(), ec)
+                && std::filesystem::exists(workingDir.absoluteFilePath("uab-loader").toStdString(),
+                                           ec)) {
+                packager.setDefaultHeader(workingDir.absoluteFilePath("uab-header"));
+                packager.setDefaultLoader(workingDir.absoluteFilePath("uab-loader"));
+            }
+        } else {
+            qWarning() << "run builder utils error: " << res.error();
+        }
+
+        auto utilsBundler =
+          [ref = *ref, option, this](const QString &bundleFile,
+                                     const QString &bundleDir) -> utils::error::Result<void> {
+            LINGLONG_TRACE("use utils to bundle file");
+            QString relativeBundleFile = workingDir.relativeFilePath(bundleFile);
+            QString relativeBundleDir = workingDir.relativeFilePath(bundleDir);
+            if (relativeBundleFile.startsWith("../") || relativeBundleDir.startsWith("../")) {
+                return LINGLONG_ERR("file must be in project directory");
+            }
+            QStringList args = {
+                "/opt/apps/cn.org.linyaps.builder.utils/files/bin/ll-builder-export",
+                "--packdir",
+                QString("%1:%2").arg(QDir("/project").absoluteFilePath(relativeBundleDir),
+                                     QDir("/project").absoluteFilePath(relativeBundleFile))
+            };
+            if (!option.compressor.empty()) {
+                args << "-z" << QString::fromStdString(option.compressor);
+            }
+            return run({ "binary" }, args, false, ref);
+        };
+        packager.setBundleCB(utilsBundler);
+    }
+
     if (!option.iconPath.empty()) {
         if (auto ret = packager.setIcon(QFileInfo{ option.iconPath.c_str() }); !ret) {
             return LINGLONG_ERR(ret);
@@ -1748,12 +1797,20 @@ utils::error::Result<void> Builder::importLayer(repo::OSTreeRepo &ostree, const 
 
 utils::error::Result<void> Builder::run(const QStringList &modules,
                                         const QStringList &args,
-                                        bool debug)
+                                        bool debug,
+                                        std::optional<package::Reference> runWith)
 {
     LINGLONG_TRACE("run application");
-    auto curRef = currentReference(this->project);
-    if (!curRef) {
-        return LINGLONG_ERR(curRef);
+
+    std::optional<package::Reference> curRef;
+    if (runWith) {
+        curRef = std::move(runWith).value();
+    } else {
+        auto ref = currentReference(this->project);
+        if (!ref) {
+            return LINGLONG_ERR(ref);
+        }
+        curRef = std::move(ref).value();
     }
 
     auto containerID = runtime::genContainerID(*curRef);

--- a/libs/linglong/src/linglong/builder/linglong_builder.h
+++ b/libs/linglong/src/linglong/builder/linglong_builder.h
@@ -79,9 +79,11 @@ public:
     static auto importLayer(repo::OSTreeRepo &repo, const QString &path)
       -> utils::error::Result<void>;
 
-    auto run(const QStringList &modules,
-             const QStringList &args,
-             bool debug = false) -> utils::error::Result<void>;
+    auto
+    run(const QStringList &modules,
+        const QStringList &args,
+        bool debug = false,
+        std::optional<package::Reference> runWith = std::nullopt) -> utils::error::Result<void>;
     auto runtimeCheck() -> utils::error::Result<void>;
 
     void setBuildOptions(const BuilderBuildOptions &options) noexcept { buildOptions = options; }
@@ -102,7 +104,8 @@ private:
     utils::error::Result<void> commitToLocalRepo() noexcept;
     std::unique_ptr<utils::OverlayFS> makeOverlay(QString lowerdir, QString overlayDir) noexcept;
     utils::error::Result<package::Reference> clearDependency(const std::string &ref,
-                                                             bool onlyLocal) noexcept;
+                                                             bool forceRemote,
+                                                             bool fallbackToRemote) noexcept;
     auto generateEntryScript() noexcept -> utils::error::Result<void>;
     auto generateBuildDependsScript() noexcept -> utils::error::Result<bool>;
     auto generateDependsScript() noexcept -> utils::error::Result<bool>;

--- a/libs/linglong/src/linglong/builder/linglong_builder.h
+++ b/libs/linglong/src/linglong/builder/linglong_builder.h
@@ -63,9 +63,9 @@ public:
     auto build(const QStringList &args = { "/project/linglong/entry.sh" }) noexcept
       -> utils::error::Result<void>;
 
-    auto exportUAB(const ExportOption &option) -> utils::error::Result<void>;
-    auto exportLayer(const QString &compressor,
-                     const bool &noExportDevelop) -> utils::error::Result<void>;
+    auto exportUAB(const ExportOption &option, const std::filesystem::path outputFile = {})
+      -> utils::error::Result<void>;
+    auto exportLayer(const ExportOption &option) -> utils::error::Result<void>;
 
     static auto extractLayer(const QString &layerPath, const QString &destination)
       -> utils::error::Result<void>;

--- a/libs/linglong/src/linglong/package/uab_packager.h
+++ b/libs/linglong/src/linglong/package/uab_packager.h
@@ -76,6 +76,11 @@ public:
     utils::error::Result<void> loadNeededFiles() noexcept;
     utils::error::Result<void> setLoader(const QString &loader) noexcept;
     utils::error::Result<void> setCompressor(const QString &compressor) noexcept;
+    utils::error::Result<void> setDefaultHeader(const QString &header) noexcept;
+    utils::error::Result<void> setDefaultLoader(const QString &loader) noexcept;
+    utils::error::Result<void>
+    setBundleCB(std::function<utils::error::Result<void>(const QString &, const QString &)>
+                  bundleCB) noexcept;
 
 private:
     [[nodiscard]] utils::error::Result<void> packIcon() noexcept;
@@ -98,5 +103,8 @@ private:
     std::filesystem::path workDir;
     QString loader;
     QString compressor = "lz4";
+    QString defaultHeader;
+    QString defaultLoader;
+    std::function<utils::error::Result<void>(const QString &, const QString &)> bundleCB;
 };
 } // namespace linglong::package

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+version: "1"
+
+package:
+  id: cn.org.linyaps.builder.utils
+  name: ll-builder-utils
+  version: 0.0.1.0
+  kind: app
+  description: |
+    Utils for ll-builder
+
+command: [/opt/apps/cn.org.linyaps.builder.utils/files/bin/ll-builder-export]
+
+base: org.deepin.base/25.2.0
+
+sources:
+  - kind: archive
+    url:  https://github.com/erofs/erofs-utils/archive/refs/tags/v1.8.6.tar.gz
+    digest: 5b221dc3fd6d151425b30534ede46fb7a90dc233a8659cba0372796b0a066547
+  - kind: archive
+    url:  https://github.com/libfuse/libfuse/releases/download/fuse-3.17.1/fuse-3.17.1.tar.gz
+    digest: 2d8ae87a4525fbfa1db5e5eb010ff6f38140627a7004554ed88411c1843d51b2
+
+build: |
+  echo "$PREFIX"
+
+  # build libfuse static library
+  cd /project/linglong/sources/fuse-3.17.1.tar.gz/fuse-3.17.1
+  patch lib/mount.c /project/apps/ll-builder-utils/patch/libfuse.patch
+  mkdir build
+  cd build
+  meson setup ../
+  meson configure --default-library static -D utils=false -D examples=false -D tests=false -D disable-libc-symbol-version=false
+  ninja && ninja install
+
+  # build erofsfuse static library
+  cd /project/linglong/sources/v1.8.6.tar.gz/erofs-utils-1.8.6
+  ./autogen.sh
+  ./configure -with-libzstd --enable-fuse --enable-static-fuse --with-libdeflate --without-xxhash libdeflate_LIBS=-ldeflate libdeflate_CFLAGS=-ldeflate
+  make -j4
+  make install
+
+  cd /project
+  cmake -B build-linglong -DCPM_LOCAL_PACKAGES_ONLY=true -DENABLE_TESTING=false -DBUILD_LINGLONG_BUILDER_UTILS_IN_BOX=true
+  cmake --build build-linglong -j8
+  cmake --install build-linglong --prefix=$PREFIX
+  install /usr/local/bin/mkfs.erofs $PREFIX/bin/
+
+buildext:
+  apt:
+    build_depends: [patch, meson, libtool, pkg-config, uuid-dev, libdeflate-dev, libzstd-dev, nlohmann-json3-dev, libyaml-cpp-dev, liblz4-dev, liblzma-dev, libselinux1-dev, libpcre2-dev, libelf-dev]


### PR DESCRIPTION
1. export UAB add -o,--output option.
2. add ll-builder-utils to build uab-header and uab-loader, which is a linglong APP. To build ll-builder-utils, enable flag ENABLE_LINGLONG_APP_BUILDER_UTILS, and make ll-builder-utils.
4. ll-builder will try to use ll-builder-utils to export UAB file.