### PR TITLE
chore: revert LINGLONG_EXPORT_VERSION

### DIFF
--- a/configure.h.in
+++ b/configure.h.in
@@ -25,7 +25,7 @@
 // The directory where the package install hooks reside.
 #define LINGLONG_INSTALL_HOOKS_DIR "@CMAKE_INSTALL_FULL_SYSCONFDIR@/linglong/config.d"
 
-#define LINGLONG_EXPORT_VERSION "1.0.0.2"
+#define LINGLONG_EXPORT_VERSION "1.0.0.1"
 // The package's locale domain.
 #define PACKAGE_LOCALE_DOMAIN "@GETTEXT_DOMAIN_NAME@"
 


### PR DESCRIPTION
Revert LINGLONG_EXPORT_VERSION and do not fix export dirs.