### PR TITLE
feat: handle missing refs gracefully in removeOstreeRef

### DIFF
--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -600,21 +600,16 @@ OSTreeRepo::removeOstreeRef(const api::types::v1::RepositoryCacheLayersItem &lay
                                     FALSE,
                                     OstreeRepoResolveRevExtFlags::OSTREE_REPO_RESOLVE_REV_EXT_NONE,
                                     &rev,
-                                    &gErr)
-        == FALSE) {
-        return LINGLONG_ERR(QString{ "couldn't resolve ref %1 on local machine" }.arg(
-                              QString::fromStdString(refspec)),
-                            gErr);
-    }
-
-    if (ostree_repo_set_ref_immediate(this->ostreeRepo.get(),
-                                      layer.repo.c_str(),
-                                      ref.c_str(),
-                                      nullptr,
-                                      nullptr,
-                                      &gErr)
-        == FALSE) {
-        return LINGLONG_ERR("ostree_repo_set_ref_immediate", gErr);
+                                    &gErr)) {
+        if (ostree_repo_set_ref_immediate(this->ostreeRepo.get(),
+                                          layer.repo.c_str(),
+                                          ref.c_str(),
+                                          nullptr,
+                                          nullptr,
+                                          &gErr)
+            == FALSE) {
+            return LINGLONG_ERR("ostree_repo_set_ref_immediate", gErr);
+        }
     }
 
     auto ret = this->cache->deleteLayerItem(layer);


### PR DESCRIPTION
在删除ref时, 如果ostree不存在对应的ref, 不需要报错,
避免因缓存不一致导致无法卸载应用