### PR TITLE
refactor: simplify environment variable handling in systemd generator

### DIFF
--- a/misc/lib/systemd/system-environment-generators/61-linglong
+++ b/misc/lib/systemd/system-environment-generators/61-linglong
@@ -13,7 +13,10 @@
 source_script="@CMAKE_INSTALL_PREFIX@/lib/linglong/generate-xdg-data-dirs.sh"
 
 # Source the script and export XDG_DATA_DIRS if successful
-[ -r "${source_script}" ] && . "${source_script}" && [ -n "${XDG_DATA_DIRS}" ] && export XDG_DATA_DIRS
+[ -r "${source_script}" ] && . "${source_script}" 
 
-# Log error in debug mode if sourcing failed
-[ "${DEBUG:-0}" = "1" ] && [ ! -r "${source_script}" ] && echo "Source script not found: ${source_script}" >&2
+if  [ -n "${XDG_DATA_DIRS}" ]; then
+# !!!systemd requires environment variables to be printed to standard output!!!
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.environment-generator.html
+echo "XDG_DATA_DIRS=${XDG_DATA_DIRS}"
+fi


### PR DESCRIPTION
1. Removed debug logging code that was checking for script readability
2. Changed from direct export to echo output for systemd environment handling
3. Simplified the logic by removing redundant checks since systemd generators expect echo output
4. The change aligns better with systemd's environment generator expectations where variables should be echoed rather than exported directly

refactor: 简化 systemd 生成器中的环境变量处理

1. 移除了检查脚本可读性的调试日志代码
2. 将直接导出改为 echo 输出以适配 systemd 环境处理
3. 通过移除冗余检查简化了逻辑，因为 systemd 生成器期望 echo 输出
4. 此变更更符合 systemd 环境生成器的预期，变量应该通过 echo 输出而非直接 导出