### PR TITLE
feat: improve shell completions to show only apps when appropriate

### DIFF
--- a/misc/share/bash-completion/completions/ll-cli
+++ b/misc/share/bash-completion/completions/ll-cli
@@ -12,6 +12,10 @@ __ll_cli_get_container_list() {
         ll-cli ps | tail -n+2 | awk '{print $1}' | tr '\n' ' '
 }
 
+__ll_cli_get_installed_app_list() {
+        ll-cli list --type=app | tail -n+2 | awk '{print $1}' | tr '\n' ' '
+}
+
 __ll_cli_get_installed_list() {
         ll-cli list | tail -n+2 | awk '{print $1}' | tr '\n' ' '
 }
@@ -87,7 +91,7 @@ _ll_cli_complete() {
                 local run_options="--file --url"
                 local installed_list
                 if [[ "${prev}" == "run" ]]; then
-                        installed_list="$(__ll_cli_get_installed_list)"
+                        installed_list="$(__ll_cli_get_installed_app_list)"
                 fi
                 output_options="${output_options} ${run_options} ${installed_list}"
                 ;;
@@ -142,7 +146,7 @@ _ll_cli_complete() {
                 local uninstall_options
                 local installed_list
                 if [[ "${prev}" == "uninstall" ]]; then
-                        installed_list="$(__ll_cli_get_installed_list)"
+                        installed_list="$(__ll_cli_get_installed_app_list)"
                 fi
                 output_options="${output_options} ${uninstall_options} ${installed_list}"
                 ;;
@@ -157,7 +161,7 @@ _ll_cli_complete() {
                 output_options="${output_options} $(__ll_cli_get_installed_list) $(__ll_cli_get_layer_list ${cur}))"
                 ;;
         content)
-                output_options="${output_options} $(__ll_cli_get_installed_list)"
+                output_options="${output_options} $(__ll_cli_get_installed_app_list)"
                 ;;
         search)
                 search_target="."

--- a/misc/share/zsh/vendor-completions/_ll-cli
+++ b/misc/share/zsh/vendor-completions/_ll-cli
@@ -12,6 +12,10 @@ __ll_cli_get_installed_list() {
     ll-cli list | tail -n+2 | awk '{print $1line}' || echo ""
 }
 
+__ll_cli_get_installed_app_list() {
+    ll-cli list --type=all | tail -n+2 | awk '{print $1line}' || echo ""
+}
+
 __ll_cli_get_app_list() {
     ll-cli search $1 | tail -n+2 | awk '{print $1}' || echo ""
 }
@@ -45,7 +49,7 @@ _ll-cli() {
 
     case "$line[1]" in
         run)
-            local installed_list=(${(f)"$(__ll_cli_get_installed_list)"})
+            local installed_list=(${(f)"$(__ll_cli_get_installed_app_list)"})
             local run_options=(
                 '--file:file:_files'
                 '--url:url:_urls'
@@ -122,7 +126,7 @@ _ll-cli() {
             local uninstall_options=(
                 '--module[Specify the module to uninstall]'
             )
-            local installed_list=(${(f)"$(__ll_cli_get_installed_list)"})
+            local installed_list=(${(f)"$(__ll_cli_get_installed_app_list)"})
             if [[ ${#installed_list[@]} -gt 0 ]]; then
                 _arguments \
                     '1: :{_values "installed applications" "${installed_list[@]}"}' \
@@ -161,7 +165,7 @@ _ll-cli() {
             fi
             ;;
         content)
-            local installed_list=(${(f)"$(__ll_cli_get_installed_list)"})
+            local installed_list=(${(f)"$(__ll_cli_get_installed_app_list)"})
             if [[ ${#installed_list[@]} -gt 0 ]]; then
                 _arguments \
                     '1: :{_values "installed applications" "${installed_list[@]}"}' \


### PR DESCRIPTION
This change enhances both bash and zsh completions for the ll-cli tool by:
1. Adding a new function to specifically list installed applications
2. Updating the run, uninstall, and content commands to show only apps in their tab completion suggestions instead of all installed components
3. Making the completion more contextually relevant for these commands