### PR TITLE
fix: disable static deltas in OSTree pull operations

### DIFF
--- a/docs/mirrors.md
+++ b/docs/mirrors.md
@@ -1,0 +1,68 @@
+# 玲珑仓库 mirror 功能设计
+
+在ll-cli和ll-builder中添加了enable-mirror和disable-mirror命令，用于启用和禁用镜像功能。
+
+在对某个仓库启用mirror功能时，会更新ostree的config文件，添加contenturl配置项：
+
+```diff
+url=$repo_url/repos/$repo_name
+gpg-verify=false
+http2=false
++ contenturl=mirrorlist=$repo_url/api/v2/mirrors/$repo_name
+```
+
+当添加contenturl配置项后，ostree会优先使用contenturl下载静态文件如files, url仅用于获取元数据如summary, contenturl支持file://、http://、https://三种协议。
+
+如果在url前面添加mirrorlist=，则ostree会先从url获取按行分割的镜像列表，然后从镜像列表中选择镜像用于下载文件，具体逻辑见 [ostree_pull](#ostree-pull-步骤) 章节。
+
+/api/v2/mirrors/$repo_name 是玲珑服务器的一个API接口，通过客户端IP获取客户端所在国家，从配置文件获取对应国家的镜像列表，然后返回给ostree，这样就实现了根据用户所在国家自动分流仓库文件下载的功能更。
+
+
+## 镜像站配置
+
+玲珑的镜像站只提供仓库静态文件的https访问即可，玲珑仓库支持rsync和ostree两种同步协议。
+
+### 使用 rsync 同步配置
+
+优点是同步速度快，缺点是需从支持rsync协议的镜像站或官方仓库同步仓库。
+
+```bash
+rsync rsync://rsync.linyaps.org.cn/repos/stable $www_root/repos/stable
+```
+
+### 使用 ostree 同步配置
+
+优点是无需协议支持，可从任意镜像站同步仓库，缺点是同步速度较慢。
+
+保存下面脚本，并命名为 sync.sh，然后执行`sh sync.sh https://mirror-repo-linglong.deepin.com/repos/stable/ $www_root/repos/stable`
+
+```bash
+#!/bin/bash
+set -e
+url=$1
+dir=$2
+echo sync $url to $dir
+sleep 3
+ostree init --repo=$dir --mode archive
+ostree --repo=$dir remote add --if-not-exists --no-sign-verify remote $url
+for ref in $(ostree --repo=$dir remote refs remote); do 
+    echo pull $ref; 
+    ostree --repo=$dir pull --mirror $ref;
+done
+```
+
+## ostree pull 步骤
+
+### 判断镜像是否可用
+在pull时，ostree 先从contenturl获取镜像列表，然后从每个url获取/config文件，如果获取不到/config文件，则认为该mirror不可用，如果获取到/config文件，则认为该mirror可用。如果没有可用mirror，pull失败。
+
+### 获取summary文件
+ostree会从url获取summary文件，如果获取不到summary文件，或者summary文件不存在ref，pull失败。
+
+### delta-indexes文件获取
+
+ostree会在每个可用的mirror中获取delta-indexes，如果mirror服务器返回4xx或5xx，则在下一个mirror中获取delta-indexes，如果最后的mirror返回5xx，则pull失败，如果最后的mirror返回4xx，则跳过dalta步骤直接拉取files。
+
+### files文件获取
+
+ostree会按顺序从可用的mirror中获取files，如果mirror服务器返回403, 404， 410，则认为错误不可恢复，pull失败，如果mirror服务器返回其他错误码，则使用下一个mirror获取files。如果所有mirror都无法获取files，则pull失败。

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -1302,6 +1302,10 @@ void OSTreeRepo::pull(service::PackageTask &taskContext,
                           "{s@v}",
                           "append-user-agent",
                           g_variant_new_variant(g_variant_new_string(userAgent.c_str())));
+    g_variant_builder_add(&builder,
+                          "{s@v}",
+                          "disable-static-deltas",
+                          g_variant_new_variant(g_variant_new_boolean(true)));
 
     g_autoptr(GVariant) pull_options = g_variant_ref_sink(g_variant_builder_end(&builder));
     // 这里不能使用g_main_context_push_thread_default，因为会阻塞Qt的事件循环
@@ -1345,6 +1349,10 @@ void OSTreeRepo::pull(service::PackageTask &taskContext,
                               "{s@v}",
                               "append-user-agent",
                               g_variant_new_variant(g_variant_new_string(userAgent.c_str())));
+        g_variant_builder_add(&builder,
+                              "{s@v}",
+                              "disable-static-deltas",
+                              g_variant_new_variant(g_variant_new_boolean(true)));
 
         g_autoptr(GVariant) pull_options = g_variant_ref_sink(g_variant_builder_end(&builder));
 
@@ -1997,7 +2005,8 @@ utils::error::Result<void> OSTreeRepo::exportDir(const std::string &appID,
         if (is_regular_file) {
             // 如果有指定的后缀名，则只处理指定后缀名的文件
             if (fileSuffix.has_value()
-                && !endWithFunc(std::string_view(source_path.string()), std::string_view(fileSuffix.value()))) {
+                && !endWithFunc(std::string_view(source_path.string()),
+                                std::string_view(fileSuffix.value()))) {
                 continue;
             }
 
@@ -2042,7 +2051,7 @@ utils::error::Result<void> OSTreeRepo::exportDir(const std::string &appID,
                     if (ec) {
                         return LINGLONG_ERR("copy file failed: " + sourceNewPath, ec);
                     }
-                    
+
                     // TODO 这部分代码可以删除
                     exists = std::filesystem::exists(sourceNewPath, ec);
                     if (ec) {
@@ -2061,7 +2070,8 @@ utils::error::Result<void> OSTreeRepo::exportDir(const std::string &appID,
                         return LINGLONG_ERR("get hard link count", ec);
                     }
                     if (hard_link_count > 1) {
-                        auto ret = IniLikeFileRewrite(QFileInfo(sourceNewPath.c_str()), appID.c_str());
+                        auto ret =
+                          IniLikeFileRewrite(QFileInfo(sourceNewPath.c_str()), appID.c_str());
                         if (!ret) {
                             qWarning() << "rewrite file failed: " << ret.error().message();
                             continue;


### PR DESCRIPTION
1. Added "disable-static-deltas" option set to true in OSTree pull operations
2. This change prevents the use of static deltas which can cause issues with certain repository configurations
3. The modification was made in both pull operation variants for consistency
4. Static deltas can sometimes lead to corrupted downloads or inefficient storage usage

fix: 在OSTree拉取操作中禁用静态增量

1. 在OSTree拉取操作中添加了"disable-static-deltas"选项并设为true
2. 此变更防止使用静态增量，某些仓库配置下会导致问题
3. 修改在两个拉取操作变体中保持一致
4. 静态增量有时会导致下载损坏或存储使用效率低下

## Summary by Sourcery

Disable static deltas in OSTree pull operations to avoid repository-specific issues and add mirror feature design documentation

Bug Fixes:
- Disable static deltas in OSTree pull operations to prevent corrupted downloads and storage inefficiency

Enhancements:
- Apply the disable-static-deltas option consistently across both OSTree pull operation variants

Documentation:
- Add mirror functionality design documentation in docs/mirrors.md