### PR TITLE
fix: improve ld.so.cache validation and regeneration

### DIFF
--- a/apps/uab/header/src/sha256.h
+++ b/apps/uab/header/src/sha256.h
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <cstring>
 
 namespace digest {
 
@@ -149,7 +150,9 @@ private:
         for (std::size_t i = 0; i < block_num; ++i) {
             std::array<uint32_t, 16> M{};
             for (int j = 0; j < 16; ++j) {
-                M[j] = details::to_big_endian(reinterpret_cast<const uint32_t *>(data)[i * 16 + j]);
+                uint32_t tmp = 0;
+                std::memcpy(&tmp, &data[i * 64 + j * 4], 4);
+                M[j] = details::to_big_endian(tmp);
             }
 
             std::array<uint32_t, 64> W{};

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -19,6 +19,14 @@
 
 #include <CLI/App.hpp>
 
+namespace linglong::runtime {
+class RunContext;
+}
+
+namespace linglong::generator {
+class ContainerCfgBuilder;
+}
+
 namespace linglong::cli {
 
 class Printer;
@@ -121,9 +129,8 @@ private:
     utils::error::Result<std::vector<api::types::v1::UpgradeListResult>>
     listUpgradable(const std::string &type = "app");
     int generateCache(const package::Reference &ref);
-    utils::error::Result<std::string>
-    ensureCache(const package::Reference &ref,
-                const api::types::v1::RepositoryCacheLayersItem &appLayerItem) noexcept;
+    utils::error::Result<std::filesystem::path> ensureCache(
+      runtime::RunContext &runContext, const generator::ContainerCfgBuilder &cfgBuilder) noexcept;
     QDBusReply<QString> authorization();
     void updateAM() noexcept;
 

--- a/libs/linglong/src/linglong/runtime/run_context.h
+++ b/libs/linglong/src/linglong/runtime/run_context.h
@@ -78,6 +78,8 @@ public:
 
     const std::optional<RuntimeLayer> &getRuntimeLayer() const { return runtimeLayer; }
 
+    const std::optional<RuntimeLayer> &getAppLayer() const { return appLayer; }
+
     utils::error::Result<std::filesystem::path> getBaseLayerPath() const;
     utils::error::Result<std::filesystem::path> getRuntimeLayerPath() const;
 

--- a/libs/oci-cfg-generators/CMakeLists.txt
+++ b/libs/oci-cfg-generators/CMakeLists.txt
@@ -21,4 +21,4 @@ pfl_add_library(
   )
 
 get_real_target_name(GEN linglong::oci-cfg-generators)
-target_include_directories(${GEN} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src/linglong/oci-cfg-generators)
+target_include_directories(${GEN} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src/linglong/oci-cfg-generators ${CMAKE_SOURCE_DIR}/apps/uab/header/src)

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
@@ -172,7 +172,7 @@ public:
         return *this;
     }
 
-    std::string ldConf(const std::string &triplet);
+    std::string ldConf(const std::string &triplet) const;
 
     bool build() noexcept;
 


### PR DESCRIPTION
- Add content-based validation for ld.so.conf to detect layer path changes
- Include configuration sources hash in ld.so.conf for validation
- In PackageManager GenerateCache always generate cache, tryGenerateCache will skip it if cache directory exists
- use memcpy in sha256 to avoid unaligned visit

This ensures that ld.so.cache is properly regenerated when the underlying layer configuration changes, preventing stale cache issues.