### PR TITLE
refactor: Move uninstall logic to package manager service

### DIFF
--- a/api/schema/v1.json
+++ b/api/schema/v1.json
@@ -125,6 +125,13 @@
         },
         "runtime": {
           "type": "string"
+        },
+        "extensions": {
+          "type": "array",
+          "description": "extensions of container",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -113,6 +113,11 @@ $defs:
         type: string
       runtime:
         type: string
+      extensions:
+        type: array
+        description: extensions of container
+        items:
+          type: string
   InteractionRequest:
     description: |
       structured message which inspired by freedesktop Notification Spec.

--- a/libs/api/src/linglong/api/types/v1/ContainerProcessStateInfo.hpp
+++ b/libs/api/src/linglong/api/types/v1/ContainerProcessStateInfo.hpp
@@ -36,6 +36,10 @@ struct ContainerProcessStateInfo {
 std::string app;
 std::string base;
 std::string containerID;
+/**
+* extensions of container
+*/
+std::optional<std::vector<std::string>> extensions;
 std::optional<std::string> runtime;
 };
 }

--- a/libs/api/src/linglong/api/types/v1/Generators.hpp
+++ b/libs/api/src/linglong/api/types/v1/Generators.hpp
@@ -552,6 +552,7 @@ inline void from_json(const json & j, ContainerProcessStateInfo& x) {
 x.app = j.at("app").get<std::string>();
 x.base = j.at("base").get<std::string>();
 x.containerID = j.at("containerID").get<std::string>();
+x.extensions = get_stack_optional<std::vector<std::string>>(j, "extensions");
 x.runtime = get_stack_optional<std::string>(j, "runtime");
 }
 
@@ -560,6 +561,9 @@ j = json::object();
 j["app"] = x.app;
 j["base"] = x.base;
 j["containerID"] = x.containerID;
+if (x.extensions) {
+j["extensions"] = x.extensions;
+}
 if (x.runtime) {
 j["runtime"] = x.runtime;
 }

--- a/libs/linglong/src/linglong/cli/cli_printer.cpp
+++ b/libs/linglong/src/linglong/cli/cli_printer.cpp
@@ -33,8 +33,7 @@ std::wstring subwstr(std::wstring wstr, int width)
 
 void CLIPrinter::printErr(const utils::error::Error &err)
 {
-    std::cout << "Error: CODE=" << err.code() << std::endl
-              << err.message().toStdString() << std::endl;
+    std::cerr << "Error " << err.code() << ": " << err.message().toStdString() << std::endl;
 }
 
 void CLIPrinter::printPruneResult(const std::vector<api::types::v1::PackageInfoV2> &list)

--- a/libs/linglong/src/linglong/package/fuzzy_reference.cpp
+++ b/libs/linglong/src/linglong/package/fuzzy_reference.cpp
@@ -15,7 +15,7 @@ namespace linglong::package {
 
 utils::error::Result<FuzzyReference> FuzzyReference::parse(const QString &raw) noexcept
 {
-    LINGLONG_TRACE("parse fuzz reference string " + raw);
+    LINGLONG_TRACE("parse fuzzy reference string " + raw);
 
     static auto regexp = []() noexcept {
         QRegularExpression regexp(
@@ -26,7 +26,8 @@ utils::error::Result<FuzzyReference> FuzzyReference::parse(const QString &raw) n
 
     auto matches = regexp.match(raw);
     if (not(matches.isValid() and matches.hasMatch())) {
-        return LINGLONG_ERR("regexp mismatched.", utils::error::ErrorCode::Unknown);
+        return LINGLONG_ERR("invalid fuzzy reference",
+                            utils::error::ErrorCode::InvalidFuzzyReference);
     }
 
     std::optional<QString> channel = matches.captured("channel");
@@ -48,7 +49,7 @@ utils::error::Result<FuzzyReference> FuzzyReference::parse(const QString &raw) n
         auto tmpArchitecture = Architecture::parse(architectureStr.toStdString());
         if (!tmpArchitecture) {
             return LINGLONG_ERR(tmpArchitecture.error().message(),
-                                utils::error::ErrorCode::Unknown);
+                                utils::error::ErrorCode::UnknownArchitecture);
         }
         architecture = std::move(tmpArchitecture).value();
     }

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -546,12 +546,7 @@ utils::error::Result<package::Reference> clearReferenceLocal(const linglong::rep
         return LINGLONG_ERR(foundRef);
     }
 
-    auto ver = linglong::package::Version::parse(QString::fromStdString(foundRef->info.version));
-    auto arch = linglong::package::Architecture::parse(foundRef->info.arch[0]);
-    return package::Reference::create(QString::fromStdString(foundRef->info.channel),
-                                      QString::fromStdString(foundRef->info.id),
-                                      *ver,
-                                      *arch);
+    return package::Reference::fromPackageInfo(foundRef->info);
 };
 
 std::optional<package::Reference> matchReference(const api::types::v1::PackageInfoV2 &record,

--- a/libs/linglong/src/linglong/runtime/run_context.cpp
+++ b/libs/linglong/src/linglong/runtime/run_context.cpp
@@ -576,6 +576,11 @@ api::types::v1::ContainerProcessStateInfo RunContext::stateInfo()
         state.runtime = runtimeLayer->getReference().toString().toStdString();
     }
 
+    state.extensions = std::vector<std::string>{};
+    for (auto &ext : extensionLayers) {
+        state.extensions->push_back(ext.getReference().toString().toStdString());
+    }
+
     return state;
 }
 

--- a/libs/utils/src/linglong/utils/error/error.h
+++ b/libs/utils/src/linglong/utils/error/error.h
@@ -49,6 +49,8 @@ enum class ErrorCode : int {
     AppUninstallNotFoundFromLocal = 2102, // 本地不存在对应应用
     AppUninstallAppIsRunning = 2103,      // 卸载的app正在运行
     LayerCompatibilityError = 2104,       // 找不到兼容的layer
+    AppUninstallMultipleVersions = 2105,
+    AppUninstallBaseOrRuntime = 2106,
     /* 升级 */
     AppUpgradeFailed = 2201,          // 升级失败
     AppUpgradeNotFound = 2202,        // 本地不存在对应应用
@@ -56,6 +58,10 @@ enum class ErrorCode : int {
 
     /* 网络 */
     NetworkError = 3001, // 网络错误
+
+    /* fuzzy reference */
+    InvalidFuzzyReference = 4001,
+    UnknownArchitecture = 4002,
 };
 
 class Error


### PR DESCRIPTION
This refactoring moves the core uninstall logic from the cli to PM.

Key changes:
- Support uninstall extension
- Added robust error handling for uninstalling:
  - Returns an error if multiple versions are installed and the user input is ambiguous.
  - Prevents uninstalling 'base' or 'runtime' packages directly.
  - Checks if an application or its dependencies are running before proceeding.