### PR TITLE
Add nvidia env

### DIFF
--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -350,7 +350,15 @@ ContainerCfgBuilder &ContainerCfgBuilder::forwardDefaultEnv() noexcept
       "GIO_LAUNCHED_DESKTOP_FILE", // 系统监视器
       "GNOME_DESKTOP_SESSION_ID",  // gnome 桌面标识，有些应用会读取此变量以使用gsettings配置,
       // 如chrome
-      "TERM" });
+      "TERM",
+      // 控制应用将渲染任务路由到 NVIDIA 独立显卡
+      "__NV_PRIME_RENDER_OFFLOAD",
+      // 控制应用使用哪个OpenGL厂商提供的驱动库来与显卡通信和渲染。
+      "__GLX_VENDOR_LIBRARY_NAME",
+      // 控制NVIDIA独立显卡在Vulkan应用程序枚举GPU时拥有更高的优先级
+      "__VK_LAYER_NV_optimus",
+      // 控制应用尝试使用非默认（通常是独立显卡）的GPU来执行OpenGL渲染任务
+      "DRI_PRIME" });
 }
 
 ContainerCfgBuilder &

--- a/libs/utils/src/linglong/utils/command/env.cpp
+++ b/libs/utils/src/linglong/utils/command/env.cpp
@@ -10,43 +10,6 @@
 
 namespace linglong::utils::command {
 
-const QStringList envList = {
-    "DISPLAY",
-    "LANG",
-    "LANGUAGE",
-    "XAUTHORITY",
-    "XDG_SESSION_DESKTOP",
-    "D_DISABLE_RT_SCREEN_SCALE",
-    "XMODIFIERS",
-    "DESKTOP_SESSION",
-    "DEEPIN_WINE_SCALE",
-    "XDG_CURRENT_DESKTOP",
-    "XDG_DATA_HOME",
-    "XIM",
-    "XDG_SESSION_TYPE",
-    "XDG_RUNTIME_DIR",
-    "CLUTTER_IM_MODULE",
-    "QT4_IM_MODULE",
-    "GTK_IM_MODULE",
-    "auto_proxy",   // 网络系统代理自动代理
-    "http_proxy",   // 网络系统代理手动http代理
-    "https_proxy",  // 网络系统代理手动https代理
-    "ftp_proxy",    // 网络系统代理手动ftp代理
-    "SOCKS_SERVER", // 网络系统代理手动socks代理
-    "no_proxy",     // 网络系统代理手动配置代理
-    "USER",         // wine应用会读取此环境变量
-    "HOME",
-    "QT_IM_MODULE",    // 输入法
-    "LINGLONG_ROOT",   // 玲珑安装位置
-    "WAYLAND_DISPLAY", // 导入wayland相关环境变量
-    "QT_QPA_PLATFORM",
-    "QT_WAYLAND_SHELL_INTEGRATION",
-    "GDMSESSION",
-    "QT_WAYLAND_FORCE_DPI",
-    "GIO_LAUNCHED_DESKTOP_FILE", // 系统监视器
-    "GNOME_DESKTOP_SESSION_ID" // gnome 桌面标识，有些应用会读取此变量以使用gsettings配置, 如chrome
-};
-
 QStringList getUserEnv(const QStringList &filters)
 {
     auto sysEnv = QProcessEnvironment::systemEnvironment();

--- a/libs/utils/src/linglong/utils/command/env.h
+++ b/libs/utils/src/linglong/utils/command/env.h
@@ -16,7 +16,6 @@ namespace linglong::utils::command {
 
 error::Result<QString> Exec(const QString &command, const QStringList &args) noexcept;
 QStringList getUserEnv(const QStringList &filters);
-extern const QStringList envList;
 
 class EnvironmentVariableGuard
 {


### PR DESCRIPTION
## Summary by Sourcery

Remove the hardcoded user environment list and enhance container config builder to forward NVIDIA GPU offload variables while tidying up minor comment formatting.

Enhancements:
- Forward __NV_PRIME_RENDER_OFFLOAD, __GLX_VENDOR_LIBRARY_NAME, __VK_LAYER_NV_optimus, and DRI_PRIME in the OCI container config builder

Chores:
- Remove the unused envList definition and its extern declaration from the utils command environment module
- Clean up trailing whitespace in the shouldFix comment