### PR TITLE
feat: enhance inspect command with dir type

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -569,42 +569,35 @@ void addInspectCommand(CLI::App &commandParser,
 {
     auto *cliInspect =
       commandParser
-        .add_subcommand("inspect", _("Display the information of installed application"))
+        .add_subcommand("inspect",
+                        _("Display the inspect information of the installed application"))
         ->group(group)
-        ->usage(_("Usage: ll-cli inspect [OPTIONS]"));
-    cliInspect->footer("This subcommand is for internal use only currently");
-    cliInspect->add_option("-p,--pid", inspectOptions.pid, _("Specify the process id"))
-      ->check([](const std::string &input) -> std::string {
-          if (input.empty()) {
-              return _("Input parameter is empty, please input valid parameter instead");
-          }
+        ->usage(_("Usage: ll-cli inspect SUBCOMMAND [OPTIONS]"));
 
-          try {
-              auto pid = std::stoull(input);
-              if (pid <= 0) {
-                  return _("Invalid process id");
-              }
-          } catch (std::exception &e) {
-              return _("Invalid pid format");
-          }
+    cliInspect->require_subcommand(1);
 
-          return {};
-      });
-}
-
-// Function to add the dir subcommand
-void addDirCommand(CLI::App &commandParser, DirOptions &dirOptions, const std::string &group)
-{
-    auto cliLayerDir =
-      commandParser.add_subcommand("dir", "Get the layer directory of app(base or runtime)")
-        ->group(group);
-    cliLayerDir->footer("This subcommand is for internal use only currently");
-    cliLayerDir
-      ->add_option("APP", dirOptions.appid, _("Specify the installed app(base or runtime)"))
+    // 创建 inspect dir 子命令
+    auto *cliInspectDir = cliInspect->add_subcommand(
+      "dir",
+      _("Display the data(bundle) directory of the installed(running) application"));
+    cliInspectDir->usage(_("Usage: ll-cli inspect dir [OPTIONS] APP"));
+    cliInspectDir
+      ->add_option("APP",
+                   inspectOptions.appid,
+                   _("Specify the application ID, and it can also be reference"))
       ->required()
       ->check(validatorString);
-    cliLayerDir->add_option("--module", dirOptions.module, _("Specify a module"))
-      ->type_name("MODULE")
+    cliInspectDir
+      ->add_option("-t, --type",
+                   inspectOptions.dirType,
+                   _("Specify the directory type (layer or bundle),the default is layer"))
+      ->type_name("TYPE")
+      ->capture_default_str()
+      ->check(validatorString);
+    cliInspectDir
+      ->add_option("-m, --module",
+                   inspectOptions.module,
+                   _("Specify the module type (binary or develop). Only works when type is layer"))
       ->check(validatorString);
 }
 
@@ -693,7 +686,6 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     ContentOptions contentOptions{};
     RepoOptions repoOptions{};
     InspectOptions inspectOptions{};
-    DirOptions dirOptions{};
 
     // groups for subcommands
     auto *CliBuildInGroup = _("Managing installed applications and runtimes");
@@ -716,7 +708,6 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     addContentCommand(commandParser, contentOptions, CliBuildInGroup);
     addPruneCommand(commandParser, CliAppManagingGroup);
     addInspectCommand(commandParser, inspectOptions, CliHiddenGroup);
-    addDirCommand(commandParser, dirOptions, CliHiddenGroup);
 
     auto res = transformOldExec(argc, argv);
     CLI11_PARSE(commandParser, std::move(res));
@@ -922,11 +913,9 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     } else if (name == "prune") {
         result = cli->prune();
     } else if (name == "inspect") {
-        result = cli->inspect(inspectOptions);
+        result = cli->inspect(*ret, inspectOptions);
     } else if (name == "repo") {
         result = cli->repo(*ret, repoOptions);
-    } else if (name == "dir") {
-        result = cli->dir(dirOptions);
     } else {
         // if subcommand name is not found, print help
         std::cout << commandParser.help("", CLI::AppFormatMode::All);

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -120,13 +120,9 @@ struct RepoOptions
 
 struct InspectOptions
 {
-    std::optional<pid_t> pid;
-};
-
-struct DirOptions
-{
     std::string appid;
     std::string module;
+    std::string dirType{ "layer" };
 };
 
 class Cli : public QObject
@@ -159,8 +155,7 @@ public:
     int info(const InfoOptions &options);
     int content(const ContentOptions &options);
     int prune();
-    int inspect(const InspectOptions &options);
-    int dir(const DirOptions &options);
+    int inspect(CLI::App *subcommand, const InspectOptions &options);
 
     void cancelCurrentTask();
 
@@ -199,6 +194,9 @@ private:
       runtime::RunContext &runContext, const generator::ContainerCfgBuilder &cfgBuilder) noexcept;
     QDBusReply<QString> authorization();
     void updateAM() noexcept;
+    std::vector<std::string> getRunningAppContainers(const std::string &appid);
+    int getLayerDir(const InspectOptions &options);
+    int getBundleDir(const InspectOptions &options);
 
 private Q_SLOTS:
     // maybe use in the future

--- a/po/linyaps.pot
+++ b/po/linyaps.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-22 11:10+0800\n"
+"POT-Creation-Date: 2025-10-21 17:24+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,93 +21,100 @@ msgstr ""
 msgid "Permission denied, please check whether you are running as root."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:528
+#: ../libs/linglong/src/linglong/cli/cli.cpp:537
 msgid "To install the module, one must first install the app."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:531
+#: ../libs/linglong/src/linglong/cli/cli.cpp:540
 msgid "Module is already installed."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:534
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1260
+#: ../libs/linglong/src/linglong/cli/cli.cpp:543
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1297
 msgid "Install failed"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:537
+#: ../libs/linglong/src/linglong/cli/cli.cpp:546
 msgid "The module could not be found remotely."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:540
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1732
+#: ../libs/linglong/src/linglong/cli/cli.cpp:549
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1784
 msgid "Uninstall failed"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:543
+#: ../libs/linglong/src/linglong/cli/cli.cpp:552
 msgid "Upgrade failed"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:546
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1713
+#: ../libs/linglong/src/linglong/cli/cli.cpp:555
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1765
 msgid "Application is not installed."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:549
+#: ../libs/linglong/src/linglong/cli/cli.cpp:558
+msgid "Remote application is not found."
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:561
 msgid "Latest version is already installed."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1234
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1528
+#: ../libs/linglong/src/linglong/cli/cli.cpp:796
+msgid "privileged mode requires running as root"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1271
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1570
 msgid ""
 "Network connection failed. Please:\n"
 "1. Check your internet connection\n"
 "2. Verify network proxy settings if used"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1240
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1277
 msgid ""
 "Application already installed, If you want to replace it, try using 'll-cli "
 "install %1 --force'"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1246
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1283
 msgid "Application %1 is not found in remote repo."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1250
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1287
 msgid "Cannot specify a version when installing a module."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1254
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1291
 msgid ""
 "The latest version has been installed. If you want to replace it, try using "
 "'ll-cli install %1/version --force'"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1717
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1769
 msgid ""
 "Multiple versions of the package are installed. Please specify a single "
 "version to uninstall:\n"
 "%1"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1723
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1775
 msgid ""
 "The application is currently running and cannot be uninstalled. Please turn "
 "off the application and try again."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1728
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1780
 msgid "Base or runtime cannot be uninstalled, please use 'll-cli prune'."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2746
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2800
 msgid ""
 "The cache generation failed, please uninstall and reinstall the application."
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:146 ../apps/ll-cli/src/main.cpp:563
-#: ../apps/ll-builder/src/main.cpp:96
+#: ../apps/ll-cli/src/main.cpp:146 ../apps/ll-builder/src/main.cpp:100
 msgid "Input parameter is empty, please input valid parameter instead"
 msgstr ""
 
@@ -145,63 +152,75 @@ msgstr ""
 msgid "Set environment variables for the application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:188
+#: ../apps/ll-cli/src/main.cpp:189
 msgid "Input parameter is invalid, please input valid parameter instead"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:194
+#: ../apps/ll-cli/src/main.cpp:195
 msgid "Specify the base used by the application to run"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:200
+#: ../apps/ll-cli/src/main.cpp:201
 msgid "Specify the runtime used by the application to run"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:203 ../apps/ll-cli/src/main.cpp:234
+#: ../apps/ll-cli/src/main.cpp:207
+msgid "Specify extension(s) used by the application to run"
+msgstr ""
+
+#: ../apps/ll-cli/src/main.cpp:213
+msgid "Run the application in privileged mode"
+msgstr ""
+
+#: ../apps/ll-cli/src/main.cpp:215
+msgid "Add capabilities to the application"
+msgstr ""
+
+#: ../apps/ll-cli/src/main.cpp:219 ../apps/ll-cli/src/main.cpp:250
 msgid "Run commands in a running sandbox"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:209
+#: ../apps/ll-cli/src/main.cpp:225
 msgid "List running applications"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:212
+#: ../apps/ll-cli/src/main.cpp:228
 msgid "Usage: ll-cli ps [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:221
+#: ../apps/ll-cli/src/main.cpp:237
 msgid "Enter the namespace where the application is running"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:227
+#: ../apps/ll-cli/src/main.cpp:243
 msgid "Specify the application running instance(you can get it by ps command)"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:231
+#: ../apps/ll-cli/src/main.cpp:247
 msgid "Specify working directory"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:240
+#: ../apps/ll-cli/src/main.cpp:256
 msgid "Stop running applications"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:243
+#: ../apps/ll-cli/src/main.cpp:259
 msgid "Usage: ll-cli kill [OPTIONS] APP"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:247
+#: ../apps/ll-cli/src/main.cpp:263
 msgid "Specify the signal to send to the application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:249
+#: ../apps/ll-cli/src/main.cpp:265
 msgid "Specify the running application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:260
+#: ../apps/ll-cli/src/main.cpp:276
 msgid "Installing an application or runtime"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:263
+#: ../apps/ll-cli/src/main.cpp:279
 msgid ""
 "Usage: ll-cli install [OPTIONS] APP\n"
 "\n"
@@ -221,72 +240,72 @@ msgid ""
 "    "
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:282
+#: ../apps/ll-cli/src/main.cpp:298
 msgid "Specify the application ID, and it can also be a .uab or .layer file"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:285
+#: ../apps/ll-cli/src/main.cpp:301
 msgid "Install a specify module"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:288
+#: ../apps/ll-cli/src/main.cpp:304
 msgid "Install from a specific repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:291
+#: ../apps/ll-cli/src/main.cpp:307
 msgid "Force install the application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:294
+#: ../apps/ll-cli/src/main.cpp:310
 msgid "Automatically answer yes to all questions"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:303
+#: ../apps/ll-cli/src/main.cpp:319
 msgid "Uninstall the application or runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:306
+#: ../apps/ll-cli/src/main.cpp:322
 msgid "Usage: ll-cli uninstall [OPTIONS] APP"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:307
+#: ../apps/ll-cli/src/main.cpp:323
 msgid "Specify the applications ID"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:310
+#: ../apps/ll-cli/src/main.cpp:326
 msgid "Uninstall a specify module"
 msgstr ""
 
 #. below options are used for compatibility with old ll-cli
-#: ../apps/ll-cli/src/main.cpp:315
+#: ../apps/ll-cli/src/main.cpp:331
 msgid "Remove all unused modules"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:319
+#: ../apps/ll-cli/src/main.cpp:335
 msgid "Uninstall all modules"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:329
+#: ../apps/ll-cli/src/main.cpp:345
 msgid "Upgrade the application or runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:332
+#: ../apps/ll-cli/src/main.cpp:348
 msgid "Usage: ll-cli upgrade [OPTIONS] [APP]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:336
+#: ../apps/ll-cli/src/main.cpp:352
 msgid ""
 "Specify the application ID. If it not be specified, all applications will be "
 "upgraded"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:348
+#: ../apps/ll-cli/src/main.cpp:364
 msgid ""
 "Search the applications/runtimes containing the specified text from the "
 "remote repository"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:352
+#: ../apps/ll-cli/src/main.cpp:368
 msgid ""
 "Usage: ll-cli search [OPTIONS] KEYWORDS\n"
 "\n"
@@ -301,33 +320,33 @@ msgid ""
 "ll-cli search . --type=runtime"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:363
+#: ../apps/ll-cli/src/main.cpp:379
 msgid "Specify the Keywords"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:370 ../apps/ll-cli/src/main.cpp:409
+#: ../apps/ll-cli/src/main.cpp:386 ../apps/ll-cli/src/main.cpp:425
 msgid ""
 "Filter result with specify type. One of \"runtime\", \"base\", \"app\" or "
 "\"all\""
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:374
+#: ../apps/ll-cli/src/main.cpp:390
 msgid "Specify the repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:379
+#: ../apps/ll-cli/src/main.cpp:395
 msgid "Include develop application in result"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:382
+#: ../apps/ll-cli/src/main.cpp:398
 msgid "Show all versions of an application(s), base(s) or runtime(s)"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:390
+#: ../apps/ll-cli/src/main.cpp:406
 msgid "List installed application(s), base(s) or runtime(s)"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:393
+#: ../apps/ll-cli/src/main.cpp:409
 msgid ""
 "Usage: ll-cli list [OPTIONS]\n"
 "\n"
@@ -342,199 +361,201 @@ msgid ""
 "ll-cli list --upgradable\n"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:415
+#: ../apps/ll-cli/src/main.cpp:431
 msgid ""
 "Show the list of latest version of the currently installed application(s), "
 "base(s) or runtime(s)"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:425
+#: ../apps/ll-cli/src/main.cpp:441
 msgid "Display or modify information of the repository currently using"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:427
+#: ../apps/ll-cli/src/main.cpp:443
 msgid "Usage: ll-cli repo SUBCOMMAND [OPTIONS]"
 msgstr ""
 
 #. add repo sub command add
-#: ../apps/ll-cli/src/main.cpp:431 ../apps/ll-builder/src/main.cpp:957
+#: ../apps/ll-cli/src/main.cpp:447 ../apps/ll-builder/src/main.cpp:959
 msgid "Add a new repository"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:432
+#: ../apps/ll-cli/src/main.cpp:448
 msgid "Usage: ll-cli repo add [OPTIONS] NAME URL"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:433 ../apps/ll-cli/src/main.cpp:445
-#: ../apps/ll-builder/src/main.cpp:959
+#: ../apps/ll-cli/src/main.cpp:449 ../apps/ll-cli/src/main.cpp:461
+#: ../apps/ll-builder/src/main.cpp:961
 msgid "Specify the repo name"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:436 ../apps/ll-cli/src/main.cpp:448
-#: ../apps/ll-cli/src/main.cpp:466 ../apps/ll-builder/src/main.cpp:962
-#: ../apps/ll-builder/src/main.cpp:985
+#: ../apps/ll-cli/src/main.cpp:452 ../apps/ll-cli/src/main.cpp:464
+#: ../apps/ll-cli/src/main.cpp:482 ../apps/ll-builder/src/main.cpp:964
+#: ../apps/ll-builder/src/main.cpp:987
 msgid "Url of the repository"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:439 ../apps/ll-cli/src/main.cpp:455
-#: ../apps/ll-cli/src/main.cpp:463 ../apps/ll-cli/src/main.cpp:474
-#: ../apps/ll-cli/src/main.cpp:486 ../apps/ll-cli/src/main.cpp:496
-#: ../apps/ll-cli/src/main.cpp:503 ../apps/ll-builder/src/main.cpp:966
-#: ../apps/ll-builder/src/main.cpp:974 ../apps/ll-builder/src/main.cpp:982
-#: ../apps/ll-builder/src/main.cpp:994 ../apps/ll-builder/src/main.cpp:1003
-#: ../apps/ll-builder/src/main.cpp:1012
+#: ../apps/ll-cli/src/main.cpp:455 ../apps/ll-cli/src/main.cpp:471
+#: ../apps/ll-cli/src/main.cpp:479 ../apps/ll-cli/src/main.cpp:490
+#: ../apps/ll-cli/src/main.cpp:502 ../apps/ll-cli/src/main.cpp:512
+#: ../apps/ll-cli/src/main.cpp:519 ../apps/ll-builder/src/main.cpp:968
+#: ../apps/ll-builder/src/main.cpp:976 ../apps/ll-builder/src/main.cpp:984
+#: ../apps/ll-builder/src/main.cpp:996 ../apps/ll-builder/src/main.cpp:1005
+#: ../apps/ll-builder/src/main.cpp:1014
 msgid "Alias of the repo name"
 msgstr ""
 
 #. add repo sub command modify
-#: ../apps/ll-cli/src/main.cpp:444
+#: ../apps/ll-cli/src/main.cpp:460
 msgid "Modify repository URL"
 msgstr ""
 
 #. add repo sub command remove
-#: ../apps/ll-cli/src/main.cpp:453 ../apps/ll-builder/src/main.cpp:971
+#: ../apps/ll-cli/src/main.cpp:469 ../apps/ll-builder/src/main.cpp:973
 msgid "Remove a repository"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:454
+#: ../apps/ll-cli/src/main.cpp:470
 msgid "Usage: ll-cli repo remove [OPTIONS] NAME"
 msgstr ""
 
 #. add repo sub command update
 #. TODO: add --repo and --url options
 #. add repo sub command update
-#: ../apps/ll-cli/src/main.cpp:461 ../apps/ll-builder/src/main.cpp:979
+#: ../apps/ll-cli/src/main.cpp:477 ../apps/ll-builder/src/main.cpp:981
 msgid "Update the repository URL"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:462
+#: ../apps/ll-cli/src/main.cpp:478
 msgid "Usage: ll-cli repo update [OPTIONS] NAME URL"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:472 ../apps/ll-builder/src/main.cpp:991
+#: ../apps/ll-cli/src/main.cpp:488 ../apps/ll-builder/src/main.cpp:993
 msgid "Set a default repository name"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:473
+#: ../apps/ll-cli/src/main.cpp:489
 msgid "Usage: ll-cli repo set-default [OPTIONS] NAME"
 msgstr ""
 
 #. add repo sub command show
-#: ../apps/ll-cli/src/main.cpp:479 ../apps/ll-builder/src/main.cpp:1017
+#: ../apps/ll-cli/src/main.cpp:495 ../apps/ll-builder/src/main.cpp:1019
 msgid "Show repository information"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:480
+#: ../apps/ll-cli/src/main.cpp:496
 msgid "Usage: ll-cli repo show [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:484
+#: ../apps/ll-cli/src/main.cpp:500
 msgid "Set the priority of the repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:485
+#: ../apps/ll-cli/src/main.cpp:501
 msgid "Usage: ll-cli repo set-priority ALIAS PRIORITY"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:489
+#: ../apps/ll-cli/src/main.cpp:505
 msgid "Priority of the repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:494 ../apps/ll-builder/src/main.cpp:1000
+#: ../apps/ll-cli/src/main.cpp:510 ../apps/ll-builder/src/main.cpp:1002
 msgid "Enable mirror for the repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:495
+#: ../apps/ll-cli/src/main.cpp:511
 msgid "Usage: ll-cli repo enable-mirror [OPTIONS] ALIAS"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:501 ../apps/ll-builder/src/main.cpp:1009
+#: ../apps/ll-cli/src/main.cpp:517 ../apps/ll-builder/src/main.cpp:1011
 msgid "Disable mirror for the repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:502
+#: ../apps/ll-cli/src/main.cpp:518
 msgid "Usage: ll-cli repo disable-mirror [OPTIONS] ALIAS"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:513
+#: ../apps/ll-cli/src/main.cpp:529
 msgid "Display information about installed apps or runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:516
+#: ../apps/ll-cli/src/main.cpp:532
 msgid "Usage: ll-cli info [OPTIONS] APP"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:520
+#: ../apps/ll-cli/src/main.cpp:536
 msgid "Specify the application ID, and it can also be a .layer file"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:532
+#: ../apps/ll-cli/src/main.cpp:548
 msgid "Display the exported files of installed application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:535
+#: ../apps/ll-cli/src/main.cpp:551
 msgid "Usage: ll-cli content [OPTIONS] APP"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:536
+#: ../apps/ll-cli/src/main.cpp:552
 msgid "Specify the installed application ID"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:544
+#: ../apps/ll-cli/src/main.cpp:560
 msgid "Remove the unused base or runtime"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:546
+#: ../apps/ll-cli/src/main.cpp:562
 msgid "Usage: ll-cli prune [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:556
-msgid "Display the information of installed application"
+#: ../apps/ll-cli/src/main.cpp:573
+msgid "Display the inspect information of the installed application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:558
-msgid "Usage: ll-cli inspect [OPTIONS]"
+#: ../apps/ll-cli/src/main.cpp:575
+msgid "Usage: ll-cli inspect SUBCOMMAND [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:560
-msgid "Specify the process id"
+#: ../apps/ll-cli/src/main.cpp:582
+msgid ""
+"Display the data(bundle) directory of the installed(running) application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:569
-msgid "Invalid process id"
-msgstr ""
-
-#: ../apps/ll-cli/src/main.cpp:572
-msgid "Invalid pid format"
+#: ../apps/ll-cli/src/main.cpp:583
+msgid "Usage: ll-cli inspect dir [OPTIONS] APP"
 msgstr ""
 
 #: ../apps/ll-cli/src/main.cpp:587
-msgid "Specify the installed app(base or runtime)"
+msgid "Specify the application ID, and it can also be reference"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:590
-msgid "Specify a module"
+#: ../apps/ll-cli/src/main.cpp:593
+msgid "Specify the directory type (layer or bundle),the default is layer"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:630
+#: ../apps/ll-cli/src/main.cpp:600
+msgid ""
+"Specify the module type (binary or develop). Only works when type is layer"
+msgstr ""
+
+#: ../apps/ll-cli/src/main.cpp:639
 msgid ""
 "linyaps CLI\n"
 "A CLI program to run application and manage application and runtime\n"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:638 ../apps/ll-builder/src/main.cpp:754
+#: ../apps/ll-cli/src/main.cpp:647 ../apps/ll-builder/src/main.cpp:747
 msgid "Print this help message and exit"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:639 ../apps/ll-builder/src/main.cpp:755
+#: ../apps/ll-cli/src/main.cpp:648 ../apps/ll-builder/src/main.cpp:748
 msgid "Expand all help"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:640
+#: ../apps/ll-cli/src/main.cpp:649
 msgid "Usage: ll-cli [OPTIONS] [SUBCOMMAND]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:641
+#: ../apps/ll-cli/src/main.cpp:650
 msgid ""
 "If you found any problems during use,\n"
 "You can report bugs to the linyaps team under this project: https://github."
@@ -542,43 +563,43 @@ msgid ""
 msgstr ""
 
 #. version flag
-#: ../apps/ll-cli/src/main.cpp:648 ../apps/ll-builder/src/main.cpp:779
+#: ../apps/ll-cli/src/main.cpp:657 ../apps/ll-builder/src/main.cpp:772
 msgid "Show version"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:653
+#: ../apps/ll-cli/src/main.cpp:662
 msgid ""
 "Use peer to peer DBus, this is used only in case that DBus daemon is not "
 "available"
 msgstr ""
 
 #. json flag
-#: ../apps/ll-cli/src/main.cpp:658
+#: ../apps/ll-cli/src/main.cpp:667
 msgid "Use json format to output result"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:665
+#: ../apps/ll-cli/src/main.cpp:674
 msgid "Show debug info (verbose logs)"
 msgstr ""
 
 #. groups for subcommands
-#: ../apps/ll-cli/src/main.cpp:683
+#: ../apps/ll-cli/src/main.cpp:691
 msgid "Managing installed applications and runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:684
+#: ../apps/ll-cli/src/main.cpp:692
 msgid "Managing running applications"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:685
+#: ../apps/ll-cli/src/main.cpp:693
 msgid "Finding applications and runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:686
+#: ../apps/ll-cli/src/main.cpp:694
 msgid "Managing remote repositories"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:713
+#: ../apps/ll-cli/src/main.cpp:720
 msgid "linyaps CLI version "
 msgstr ""
 
@@ -662,263 +683,267 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:752
+#: ../apps/ll-builder/src/main.cpp:745
 msgid ""
 "linyaps builder CLI \n"
 "A CLI program to build linyaps application\n"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:757
+#: ../apps/ll-builder/src/main.cpp:750
 msgid "Usage: ll-builder [OPTIONS] [SUBCOMMAND]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:759
+#: ../apps/ll-builder/src/main.cpp:752
 msgid ""
 "If you found any problems during use\n"
 "You can report bugs to the linyaps team under this project: https://github."
 "com/OpenAtom-Linyaps/linyaps/issues"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:783
+#: ../apps/ll-builder/src/main.cpp:776
 msgid "Create linyaps build template project"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:784
+#: ../apps/ll-builder/src/main.cpp:777
 msgid "Usage: ll-builder create [OPTIONS] NAME"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:785
+#: ../apps/ll-builder/src/main.cpp:778
 msgid "Project name"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:793
+#: ../apps/ll-builder/src/main.cpp:786
 msgid "Build a linyaps project"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:794
+#: ../apps/ll-builder/src/main.cpp:787
 msgid "Usage: ll-builder build [OPTIONS] [COMMAND...]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:795 ../apps/ll-builder/src/main.cpp:836
-#: ../apps/ll-builder/src/main.cpp:866 ../apps/ll-builder/src/main.cpp:912
+#: ../apps/ll-builder/src/main.cpp:788 ../apps/ll-builder/src/main.cpp:829
+#: ../apps/ll-builder/src/main.cpp:868 ../apps/ll-builder/src/main.cpp:914
 msgid "File path of the linglong.yaml"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:801
+#: ../apps/ll-builder/src/main.cpp:794
 msgid "Enter the container to execute command instead of building applications"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:804
+#: ../apps/ll-builder/src/main.cpp:797
 msgid ""
 "Only use local files. This implies --skip-fetch-source and --skip-pull-"
 "depend will be set"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:809
+#: ../apps/ll-builder/src/main.cpp:802
 msgid "Build full develop packages, runtime requires"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:813
+#: ../apps/ll-builder/src/main.cpp:806
 msgid "Skip fetch sources"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:816
+#: ../apps/ll-builder/src/main.cpp:809
 msgid "Skip pull dependency"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:819
+#: ../apps/ll-builder/src/main.cpp:812
 msgid "Skip run container"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:822
+#: ../apps/ll-builder/src/main.cpp:815
 msgid "Skip commit build output"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:825
+#: ../apps/ll-builder/src/main.cpp:818
 msgid "Skip output check"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:828
+#: ../apps/ll-builder/src/main.cpp:821
 msgid "Skip strip debug symbols"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:831
+#: ../apps/ll-builder/src/main.cpp:824
 msgid "Build in an isolated network environment"
 msgstr ""
 
 #. add builder run
-#: ../apps/ll-builder/src/main.cpp:834
+#: ../apps/ll-builder/src/main.cpp:827
 msgid "Run built linyaps app"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:835
+#: ../apps/ll-builder/src/main.cpp:828
 msgid "Usage: ll-builder run [OPTIONS] [COMMAND...]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:842
+#: ../apps/ll-builder/src/main.cpp:835
 msgid "Run specified module. eg: --modules binary,develop"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:848
+#: ../apps/ll-builder/src/main.cpp:842
 msgid "Enter the container to execute command instead of running application"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:851
+#: ../apps/ll-builder/src/main.cpp:845
 msgid "Run in debug mode (enable develop module)"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:853
-msgid "List built linyaps app"
-msgstr ""
-
-#: ../apps/ll-builder/src/main.cpp:854
-msgid "Usage: ll-builder list [OPTIONS]"
+#: ../apps/ll-builder/src/main.cpp:849
+msgid "Specify extension(s) used by the app to run"
 msgstr ""
 
 #: ../apps/ll-builder/src/main.cpp:855
-msgid "Remove built linyaps app"
+msgid "List built linyaps app"
 msgstr ""
 
 #: ../apps/ll-builder/src/main.cpp:856
+msgid "Usage: ll-builder list [OPTIONS]"
+msgstr ""
+
+#: ../apps/ll-builder/src/main.cpp:857
+msgid "Remove built linyaps app"
+msgstr ""
+
+#: ../apps/ll-builder/src/main.cpp:858
 msgid "Usage: ll-builder remove [OPTIONS] [APP...]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:859
+#: ../apps/ll-builder/src/main.cpp:861
 msgid "Do not clean objects files before remove apps"
 msgstr ""
 
 #. build export
-#: ../apps/ll-builder/src/main.cpp:863
+#: ../apps/ll-builder/src/main.cpp:865
 msgid "Export to linyaps layer or uab"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:864
+#: ../apps/ll-builder/src/main.cpp:866
 msgid "Usage: ll-builder export [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:876
+#: ../apps/ll-builder/src/main.cpp:878
 msgid "Uab icon (optional)"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:881
+#: ../apps/ll-builder/src/main.cpp:883
 msgid "Export to linyaps layer file (deprecated)"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:884
+#: ../apps/ll-builder/src/main.cpp:886
 msgid "Use custom loader"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:891
+#: ../apps/ll-builder/src/main.cpp:893
 msgid "Don't export the develop module"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:893
+#: ../apps/ll-builder/src/main.cpp:895
 msgid "Output file"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:897
+#: ../apps/ll-builder/src/main.cpp:899
 msgid "Reference of the package"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:902
+#: ../apps/ll-builder/src/main.cpp:904
 msgid "Modules to export"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:910
+#: ../apps/ll-builder/src/main.cpp:912
 msgid "Push linyaps app to remote repo"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:911
+#: ../apps/ll-builder/src/main.cpp:913
 msgid "Usage: ll-builder push [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:915
+#: ../apps/ll-builder/src/main.cpp:917
 msgid "Remote repo url"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:918
+#: ../apps/ll-builder/src/main.cpp:920
 msgid "Remote repo name"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:921
+#: ../apps/ll-builder/src/main.cpp:923
 msgid "Push single module"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:925
+#: ../apps/ll-builder/src/main.cpp:927
 msgid "Import linyaps layer to build repo"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:926
+#: ../apps/ll-builder/src/main.cpp:928
 msgid "Usage: ll-builder import [OPTIONS] LAYER"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:927 ../apps/ll-builder/src/main.cpp:944
+#: ../apps/ll-builder/src/main.cpp:929 ../apps/ll-builder/src/main.cpp:946
 msgid "Layer file path"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:934
+#: ../apps/ll-builder/src/main.cpp:936
 msgid "Import linyaps layer dir to build repo"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:936
+#: ../apps/ll-builder/src/main.cpp:938
 msgid "Usage: ll-builder import-dir PATH"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:937
+#: ../apps/ll-builder/src/main.cpp:939
 msgid "Layer dir path"
 msgstr ""
 
 #. add build extract
-#: ../apps/ll-builder/src/main.cpp:942
+#: ../apps/ll-builder/src/main.cpp:944
 msgid "Extract linyaps layer to dir"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:943
+#: ../apps/ll-builder/src/main.cpp:945
 msgid "Usage: ll-builder extract [OPTIONS] LAYER DIR"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:947
+#: ../apps/ll-builder/src/main.cpp:949
 msgid "Destination directory"
 msgstr ""
 
 #. add build repo
-#: ../apps/ll-builder/src/main.cpp:952
+#: ../apps/ll-builder/src/main.cpp:954
 msgid "Display and manage repositories"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:953
+#: ../apps/ll-builder/src/main.cpp:955
 msgid "Usage: ll-builder repo [OPTIONS] SUBCOMMAND"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:958
+#: ../apps/ll-builder/src/main.cpp:960
 msgid "Usage: ll-builder repo add [OPTIONS] NAME URL"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:972
+#: ../apps/ll-builder/src/main.cpp:974
 msgid "Usage: ll-builder repo remove [OPTIONS] NAME"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:980
+#: ../apps/ll-builder/src/main.cpp:982
 msgid "Usage: ll-builder repo update [OPTIONS] NAME URL"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:992
+#: ../apps/ll-builder/src/main.cpp:994
 msgid "Usage: ll-builder repo set-default [OPTIONS] NAME"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:1001
+#: ../apps/ll-builder/src/main.cpp:1003
 msgid "Usage: ll-builder repo enable-mirror [OPTIONS] ALIAS"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:1010
+#: ../apps/ll-builder/src/main.cpp:1012
 msgid "Usage: ll-builder repo disable-mirror [OPTIONS] ALIAS"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:1018
+#: ../apps/ll-builder/src/main.cpp:1020
 msgid "Usage: ll-builder repo show [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:1023
+#: ../apps/ll-builder/src/main.cpp:1025
 msgid "linyaps build tool version "
 msgstr ""
 


### PR DESCRIPTION
1.  Refactored the `inspect` command to support the `dir` subcommand for displaying application directories.
2.  Added options to specify the directory type (`layer` or `bundle`) and module type (`binary` or `develop`) when using the `dir` subcommand.
3.  Introduced a version option to retrieve directories for specific application versions.
4.  Implemented `getLayerDir` and `getBundleDir` methods to fetch and print the respective directory paths.
5.  The original `inspect` command that used pid is currently removed because it is not commonly used and requires more discussion if needed.

Log: Added inspect command's dir subcommand to get the layer or bundle directory of the installed(running) application.

Influence:
1. Test the `ll-cli inspect dir APP` command to verify it displays the correct layer directory by default.
2. Test the `ll-cli inspect dir APP --type bundle` command to verify it displays the correct bundle directory.
3. Test the `ll-cli inspect dir APP --type layer --module binary` command to verify it displays the correct directory for the binary module.
4. Test the `ll-cli inspect dir APP --version VERSION` command to verify it displays the correct directory for the specified version of the application.
5. Test with invalid application IDs and options to ensure proper error handling and messages.

feat: 增强 inspect 命令，支持目录类型

1.  重构了 `inspect` 命令，以支持 `dir` 子命令来显示应用程序目录。
2.  添加了选项，用于在使用 `dir` 子命令时指定目录类型（`layer` 或 `bundle`）和模块类型（`binary` 或 `develop`）。
3.  引入了版本选项，以检索特定应用程序版本的目录。
4.  实现了 `getLayerDir` 和 `getBundleDir` 方法来获取和打印相应的目录 路径。
5.  原先使用 pid 的 `inspect` 命令已被移除，因为使用场景较少，并且如果需 要可能需要进行更多讨论。

Log: 增加了 inspect 命令的 dir 子命令，用于获取已安装（正在运行）应用程
序的 layer 或 bundle 目录。

Influence:
1. 测试 `ll-cli inspect dir APP` 命令，验证它默认显示正确的 layer 目录。
2. 测试 `ll-cli inspect dir APP --type bundle` 命令，验证它显示正确的 bundle 目录。
3. 测试 `ll-cli inspect dir APP --type layer --module binary` 命令，验证 它显示 binary 模块的正确目录。
4. 测试 `ll-cli inspect dir APP --version VERSION` 命令，验证它显示指定 版本应用程序的正确目录。
5. 使用无效的应用程序 ID 和选项进行测试，以确保正确的错误处理和消息。