### PR TITLE
chore: hide linyaps desktop file

### DIFF
--- a/misc/share/applications/linyaps.desktop
+++ b/misc/share/applications/linyaps.desktop
@@ -4,6 +4,7 @@ Encoding=UTF-8
 Type=Application
 Exec=/usr/bin/ll-cli install %f
 NoDisplay=true
+Hidden=true
 Terminal=true
 Name[zh_CN]=如意玲珑
 MimeType=application/vnd.linyaps.uab;


### PR DESCRIPTION
This change hides the `linyaps.desktop` file by setting `Hidden=true`. This is necessary because the application is not intended to be launched directly by the user through the desktop environment.  The intended use is via command line invocation through `ll-cli install`. Preventing direct launching reduces potential user confusion, as it requires specific arguments only provided via the command line interface.

Influence:
1. Verify that the application is not visible in the desktop environment application launcher or file manager.
2. Confirm that the application can still be invoked through the command line using `ll-cli install`.

chore: 隐藏如意玲珑桌面文件

此更改通过设置 `Hidden=true` 来隐藏 `linyaps.desktop` 文件。 这是必要 的，因为该应用程序不打算由用户通过桌面环境直接启动。 预期用途是通过 `ll-
cli install` 的命令行调用。 阻止直接启动可减少潜在的用户困惑，因为它需要
仅通过命令行界面提供的特定参数。

Influence:
1. 验证该应用程序在桌面环境应用程序启动器或文件管理器中不可见。
2. 确认仍然可以使用 `ll-cli install` 通过命令行调用该应用程序。