### PR TITLE
chore: update linyaps-box

### DIFF
--- a/linglong.yaml
+++ b/linglong.yaml
@@ -21,8 +21,8 @@ sources:
     url:  https://github.com/libfuse/libfuse/releases/download/fuse-3.17.1/fuse-3.17.1.tar.gz
     digest: 2d8ae87a4525fbfa1db5e5eb010ff6f38140627a7004554ed88411c1843d51b2
   - kind: archive
-    url:  https://github.com/OpenAtom-Linyaps/linyaps-box/archive/refs/tags/2.0.0-rc.5.tar.gz
-    digest: 109bf9e8539ce5818f52be4283de12bf9a1adf4d6a7ae422f02a3e66cc5ab0e6
+    url:  https://github.com/OpenAtom-Linyaps/linyaps-box/archive/refs/tags/2.0.1.tar.gz
+    digest: a1e128736ff53f5da6613eb698789ed93df1e1d48dd808c50def1afbfcf1c130
 build: |
   echo "$PREFIX"
 
@@ -43,7 +43,7 @@ build: |
   make install
 
   # build static ll-box
-  cd /project/linglong/sources/2.0.0-rc.5.tar.gz/linyaps-box-2.0.0-rc.5/
+  cd /project/linglong/sources/2.0.1.tar.gz/linyaps-box-2.0.1/
   cmake --preset static
   cmake --build build-static -j$(nproc)
   cmake --install build-static --prefix=$PREFIX


### PR DESCRIPTION
## Summary by Sourcery

Bump linyaps-box dependency to version 2.0.1 in the linglong build configuration.

Enhancements:
- Update linyaps-box archive URL and checksum to version 2.0.1
- Adjust build directory path for linyaps-box 2.0.1