### PR TITLE
fix: remove binding host certs for now

### DIFF
--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -313,7 +313,7 @@ ContainerCfgBuilder &ContainerCfgBuilder::bindHostStatics() noexcept
     std::vector<std::string> statics{
         "/etc/machine-id",
         "/etc/resolvconf",
-        "/etc/ssl/certs",
+        // FIXME: support for host /etc/ssl, ref https://github.com/p11-glue/p11-kit
         "/usr/lib/locale",
         "/usr/share/fonts",
         "/usr/share/icons",


### PR DESCRIPTION
Certificate name resolvtion is very complicated
we shouldn't bind /etc/ssl/certs to container directly