### PR TITLE
feat: implement printMessage method for JSONPrinter

### DIFF
--- a/libs/linglong/src/linglong/cli/json_printer.cpp
+++ b/libs/linglong/src/linglong/cli/json_printer.cpp
@@ -118,4 +118,9 @@ void JSONPrinter::printInspect(const api::types::v1::InspectResult &result)
     std::cout << nlohmann::json(result).dump(4) << std::endl;
 }
 
+void JSONPrinter::printMessage(const QString &message)
+{
+    std::cout << nlohmann::json{ { "message", message.toStdString() } }.dump() << std::endl;
+}
+
 } // namespace linglong::cli

--- a/libs/linglong/src/linglong/cli/json_printer.h
+++ b/libs/linglong/src/linglong/cli/json_printer.h
@@ -30,7 +30,7 @@ public:
     void printContent(const QStringList &desktopPaths) override;
     void printUpgradeList(std::vector<api::types::v1::UpgradeListResult> &) override;
     void printInspect(const api::types::v1::InspectResult &) override;
-    void printMessage([[maybe_unused]] const QString &message) override { };
+    void printMessage(const QString &message) override;
 };
 
 } // namespace linglong::cli


### PR DESCRIPTION
Added implementation for JSONPrinter::printMessage method to output messages
in JSON format. The method serializes the message as a JSON object with a
"message" property. This enhances the JSON output capability by properly handling messages alongside other data types.