### PR TITLE
Fix: Correct build order and fix private mounting

### DIFF
--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -703,12 +703,25 @@ bool ContainerCfgBuilder::buildMountHome() noexcept
     }
     environment["XDG_DATA_HOME"] = containerDataHome;
 
+    auto checkPrivatePath = [this](const std::filesystem::path &path) -> std::filesystem::path {
+        if (!privateMount) {
+            return std::filesystem::path{};
+        }
+
+        std::error_code ec;
+        if (std::filesystem::exists(privateAppDir / path, ec)) {
+            return privateAppDir / path;
+        }
+
+        return std::filesystem::path{};
+    };
+
     value = getenv("XDG_CONFIG_HOME");
     std::filesystem::path XDG_CONFIG_HOME =
       value ? std::filesystem::path{ value } : *homePath / ".config";
     std::filesystem::path XDGConfigHome = XDG_CONFIG_HOME;
-    auto privateConfigPath = privatePath / "config";
-    if (std::filesystem::exists(privateConfigPath, ec)) {
+    auto privateConfigPath = checkPrivatePath("config");
+    if (!privateConfigPath.empty()) {
         XDGConfigHome = privateConfigPath;
     }
     std::string containerConfigHome = containerHome + "/.config";
@@ -725,8 +738,8 @@ bool ContainerCfgBuilder::buildMountHome() noexcept
     std::filesystem::path XDG_CACHE_HOME =
       value ? std::filesystem::path{ value } : *homePath / ".cache";
     std::filesystem::path XDGCacheHome = XDG_CACHE_HOME;
-    auto privateCachePath = privatePath / "cache";
-    if (std::filesystem::exists(privateCachePath, ec)) {
+    auto privateCachePath = checkPrivatePath("cache");
+    if (!privateCachePath.empty()) {
         XDGCacheHome = privateCachePath;
     }
     std::string containerCacheHome = containerHome + "/.cache";
@@ -742,8 +755,8 @@ bool ContainerCfgBuilder::buildMountHome() noexcept
     value = getenv("XDG_STATE_HOME");
     std::filesystem::path XDG_STATE_HOME =
       value ? std::filesystem::path{ value } : *homePath / ".local" / "state";
-    auto privateStatePath = privatePath / "state";
-    if (std::filesystem::exists(privateStatePath, ec)) {
+    auto privateStatePath = checkPrivatePath("state");
+    if (!privateStatePath.empty()) {
         XDG_STATE_HOME = privateStatePath;
     }
     std::string containerStateHome = containerHome + "/.local/state";
@@ -2025,7 +2038,7 @@ bool ContainerCfgBuilder::build() noexcept
         return false;
     }
 
-    if (!buildMountHome() || !buildTmp() || !buildPrivateDir() || !buildPrivateMapped()) {
+    if (!buildTmp() || !buildPrivateDir() || !buildMountHome() || !buildPrivateMapped()) {
         return false;
     }
 


### PR DESCRIPTION
Move buildMountHome after buildPrivateDir, because it depends on private directory that are initialized within buildPrivateDir.

Correct private config, cache, state directory mounting.