### PR TITLE
fix: ensure correct /etc/localtime mounting

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.h
+++ b/libs/linglong/src/linglong/builder/linglong_builder.h
@@ -103,6 +103,7 @@ private:
     utils::error::Result<void> processBuildDepends() noexcept;
     utils::error::Result<void> commitToLocalRepo() noexcept;
     std::unique_ptr<utils::OverlayFS> makeOverlay(QString lowerdir, QString overlayDir) noexcept;
+    void fixLocaltimeInOverlay(std::unique_ptr<utils::OverlayFS> &base);
     utils::error::Result<package::Reference> ensureUtils(const std::string &id) noexcept;
     utils::error::Result<package::Reference> clearDependency(const std::string &ref,
                                                              bool forceRemote,

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -12,6 +12,8 @@
 #include "ocppi/runtime/config/types/Generators.hpp"
 #include "sha256.h"
 
+#include <linux/limits.h>
+
 #include <algorithm>
 #include <fstream>
 #include <iomanip>
@@ -38,6 +40,30 @@ using ocppi::runtime::config::types::NamespaceReference;
 using ocppi::runtime::config::types::NamespaceType;
 using ocppi::runtime::config::types::Process;
 using ocppi::runtime::config::types::RootfsPropagation;
+
+namespace {
+bool bindIfExist(std::vector<Mount> &mounts,
+                 std::filesystem::path source,
+                 std::string destination = "",
+                 bool ro = true) noexcept
+{
+    std::error_code ec;
+    if (!std::filesystem::exists(source, ec)) {
+        return false;
+    }
+
+    if (destination.empty()) {
+        destination = source.string();
+    }
+
+    mounts.emplace_back(Mount{ .destination = destination,
+                               .options = string_list{ "rbind", ro ? "ro" : "rw" },
+                               .source = source,
+                               .type = "bind" });
+
+    return true;
+}
+} // namespace
 
 ContainerCfgBuilder &ContainerCfgBuilder::addUIdMapping(int64_t containerID,
                                                         int64_t hostID,
@@ -356,33 +382,19 @@ ContainerCfgBuilder &ContainerCfgBuilder::bindHostRoot() noexcept
 
 ContainerCfgBuilder &ContainerCfgBuilder::bindHostStatics() noexcept
 {
-    std::vector<std::string> statics{
+    std::vector<std::filesystem::path> statics{
         "/etc/machine-id",
-        "/etc/resolvconf",
         // FIXME: support for host /etc/ssl, ref https://github.com/p11-glue/p11-kit
         "/usr/lib/locale",
         "/usr/share/fonts",
         "/usr/share/icons",
         "/usr/share/themes",
-        "/usr/share/zoneinfo",
         "/var/cache/fontconfig",
-        // TODO It's better to move to volatileMount
-        "/etc/localtime",
-        "/etc/resolv.conf",
-        "/etc/timezone",
-        "/etc/hosts"
     };
 
     hostStaticsMount = std::vector<Mount>{};
-    std::error_code ec;
     for (const auto &loc : statics) {
-        if (!std::filesystem::exists(loc, ec)) {
-            continue;
-        }
-        hostStaticsMount->emplace_back(Mount{ .destination = loc,
-                                              .options = string_list{ "rbind", "ro" },
-                                              .source = loc,
-                                              .type = "bind" });
+        bindIfExist(*hostStaticsMount, loc);
     }
 
     return *this;
@@ -920,20 +932,7 @@ bool ContainerCfgBuilder::buildMountIPC() noexcept
         return false;
     }
 
-    auto bindIfExist = [this](std::string_view source, std::string_view destination) mutable {
-        std::error_code ec;
-        if (!std::filesystem::exists(source, ec)) {
-            return;
-        }
-
-        auto realDest = destination.empty() ? source : destination;
-        ipcMount->emplace_back(Mount{ .destination = std::string{ realDest },
-                                      .options = string_list{ "rbind" },
-                                      .source = std::string{ source },
-                                      .type = "bind" });
-    };
-
-    bindIfExist("/tmp/.X11-unix", "");
+    bindIfExist(*ipcMount, "/tmp/.X11-unix", "", false);
 
     // TODO 应该参考规范文档实现更完善的地址解析支持
     // https://dbus.freedesktop.org/doc/dbus-specification.html#addresses
@@ -975,7 +974,7 @@ bool ContainerCfgBuilder::buildMountIPC() noexcept
           std::string("unix:path=/run/dbus/system_bus_socket") + options;
     }();
 
-    [this, &bindIfExist]() {
+    [this]() {
         auto *XDGRuntimeDirEnv = getenv("XDG_RUNTIME_DIR"); // NOLINT
         if (XDGRuntimeDirEnv == nullptr) {
             return;
@@ -1004,10 +1003,14 @@ bool ContainerCfgBuilder::buildMountIPC() noexcept
 
         auto cognitiveXDGRuntimeDir = std::filesystem::path{ environment["XDG_RUNTIME_DIR"] };
 
-        bindIfExist((hostXDGRuntimeDir / "pulse").string(),
-                    (cognitiveXDGRuntimeDir / "pulse").string());
-        bindIfExist((hostXDGRuntimeDir / "gvfs").string(),
-                    (cognitiveXDGRuntimeDir / "gvfs").string());
+        bindIfExist(*ipcMount,
+                    hostXDGRuntimeDir / "pulse",
+                    (cognitiveXDGRuntimeDir / "pulse").string(),
+                    false);
+        bindIfExist(*ipcMount,
+                    hostXDGRuntimeDir / "gvfs",
+                    (cognitiveXDGRuntimeDir / "gvfs").string(),
+                    false);
 
         [this, &hostXDGRuntimeDir, &cognitiveXDGRuntimeDir]() {
             auto *waylandDisplayEnv = getenv("WAYLAND_DISPLAY"); // NOLINT
@@ -1160,6 +1163,82 @@ bool ContainerCfgBuilder::buildLDCache() noexcept
                                       .source = *appCache / "ld.so.cache",
                                       .type = "bind" });
 
+    return true;
+}
+
+bool ContainerCfgBuilder::buildMountLocalTime() noexcept
+{
+    // always bind host's localtime
+    // assume /etc/localtime is a symlink to /usr/share/zoneinfo/XXX/NNN
+    localtimeMount = std::vector<Mount>{};
+
+    std::filesystem::path localtime{ "/etc/localtime" };
+    std::error_code ec;
+    if (std::filesystem::exists(localtime, ec)) {
+        bool isSymLink = false;
+        if (std::filesystem::is_symlink(localtime, ec)) {
+            isSymLink = true;
+        }
+        localtimeMount->emplace_back(Mount{ .destination = localtime.string(),
+                                            .options = isSymLink ? string_list{ "copy-symlink" }
+                                                                 : string_list{ "rbind", "ro" },
+                                            .source = localtime,
+                                            .type = "bind" });
+    }
+
+    bindIfExist(*localtimeMount, "/usr/share/zoneinfo");
+    bindIfExist(*localtimeMount, "/etc/timezone");
+
+    return true;
+}
+
+bool ContainerCfgBuilder::buildMountNetworkConf() noexcept
+{
+    networkConfMount = std::vector<Mount>{};
+
+    std::filesystem::path resolvConf{ "/etc/resolv.conf" };
+    std::error_code ec;
+    if (std::filesystem::exists(resolvConf, ec)) {
+        if (std::filesystem::is_symlink(resolvConf, ec) && hostRootMount) {
+            // If /etc/resolv.conf is a symlink, its target may be a relative path that is
+            // invalid inside the container. To work around this, we create a new symlink
+            // in the bundle directory pointing to the actual target, and then mount it with
+            // the 'copy-symlink' option, which tells the runtime to recreate the symlink
+            // inside the container.
+            std::array<char, PATH_MAX + 1> buf{};
+            auto *rpath = realpath(resolvConf.string().c_str(), buf.data());
+            if (rpath == nullptr) {
+                error_.reason =
+                  "Failed to read symlink " + resolvConf.string() + ": " + strerror(errno);
+                error_.code = BUILD_NETWORK_CONF_ERROR;
+                return false;
+            }
+
+            std::filesystem::path target = std::filesystem::path{ "/run/host/rootfs" }
+              / std::filesystem::path{ rpath }.lexically_relative("/");
+            auto bundleResolvConf = bundlePath / "resolv.conf";
+            std::filesystem::create_symlink(target, bundleResolvConf, ec);
+            if (ec) {
+                error_.reason =
+                  "Failed to create symlink " + bundleResolvConf.string() + ": " + ec.message();
+                error_.code = BUILD_NETWORK_CONF_ERROR;
+                return false;
+            }
+
+            networkConfMount->emplace_back(Mount{ .destination = resolvConf.string(),
+                                                  .options = string_list{ "copy-symlink" },
+                                                  .source = bundleResolvConf,
+                                                  .type = "bind" });
+        } else {
+            networkConfMount->emplace_back(Mount{ .destination = resolvConf.string(),
+                                                  .options = string_list{ "rbind", "ro" },
+                                                  .source = resolvConf,
+                                                  .type = "bind" });
+        }
+    }
+
+    bindIfExist(*networkConfMount, "/etc/resolvconf");
+    bindIfExist(*networkConfMount, "/etc/hosts");
     return true;
 }
 
@@ -1549,6 +1628,14 @@ bool ContainerCfgBuilder::mergeMount() noexcept
         std::move(ldCacheMount->begin(), ldCacheMount->end(), std::back_inserter(mounts));
     }
 
+    if (localtimeMount) {
+        std::move(localtimeMount->begin(), localtimeMount->end(), std::back_inserter(mounts));
+    }
+
+    if (networkConfMount) {
+        std::move(networkConfMount->begin(), networkConfMount->end(), std::back_inserter(mounts));
+    }
+
     if (privateMount) {
         std::move(privateMount->begin(), privateMount->end(), std::back_inserter(mounts));
     }
@@ -1924,7 +2011,7 @@ bool ContainerCfgBuilder::build() noexcept
         return false;
     }
 
-    if (!buildMountIPC()) {
+    if (!buildMountIPC() || !buildMountLocalTime() || !buildMountNetworkConf()) {
         return false;
     }
 

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
@@ -41,6 +41,7 @@ public:
         BUILD_LDCONF_ERROR,
         BUILD_LDCACHE_ERROR,
         BUILD_ENV_ERROR,
+        BUILD_NETWORK_CONF_ERROR,
     };
 
     class Error
@@ -202,6 +203,8 @@ private:
     bool buildMountIPC() noexcept;
     bool buildMountCache() noexcept;
     bool buildLDCache() noexcept;
+    bool buildMountLocalTime() noexcept;
+    bool buildMountNetworkConf() noexcept;
     bool buildQuirkVolatile() noexcept;
     bool buildEnv() noexcept;
     bool applyPatch() noexcept;
@@ -258,6 +261,8 @@ private:
     std::optional<std::vector<ocppi::runtime::config::types::Mount>> hostRootMount;
     std::optional<std::vector<ocppi::runtime::config::types::Mount>> hostStaticsMount;
     std::optional<std::vector<ocppi::runtime::config::types::Mount>> ipcMount;
+    std::optional<std::vector<ocppi::runtime::config::types::Mount>> localtimeMount;
+    std::optional<std::vector<ocppi::runtime::config::types::Mount>> networkConfMount;
 
     // cache
     std::optional<std::vector<ocppi::runtime::config::types::Mount>> cacheMount;


### PR DESCRIPTION
Mounting may fail if the file types differed between the layer and host (e.g., regular file vs. symbolic link).

Implemented solution through two approaches
1. Build phase: Proactively remove /etc/localtime from build layer during overlayfs preparation to prevent conflicts with host timezone file mounting.
2. Container configuration: Introduced dedicated buildMountLocalTime method to handle timezone mounts, with enableSelfAdjustingMount properly managing these cases.