### PR TITLE
feat: implement multi-repository installation and upgrade

### DIFF
--- a/api/schema/v1.json
+++ b/api/schema/v1.json
@@ -934,6 +934,10 @@
             }
           }
         },
+        "repo": {
+          "type": "string",
+          "description": "repo alias of package manager install parameters"
+        },
         "options": {
           "$ref": "#/$defs/CommonOptions"
         }

--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -729,6 +729,9 @@ $defs:
             type: array
             items:
               type: string
+      repo:
+        type: string
+        description: repo alias of package manager install parameters
       options:
         $ref: '#/$defs/CommonOptions'
   PackageManager1PackageTaskResult:

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -325,6 +325,9 @@ ll-cli install stable:org.deepin.demo/0.0.0.1/x86_64
     cliInstall->add_option("--module", options.module, _("Install a specify module"))
       ->type_name("MODULE")
       ->check(validatorString);
+    cliInstall->add_option("--repo", options.repo, _("Install from a specific repo"))
+      ->type_name("REPO")
+      ->check(validatorString);
     cliInstall->add_flag("--force", options.forceOpt, _("Force install the application"));
     cliInstall->add_flag("-y", options.confirmOpt, _("Automatically answer yes to all questions"));
 

--- a/libs/api/src/linglong/api/types/v1/Generators.hpp
+++ b/libs/api/src/linglong/api/types/v1/Generators.hpp
@@ -779,12 +779,16 @@ j["version"] = x.version;
 inline void from_json(const json & j, PackageManager1InstallParameters& x) {
 x.options = j.at("options").get<CommonOptions>();
 x.package = j.at("package").get<PackageManager1InstallParametersPacakge>();
+x.repo = get_stack_optional<std::string>(j, "repo");
 }
 
 inline void to_json(json & j, const PackageManager1InstallParameters & x) {
 j = json::object();
 j["options"] = x.options;
 j["package"] = x.package;
+if (x.repo) {
+j["repo"] = x.repo;
+}
 }
 
 inline void from_json(const json & j, PackageManager1JobInfo& x) {

--- a/libs/api/src/linglong/api/types/v1/PackageManager1InstallParameters.hpp
+++ b/libs/api/src/linglong/api/types/v1/PackageManager1InstallParameters.hpp
@@ -36,6 +36,10 @@ using nlohmann::json;
 struct PackageManager1InstallParameters {
 CommonOptions options;
 PackageManager1InstallParametersPacakge package;
+/**
+* repo alias of package manager install parameters
+*/
+std::optional<std::string> repo;
 };
 }
 }

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -114,7 +114,7 @@ private:
     utils::error::Result<std::vector<api::types::v1::UpgradeListResult>>
     listUpgradable(const std::vector<api::types::v1::PackageInfoV2> &pkgs);
     utils::error::Result<std::vector<api::types::v1::UpgradeListResult>>
-    listUpgradable(const std::string &type);
+    listUpgradable(const std::string &type = "app");
     int generateCache(const package::Reference &ref);
     utils::error::Result<std::string>
     ensureCache(const package::Reference &ref,

--- a/libs/linglong/src/linglong/package/layer_packager.cpp
+++ b/libs/linglong/src/linglong/package/layer_packager.cpp
@@ -15,6 +15,8 @@
 
 #include <string>
 
+#include <unistd.h>
+
 namespace linglong::package {
 
 LayerPackager::LayerPackager(const QDir &workDir)

--- a/libs/linglong/src/linglong/package/reference.h
+++ b/libs/linglong/src/linglong/package/reference.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "linglong/api/types/v1/PackageInfoV2.hpp"
+#include "linglong/api/types/v1/Repo.hpp"
 #include "linglong/package/architecture.h"
 #include "linglong/package/version.h"
 
@@ -42,6 +43,12 @@ private:
               const QString &id,
               const Version &version,
               const Architecture &architecture);
+};
+
+struct ReferenceWithRepo
+{
+    api::types::v1::Repo repo;
+    Reference reference;
 };
 
 } // namespace linglong::package

--- a/libs/linglong/src/linglong/package_manager/package_manager.h
+++ b/libs/linglong/src/linglong/package_manager/package_manager.h
@@ -8,6 +8,8 @@
 
 #include "linglong/api/types/v1/CommonOptions.hpp"
 #include "linglong/api/types/v1/ContainerProcessStateInfo.hpp"
+#include "linglong/api/types/v1/Repo.hpp"
+#include "linglong/package/reference.h"
 #include "linglong/repo/ostree_repo.h"
 #include "linglong/runtime/container_builder.h"
 #include "package_task.h"
@@ -16,6 +18,8 @@
 #include <QDBusContext>
 #include <QList>
 #include <QObject>
+
+#include <optional>
 
 namespace linglong::service {
 
@@ -75,9 +79,6 @@ public:
     PackageManager(PackageManager &&) = delete;
     auto operator=(const PackageManager &) -> PackageManager & = delete;
     auto operator=(PackageManager &&) -> PackageManager & = delete;
-    void Update(PackageTask &taskContext,
-                const package::Reference &ref,
-                const package::Reference &newRef) noexcept;
 
 public
     Q_SLOT : [[nodiscard]] auto getConfiguration() const noexcept -> QVariantMap;
@@ -121,10 +122,15 @@ private:
     void Install(PackageTask &taskContext,
                  const package::Reference &newRef,
                  std::optional<package::Reference> oldRef,
-                 const std::vector<std::string> &modules) noexcept;
+                 const std::vector<std::string> &modules,
+                 const std::optional<api::types::v1::Repo> &repo) noexcept;
     void InstallRef(PackageTask &taskContext,
                     const package::Reference &ref,
-                    std::vector<std::string> modules) noexcept;
+                    std::vector<std::string> modules,
+                    const api::types::v1::Repo &repo) noexcept;
+    void Update(PackageTask &taskContext,
+                const package::Reference &ref,
+                const package::ReferenceWithRepo &newRef) noexcept;
     void UninstallRef(PackageTask &taskContext,
                       const package::Reference &ref,
                       const std::vector<std::string> &modules) noexcept;
@@ -145,8 +151,6 @@ private:
     utils::error::Result<void> removeAfterInstall(const package::Reference &oldRef,
                                                   const package::Reference &newRef,
                                                   const std::vector<std::string> &modules) noexcept;
-    utils::error::Result<package::Reference>
-    latestRemoteReference(const std::string &kind, package::FuzzyReference &fuzzyRef) noexcept;
     utils::error::Result<void>
     Prune(std::vector<api::types::v1::PackageInfoV2> &removedInfo) noexcept;
     utils::error::Result<void> generateCache(const package::Reference &ref) noexcept;

--- a/libs/utils/src/linglong/utils/error/error.h
+++ b/libs/utils/src/linglong/utils/error/error.h
@@ -42,6 +42,7 @@ enum class ErrorCode : int {
     AppInstallModuleRequireAppFirst = 2006, // 安装模块时需要先安装应用
     AppInstallModuleAlreadyExists = 2007,   // 安装模块时已存在相同版本的模块
     AppInstallArchNotMatch = 2008,          // 安装app的架构不匹配
+    AppInstallModuleNotFound = 2009,        // 远程不存在对应模块
     /* 卸载 */
     AppUninstallFailed = 2101,            // 卸载失败
     AppUninstallNotFoundFromLocal = 2102, // 本地不存在对应应用


### PR DESCRIPTION
1. Added `--repo` option to CLI for selecting specific repositories
2. Modified installation process to install from specified repositories
3. Enhanced repository priority management with temporary priority boost
4. Added repository awareness to package upgrade process
5. Improved remote reference resolution across multiple repositories
6. Added new error code for modules not found remotely