### PR TITLE
fix: prevent crash in prune command after loop exit

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -1513,11 +1513,13 @@ int Cli::prune([[maybe_unused]] CLI::App *subcommand)
           if (!ret) {
               this->printer.printErr(ret.error());
               loop.exit(-1);
+              return;
           }
 
           if (!ret->packages) {
               this->printer.printErr(LINGLONG_ERRV("No packages to prune."));
               loop.exit(0);
+              return;
           }
 
           this->printer.printPruneResult(*ret->packages);


### PR DESCRIPTION
Added missing return statements after loop.exit() calls in the prune command
to prevent function execution from continuing after exit is called. This fixes a crash that occurred when the function continued executing code after
requesting the event loop to exit, potentially accessing invalid memory.