### PR TITLE
feat(run): add option '--env'

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -240,6 +240,18 @@ ll-cli run org.deepin.demo -- bash -x /path/to/bash/script)"));
       ->add_option("--url", options.fileUrls, _("Pass url to applications running in a sandbox"))
       ->type_name("URL")
       ->expected(0, -1);
+    cliRun->add_option("--env", options.envs, _("Set environment variables for the application"))
+      ->type_name("ENV")
+      ->expected(0, -1)
+      ->check([](const std::string &env) -> std::string {
+          if (env.find('=') == std::string::npos) {
+              return std::string{ _(
+                "Input parameter is invalid, please input valid parameter instead") };
+          }
+
+          return {};
+      });
+
     cliRun->add_option("COMMAND", options.commands, _("Run commands in a running sandbox"));
 
     // add sub command ps

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -773,6 +773,14 @@ int Cli::run([[maybe_unused]] CLI::App *subcommand)
                                               .options = std::vector<std::string>{ "bind" },
                                               .source = socketDir.string(),
                                               .type = "bind" });
+
+    for (const auto &env : options.envs) {
+        auto split = env.cbegin() + env.find('='); // already checked by CLI
+        cfgBuilder.appendEnv(std::string(env.cbegin(), split),
+                             std::string(split + 1, env.cend()),
+                             true);
+    }
+
 #ifdef LINGLONG_FONT_CACHE_GENERATOR
     cfgBuilder.enableFontCache();
 #endif

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -44,6 +44,7 @@ struct CliOptions
 {
     std::vector<std::string> filePaths;
     std::vector<std::string> fileUrls;
+    std::vector<std::string> envs;
     std::string workDir;
     std::string appid;
     std::string instance;


### PR DESCRIPTION
Adding a '--env' option to the ll-cli run command, allowing users to set environment variables when running applications. This feature supports multiple environment variables in KEY=VALUE format with input validation to ensure proper formatting.