### PR TITLE
chore: use CMAKE_INSTALL_FULL_SYSCONFDIR

### DIFF
--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -167,11 +167,11 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/icons/linyaps.svg
 
 # set linglong XDG_DATA_DIRS environtment
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/script/linglong.sh
-        DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/profile.d)
+        DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/profile.d)
 
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/script/linglong.sh
-  DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/X11/Xsession.d/
+  DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/X11/Xsession.d/
   RENAME 21linglong)
 
 # polkit actions


### PR DESCRIPTION
Update installation paths for shell scripts to use `CMAKE_INSTALL_FULL_SYSCONFDIR` instead of `CMAKE_INSTALL_SYSCONFDIR`. This ensures that the scripts are installed in the correct location, even when the installation prefix is not the root directory. This fixes issues where linglong related scripts were not correctly installed in non-standard installation paths.

Influence:
1. Verify that linglong.sh is installed to the correct path, both when installing to /usr and to a non-standard prefix.
2. Check that the environment variables set in the script are correctly sourced when a new session starts.