### PR TITLE
refactor: remove develop module check

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -533,13 +533,6 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
 
     const auto &packageInfo = *packageInfoRet;
 
-    // FIXME: need to support install develop
-    if (packageInfo.packageInfoV2Module != "binary"
-        && packageInfo.packageInfoV2Module != "runtime") {
-        return toDBusReply(-1,
-                           "The current version does not support the develop module installation.");
-    }
-
     auto architectureRet = package::Architecture::parse(packageInfo.arch[0]);
     if (!architectureRet) {
         return toDBusReply(architectureRet);


### PR DESCRIPTION
This commit removes the check that prevented installation of packages with `packageInfoV2Module` set to anything other than "binary" or "runtime". This restriction was unnecessary and blocked the installation of development modules. Removing it allows for greater flexibility in package definitions and enables the installation of a wider range of packages.

Influence:
1. Test installation of packages with `packageInfoV2Module` set to "binary", "runtime", and other valid values.
2. Verify that development modules can now be installed successfully.
3. Ensure no regressions in the installation process of binary and runtime modules.

重构: 移除开发模块检查

此提交移除了对 `packageInfoV2Module` 设置为 "binary" 或 "runtime" 之外的 值的软件包安装的检查。 此限制是不必要的，并且阻止了开发模块的安装。 删除
它允许软件包定义中更大的灵活性，并支持安装更广泛的软件包。

Influence:
1. 测试将 `packageInfoV2Module` 设置为 "binary"、"runtime" 和其他有效值 的软件包的安装。
2. 验证现在可以成功安装开发模块。
3. 确保二进制和运行时模块的安装过程中没有发生回归。