### PR TITLE
refactor: rework container init process

### DIFF
--- a/libs/linglong/src/linglong/runtime/container.cpp
+++ b/libs/linglong/src/linglong/runtime/container.cpp
@@ -203,7 +203,7 @@ utils::error::Result<void> Container::run(const ocppi::runtime::config::types::P
 
         // TODO: maybe we could use a symlink '/usr/bin/ll-init' points to
         // '/run/linglong/container-init' will be better
-        ofs << "#!/run/linglong/container-init /bin/bash\n";
+        ofs << "#!/bin/bash\n";
         ofs << "source /etc/profile\n"; // we need use /etc/profile to generate all needed
                                         // environment variables
         ofs << "exec ";
@@ -225,7 +225,12 @@ utils::error::Result<void> Container::run(const ocppi::runtime::config::types::P
       .type = "bind",
     });
 
-    this->cfg.process->args = { "/run/linglong/entrypoint.sh" };
+    auto cmd = std::vector<std::string>{
+        "/run/linglong/container-init", "env", "-i", "/bin/bash", "--noprofile", "--norc", "-c",
+        "/run/linglong/entrypoint.sh"
+    };
+
+    this->cfg.process->args = cmd;
 
 #ifdef LINGLONG_FONT_CACHE_GENERATOR
     {

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -868,20 +868,6 @@ bool ContainerCfgBuilder::buildMountHome() noexcept
                                     .type = "bind" });
     }
 
-    // NOTE:
-    // Running ~/.bashrc from user home is meaningless in linglong container,
-    // and might cause some issues, so we mask it with the default one.
-    // https://github.com/linuxdeepin/linglong/issues/459
-    constexpr auto defaultBashrc = "/etc/skel/.bashrc";
-    if (std::filesystem::exists(defaultBashrc, ec)) {
-        homeMount->push_back(Mount{
-          .destination = *homePath / ".bashrc",
-          .options = string_list{ "ro", "rbind" },
-          .source = defaultBashrc,
-          .type = "bind",
-        });
-    }
-
     return true;
 }
 


### PR DESCRIPTION
1. Changed the entrypoint execution method within the container.
2. Replaced the direct execution of `/run/linglong/container-init` within the `entrypoint.sh` script with a `bash` command that sources `/ etc/profile` and executes `entrypoint.sh`.
3. Modified `Container::run` to use `container-init env -i /bin/bash --noprofile --norc -c /run/linglong/entrypoint.sh` to execute the container entrypoint.
4. Removed masking of `~/.bashrc` in `ContainerCfgBuilder::buildMountHome`.

The previous approach used a shebang in `entrypoint.sh` to invoke `container-init`, which was suboptimal. This change uses `container- init` to set up the environment, then uses a clean `bash` instance to execute the `entrypoint.sh` script. This provides better isolation and control over the environment in which the application runs and ensures environment variables set in `/etc/profile` are available. Removing the `.bashrc` masking follows discussion around user customization.

Influence:
1. Verify that applications within the container now have access to the environment variables set in `/etc/profile`.
2. Ensure existing applications continue to function as expected after the changes to the entrypoint execution.
3. Test applications relying on user specific configurations in their home directories.
4. Test application startup time is not significantly increased.
5. Test with different base images and entrypoint scripts.