### PR TITLE
refactor: extract OSTree pull options initialization

### DIFF
--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -82,8 +82,6 @@ public:
                  const std::string &url,
                  const package::Reference &reference,
                  const std::string &module = "binary") const noexcept;
-    utils::error::Result<std::vector<guint64>> getCommitSize(const std::string &remote,
-                                                             const std::string &refString) noexcept;
     void pull(service::PackageTask &taskContext,
               const package::Reference &reference,
               const std::string &module = "binary",
@@ -206,6 +204,9 @@ private:
               const std::optional<std::string> &fileSuffix = std::nullopt);
     // exportEntries will clear the entries/share and export all applications to the entries/share
     utils::error::Result<void> exportAllEntries() noexcept;
+    utils::error::Result<std::vector<guint64>> getCommitSize(const std::string &remote,
+                                                             const std::string &refString) noexcept;
+    GVariantBuilder initOStreePullOptions(const std::string &ref) noexcept;
 };
 
 } // namespace linglong::repo


### PR DESCRIPTION
Extracted the common OSTree pull options initialization code into a separate method initOStreePullOptions to avoid code duplication. The method handles:
1. Creating GVariantBuilder with common options
2. Setting refs and user agent
3. Disabling static deltas by default This change makes the pull operation code cleaner and more maintainable by centralizing the options configuration logic.

refactor: 提取 OSTree 拉取选项初始化代码

将 OSTree 拉取选项的初始化代码提取到单独的 initOStreePullOptions 方法中 以避免重复代码。该方法处理：
1. 创建带有通用选项的 GVariantBuilder
2. 设置refs和user-agent
3. 默认禁用静态增量 通过集中管理选项配置逻辑，使拉取操作代码更清晰且更易于维护。