### PR TITLE
feat: bind /etc/hosts to container

### DIFF
--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -365,6 +365,7 @@ ContainerCfgBuilder &ContainerCfgBuilder::bindHostStatics() noexcept
         "/etc/localtime",
         "/etc/resolv.conf",
         "/etc/timezone",
+        "/etc/hosts"
     };
 
     hostStaticsMount = std::vector<Mount>{};


### PR DESCRIPTION
Bind /etc/hosts to the container to facilitate network debugging.