### PR TITLE
fix: Preserve host's HOME env in container.

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -1807,9 +1807,8 @@ utils::error::Result<void> Builder::run(const QStringList &modules,
     }
 
     auto *homeEnv = ::getenv("HOME");
-    auto *userNameEnv = ::getenv("USER");
-    if (homeEnv == nullptr || userNameEnv == nullptr) {
-        return LINGLONG_ERR("Couldn't get HOME or USER from env.");
+    if (homeEnv == nullptr) {
+        return LINGLONG_ERR("Couldn't get HOME env.");
     }
 
     std::vector<ocppi::runtime::config::types::Mount> applicationMounts{};
@@ -1833,7 +1832,7 @@ utils::error::Result<void> Builder::run(const QStringList &modules,
             f << "set debug-file-directory " + debugDir << std::endl;
 
             applicationMounts.push_back(ocppi::runtime::config::types::Mount{
-              .destination = std::string("/home/") + userNameEnv + "/.gdbinit",
+              .destination = std::string{ homeEnv } + "/.gdbinit",
               .options = { { "ro", "rbind" } },
               .source = gdbinit,
               .type = "bind",
@@ -1924,10 +1923,10 @@ utils::error::Result<void> Builder::run(const QStringList &modules,
       .bindMedia()
       .bindHostRoot()
       .bindHostStatics()
-      .bindHome(homeEnv, userNameEnv)
+      .bindHome(homeEnv)
       .enablePrivateDir()
-      .mapPrivate(std::string("/home/") + userNameEnv + "/.ssh", true)
-      .mapPrivate(std::string("/home/") + userNameEnv + "/.gnupg", true)
+      .mapPrivate(std::string{ homeEnv } + "/.ssh", true)
+      .mapPrivate(std::string{ homeEnv } + "/.gnupg", true)
       .bindIPC()
       .forwardDefaultEnv()
       .addExtraMounts(applicationMounts)

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -689,9 +689,8 @@ int Cli::run([[maybe_unused]] CLI::App *subcommand)
     }
 
     auto *homeEnv = ::getenv("HOME");
-    auto *userNameEnv = ::getenv("USER");
-    if (homeEnv == nullptr || userNameEnv == nullptr) {
-        qCritical() << "Couldn't get HOME or USER from env.";
+    if (homeEnv == nullptr) {
+        qCritical() << "Couldn't get HOME env.";
         return -1;
     }
 
@@ -714,10 +713,10 @@ int Cli::run([[maybe_unused]] CLI::App *subcommand)
       .bindMedia()
       .bindHostRoot()
       .bindHostStatics()
-      .bindHome(homeEnv, userNameEnv)
+      .bindHome(homeEnv)
       .enablePrivateDir()
-      .mapPrivate(std::string("/home/") + userNameEnv + "/.ssh", true)
-      .mapPrivate(std::string("/home/") + userNameEnv + "/.gnupg", true)
+      .mapPrivate(std::string{ homeEnv } + "/.ssh", true)
+      .mapPrivate(std::string{ homeEnv } + "/.gnupg", true)
       .bindIPC()
       .forwardDefaultEnv()
       .enableSelfAdjustingMount();

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
@@ -132,7 +132,7 @@ public:
 
     ContainerCfgBuilder &bindHostRoot() noexcept;
     ContainerCfgBuilder &bindHostStatics() noexcept;
-    ContainerCfgBuilder &bindHome(std::filesystem::path hostHome, std::string user) noexcept;
+    ContainerCfgBuilder &bindHome(std::filesystem::path hostHome) noexcept;
 
     ContainerCfgBuilder &enablePrivateDir() noexcept;
     ContainerCfgBuilder &mapPrivate(std::string containerPath, bool isDir) noexcept;


### PR DESCRIPTION
1. Ensure container HOME env matches the host environment exactly, we rely on it before support portal well.
2. remove /run/udev bind, udev database path and file across different versions are not guaranteed to be compatible.
3. add all_proxy env to defulat forward list.