### PR TITLE
fix: use CMAKE_INSTALL_SYSCONFDIR for config paths

### DIFF
--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -164,11 +164,11 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/applications/linyaps.desktop
 
 # set linglong XDG_DATA_DIRS environtment
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/script/linglong.sh
-        DESTINATION /etc/profile.d)
+        DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/profile.d)
 
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/script/linglong.sh
-  DESTINATION /etc/X11/Xsession.d/
+  DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/X11/Xsession.d/
   RENAME 21linglong)
 
 # polkit actions


### PR DESCRIPTION
1. Replace hardcoded /etc paths with CMAKE_INSTALL_SYSCONFDIR variable
2. Fix two installation destinations in the CMakeLists.txt file:
   - Changed /etc/profile.d to ${CMAKE_INSTALL_SYSCONFDIR}/profile.d
   - Changed /etc/X11/Xsession.d to ${CMAKE_INSTALL_SYSCONFDIR}/X11/ Xsession.d
3. This makes the installation paths configurable through CMake rather than hardcoded
4. The change ensures better compatibility across different Linux distributions and packaging systems

Influence:
1. Test installation on target system to verify script placement
2. Check that environment variables are properly set in both profile.d and Xsession.d locations
3. Verify package builds work correctly with custom CMAKE_INSTALL_SYSCONFDIR values

fix: 使用 CMAKE_INSTALL_SYSCONFDIR 变量替代配置路径中的硬编码值

1. 将原有的硬编码路径 /etc 替换为 CMAKE_INSTALL_SYSCONFDIR 变量
2. 修改了 CMakeLists.txt 中的两个安装路径：
   - 将 /etc/profile.d 替换为 ${CMAKE_INSTALL_SYSCONFDIR}/profile.d
   - 将 /etc/X11/Xsession.d 替换为 ${CMAKE_INSTALL_SYSCONFDIR}/X11/ Xsession.d
3. 这使得安装路径可以通过 CMake 配置而非固定写死
4. 此修改提升了不同 Linux 发行版和打包系统的兼容性

Influence:
1. 在目标系统上测试安装以验证脚本位置的正确性
2. 检查 profile.d 和 Xsession.d 中的环境变量是否正确设置
3. 验证使用自定义 CMAKE_INSTALL_SYSCONFDIR 值时的包构建过程