### PR TITLE
fix: Isolate app-specific patches in dedicated directories

### DIFF
--- a/misc/lib/linglong/container/README.md
+++ b/misc/lib/linglong/container/README.md
@@ -50,15 +50,14 @@ can be found at [/api/schema/v1.yaml].
 
 ## Application-specific patches
 
-Patches whose filenames match the application ID are treated as application-specific.
-These patches are applied after global patches.
+Patches in application ID-named directories are application-specific and apply after global patches
 
 ## Examples
 
 - Global patch:   `99-dump-conf`
-- App patch:     `com.example.app.json` (matches app ID)
+- App patch:     `com.example.app/99-test.json`
 
-com.example.app.json:
+com.example.app/99-test.json:
 
 ```json
 {
@@ -80,7 +79,7 @@ com.example.app.json:
 }
 ```
 
-com.example.app.json add an extra mounts, which bind host's `/opt/apps` to container's `/opt/host-apps`,
+com.example.app/99-test.json add an extra mounts, which bind host's `/opt/apps` to container's `/opt/host-apps`,
 this patch will applied after 99-dump-conf.
 
 99-dump-conf can write following content to print the container's configuration:


### PR DESCRIPTION
Previously, app-specific patches were identified by matching the patch filename (without the extension) against the application ID. This approach was flawed as it caused patch conflicts between different applications. For example, a patch named `com.app.A.json`, intended only for `com.app.A`, would be incorrectly applied as a global patch to `com.app.B`.

This commit introduces a directory-based mechanism to correctly isolate application-specific patches. All patches for a specific app must now reside within a subdirectory named after the app ID.