### PR TITLE
fix: builder build crash when parsing version number

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -106,8 +106,8 @@ parseProjectConfig(const QString &filename)
     if (!project) {
         return project;
     }
-    auto version = linglong::package::Version(QString::fromStdString(project->package.version));
-    if (!version.tweak) {
+    auto version = linglong::package::Version::parse(QString::fromStdString(project->package.version));
+    if (!version || !version->tweak) {
         return LINGLONG_ERR("Please ensure the package.version number has three parts formatted as "
                             "'MAJOR.MINOR.PATCH.TWEAK'");
     }


### PR DESCRIPTION
When writing a version number incorrectly, it should return an error and exit instead of crashing directly.