### PR TITLE
fix: update size type to int64_t and initialize struct stat in calculateDirectorySize

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -1371,7 +1371,7 @@ utils::error::Result<void> Builder::commitToLocalRepo() noexcept
         if (!ret) {
             return LINGLONG_ERR(ret);
         }
-        info.size = static_cast<int>(*ret);
+        info.size = static_cast<int64_t>(*ret);
 
         QFile infoFile{ moduleOutput.filePath("info.json") };
         if (!infoFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {

--- a/libs/linglong/src/linglong/package/uab_packager.cpp
+++ b/libs/linglong/src/linglong/package/uab_packager.cpp
@@ -702,7 +702,7 @@ utils::error::Result<void> UABPackager::prepareBundle(const QDir &bundleDir, boo
             if (!newSize) {
                 return LINGLONG_ERR(newSize);
             }
-            info.size = static_cast<int>(*newSize);
+            info.size = static_cast<int64_t>(*newSize);
 
             stream << nlohmann::json(info).dump();
             layerInfoRef.info = info;


### PR DESCRIPTION
…kager and Builder

Changed the size type from int to int64_t in both Builder and UABPackager to ensure proper handling of larger values. Additionally, initialized struct stat variables to improve code clarity and maintainability.