### PR TITLE
feat: enhance package search with multi-repository support

### DIFF
--- a/api/schema/v1.json
+++ b/api/schema/v1.json
@@ -1008,12 +1008,20 @@
       "type": "object",
       "description": "package manager search parameters",
       "required": [
-        "id"
+        "id",
+        "repos"
       ],
       "properties": {
         "id": {
           "type": "string",
           "description": "id of package manager search"
+        },
+        "repos": {
+          "type": "array",
+          "description": "repo of package manager search",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -1025,6 +1033,9 @@
           "$ref": "#/$defs/CommonResult"
         }
       ],
+      "required": [
+        "id"
+      ],
       "properties": {
         "id": {
           "type": "string",
@@ -1033,6 +1044,27 @@
       }
     },
     "PackageManager1SearchResult": {
+      "type": "object",
+      "description": "result of package manager search",
+      "allOf": [
+        {
+          "$ref": "#/$defs/CommonResult"
+        }
+      ],
+      "properties": {
+        "packages": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/PackageInfoV2"
+            },
+            "description": "package info of package manager search"
+          }
+        }
+      }
+    },
+    "PackageManager1PruneResult": {
       "type": "object",
       "description": "result of package manager search",
       "allOf": [
@@ -1360,6 +1392,9 @@
     },
     "PackageManager1SearchResult": {
       "$ref": "#/$defs/PackageManager1SearchResult"
+    },
+    "PackageManager1PruneResult": {
+      "$ref": "#/$defs/PackageManager1PruneResult"
     },
     "PackageManager1GetRepoInfoResult": {
       "$ref": "#/$defs/PackageManager1GetRepoInfoResult"

--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -779,20 +779,41 @@ $defs:
     description: package manager search parameters
     required:
       - id
+      - repos
     properties:
       id:
         type: string
         description: id of package manager search
+      repos:
+        type: array
+        description: repo of package manager search
+        items:
+          type: string
   PackageManager1JobInfo:
     type: object
     description: Get the job result using an ID
     allOf:
       - $ref: '#/$defs/CommonResult'
+    required:
+      - id
     properties:
       id:
         type: string
         description: id of job info
   PackageManager1SearchResult:
+    type: object
+    description: result of package manager search
+    allOf:
+      - $ref: '#/$defs/CommonResult'
+    properties:
+      packages:
+        type: object
+        additionalProperties:
+          type: array
+          items:
+            $ref: '#/$defs/PackageInfoV2'
+          description: package info of package manager search
+  PackageManager1PruneResult:
     type: object
     description: result of package manager search
     allOf:

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -394,6 +394,9 @@ ll-cli search . --type=runtime)"));
       ->type_name("TYPE")
       ->capture_default_str()
       ->check(validatorString);
+    cliSearch->add_option("--repo", options.repo, _("Specify the repo"))
+      ->type_name("REPO")
+      ->check(validatorString);
     cliSearch->add_flag("--dev", options.showDevel, _("include develop application in result"));
     cliSearch->add_flag("--all", options.showAll, _("Show all results"));
 

--- a/libs/api/src/linglong/api/types/v1/Generators.hpp
+++ b/libs/api/src/linglong/api/types/v1/Generators.hpp
@@ -36,6 +36,7 @@
 #include "linglong/api/types/v1/PackageManager1SearchResult.hpp"
 #include "linglong/api/types/v1/PackageManager1SearchParameters.hpp"
 #include "linglong/api/types/v1/PackageManager1RequestInteractionAdditionalMessage.hpp"
+#include "linglong/api/types/v1/PackageManager1PruneResult.hpp"
 #include "linglong/api/types/v1/PackageManager1PackageTaskResult.hpp"
 #include "linglong/api/types/v1/PackageManager1Package.hpp"
 #include "linglong/api/types/v1/PackageManager1ModifyRepoParameters.hpp"
@@ -181,6 +182,9 @@ void to_json(json & j, const PackageManager1Package & x);
 
 void from_json(const json & j, PackageManager1PackageTaskResult & x);
 void to_json(json & j, const PackageManager1PackageTaskResult & x);
+
+void from_json(const json & j, PackageManager1PruneResult & x);
+void to_json(json & j, const PackageManager1PruneResult & x);
 
 void from_json(const json & j, PackageManager1RequestInteractionAdditionalMessage & x);
 void to_json(json & j, const PackageManager1RequestInteractionAdditionalMessage & x);
@@ -784,7 +788,7 @@ j["package"] = x.package;
 }
 
 inline void from_json(const json & j, PackageManager1JobInfo& x) {
-x.id = get_stack_optional<std::string>(j, "id");
+x.id = j.at("id").get<std::string>();
 x.code = j.at("code").get<int64_t>();
 x.message = j.at("message").get<std::string>();
 x.type = j.at("type").get<std::string>();
@@ -792,9 +796,7 @@ x.type = j.at("type").get<std::string>();
 
 inline void to_json(json & j, const PackageManager1JobInfo & x) {
 j = json::object();
-if (x.id) {
 j["id"] = x.id;
-}
 j["code"] = x.code;
 j["message"] = x.message;
 j["type"] = x.type;
@@ -849,6 +851,23 @@ j["message"] = x.message;
 j["type"] = x.type;
 }
 
+inline void from_json(const json & j, PackageManager1PruneResult& x) {
+x.packages = get_stack_optional<std::vector<PackageInfoV2>>(j, "packages");
+x.code = j.at("code").get<int64_t>();
+x.message = j.at("message").get<std::string>();
+x.type = j.at("type").get<std::string>();
+}
+
+inline void to_json(json & j, const PackageManager1PruneResult & x) {
+j = json::object();
+if (x.packages) {
+j["packages"] = x.packages;
+}
+j["code"] = x.code;
+j["message"] = x.message;
+j["type"] = x.type;
+}
+
 inline void from_json(const json & j, PackageManager1RequestInteractionAdditionalMessage& x) {
 x.localRef = j.at("LocalRef").get<std::string>();
 x.remoteRef = j.at("RemoteRef").get<std::string>();
@@ -862,15 +881,17 @@ j["RemoteRef"] = x.remoteRef;
 
 inline void from_json(const json & j, PackageManager1SearchParameters& x) {
 x.id = j.at("id").get<std::string>();
+x.repos = j.at("repos").get<std::vector<std::string>>();
 }
 
 inline void to_json(json & j, const PackageManager1SearchParameters & x) {
 j = json::object();
 j["id"] = x.id;
+j["repos"] = x.repos;
 }
 
 inline void from_json(const json & j, PackageManager1SearchResult& x) {
-x.packages = get_stack_optional<std::vector<PackageInfoV2>>(j, "packages");
+x.packages = get_stack_optional<std::map<std::string, std::vector<PackageInfoV2>>>(j, "packages");
 x.code = j.at("code").get<int64_t>();
 x.message = j.at("message").get<std::string>();
 x.type = j.at("type").get<std::string>();
@@ -1091,6 +1112,7 @@ x.packageManager1ModifyRepoParameters = get_stack_optional<PackageManager1Modify
 x.packageManager1ModifyRepoResult = get_stack_optional<CommonResult>(j, "PackageManager1ModifyRepoResult");
 x.packageManager1Package = get_stack_optional<PackageManager1Package>(j, "PackageManager1Package");
 x.packageManager1PackageTaskResult = get_stack_optional<PackageManager1PackageTaskResult>(j, "PackageManager1PackageTaskResult");
+x.packageManager1PruneResult = get_stack_optional<PackageManager1PruneResult>(j, "PackageManager1PruneResult");
 x.packageManager1RequestInteractionAdditionalMessage = get_stack_optional<PackageManager1RequestInteractionAdditionalMessage>(j, "PackageManager1RequestInteractionAdditionalMessage");
 x.packageManager1SearchParameters = get_stack_optional<PackageManager1SearchParameters>(j, "PackageManager1SearchParameters");
 x.packageManager1SearchResult = get_stack_optional<PackageManager1SearchResult>(j, "PackageManager1SearchResult");
@@ -1192,6 +1214,9 @@ j["PackageManager1Package"] = x.packageManager1Package;
 }
 if (x.packageManager1PackageTaskResult) {
 j["PackageManager1PackageTaskResult"] = x.packageManager1PackageTaskResult;
+}
+if (x.packageManager1PruneResult) {
+j["PackageManager1PruneResult"] = x.packageManager1PruneResult;
 }
 if (x.packageManager1RequestInteractionAdditionalMessage) {
 j["PackageManager1RequestInteractionAdditionalMessage"] = x.packageManager1RequestInteractionAdditionalMessage;

--- a/libs/api/src/linglong/api/types/v1/LinglongAPIV1.hpp
+++ b/libs/api/src/linglong/api/types/v1/LinglongAPIV1.hpp
@@ -42,6 +42,7 @@
 #include "linglong/api/types/v1/PackageManager1ModifyRepoParameters.hpp"
 #include "linglong/api/types/v1/PackageManager1Package.hpp"
 #include "linglong/api/types/v1/PackageManager1PackageTaskResult.hpp"
+#include "linglong/api/types/v1/PackageManager1PruneResult.hpp"
 #include "linglong/api/types/v1/PackageManager1RequestInteractionAdditionalMessage.hpp"
 #include "linglong/api/types/v1/PackageManager1SearchParameters.hpp"
 #include "linglong/api/types/v1/PackageManager1SearchResult.hpp"
@@ -111,6 +112,7 @@ std::optional<PackageManager1ModifyRepoParameters> packageManager1ModifyRepoPara
 std::optional<CommonResult> packageManager1ModifyRepoResult;
 std::optional<PackageManager1Package> packageManager1Package;
 std::optional<PackageManager1PackageTaskResult> packageManager1PackageTaskResult;
+std::optional<PackageManager1PruneResult> packageManager1PruneResult;
 std::optional<PackageManager1RequestInteractionAdditionalMessage> packageManager1RequestInteractionAdditionalMessage;
 std::optional<PackageManager1SearchParameters> packageManager1SearchParameters;
 std::optional<PackageManager1SearchResult> packageManager1SearchResult;

--- a/libs/api/src/linglong/api/types/v1/PackageInfoV2.hpp
+++ b/libs/api/src/linglong/api/types/v1/PackageInfoV2.hpp
@@ -25,12 +25,16 @@ namespace types {
 namespace v1 {
 /**
 * this is the each item output of ll-cli list --json
+*
+* package info of package manager search
 */
 
 using nlohmann::json;
 
 /**
 * this is the each item output of ll-cli list --json
+*
+* package info of package manager search
 */
 struct PackageInfoV2 {
 /**

--- a/libs/api/src/linglong/api/types/v1/PackageManager1JobInfo.hpp
+++ b/libs/api/src/linglong/api/types/v1/PackageManager1JobInfo.hpp
@@ -38,7 +38,7 @@ struct PackageManager1JobInfo {
 /**
 * id of job info
 */
-std::optional<std::string> id;
+std::string id;
 /**
 * We do not use DBus error. We return an error code instead. Non-zero code indicated errors
 * occurs and message should be displayed to user.

--- a/libs/api/src/linglong/api/types/v1/PackageManager1PruneResult.hpp
+++ b/libs/api/src/linglong/api/types/v1/PackageManager1PruneResult.hpp
@@ -9,7 +9,7 @@
 //
 //  Then include this file, and then do
 //
-//     PackageManager1SearchResult.hpp data = nlohmann::json::parse(jsonString);
+//     PackageManager1PruneResult.hpp data = nlohmann::json::parse(jsonString);
 
 #pragma once
 
@@ -36,8 +36,8 @@ using nlohmann::json;
 *
 * this is common error result of ll-cli command --json
 */
-struct PackageManager1SearchResult {
-std::optional<std::map<std::string, std::vector<PackageInfoV2>>> packages;
+struct PackageManager1PruneResult {
+std::optional<std::vector<PackageInfoV2>> packages;
 /**
 * We do not use DBus error. We return an error code instead. Non-zero code indicated errors
 * occurs and message should be displayed to user.

--- a/libs/api/src/linglong/api/types/v1/PackageManager1SearchParameters.hpp
+++ b/libs/api/src/linglong/api/types/v1/PackageManager1SearchParameters.hpp
@@ -35,6 +35,10 @@ struct PackageManager1SearchParameters {
 * id of package manager search
 */
 std::string id;
+/**
+* repo of package manager search
+*/
+std::vector<std::string> repos;
 };
 }
 }

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -39,6 +39,7 @@ struct CliOptions
     std::string instance;
     std::string module;
     std::string type;
+    std::optional<std::string> repo;
     RepoOptions repoOptions;
     std::vector<std::string> commands;
     bool showDevel;
@@ -98,10 +99,10 @@ private:
     filePathMapping(const std::vector<std::string> &command) const noexcept;
     static std::string mappingFile(const std::filesystem::path &file) noexcept;
     static std::string mappingUrl(std::string_view url) noexcept;
-    static void filterPackageInfosFromType(std::vector<api::types::v1::PackageInfoV2> &list,
+    static void filterPackageInfosByType(std::map<std::string,std::vector<api::types::v1::PackageInfoV2>> &list,
                                            const std::string &type) noexcept;
     static utils::error::Result<void>
-    filterPackageInfosFromVersion(std::vector<api::types::v1::PackageInfoV2> &list) noexcept;
+    filterPackageInfosByVersion(std::map<std::string,std::vector<api::types::v1::PackageInfoV2>> &list) noexcept;
     void printProgress() noexcept;
     [[nodiscard]] utils::error::Result<std::vector<api::types::v1::CliContainer>>
     getCurrentContainers() const noexcept;

--- a/libs/linglong/src/linglong/cli/cli_printer.cpp
+++ b/libs/linglong/src/linglong/cli/cli_printer.cpp
@@ -100,6 +100,47 @@ void CLIPrinter::printPackages(const std::vector<api::types::v1::PackageInfoV2> 
     }
 }
 
+void CLIPrinter::printSearchResult(const std::map<std::string, std::vector<api::types::v1::PackageInfoV2>> &list)
+{
+    if (list.empty()) {
+        std::cout << _("No packages found in the remote repo.") << std::endl;
+        return;
+    }
+    std::cout << "\033[38;5;214m" << std::left << adjustDisplayWidth(qUtf8Printable(_("ID")), 43)
+              << adjustDisplayWidth(qUtf8Printable(_("Name")), 33)
+              << adjustDisplayWidth(qUtf8Printable(_("Version")), 16)
+              << adjustDisplayWidth(qUtf8Printable(_("Channel")), 16)
+              << adjustDisplayWidth(qUtf8Printable(_("Module")), 12)
+              << adjustDisplayWidth(qUtf8Printable(_("Repo")), 10)
+              << qUtf8Printable(_("Description")) << "\033[0m" << std::endl;
+    for (const auto &[pkgRepo, packages] : list) {
+        for (const auto &pkg : packages) {
+            auto simpleDescription = QString::fromStdString(pkg.description.value_or("")).simplified();
+            auto simpleDescriptionWStr = simpleDescription.toStdWString();
+            auto simpleDescriptionWcswidth = wcswidth(simpleDescriptionWStr.c_str(), -1);
+            if (simpleDescriptionWcswidth > 56) {
+                simpleDescriptionWStr = subwstr(simpleDescriptionWStr, 53) + L"...";
+                simpleDescription = QString::fromStdWString(simpleDescriptionWStr);
+            }
+
+            auto name = QString::fromStdString(pkg.name).simplified();
+            auto nameWStr = name.toStdWString();
+            auto nameWcswidth = wcswidth(nameWStr.c_str(), -1);
+            if (nameWcswidth > 33) {
+                nameWStr = subwstr(nameWStr, 29) + L"...";
+                nameWcswidth = wcswidth(nameWStr.c_str(), -1);
+                name = QString::fromStdWString(nameWStr);
+            }
+            auto nameStr = name.toStdString();
+            auto nameOffset = nameStr.size() - nameWcswidth;
+            std::cout << std::setw(43) << pkg.id + " " << std::setw(33 + nameOffset) << nameStr + " "
+                    << std::setw(16) << pkg.version + " " << std::setw(16) << pkg.channel + " "
+                    << std::setw(12) << pkg.packageInfoV2Module + " " << std::setw(10) << pkgRepo + " "
+                    << simpleDescription.toStdString() << std::endl;
+        }
+    }
+}
+
 void CLIPrinter::printContainers(const std::vector<api::types::v1::CliContainer> &list)
 {
     if (list.empty()) {

--- a/libs/linglong/src/linglong/cli/cli_printer.h
+++ b/libs/linglong/src/linglong/cli/cli_printer.h
@@ -35,6 +35,7 @@ public:
     void printErr(const utils::error::Error &) override;
     void printPackage(const api::types::v1::PackageInfoV2 &) override;
     void printPackages(const std::vector<api::types::v1::PackageInfoV2> &) override;
+    void printSearchResult(const std::map<std::string, std::vector<api::types::v1::PackageInfoV2>> &) override;
     void printPruneResult(const std::vector<api::types::v1::PackageInfoV2> &list) override;
     void printContainers(const std::vector<api::types::v1::CliContainer> &) override;
     void printReply(const api::types::v1::CommonResult &) override;

--- a/libs/linglong/src/linglong/cli/json_printer.h
+++ b/libs/linglong/src/linglong/cli/json_printer.h
@@ -16,6 +16,7 @@ public:
     void printErr(const utils::error::Error &) override;
     void printPackage(const api::types::v1::PackageInfoV2 &) override;
     void printPackages(const std::vector<api::types::v1::PackageInfoV2> &) override;
+    void printSearchResult(const std::map<std::string, std::vector<api::types::v1::PackageInfoV2>> &) override {};
     void printPruneResult(const std::vector<api::types::v1::PackageInfoV2> &) override;
     void printContainers(const std::vector<api::types::v1::CliContainer> &) override;
     void printReply(const api::types::v1::CommonResult &) override;

--- a/libs/linglong/src/linglong/cli/printer.h
+++ b/libs/linglong/src/linglong/cli/printer.h
@@ -76,6 +76,7 @@ public:
     virtual void printErr(const utils::error::Error &) = 0;
     virtual void printPackage(const api::types::v1::PackageInfoV2 &) = 0;
     virtual void printPackages(const std::vector<api::types::v1::PackageInfoV2> &) = 0;
+    virtual void printSearchResult(const std::map<std::string, std::vector<api::types::v1::PackageInfoV2>> &) = 0;
     virtual void printPruneResult(const std::vector<api::types::v1::PackageInfoV2> &) = 0;
     virtual void printContainers(const std::vector<api::types::v1::CliContainer> &) = 0;
     virtual void printReply(const api::types::v1::CommonResult &) = 0;

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "linglong/api/types/v1/Repo.hpp"
 #include "linglong/api/types/v1/RepoConfigV2.hpp"
 #include "linglong/package/fuzzy_reference.h"
 #include "linglong/package/layer_dir.h"
@@ -46,6 +47,7 @@ public:
     ~OSTreeRepo() override;
 
     [[nodiscard]] const api::types::v1::RepoConfigV2 &getConfig() const noexcept;
+    [[nodiscard]] api::types::v1::RepoConfigV2 getOrderedConfig() noexcept;
     utils::error::Result<void> setConfig(const api::types::v1::RepoConfigV2 &cfg) noexcept;
 
     utils::error::Result<package::LayerDir>
@@ -79,7 +81,7 @@ public:
     utils::error::Result<std::vector<api::types::v1::PackageInfoV2>>
     listLocalLatest() const noexcept;
     utils::error::Result<std::vector<api::types::v1::PackageInfoV2>>
-    listRemote(const package::FuzzyReference &fuzzyRef) const noexcept;
+    listRemote(const package::FuzzyReference &fuzzyRef, const std::optional<api::types::v1::Repo> &repo = std::nullopt) const noexcept;
     [[nodiscard]] utils::error::Result<std::vector<api::types::v1::RepositoryCacheLayersItem>>
     listLocalBy(const linglong::repo::repoCacheQuery &query) const noexcept;
 


### PR DESCRIPTION
1. Added repository field to search parameters requiring specifying
repos to search
2. Modified search implementation to support searching in multiple
repositories
3. Restructured search results to group packages by repository source
4. Added --repo option to the CLI search command
5. Updated display format to show repository information in search
results
6. Improved filtering logic to work with the repository-grouped package
structure
7. Added PackageManager1PruneResult type to separate it from search
results