### PR TITLE
feat: Add Linyaps application icon

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -194,3 +194,9 @@ path = "apps/ll-builder-utils/patch/libfuse.patch"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "UnionTech Software Technology Co., Ltd."
 SPDX-License-Identifier = "LGPL-3.0-or-later"
+
+[[annotations]]
+path = ["misc/share/icons/**.svg"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "UnionTech Software Technology Co., Ltd."
+SPDX-License-Identifier = "LGPL-3.0-or-later"

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -46,6 +46,7 @@ configure_files(
   share/linglong/config.yaml
   share/mime/packages/vnd.linyaps.uab.xml
   share/polkit-1/actions/org.deepin.linglong.PackageManager1.policy
+  share/icons/linyaps.svg
   share/applications/linyaps.desktop)
 
 # bash-completion
@@ -161,6 +162,8 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/share/mime/packages
         DESTINATION ${CMAKE_INSTALL_DATADIR}/mime)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/applications/linyaps.desktop
         DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/icons/linyaps.svg
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps)
 
 # set linglong XDG_DATA_DIRS environtment
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/script/linglong.sh

--- a/misc/share/applications/linyaps.desktop
+++ b/misc/share/applications/linyaps.desktop
@@ -2,6 +2,7 @@
 Name=Linyaps
 Encoding=UTF-8
 Type=Application
+Icon=linyaps
 Exec=/usr/bin/ll-cli install %f
 NoDisplay=true
 Terminal=true

--- a/misc/share/icons/linyaps.svg
+++ b/misc/share/icons/linyaps.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="128px" height="128px" viewBox="0 0 128 128" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>LOGO-svg2</title>
+    <g id="LOGO-svg2" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="编组-3">
+            <rect id="矩形" fill="#025BFF" x="0" y="0" width="128" height="128" rx="32"></rect>
+            <g id="编组" transform="translate(24.000000, 17.000000)">
+                <polygon id="路径-10" fill="#8BAFF5" points="80 25.0811618 60 34 60 58 40 67.2940338 40 92 80 74"></polygon>
+                <polygon id="路径-11" fill="#FFFFFF" points="60 58 40 49 40 25.0811618 60 34"></polygon>
+                <polygon id="路径-12" fill="#467FEF" points="80 25.0811618 60 15 40 25.0811618 60 34"></polygon>
+                <polygon id="路径-13" fill="#FFFFFF" points="40 92 20 82 20 58 40 67.2940338"></polygon>
+                <polygon id="路径-14" fill="#467FEF" points="20 58 40 49 60 58 40 67.2940338"></polygon>
+                <polygon id="矩形" fill="#FFFFFF" points="2.84217094e-13 19 20 28 20 77 0 67"></polygon>
+                <polygon id="路径-8" fill="#467FEF" points="20 28 60 9 40 -3.42087469e-15 4.26325641e-13 19"></polygon>
+                <polygon id="路径-9" fill="#8BAFF5" points="20 28 20 77 40 67.2940338 40 43 60 34 60 9"></polygon>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
This commit adds a new application icon for Linyaps and integrates it into the desktop entry.

The `linyaps.svg` file contains the vector graphic for the icon. The CMakeLists.txt file is updated to install the icon to the correct location in the file system (`/usr/share/icons/hicolor/scalable/apps`). The `linyaps.desktop` file is modified to use the new icon by setting the `Icon` field to "linyaps".

This change improves the visual presentation of the Linyaps application in the desktop environment.

Log: Added application icon for Linyaps

Influence:
1. Verify that the Linyaps icon is displayed correctly in application launchers and desktop environments.
2. Check that the icon is visually appealing and consistent with the application's branding.
3. Test the icon at different sizes to ensure it remains clear and recognizable.
4. Confirm that the icon is correctly installed to the system's icon directory.