### PR TITLE
fix: Return exit code of initial child process

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -760,7 +760,8 @@ utils::error::Result<void> Builder::processBuildDepends() noexcept
         .options = { { "rbind", "ro" } },
         .source = this->workingDir.absolutePath().toStdString(),
         .type = "bind" })
-      .forwardDefaultEnv();
+      .forwardDefaultEnv()
+      .appendEnv("LINYAPS_INIT_SINGLE_MODE", "1");
 
     // overwrite runtime overlay directory
     if (cfgBuilder.getRuntimePath()) {


### PR DESCRIPTION
The init process will now exit with the same code as the initial child process it manages.  This is crucial for environments like the builder, where the success or failure of a command must be detected.

Add missing LINYAPS_INIT_SINGLE_MODE in handling process build depends.