### PR TITLE
fix: add rbind option alongside copy-symlink

### DIFF
--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -1193,8 +1193,9 @@ bool ContainerCfgBuilder::buildMountLocalTime() noexcept
             isSymLink = true;
         }
         localtimeMount->emplace_back(Mount{ .destination = localtime.string(),
-                                            .options = isSymLink ? string_list{ "copy-symlink" }
-                                                                 : string_list{ "rbind", "ro" },
+                                            .options = isSymLink
+                                              ? string_list{ "rbind", "copy-symlink" }
+                                              : string_list{ "rbind", "ro" },
                                             .source = localtime,
                                             .type = "bind" });
     }
@@ -1239,7 +1240,7 @@ bool ContainerCfgBuilder::buildMountNetworkConf() noexcept
             }
 
             networkConfMount->emplace_back(Mount{ .destination = resolvConf.string(),
-                                                  .options = string_list{ "copy-symlink" },
+                                                  .options = string_list{ "rbind", "copy-symlink" },
                                                   .source = bundleResolvConf,
                                                   .type = "bind" });
         } else {


### PR DESCRIPTION
## Summary by Sourcery

Ensure that mounts using the copy-symlink option also include the rbind flag for proper bind propagation.

Bug Fixes:
- Add rbind to options alongside copy-symlink for localtime bind mounts when the source is a symlink
- Include rbind in options for the network resolv.conf bind mount when using copy-symlink