### PR TITLE
fix: invert condition in filterPackageInfosByType to correctly filter

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -2270,7 +2270,7 @@ void Cli::filterPackageInfosByType(std::vector<api::types::v1::PackageInfoDispla
     list.erase(std::remove_if(list.begin(),
                               list.end(),
                               [&type](const api::types::v1::PackageInfoDisplay &pkg) {
-                                  return pkg.kind == type;
+                                  return pkg.kind != type;
                               }),
                list.end());
 }


### PR DESCRIPTION
invert condition in filterPackageInfosByType to correctly filter package types