### PR TITLE
fix: returns only if creating directories failed

### DIFF
--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -717,8 +717,11 @@ utils::error::Result<QDir> OSTreeRepo::ensureEmptyLayerDir(const std::string &co
     }
 
     if (!std::filesystem::create_directories(dir, ec)) {
-        return LINGLONG_ERR(
-          QString{ "failed to create layer dir %1: %2" }.arg(dir.c_str(), ec.message().c_str()));
+        if (ec) {
+            return LINGLONG_ERR(
+              QString{ "failed to create layer dir %1: %2" }.arg(dir.c_str(),
+                                                                 ec.message().c_str()));
+        }
     }
 
     return QDir{ dir.c_str() };


### PR DESCRIPTION
std::filesystem::creat_directories does not treated this as an error