### PR TITLE
refactor: improve UAB file handling and cleanup

### DIFF
--- a/libs/linglong/src/linglong/package/layer_packager.h
+++ b/libs/linglong/src/linglong/package/layer_packager.h
@@ -34,10 +34,10 @@ public:
                                                          const QString &layerFilePath) const;
     utils::error::Result<LayerDir> unpack(LayerFile &file);
     utils::error::Result<void> setCompressor(const QString &compressor) noexcept;
-    const QDir &getWorkDir() const;
+    const std::filesystem::path &getWorkDir() const;
 
 private:
-    QDir workDir;
+    std::filesystem::path workDir;
     QString compressor = "lzma";
     bool isMounted = false;
     // 初始化工作目录

--- a/libs/linglong/src/linglong/package/uab_file.h
+++ b/libs/linglong/src/linglong/package/uab_file.h
@@ -14,11 +14,15 @@
 #include <QString>
 
 #include <filesystem>
+#include <string>
 
 namespace linglong::package {
 
 class UABFile : public QFile
 {
+
+    friend class MockUabFile;
+
 public:
     static utils::error::Result<std::shared_ptr<UABFile>> loadFromFile(int fd) noexcept;
     UABFile(UABFile &&) = delete;
@@ -26,7 +30,7 @@ public:
     ~UABFile() override;
 
     utils::error::Result<bool> verify() noexcept;
-    utils::error::Result<std::filesystem::path> mountUab() noexcept;
+    utils::error::Result<std::filesystem::path> unpack() noexcept;
 
     // this method will extract sign data to a temporary directory, caller should remove it
     utils::error::Result<std::filesystem::path> extractSignData() noexcept;
@@ -40,7 +44,17 @@ private:
 
     Elf *e{ nullptr };
     std::unique_ptr<api::types::v1::UabMetaInfo> metaInfo{ nullptr };
-    std::filesystem::path mountPoint;
+    std::string m_mountPoint;
+    std::string m_unpackPath;
+
+    // 判断fd是否可在其他进程读取
+    virtual bool isFileReadable(const std::string &path) const;
+    // 将fd保存为文件，可以避免文件无权限的问题
+    virtual utils::error::Result<void> saveErofsToFile(const std::string &path);
+    // 创建目录，用于单元测试
+    virtual utils::error::Result<void> mkdirDir(const std::string &path) noexcept;
+    // 判断命令是否存在
+    virtual bool checkCommandExists(const std::string &command) const;
 };
 
 } // namespace linglong::package

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -927,7 +927,7 @@ QVariantMap PackageManager::installFromUAB(const QDBusUnixFileDescriptor &fd,
         taskRef.updateSubState(linglong::api::types::v1::SubState::PreAction,
                                "prepare environment");
 
-        auto mountPoint = uab->mountUab();
+        auto mountPoint = uab->unpack();
         if (!mountPoint) {
             taskRef.reportError(std::move(mountPoint).error());
             return;

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -21,6 +21,7 @@ pfl_add_executable(
   src/linglong/package/semver_prerelease_test.cpp
   src/linglong/package/semver_serialization_test.cpp
   src/linglong/package/semver_version_test.cpp
+  src/linglong/package/uab_file_test.cpp
   src/linglong/package/layer_packager_test.cpp
   src/linglong/utils/error/result_test.cpp
   src/linglong/utils/log.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/api/types/v1/Generators.hpp"
+#include "linglong/package/uab_file.h"
+#include "linglong/package/uab_packager.h"
+#include "linglong/utils/command/cmd.h"
+
+#include <QCryptographicHash>
+#include <QFileInfo>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <fcntl.h>
+
+using namespace linglong;
+
+namespace linglong::package {
+
+class MockUabFile : public package::UABFile
+{
+public:
+    MOCK_METHOD(utils::error::Result<void>, mkdirDir, (const std::string &path), (noexcept));
+    MOCK_METHOD(bool, isFileReadable, (const std::string &path), (const));
+    MOCK_METHOD(bool, checkCommandExists, (const std::string &command), (const));
+
+    explicit MockUabFile(const std::string &path)
+        : UABFile()
+    {
+        auto fd = ::open(path.c_str(), O_RDONLY);
+        EXPECT_NE(fd, -1) << "Failed to open uab file" << strerror(errno);
+        this->open(fd, QIODevice::ReadOnly, FileHandleFlag::AutoCloseHandle);
+        elf_version(EV_CURRENT);
+        auto *elf = elf_begin(fd, ELF_C_READ, nullptr);
+        this->UABFile::e = elf;
+        // 使用 lambda 表达式调用基类方法
+        ON_CALL(*this, checkCommandExists(testing::_))
+          .WillByDefault(testing::Invoke([this](const std::string &command) {
+              return this->UABFile::checkCommandExists(command);
+          }));
+        ON_CALL(*this, isFileReadable(testing::_))
+          .WillByDefault(testing::Invoke([this](const std::string &path) {
+              return this->UABFile::isFileReadable(path);
+          }));
+        ON_CALL(*this, mkdirDir(testing::_))
+          .WillByDefault(testing::Invoke([this](const std::string &path) -> utils::error::Result<void> {
+              return this->UABFile::mkdirDir(path);
+          }));
+    }
+};
+
+class UabFileTest : public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        char tempPath[] = "/var/tmp/linglong-uab-file-test-XXXXXX";
+        testDir = mkdtemp(tempPath);
+        ASSERT_FALSE(testDir.empty()) << "Failed to create temporary directory";
+        uabFile = testDir / "test.uab";
+        std::filesystem::copy_file("/proc/self/exe", uabFile);
+        auto uab = elfHelper::create(QString::fromStdString(uabFile).toLocal8Bit());
+        ASSERT_TRUE(uab.has_value()) << "Failed to create uab file";
+        // 添加bundle section
+        std::string bundleFile = testDir / "bundle.erofs";
+        {
+            std::error_code ec;
+            std::filesystem::create_directories(testDir / "bundle/layers/test/binary", ec);
+            ASSERT_FALSE(ec) << "Failed to create test directory";
+            std::string helloFilePath = testDir / "bundle" / "layers" / "test" / "binary" / "info.json";
+            std::ofstream tmpFile(helloFilePath);
+            tmpFile << "Hello, World!";
+            tmpFile.close();
+            auto ret =
+              utils::command::Cmd("mkfs.erofs").exec({ bundleFile.c_str(), (testDir / "bundle").c_str() });
+            ASSERT_TRUE(ret.has_value()) << "Failed to create erofs file" << ret.error().message().toStdString();
+            auto ret2 = uab->addNewSection("linglong.bundle", QFileInfo(bundleFile.c_str()));
+            ASSERT_TRUE(ret2.has_value()) << "Failed to add bundle section" << ret2.error().message().toStdString();
+        }
+        // 新添加 meta section
+        {
+            api::types::v1::PackageInfoV2 packageInfo;
+            packageInfo.name = "hello";
+            packageInfo.version = "1";
+            packageInfo.description = "hello world";
+            packageInfo.id = "hello";
+            packageInfo.version = "1";
+            api::types::v1::UabMetaInfo meta;
+            meta.version = api::types::v1::Version::The1;
+            meta.uuid = "b2f33c7b-615c-4d7d-9181-e1a22010a749";
+            meta.onlyApp = true;
+            meta.sections.bundle = "linglong.bundle";
+            meta.layers.push_back(api::types::v1::UabLayer{ packageInfo, false });
+            // 计算bundle哈希值
+            QFile bundle{ bundleFile.c_str() };
+            if (!bundle.open(QIODevice::ReadOnly | QIODevice::ExistingOnly)) {
+                ASSERT_TRUE(false) << "Failed to open bundle file";
+            }
+            QCryptographicHash cryptor{ QCryptographicHash::Sha256 };
+            if (!cryptor.addData(&bundle)) {
+                ASSERT_TRUE(false) << "Failed to add data to cryptor";
+            }
+            bundle.close();
+            meta.digest = cryptor.result().toHex().toStdString();
+
+            std::ofstream jsonFile(testDir / "info.json");
+            jsonFile << nlohmann::json(meta).dump();
+            jsonFile.close();
+            auto ret = uab->addNewSection("linglong.meta", QFileInfo((testDir / "info.json").string().c_str()));
+            ASSERT_TRUE(ret.has_value()) << "Failed to add meta section";
+        }
+        // 再添加sign section
+        {
+            auto signDir = testDir / "sign";
+            std::error_code ec;
+            std::filesystem::create_directories(signDir, ec);
+            ASSERT_FALSE(ec) << "Failed to create sign directory";
+            std::string helloFilePath = signDir / "hello";
+            std::ofstream tmpFile(helloFilePath);
+            tmpFile << "Hello, World!";
+            tmpFile.close();
+            auto ret = utils::command::Cmd("tar").exec(
+              { "-cvf", (testDir / "sign.tar").c_str(), "-C", signDir.c_str(), "." });
+            ASSERT_TRUE(ret.has_value()) << "Failed to create tar file";
+            auto ret2 = uab->addNewSection("linglong.bundle.sign", QFileInfo((testDir / "sign.tar").string().c_str()));
+            ASSERT_TRUE(ret2.has_value()) << "Failed to add sign section";
+        }
+    }
+
+    static void TearDownTestSuite()
+    {
+        std::error_code ec;
+        std::filesystem::remove_all(testDir, ec);
+        ASSERT_FALSE(ec) << "Failed to remove test dir";
+    }
+
+    void SetUp() override { }
+
+    void TearDown() override { }
+
+    static std::string uabFile;
+    static std::filesystem::path testDir;
+};
+
+std::string UabFileTest::uabFile;
+std::filesystem::path UabFileTest::testDir;
+
+TEST_F(UabFileTest, UnpackFuseOffset)
+{
+    // 打开UAB文件
+    int fd = open(uabFile.c_str(), O_RDONLY);
+    ASSERT_NE(fd, -1) << "Failed to open uab file" << strerror(errno);
+
+    // 初始化UABFile对象
+    auto uab = linglong::package::UABFile::loadFromFile(fd);
+    ASSERT_TRUE(uab.has_value()) << "Failed to load uab file";
+    auto uabValue = *uab;
+    auto unpackRet = uabValue->unpack();
+    ASSERT_TRUE(unpackRet.has_value())
+      << "Failed to unpack uab file" << unpackRet.error().message().toStdString();
+
+    ASSERT_TRUE(std::filesystem::exists(*unpackRet / "layers/test/binary/info.json"))
+      << "'info.json' not found in unpack dir" << *unpackRet / "info.json";
+}
+
+TEST_F(UabFileTest, UnpackFuse)
+{
+    auto uab = MockUabFile(uabFile);
+    EXPECT_CALL(uab, mkdirDir(testing::_))
+      .WillOnce([]() {
+          LINGLONG_TRACE("test");
+          return LINGLONG_ERR("Cannot create directory in /var/tmp");
+      })
+      .WillOnce([](const std::string &path) -> utils::error::Result<void> {
+          LINGLONG_TRACE("test");
+          std::filesystem::create_directories(path);
+          return LINGLONG_OK;
+      });
+    EXPECT_CALL(uab, isFileReadable(testing::_)).WillOnce(testing::Return(false));
+    auto unpackRet = uab.unpack();
+    ASSERT_TRUE(unpackRet.has_value()) << "Failed to unpack uab file";
+
+    ASSERT_TRUE(std::filesystem::exists(*unpackRet / "layers/test/binary/info.json"))
+      << "'info.json' not found in unpack dir" << *unpackRet / "info.json";
+}
+
+TEST_F(UabFileTest, UnpackFsck)
+{
+    auto uab = MockUabFile(uabFile);
+    EXPECT_CALL(uab, checkCommandExists(testing::_))
+      .WillOnce(testing::Return(false))
+      .WillOnce(testing::Return(true));
+    auto unpackRet = uab.unpack();
+    ASSERT_TRUE(unpackRet.has_value()) << "Failed to unpack uab file";
+
+    ASSERT_TRUE(std::filesystem::exists(*unpackRet / "layers/test/binary/info.json"))
+      << "'info.json' not found in unpack dir" << *unpackRet / "info.json";
+}
+
+TEST_F(UabFileTest, Verify)
+{
+    auto uab = MockUabFile(uabFile);
+    auto verifyRet = uab.verify();
+    ASSERT_TRUE(verifyRet.has_value()) << "Failed to verify uab file";
+    ASSERT_TRUE(*verifyRet) << "Verify failed";
+}
+
+TEST_F(UabFileTest, ExtractSignData)
+{
+    auto uab = MockUabFile(uabFile);
+    auto ret = uab.unpack();
+    ASSERT_TRUE(ret.has_value()) << "Failed to unpack uab file "
+                                 << ret.error().message().toStdString();
+    auto extractSignDataRet = uab.extractSignData();
+    ASSERT_TRUE(extractSignDataRet.has_value())
+      << "Failed to extract sign data " << extractSignDataRet.error().message().toStdString();
+    auto signDataDir = *extractSignDataRet / "entries" / "share" / "deepin-elf-verify" / ".elfsign";
+    ASSERT_TRUE(std::filesystem::exists(signDataDir / "hello"))
+      << "Failed to extract sign data " << signDataDir / "hello";
+    std::ifstream helloFile(signDataDir / "hello");
+    std::stringstream buffer;
+    buffer << helloFile.rdbuf();
+    ASSERT_EQ(buffer.str(), "Hello, World!") << "Failed to read hello file";
+    std::error_code ec;
+    std::filesystem::remove_all(*extractSignDataRet, ec);
+    ASSERT_FALSE(ec) << "Failed to remove extractSignDataRet" << ec.message();
+}
+
+} // namespace linglong::package

--- a/libs/utils/src/linglong/utils/command/env.cpp
+++ b/libs/utils/src/linglong/utils/command/env.cpp
@@ -23,4 +23,13 @@ QStringList getUserEnv(const QStringList &filters)
     return ret.toStringList();
 }
 
+std::optional<std::string> getEnv(const std::string &variableName)
+{
+    auto value = std::getenv(variableName.c_str());
+    if (value == nullptr) {
+        return std::nullopt;
+    }
+    return std::string(value);
+}
+
 } // namespace linglong::utils::command

--- a/libs/utils/src/linglong/utils/command/env.h
+++ b/libs/utils/src/linglong/utils/command/env.h
@@ -16,6 +16,8 @@ namespace linglong::utils::command {
 
 QStringList getUserEnv(const QStringList &filters);
 
+std::optional<std::string> getEnv(const std::string &variableName);
+
 class EnvironmentVariableGuard
 {
 public:

--- a/tools/generate-coverage.sh
+++ b/tools/generate-coverage.sh
@@ -20,9 +20,13 @@ command -v ccache &>/dev/null && {
 # shellcheck disable=SC2086
 cmake --fresh -B "$builddir" -S . "$USE_CCACHE" || exit 255
 
-cmake --build "$builddir" -j "$(nproc)" || exit 255
+NUM_JOBS=${NUM_JOBS:-$(nproc)}
+cmake --build "$builddir" -j "$NUM_JOBS" || exit 255
 
-cmake --build "$builddir" -t test
+# 用cmake会执行多次SetUpTestSuite
+# cmake --build "$builddir" -t test -- ARGS="--output-on-failure"
+
+$builddir/libs/linglong/tests/ll-tests/ll-tests
 
 mkdir -p "$builddir"/report || exit 255
 
@@ -33,3 +37,9 @@ gcovr \
     --html-nested "$builddir"/report/index.html \
     --xml "$builddir"/report/index.xml \
     --print-summary
+
+if command -v xdg-open &>/dev/null; then
+    echo "use xdg-open $builddir/report/index.html to view coverage report"
+else
+    echo "Open $builddir/report/index.html in your web browser to view the coverage report."
+fi


### PR DESCRIPTION
1. Changed LayerPackager to use std::filesystem::path instead of QDir for workDir
2. Added defensive programming in initWorkDir to handle multiple calls
3. Implemented proper cleanup in UABFile destructor for mount points and unpacked files
4. Added support for both erofsfuse and fsck.erofs unpack methods
5. Improved error handling and added new utility methods in UABFile
6. Added comprehensive unit tests for UAB file operations

refactor: 改进UAB文件处理和清理

1. 将LayerPackager中的workDir从QDir改为std::filesystem::path
2. 在initWorkDir中添加防御性编程以处理多次调用
3. 在UABFile析构函数中实现挂载点和解压文件的正确清理
4. 添加对erofsfuse和fsck.erofs两种解压方法的支持
5. 改进错误处理并在UABFile中添加新的实用方法
6. 为UAB文件操作添加全面的单元测试