### PR TITLE
fix: the context menu of the file manager displays abnormally

### DIFF
--- a/configure.h.in
+++ b/configure.h.in
@@ -25,7 +25,7 @@
 // The directory where the package install hooks reside.
 #define LINGLONG_INSTALL_HOOKS_DIR "@CMAKE_INSTALL_FULL_SYSCONFDIR@/linglong/config.d"
 
-#define LINGLONG_EXPORT_VERSION "1.0.0.1"
+#define LINGLONG_EXPORT_VERSION "1.0.0.2"
 // The package's locale domain.
 #define PACKAGE_LOCALE_DOMAIN "@GETTEXT_DOMAIN_NAME@"
 

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -197,10 +197,12 @@ private:
     static utils::error::Result<void> IniLikeFileRewrite(const QFileInfo &info,
                                                          const QString &id) noexcept;
 
-    utils::error::Result<void> exportDir(const std::string &appID,
-                                         const std::filesystem::path &source,
-                                         const std::filesystem::path &destination,
-                                         const int &max_depth);
+    utils::error::Result<void>
+    exportDir(const std::string &appID,
+              const std::filesystem::path &source,
+              const std::filesystem::path &destination,
+              const int &max_depth,
+              const std::optional<std::string> &fileSuffix = std::nullopt);
     // exportEntries will clear the entries/share and export all applications to the entries/share
     utils::error::Result<void> exportAllEntries() noexcept;
 };


### PR DESCRIPTION
Add optional file suffix filtering to exportDir, ensures only files matching the specified suffix are processed.