### PR TITLE
fix: fix duplicate runtime dependencies

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -2021,6 +2021,7 @@ void PackageManager::pullDependency(PackageTask &taskContext,
                                                           {
                                                             .forceRemote = false,
                                                             .fallbackToRemote = false,
+                                                            .semanticMatching = true,
                                                           });
             if (!localRuntime) {
                 taskContext.updateState(linglong::api::types::v1::State::Failed,
@@ -2028,7 +2029,10 @@ void PackageManager::pullDependency(PackageTask &taskContext,
                 return;
             }
 
-            runtime->reference = *localRuntime;
+            runtime =
+              linglong::package::ReferenceWithRepo{ .repo =
+                                                      this->repo.getHighestPriorityRepos().front(),
+                                                    .reference = *localRuntime };
         }
 
         // 如果runtime已存在，则直接使用, 否则从远程拉取
@@ -2087,6 +2091,7 @@ void PackageManager::pullDependency(PackageTask &taskContext,
                                                    {
                                                      .forceRemote = false,
                                                      .fallbackToRemote = false,
+                                                     .semanticMatching = true,
                                                    });
         if (!localBase) {
             taskContext.updateState(linglong::api::types::v1::State::Failed,
@@ -2094,7 +2099,9 @@ void PackageManager::pullDependency(PackageTask &taskContext,
             return;
         }
 
-        base->reference = *localBase;
+        base = linglong::package::ReferenceWithRepo{ .repo =
+                                                       this->repo.getHighestPriorityRepos().front(),
+                                                     .reference = *localBase };
     }
 
     // 如果base已存在，则直接使用, 否则从远程拉取


### PR DESCRIPTION
This change addresses an issue where runtime dependencies were not being correctly deduplicated, leading to multiple instances of the same runtime being included in the application environment. This was happening because the `reference` field of `runtime` and `base` was directly assigned with `*localRuntime` or `*localBase`, which did not include repo information. The fix involves wrapping `localRuntime` and `localBase` with `ReferenceWithRepo` and adding repo information. This ensures that the package manager can accurately identify and reuse existing runtimes. The `semanticMatching = true` option is added to `getSatisfiedPackage` to ensure the version matching works.

Influence:
1. Test installing an application with shared runtime dependencies.
2. Verify that only one instance of each runtime is present in the environment.
3. Check that the application functions correctly with the deduplicated runtimes.
4. Ensure semantic version matching works as expected.

fix: 修复重复的运行时依赖

此更改解决了运行时依赖项未被正确去重的问题，导致应用程序环境中包含同一
运行时的多个实例。发生这种情况是因为 `runtime` 和 `base` 的 `reference` 字段直接使用 `*localRuntime` 或 `*localBase` 进行赋值，未包含仓库信息。 此修复包括使用 `ReferenceWithRepo` 包装 `localRuntime` 和 `localBase` 并添加仓库信息。这确保了包管理器可以准确地识别和重用现有的运行时。
`semanticMatching = true` 选项已添加到 `getSatisfiedPackage`，以确保版本 匹配正常工作。

Influence:
1. 测试安装具有共享运行时依赖项的应用程序。
2. 验证环境中仅存在每个运行时的单个实例。
3. 检查应用程序在使用去重后的运行时时是否正常运行。
4. 确保语义版本匹配按预期工作。