### PR TITLE
docs: Update installation instructions

### DIFF
--- a/docs/pages/en/guide/start/install.md
+++ b/docs/pages/en/guide/start/install.md
@@ -36,7 +36,7 @@ The installation steps below are based on the release repository. If you'd like 
 
 :::
 
-## Installation Instructions
+## Linyaps Installation Instructions
 
 ### Arch / Manjaro / Parabola Linux
 
@@ -44,12 +44,21 @@ The installation steps below are based on the release repository. If you'd like 
 sudo pacman -Syu linyaps
 ```
 
+The Linyaps Web Store installation tool needs to be installed through the [AUR repository](https://aur.archlinux.org/packages/linyaps-web-store-installer) or [self-built source repository](https://github.com/taotieren/aur-repo).
+
+```bash
+# AUR
+yay -Syu linyaps-web-store-installer
+# 或自建源
+sudo pacman -Syu linyaps-web-store-installer
+```
+
 ### deepin 25
 
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Deepin_25/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-builder linglong-box linglong-bin
+sudo apt install linglong-bin linglong-installer
 ```
 
 ### deepin 23
@@ -57,7 +66,7 @@ sudo apt install linglong-builder linglong-box linglong-bin
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Deepin_23/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-builder linglong-box linglong-bin
+sudo apt install linglong-bin linglong-installer
 ```
 
 ### Fedora 41
@@ -65,7 +74,7 @@ sudo apt install linglong-builder linglong-box linglong-bin
 ```sh
 sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_41/linglong%3ACI%3Arelease.repo"
 sudo dnf update
-sudo dnf install linglong-builder linglong-box linglong-bin
+sudo dnf install linglong-bin linyaps-web-store-installer
 ```
 
 ### Fedora 42
@@ -73,7 +82,7 @@ sudo dnf install linglong-builder linglong-box linglong-bin
 ```sh
 sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_42/linglong%3ACI%3Arelease.repo"
 sudo dnf update
-sudo dnf install linglong-bin
+sudo dnf install linglong-bin linyaps-web-store-installer
 ```
 
 ### Ubuntu 24.04
@@ -81,7 +90,7 @@ sudo dnf install linglong-bin
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/xUbuntu_24.04/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-builder linglong-box linglong-bin
+sudo apt install linglong-bin linglong-installer
 ```
 
 ### Debian 12
@@ -89,7 +98,7 @@ sudo apt install linglong-builder linglong-box linglong-bin
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Debian_12/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-builder linglong-box linglong-bin
+sudo apt install linglong-bin linglong-installer
 ```
 
 ### Debian 13
@@ -97,7 +106,7 @@ sudo apt install linglong-builder linglong-box linglong-bin
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Debian_13/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-bin
+sudo apt install linglong-bin linglong-installer
 ```
 
 ### openEuler 23.09
@@ -106,7 +115,7 @@ sudo apt install linglong-bin
 sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_23.09/linglong%3ACI%3Arelease.repo"
 sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
 sudo dnf update
-sudo dnf install linglong-builder linglong-box linglong-bin
+sudo dnf install linglong-bin linyaps-web-store-installer
 ```
 
 ### openEuler 24.03
@@ -115,7 +124,7 @@ sudo dnf install linglong-builder linglong-box linglong-bin
 sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_24.03/linglong%3ACI%3Arelease.repo"
 sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
 sudo dnf update
-sudo dnf install linglong-bin
+sudo dnf install linglong-bin linyaps-web-store-installer
 ```
 
 ### UOS 1070
@@ -123,7 +132,7 @@ sudo dnf install linglong-bin
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/uos_1070/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-builder linglong-box linglong-bin
+sudo apt install linglong-bin linglong-installer
 ```
 
 ### AnolisOS 8
@@ -131,7 +140,7 @@ sudo apt install linglong-builder linglong-box linglong-bin
 ```sh
 sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/AnolisOS_8/linglong%3ACI%3Arelease.repo"
 sudo dnf update
-sudo dnf install linglong-builder linglong-box linglong-bin
+sudo dnf install linglong-bin linyaps-web-store-installer
 ```
 
 ### openkylin 2.0
@@ -139,5 +148,19 @@ sudo dnf install linglong-builder linglong-box linglong-bin
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/openkylin_2.0/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-builder linglong-box linglong-bin
+sudo apt install linglong-bin linglong-installer
+```
+
+## Linyaps Build Tool Installation Instructions
+
+### Debian Base
+
+```bash
+sudo apt install linglong-builder
+```
+
+### RPM Base
+
+```bash
+sudo dnf install linglong-builder
 ```

--- a/docs/pages/guide/start/install.md
+++ b/docs/pages/guide/start/install.md
@@ -34,7 +34,7 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 
 :::
 
-## 安装说明
+## 如意玲珑安装说明
 
 ### Arch / Manjaro / Parabola Linux
 
@@ -42,12 +42,21 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 sudo pacman -Syu linyaps
 ```
 
+如意玲珑网页商店安装工具需要通过 [AUR 仓库](https://aur.archlinux.org/packages/linyaps-web-store-installer)或[自建源仓库](https://github.com/taotieren/aur-repo)安装。
+
+```bash
+# AUR
+yay -Syu linyaps-web-store-installer
+# 或自建源
+sudo pacman -Syu linyaps-web-store-installer
+```
+
 ### deepin 25
 
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Deepin_25/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-builder linglong-box linglong-bin
+sudo apt install linglong-bin linglong-installer
 ```
 
 ### deepin 23
@@ -55,7 +64,7 @@ sudo apt install linglong-builder linglong-box linglong-bin
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Deepin_23/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-builder linglong-box linglong-bin
+sudo apt install linglong-bin linglong-installer
 ```
 
 ### Fedora 41
@@ -63,7 +72,7 @@ sudo apt install linglong-builder linglong-box linglong-bin
 ```sh
 sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_41/linglong%3ACI%3Arelease.repo"
 sudo dnf update
-sudo dnf install linglong-builder linglong-box linglong-bin
+sudo dnf install linglong-bin linyaps-web-store-installer
 ```
 
 ### Fedora 42
@@ -71,7 +80,7 @@ sudo dnf install linglong-builder linglong-box linglong-bin
 ```sh
 sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_42/linglong%3ACI%3Arelease.repo"
 sudo dnf update
-sudo dnf install linglong-bin
+sudo dnf install linglong-bin linyaps-web-store-installer
 ```
 
 ### Ubuntu 24.04
@@ -79,7 +88,7 @@ sudo dnf install linglong-bin
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/xUbuntu_24.04/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-builder linglong-box linglong-bin
+sudo apt install linglong-bin linglong-installer
 ```
 
 ### Debian 12
@@ -87,7 +96,7 @@ sudo apt install linglong-builder linglong-box linglong-bin
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Debian_12/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-builder linglong-box linglong-bin
+sudo apt install linglong-bin linglong-installer
 ```
 
 ### Debian 13
@@ -95,7 +104,7 @@ sudo apt install linglong-builder linglong-box linglong-bin
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Debian_13/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-bin
+sudo apt install linglong-bin linglong-installer
 ```
 
 ### openEuler 23.09
@@ -104,7 +113,7 @@ sudo apt install linglong-bin
 sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_23.09/linglong%3ACI%3Arelease.repo"
 sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
 sudo dnf update
-sudo dnf install linglong-builder linglong-box linglong-bin
+sudo dnf install linglong-bin linyaps-web-store-installer
 ```
 
 ### openEuler 24.03
@@ -113,7 +122,7 @@ sudo dnf install linglong-builder linglong-box linglong-bin
 sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_24.03/linglong%3ACI%3Arelease.repo"
 sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
 sudo dnf update
-sudo dnf install linglong-bin
+sudo dnf install linglong-bin linyaps-web-store-installer
 ```
 
 ### UOS 1070
@@ -121,7 +130,7 @@ sudo dnf install linglong-bin
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/uos_1070/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-builder linglong-box linglong-bin
+sudo apt install linglong-bin linglong-installer
 ```
 
 ### AnolisOS 8
@@ -129,7 +138,7 @@ sudo apt install linglong-builder linglong-box linglong-bin
 ```sh
 sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/AnolisOS_8/linglong%3ACI%3Arelease.repo"
 sudo dnf update
-sudo dnf install linglong-builder linglong-box linglong-bin
+sudo dnf install linglong-bin linyaps-web-store-installer
 ```
 
 ### openkylin 2.0
@@ -137,5 +146,19 @@ sudo dnf install linglong-builder linglong-box linglong-bin
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/openkylin_2.0/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-builder linglong-box linglong-bin
+sudo apt install linglong-bin linglong-installer
+```
+
+## 如意玲珑构建工具安装说明
+
+### Debian系
+
+```bash
+sudo apt install linglong-builder
+```
+
+### RPM系
+
+```bash
+sudo dnf install linglong-builder
 ```


### PR DESCRIPTION
1. Update the installation instructions for multiple distributions.
2. Replace `linglong-builder`, `linglong-box` with `linglong-installer` or `linyaps-web-store-installer` for supported distributions to align with the current installation packages.
3. Add installation instruction of Linyaps Web Store Installer.
4. Add seperate build tool installation section.
5. These changes ensure users can easily install the Linyaps package and relevant components.

Influence:
1. Verify the installation steps for each distribution: Arch/Manjaro/ Parabola, deepin 25/23, Fedora 41/42, Ubuntu 24.04, Debian 12/13, openEuler 23.09/24.03, UOS 1070, AnolisOS 8, and openkylin 2.0.
2. Confirm that `linglong-installer` and `linyaps-web-store-installer` are correctly installed where specified.
3. Test the functionality of the Linyaps Web Store Installer after installation.
4. Verify the build tool installation using `linglong-builder` on Debian and RPM-based systems.
5. Ensure the AUR repository installation instructions work as expected.

docs: 更新安装说明

1. 更新多个发行版的安装说明
2. 对于支持的发行版，使用 `linglong-installer` 或 `linyaps-web-store- installer` 替换 `linglong-builder`、`linglong-box`，以与当前的安装包保持 一致。
3. 添加 Linyaps Web Store Installer 的安装说明。
4. 添加单独的构建工具安装章节。
5. 这些更改确保用户可以轻松安装 Linyaps 包和相关组件。

Influence:
1. 验证每个发行版的安装步骤：Arch/Manjaro/Parabola、deepin 25/23、Fedora 41/42、Ubuntu 24.04、Debian 12/13、openEuler 23.09/24.03、UOS 1070、 AnolisOS 8 和 openkylin 2.0。
2. 确认在指定位置正确安装了 `linglong-installer` 和 `linyaps-web-store- installer`。
3. 测试安装后 Linyaps Web Store Installer 的功能。
4. 验证 Debian 和基于 RPM 的系统上使用 `linglong-builder` 的构建工具 安装。
5. 确保 AUR 仓库安装说明按预期工作。