### PR TITLE
fix: restrict content command to app type layers only

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -2161,6 +2161,17 @@ int Cli::content([[maybe_unused]] CLI::App *subcommand)
         return -1;
     }
 
+    auto layerItem = this->repository.getLayerItem(*ref);
+    if (!layerItem) {
+        this->printer.printErr(layerItem.error());
+        return -1;
+    }
+
+    if (layerItem->info.kind != "app") {
+        this->printer.printErr(LINGLONG_ERRV("Only supports viewing app content"));
+        return -1;
+    }
+
     auto layer = this->repository.getLayerDir(*ref, "binary");
     if (!layer) {
         this->printer.printErr(layer.error());


### PR DESCRIPTION
Added validation to ensure the content command can only be used with application layers by checking the layer kind. If the layer is not an app,
an error message is displayed to inform the user that only app content viewing is supported. This prevents potential issues when trying to view content of non-application layers.

fix: 限制内容命令仅用于应用类型层

添加验证以确保内容命令只能用于应用层，方法是检查层的类型。
如果该层不是应用类型，则显示错误消息，通知用户只支持查看应用内容。
这可以防止尝试查看非应用层内容时可能出现的问题。