### PR TITLE
fix: update task ends abnormally when there is an application running

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -1787,7 +1787,7 @@ auto PackageManager::Update(const QVariantMap &parameters) noexcept -> QVariantM
       refSpecs,
       [this, upgrades = std::move(upgrades)](PackageTask &taskRef) {
           for (const auto &[reference, newReference] : upgrades) {
-              if (isTaskDone(taskRef.subState())) {
+              if (taskRef.subState() == linglong::api::types::v1::SubState::AllDone) {
                   return;
               }
 


### PR DESCRIPTION
Should not terminate the update task when the sub-state is PackageManagerDone.