### PR TITLE
fix: Set LINGLONG_LD_SO_CACHE for compatibility

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -957,6 +957,12 @@ utils::error::Result<bool> Builder::buildStageBuild(const QStringList &args) noe
     process.cwd = "/project";
     process.env = { {
       "PREFIX=" + installPrefix,
+      // During the build stage, we use overlayfs where /etc/ld.so.cache is safe
+      // to serve as the dynamic library cache. This allows direct invocation of
+      // ldconfig without the -C option.
+      //
+      // Note: LINGLONG_LD_SO_CACHE is retained here solely for backward compatibility.
+      "LINGLONG_LD_SO_CACHE=/etc/ld.so.cache",
       "TRIPLET=" + triplet,
     } };
     process.noNewPrivileges = true;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add LINGLONG_LD_SO_CACHE=/etc/ld.so.cache to the build stage environment for compatibility.