### PR TITLE
fix: update linglong test script with cleanup and improvements

### DIFF
--- a/tools/test-linglong.sh
+++ b/tools/test-linglong.sh
@@ -6,6 +6,13 @@
 
 set -xe
 
+# 清理环境
+rm -rf org.deepin.demo || true
+ll-cli repo set-default stable
+ll-cli repo remove smoketesting || true
+ll-builder repo set-default stable
+ll-builder repo remove smoketesting || true
+
 echo "开始玲珑冒烟测试"
 
 # 修改仓库为冒烟测试仓库
@@ -16,10 +23,10 @@ ll-builder repo add smoketesting https://repo-dev.cicd.getdeepin.org
 ll-builder repo set-default smoketesting
 
 #创建玲珑项目
-ll-builder create org.dde.demo
+ll-builder create org.deepin.demo
 
 #构建玲珑应用
-pushd org.dde.demo
+pushd org.deepin.demo
 ll-builder build
 
 #导出layer文件
@@ -42,19 +49,19 @@ export DBUS_SYSTEM_BUS_ADDRESS="unix:path=/var/run/dbus/system_bus_socket,test=2
 ll-builder run -- bash -c "export" | grep DBUS_SYSTEM_BUS_ADDRESS | grep test=2
 
 #运行并安装uab
-ll-cli uninstall org.dde.demo || true
-./org.dde.demo_x86_64_0.0.0.1_main.uab
+ll-cli uninstall org.deepin.demo || true
+./org.deepin.demo_x86_64_0.0.0.1_main.uab
 
 #安装构建的应用
-ll-cli install org.dde.demo_x86_64_0.0.0.1_main.uab
-ll-cli uninstall org.dde.demo || true
-ll-cli install org.dde.demo_0.0.0.1_x86_64_binary.layer
+ll-cli install org.deepin.demo_x86_64_0.0.0.1_main.uab
+ll-cli uninstall org.deepin.demo || true
+ll-cli install org.deepin.demo_0.0.0.1_x86_64_binary.layer
 
 #运行安装好的demo
-timeout 10 ll-cli run org.dde.demo
+timeout 10 ll-cli run org.deepin.demo
 popd
-rm -rf org.dde.demo
-ll-cli uninstall org.dde.demo
+rm -rf org.deepin.demo
+ll-cli uninstall org.deepin.demo
 
 #列出已经安装的应用
 ll-cli list
@@ -87,14 +94,13 @@ ll-cli upgrade "$appid"
 
 #运行玲珑应用
 ll-cli run "$appid" &
-sleep 20
+sleep 5
 
-cur_version=$(ll-cli info "$appid" | jq '.version' | xargs)
-arch=$(uname -m)
-ll-cli kill "main:$appid/$cur_version/$arch"
+ll-cli kill -9 "$appid"
+sleep 3
+ll-cli uninstall org.dde.calendar
 
 # 测试module安装
-ll-cli uninstall org.dde.calendar
 ll-cli install org.dde.calendar/5.14.4.102
 ll-cli install --module develop org.dde.calendar
 ll-cli install --module unuse org.dde.calendar


### PR DESCRIPTION
1. Added environment cleanup at start (remove old demo, reset repos)
2. Changed org.dde.demo to org.deepin.demo for consistency
3. Reduced sleep time from 20s to 5s for faster testing
4. Simplified process killing using appid instead of version/arch
5. Fixed module test sequence by moving uninstall before install
6. Improved overall script reliability with better cleanup steps

fix: 更新玲珑测试脚本并添加清理和改进

1. 在开始时添加环境清理（移除旧demo，重置仓库）
2. 将org.dde.demo改为org.deepin.demo保持一致性
3. 将等待时间从20秒减少到5秒以加快测试
4. 简化进程终止逻辑，直接使用appid而非版本/架构
5. 修复模块测试顺序，将卸载操作移到安装前
6. 通过更好的清理步骤提高脚本整体可靠性

## Summary by Sourcery

Improve the Linglong smoke test script by cleaning up stale state, standardizing project naming, speeding up execution, simplifying process termination, and correcting test sequence ordering

Enhancements:
- Add cleanup steps at script start to remove old demo artifacts and reset repositories
- Rename project identifier from org.dde.demo to org.deepin.demo for consistency
- Reduce sleep interval from 20s to 5s to accelerate test runs
- Simplify process kill command by using direct appid targeting
- Reorder module tests to uninstall before install to ensure correct sequence