### PR TITLE
docs: update demo and install docs

### DIFF
--- a/docs/pages/en/guide/ll-builder/demo.md
+++ b/docs/pages/en/guide/ll-builder/demo.md
@@ -4,153 +4,139 @@ SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 SPDX-License-Identifier: LGPL-3.0-or-later
 -->
 
-## Initialize linyaps Projects
+# Build Example Demo
 
-```text
-ll-builder create org.deepin.calculator
-```
+## Initialize a Linglong Application Project
 
-## Edit linglong.yaml
+```bash
+ll-builder create org.deepin.demo
+````
 
-### Fill in the meta information of packages
+## Edit the linglong.yaml Configuration File
 
-```text
+### Configure Package Metadata
+
+```yaml
 package:
-  id: org.deepin.calculator
-  name: deepin-calculator
-  version: 5.9.17
+  id: org.deepin.demo
+  name: demo
   kind: app
+  version: 1.0.0.0
   description: |
-    calculator for deepin os.
+    A simple demo app.
 ```
 
-### Fill in the runtime info
+### Configure Application Startup Command
 
-```text
-runtime:
-  id: org.deepin.runtime.dtk
-  version: 23.1.0
+```yaml
+command:
+  - demo
 ```
 
-### Fill in the source code info
+### Configure Base System and Runtime Environment
 
-Use git source code
-
-```text
-source:
-  kind: git
-  url: "https://github.com/linuxdeepin/deepin-calculator.git"
-  commit: 7b5fdf8d133c356317636bb4b4a76fc73ef288c6
+```yaml
+base: org.deepin.base/23.1.0
+runtime: org.deepin.runtime.dtk/23.1.0
 ```
 
-### Fill in the dependencies
+### Configure Source Code Information
 
-```text
-depends:
-  - id: "dde-qt-dbus-factory"
-    version: 5.5.12
-  - id: googletest
-    version: 1.8.1
-  - id: icu
-    version: 63.1.0
-    type: runtime
-  - id: xcb-util
-    type: runtime
+Use Git to Fetch the Source Code
+
+```yaml
+sources:
+  - kind: git
+    url: "https://github.com/linuxdeepin/linglong-builder-demo.git"
+    commit: master
+    name: linglong-builder-demo
 ```
 
-### Choose build template
+### Configure Build Rules
 
-The source code is a cmake project, and choose the build type as cmake (see cmake.yaml for the template content).
-
-```text
-build:
-  kind: cmake
+```yaml
+  cd /project/linglong/sources/linglong-builder-demo
+  rm -rf build || true
+  mkdir build
+  cd build
+  qmake ..
+  make
+  make install
 ```
 
-### Override template content
+### Complete linglong.yaml Configuration File
 
-If the general template content does meet the build requirements, you can override the specified content in the linglong.yaml file. Variables or commands that are not re-declared in linglong.yaml will continue to be used.
+```yaml
+version: "1"
 
-Override the variable extra_args:
-
-```text
-variables:
-  extra_args: |
-   -DVERSION=1.1.1 \
-   -DPREFIX=/usr
-```
-
-Override the build command “build”:
-
-```text
-build:
-  kind: cmake
-  manual :
-    build: |
-      cd ${build_dir} && make -j8
-
-```
-
-### Complete linglong.yaml
-
-```text
 package:
-  id: org.deepin.calculator
-  name: deepin-calculator
-  version: 5.7.21
+  id: org.deepin.demo
+  name: demo
   kind: app
+  version: 1.0.0.0
   description: |
-    calculator for deepin os
-variables:
-  extra_args: |
-    -DVERSION=${VERSION} \
-    -DAPP_VERSION=5.7.21
-runtime:
-  id: org.deepin.runtime.dtk
-  version: 23.1.0
-depends:
-  - id: "dde-qt-dbus-factory"
-    version: 5.5.12
-  - id: googletest
-    version: 1.8.1
-  - id: icu
-    version: 63.1.0
-    type: runtime
-  - id: xcb-util
-    type: runtime
-source:
-  kind: git
-  url: https://github.com/linuxdeepin/deepin-calculator.git
-  commit: 7b5fdf8d133c356317636bb4b4a76fc73ef288c6
-build:
-  kind: cmake
+    A simple demo app.
+
+command:
+  - demo
+
+base: org.deepin.base/23.1.0
+runtime: org.deepin.runtime.dtk/23.1.0
+
+sources:
+  - kind: git
+    url: "https://github.com/linuxdeepin/linglong-builder-demo.git"
+    commit: master
+    name: linglong-builder-demo
+
+build: |
+  cd /project/linglong/sources/linglong-builder-demo
+  rm -rf build || true
+  mkdir build
+  cd build
+  qmake ..
+  make
+  make install
 ```
 
-## Start building
+For more details on configuration file fields, please refer to [Configuration File Description](https://www.google.com/search?q=./manifests.md)
 
-Execute the build subcommand in the root directory of linyaps projects:
+## Execute the Build Process
 
-```text
+In the root directory of the Linglong project, execute the build command:
+
+```bash
 ll-builder build
 ```
 
-## Export build content
+## Run the Application
 
-Execute the export subcommand in the root directory of linyaps projects to check out the build content and generate the bundle package.
+After a successful build, execute the run command in the Linglong project directory. The application can be run directly without installation.
 
-```text
+```bash
+ll-builder run
+```
+
+## Export Build Artifacts
+
+In the root directory of the Linglong project, execute the export command to check out the build content.
+
+```bash
 ll-builder export --layer
 ```
 
-## Push to repositories
+The directory structure after export is as follows:
 
 ```text
-ll-builder push org.deepin.calculator_5.7.21_x86_64.uab
+├── linglong
+├── linglong.yaml
+├── org.deepin.demo_1.0.0.0_x86_64_binary.layer
+└── org.deepin.demo_1.0.0.0_x86_64_develop.layer
 ```
 
-## More reference examples
+## More Reference Examples
 
-[qt5](https://github.com/linglongdev/cn.org.linyaps.demo.qt5) - qt5 program
+[qt5](https://github.com/linglongdev/cn.org.linyaps.demo.qt5) - qt5 application
 
 [dtk5](https://github.com/linglongdev/cn.org.linyaps.demo.dtk5.qmake) - dtk5 + qmake
 
@@ -158,12 +144,12 @@ ll-builder push org.deepin.calculator_5.7.21_x86_64.uab
 
 [dtkdeclarative5](https://github.com/linglongdev/cn.org.linyaps.demo.dtkdeclarative5) - dtk5 + qml
 
-[electron](https://github.com/myml/electron-vue-linyaps-app) - electron + vue Examples
+[electron](https://github.com/myml/electron-vue-linyaps-app) - electron + vue example
 
-[plantuml](https://github.com/linglongdev/com.plantuml.gpl) - A Java application that uses programmatic drawing to create flowcharts.
+[plantuml](https://github.com/linglongdev/com.plantuml.gpl) - a Java application for drawing flowcharts programmatically
 
-[org.sumatrapdfreader](https://github.com/linglongdev/org.sumatrapdfreader) - A Wine application that provides a PDF reader.
+[org.sumatrapdfreader](https://github.com/linglongdev/org.sumatrapdfreader) - a Wine application, a PDF reader
 
-## More Complete Example
+## More Complete Examples
 
-[Complete Example](../start/how_to_use.md) - This example shows how to build the app, export the build, install it, and run it.
+[Complete Example](https://www.google.com/search?q=../start/how_to_use.md) - a complete example that includes how to build an application, export build content, install, and run.

--- a/docs/pages/en/guide/start/install.md
+++ b/docs/pages/en/guide/start/install.md
@@ -62,6 +62,14 @@ sudo dnf update
 sudo dnf install linglong-builder linglong-box linglong-bin
 ```
 
+### Fedora 42
+
+```sh
+sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_42/linglong%3ACI%3Arelease.repo"
+sudo dnf update
+sudo dnf install linglong-bin
+```
+
 ### Ubuntu 24.04
 
 ```sh
@@ -78,6 +86,14 @@ sudo apt update
 sudo apt install linglong-builder linglong-box linglong-bin
 ```
 
+### Debian 13
+
+```sh
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Debian_13/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo apt update
+sudo apt install linglong-bin
+```
+
 ### openEuler 23.09
 
 ```sh
@@ -85,6 +101,15 @@ sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:
 sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
 sudo dnf update
 sudo dnf install linglong-builder linglong-box linglong-bin
+```
+
+### openEuler 24.03
+
+```sh
+sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_24.03/linglong%3ACI%3Arelease.repo"
+sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
+sudo dnf update
+sudo dnf install linglong-bin
 ```
 
 ### UOS 1070

--- a/docs/pages/guide/ll-builder/demo.md
+++ b/docs/pages/guide/ll-builder/demo.md
@@ -4,121 +4,140 @@ SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
 SPDX-License-Identifier: LGPL-3.0-or-later
 -->
 
-# demo示例
+# 构建示例演示
 
-## 初始化如意玲珑工程
+## 初始化玲珑应用项目
 
 ```bash
 ll-builder create org.deepin.demo
 ```
 
-## 编辑linglong.yaml
+## 编辑 linglong.yaml 配置文件
 
-### 填写软件包元信息
-
-```yaml
-package:
-  id: org.deepin.demo
-  name: deepin-demo
-  version: 0.0.1
-  kind: app
-  description: |
-    simple Qt demo.
-```
-
-### 填写运行时信息
-
-```yaml
-runtime:
-  id: org.deepin.Runtime
-  version: 23.0.0
-```
-
-### 填写源码信息
-
-使用git源码
-
-```yaml
-source:
-  kind: git
-  url: "https://github.com/linuxdeepin/linglong-builder-demo.git"
-  commit: 24f78c8463d87ba12b0ac393ec56218240315a9
-```
-
-### 选择构建模板
-
-源码为qmake工程，填写build 类型为qmake（模板内容见qmake.yaml）。
-
-```yaml
-build:
-  kind: qmake
-```
-
-### 完整linglong.yaml
+### 配置软件包元数据信息
 
 ```yaml
 package:
   id: org.deepin.demo
-  name: deepin-demo
-  version: 0.0.1
+  name: demo
   kind: app
+  version: 1.0.0.0
   description: |
-    simple Qt demo.
-
-runtime:
-  id: org.deepin.runtime.dtk
-  version: 23.1.0
-
-source:
-  kind: git
-  url: "https://github.com/linuxdeepin/linglong-builder-demo.git"
-  commit: 24f78c8463d87ba12b0ac393ec56218240315a9
-
-build:
-  kind: qmake
+    A simple demo app.
 ```
 
-## 开始构建
+### 配置应用程序启动命令
 
-在如意玲珑工程根目录下执行build子命令：
+```yaml
+command:
+  - demo
+```
+
+### 配置基础系统和运行时环境
+
+```yaml
+base: org.deepin.base/23.1.0
+runtime: org.deepin.runtime.dtk/23.1.0
+```
+
+### 配置源代码信息
+
+使用 Git 拉取源码
+
+```yaml
+sources:
+  - kind: git
+    url: "https://github.com/linuxdeepin/linglong-builder-demo.git"
+    commit: master
+    name: linglong-builder-demo
+```
+
+### 配置构建规则
+
+```yaml
+build: |
+  cd /project/linglong/sources/linglong-builder-demo
+  rm -rf build || true
+  mkdir build
+  cd build
+  qmake ..
+  make
+  make install
+```
+
+### 完整的 linglong.yaml 配置文件
+
+```yaml
+version: "1"
+
+package:
+  id: org.deepin.demo
+  name: demo
+  kind: app
+  version: 1.0.0.0
+  description: |
+    A simple demo app.
+
+command:
+  - demo
+
+base: org.deepin.base/23.1.0
+runtime: org.deepin.runtime.dtk/23.1.0
+
+sources:
+  - kind: git
+    url: "https://github.com/linuxdeepin/linglong-builder-demo.git"
+    commit: master
+    name: linglong-builder-demo
+
+build: |
+  cd /project/linglong/sources/linglong-builder-demo
+  rm -rf build || true
+  mkdir build
+  cd build
+  qmake ..
+  make
+  make install
+```
+
+更多配置文件字段定义请参考[配置文件说明](./manifests.md)
+
+## 执行构建流程
+
+在玲珑项目根目录下执行构建命令：
 
 ```bash
 ll-builder build
 ```
 
-## 运行应用
+## 运行应用程序
 
-构建成功后，在如意玲珑工程目录下执行run子命令，可以直接运行应用而无需安装。
+构建成功后，在玲珑项目目录下执行运行命令，无需安装即可直接运行应用程序。
 
 ```bash
 ll-builder run
 ```
 
-## 查看构建内容
+## 导出构建产物
 
-在如意玲珑工程根目录下执行export子命令，检出构建内容。
+在玲珑项目根目录下执行导出命令，检出构建内容。
 
 ```bash
 ll-builder export --layer
 ```
 
-目录结构如下：
+导出后的目录结构如下：
 
 ```text
-org.deepin.demo
-├── entries
-│   └── applications
-│        └── demo.desktop
-├── files
-│   └── bin
-│       └── demo
-├── info.json
-└── linglong.yaml
+├── linglong
+├── linglong.yaml
+├── org.deepin.demo_1.0.0.0_x86_64_binary.layer
+└── org.deepin.demo_1.0.0.0_x86_64_develop.layer
 ```
 
 ## 更多参考示例
 
-[qt5](https://github.com/linglongdev/cn.org.linyaps.demo.qt5) - qt5程序
+[qt5](https://github.com/linglongdev/cn.org.linyaps.demo.qt5) - qt5 程序
 
 [dtk5](https://github.com/linglongdev/cn.org.linyaps.demo.dtk5.qmake) - dtk5 + qmake
 
@@ -128,9 +147,9 @@ org.deepin.demo
 
 [electron](https://github.com/myml/electron-vue-linyaps-app) - electron + vue 例子
 
-[plantuml](https://github.com/linglongdev/com.plantuml.gpl) - 一个java应用，使用编程的方式绘制流程图
+[plantuml](https://github.com/linglongdev/com.plantuml.gpl) - 一个 java 应用，使用编程的方式绘制流程图
 
-[org.sumatrapdfreader](https://github.com/linglongdev/org.sumatrapdfreader) - 一个wine应用，pdf阅读器
+[org.sumatrapdfreader](https://github.com/linglongdev/org.sumatrapdfreader) - 一个 wine 应用，pdf 阅读器
 
 ## 更完整的示例
 

--- a/docs/pages/guide/start/install.md
+++ b/docs/pages/guide/start/install.md
@@ -60,6 +60,14 @@ sudo dnf update
 sudo dnf install linglong-builder linglong-box linglong-bin
 ```
 
+### Fedora 42
+
+```sh
+sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_42/linglong%3ACI%3Arelease.repo"
+sudo dnf update
+sudo dnf install linglong-bin
+```
+
 ### Ubuntu 24.04
 
 ```sh
@@ -76,6 +84,14 @@ sudo apt update
 sudo apt install linglong-builder linglong-box linglong-bin
 ```
 
+### Debian 13
+
+```sh
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Debian_13/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo apt update
+sudo apt install linglong-bin
+```
+
 ### openEuler 23.09
 
 ```sh
@@ -83,6 +99,15 @@ sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:
 sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
 sudo dnf update
 sudo dnf install linglong-builder linglong-box linglong-bin
+```
+
+### openEuler 24.03
+
+```sh
+sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_24.03/linglong%3ACI%3Arelease.repo"
+sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
+sudo dnf update
+sudo dnf install linglong-bin
 ```
 
 ### UOS 1070


### PR DESCRIPTION
1. Updated the demo documentation to use the `linglong-builder-demo` repository. This provides a more straightforward and up-to-date example for users to follow.
2. Modified installation instructions to include Fedora 42, Debian 13 and openEuler 24.03. This ensures broader OS support for users installing `linglong-bin`

Influence:
1. Verify that the demo application builds and runs successfully using the updated instructions.
2. Ensure that the installation instructions for Fedora 42, Debian 13 and openEuler 24.03 are accurate and complete.

docs: 更新演示和安装文档

1. 更新了演示文档，使用 `linglong-builder-demo` 仓库。这为用户提供了一个 更简单且最新的示例供参考。
2. 修改了安装说明，添加了 Fedora 42、Debian 13 和 openEuler 24.03 的安装 方法。这确保了用户安装 `linglong-bin` 时具有更广泛的操作系统支持

Influence:
1. 验证演示应用程序是否使用更新后的说明成功构建和运行。
2. 确保 Fedora 42、Debian 13 和 openEuler 24.03 的安装说明准确且完整。