### PR TITLE
refactor: extends ll-cli dir command with module support

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -583,8 +583,12 @@ ll-cli list --upgradable
     auto cliLayerDir =
       commandParser.add_subcommand("dir", "Get the layer directory of app(base or runtime)")
         ->group(CliHiddenGroup);
+    cliLayerDir->footer("This subcommand is for internal use only currently");
     cliLayerDir->add_option("APP", options.appid, _("Specify the installed app(base or runtime)"))
       ->required()
+      ->check(validatorString);
+    cliLayerDir->add_option("--module", options.module, _("Specify a module"))
+      ->type_name("MODULE")
       ->check(validatorString);
 
     auto res = transformOldExec(argc, argv);

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -2794,13 +2794,18 @@ int Cli::dir([[maybe_unused]] CLI::App *subcommand)
         return -1;
     }
 
-    auto layerItem = this->repository.getLayerItem(*ref);
-    if (!layerItem) {
-        this->printer.printErr(layerItem.error());
+    std::string module = "binary";
+    if (!options.module.empty()) {
+        module = options.module;
+    }
+
+    auto layerDir = this->repository.getLayerDir(*ref, module);
+    if (!layerDir) {
+        this->printer.printErr(layerDir.error());
         return -1;
     }
 
-    std::cout << layerItem->commit << std::endl;
+    std::cout << layerDir->absolutePath().toStdString() << std::endl;
     return 0;
 }
 


### PR DESCRIPTION
Adds support for specifying a module when using the `ll-cli dir` command. This allows users to retrieve the layer directory for a specific module within an application.

## Summary by Sourcery

Extend the ll-cli dir subcommand to support retrieving layer directories for specific modules by introducing a --module flag with a default value and updating its implementation to return the module's directory path.

New Features:
- Add --module option to ll-cli dir subcommand to allow specifying a module

Enhancements:
- Default module value to "binary" when none is provided
- Update dir command to call repository.getLayerDir with module and print the absolute path

Documentation:
- Add hidden footer note indicating internal use for the dir subcommand