### PR TITLE
feat: set ns_last_pid annotation

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -607,8 +607,9 @@ int Cli::run([[maybe_unused]] CLI::App *subcommand)
 {
     LINGLONG_TRACE("command run");
 
-    int64_t uid = getuid();
-    int64_t gid = getgid();
+    auto uid = getuid();
+    auto gid = getgid();
+    auto pid = getpid();
 
     // NOTE: ll-box is not support running as root for now.
     if (uid == 0) {
@@ -616,14 +617,14 @@ int Cli::run([[maybe_unused]] CLI::App *subcommand)
         return -1;
     }
 
-    auto userContainerDir = std::filesystem::path{ "/run/linglong" } / std::to_string(::getuid());
+    auto userContainerDir = std::filesystem::path{ "/run/linglong" } / std::to_string(uid);
     if (auto ret = ensureDirectory(userContainerDir); !ret) {
         this->printer.printErr(ret.error());
         return -1;
     }
 
     auto mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
-    auto pidFile = userContainerDir / std::to_string(::getpid());
+    auto pidFile = userContainerDir / std::to_string(pid);
     // placeholder file
     auto fd = ::open(pidFile.c_str(), O_WRONLY | O_CREAT | O_EXCL, mode);
     if (fd == -1) {
@@ -682,11 +683,9 @@ int Cli::run([[maybe_unused]] CLI::App *subcommand)
 
     // this lambda will dump reference of containerID, app, base and runtime to
     // /run/linglong/getuid()/getpid() to store these needed infomation
-    auto dumpContainerInfo = [uid, &runContext, this]() -> bool {
+    auto dumpContainerInfo = [&pidFile, &runContext, this]() -> bool {
         LINGLONG_TRACE("dump info")
         std::error_code ec;
-        auto pidFile = std::filesystem::path{ "/run/linglong" } / std::to_string(uid)
-          / std::to_string(::getpid());
         if (!std::filesystem::exists(pidFile, ec)) {
             if (ec) {
                 qCritical() << "couldn't get status of" << pidFile.c_str() << ":"
@@ -712,8 +711,8 @@ int Cli::run([[maybe_unused]] CLI::App *subcommand)
 
     auto containers = getCurrentContainers().value_or(std::vector<api::types::v1::CliContainer>{});
     for (const auto &container : containers) {
+        qDebug() << "found running container: " << container.package.c_str();
         if (container.package != curAppRef->toString().toStdString()) {
-            qDebug() << "mismatch:" << container.package.c_str() << " -- " << curAppRef->toString();
             continue;
         }
 
@@ -751,6 +750,7 @@ int Cli::run([[maybe_unused]] CLI::App *subcommand)
     }
 
     cfgBuilder.setAppId(curAppRef->id.toStdString())
+      .setAnnotation(generator::ANNOTATION::LAST_PID, std::to_string(pid))
       .addUIdMapping(uid, uid, 1)
       .addGIdMapping(gid, gid, 1)
       .bindDefault()
@@ -898,6 +898,10 @@ Cli::getCurrentContainers() const noexcept
         if (!std::filesystem::exists(process, ec)) {
             // this process may exit abnormally, skip it.
             qDebug() << process.c_str() << "doesn't exist";
+            continue;
+        }
+
+        if (pidFile.file_size(ec) == 0) {
             continue;
         }
 

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -65,6 +65,30 @@ bool bindIfExist(std::vector<Mount> &mounts,
 }
 } // namespace
 
+ContainerCfgBuilder &ContainerCfgBuilder::setAnnotation(ANNOTATION key, std::string value) noexcept
+{
+    if (!config.annotations) {
+        config.annotations = std::map<std::string, std::string>();
+    }
+
+    switch (key) {
+    case ANNOTATION::APPID:
+        config.annotations->insert_or_assign("org.deepin.linglong.appID", std::move(value));
+        break;
+    case ANNOTATION::BASEDIR:
+        config.annotations->insert_or_assign("org.deepin.linglong.baseDir", std::move(value));
+        break;
+    case ANNOTATION::LAST_PID:
+        config.annotations->insert_or_assign("cn.org.linyaps.runtime.ns_last_pid",
+                                             std::move(value));
+        break;
+    default:
+        break;
+    }
+
+    return *this;
+}
+
 ContainerCfgBuilder &ContainerCfgBuilder::addUIdMapping(int64_t containerID,
                                                         int64_t hostID,
                                                         int64_t size) noexcept

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
@@ -17,8 +17,9 @@
 namespace linglong::generator {
 
 enum class ANNOTATION {
-    ANNOTATION_APPID,
-    ANNOTATION_BASEDIR,
+    APPID,
+    BASEDIR,
+    LAST_PID,
 };
 
 class ContainerCfgBuilder


### PR DESCRIPTION
Use this annotation with ll-box to configure ns_last_pid in new pid namespace to avoid pid collisions.