### PR TITLE
fix: fix pull dependency in offline scenarios

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -2014,10 +2014,21 @@ void PackageManager::pullDependency(PackageTask &taskContext,
                                                                {
                                                                  .semanticMatching = true,
                                                                });
+        // 如果远程没有获取到runtime(可能是网络原因或者离线场景)， 应该再从本地查找，
+        // 如果本地也找不到再返回
         if (!runtime) {
-            taskContext.updateState(linglong::api::types::v1::State::Failed,
-                                    runtime.error().message());
-            return;
+            auto localRuntime = this->repo.clearReference(*fuzzyRuntime,
+                                                          {
+                                                            .forceRemote = false,
+                                                            .fallbackToRemote = false,
+                                                          });
+            if (!localRuntime) {
+                taskContext.updateState(linglong::api::types::v1::State::Failed,
+                                        runtime.error().message());
+                return;
+            }
+
+            runtime->reference = *localRuntime;
         }
 
         // 如果runtime已存在，则直接使用, 否则从远程拉取
@@ -2069,10 +2080,21 @@ void PackageManager::pullDependency(PackageTask &taskContext,
                                                         {
                                                           .semanticMatching = true,
                                                         });
+    // 如果远程没有获取到base(可能是网络原因或者离线场景)， 应该再从本地查找，
+    // 如果本地也找不到再返回
     if (!base) {
-        taskContext.updateState(linglong::api::types::v1::State::Failed,
-                                LINGLONG_ERRV(base).message());
-        return;
+        auto localBase = this->repo.clearReference(*fuzzyBase,
+                                                   {
+                                                     .forceRemote = false,
+                                                     .fallbackToRemote = false,
+                                                   });
+        if (!localBase) {
+            taskContext.updateState(linglong::api::types::v1::State::Failed,
+                                    LINGLONG_ERRV(base).message());
+            return;
+        }
+
+        base->reference = *localBase;
     }
 
     // 如果base已存在，则直接使用, 否则从远程拉取


### PR DESCRIPTION
This commit addresses a critical issue where dependency pulling would fail in offline or unreliable network conditions. The `pullDependency` function in `PackageManager` was solely relying on remote repositories to fetch runtime and base dependencies. This change introduces a fallback mechanism: if fetching from the remote repository fails, the function now attempts to locate the dependency in the local repository before failing. This ensures that if the required dependency is already present locally (e.g., from a previous successful pull), it can be used even when offline or experiencing network issues.

Influence:
1. Test dependency pulling in offline mode after successfully pulling dependencies online.
2. Simulate network issues during dependency pulling to verify the fallback mechanism.
3. Test cases where dependencies are only available locally.

fix: 修复离线场景下依赖拉取失败的问题

此提交修复了一个在离线或网络不可靠的情况下依赖拉取会失败的关键问题。
`PackageManager` 中的 `pullDependency` 函数之前仅依赖于远程仓库来获取 runtime 和 base 依赖。此更改引入了一个回退机制：如果从远程仓库获取失败，
该函数现在会尝试在本地仓库中查找依赖项，然后再失败。这确保了如果所需的依
赖项已在本地存在（例如，从先前成功的拉取中获得），即使在离线或遇到网络问
题时也可以使用。

Influence:
1. 在成功在线拉取依赖后，测试离线模式下的依赖拉取。
2. 在依赖拉取期间模拟网络问题，以验证回退机制。
3. 测试仅在本地可用的依赖项的情况。