### PR TITLE
fix: Optimize file fetching with hard links

### DIFF
--- a/misc/libexec/linglong/fetch-file-source
+++ b/misc/libexec/linglong/fetch-file-source
@@ -18,7 +18,8 @@ then
 fi
 # Check cache
 if [ -f "$cachedir/file_$digest" ]; then
-    cp "$cachedir/file_$digest" "$outputfile"
+    # Using hard links is faster
+    cp --remove-destination --link "$cachedir/file_$digest" "$outputfile" || cp "$cachedir/file_$digest" "$outputfile"
     exit;
 fi
 # Download file
@@ -29,4 +30,4 @@ if [ "X$actual_hash" != "X$digest" ]; then
     exit 1;
 fi
 mv "$cachedir/tmp_$digest" "$cachedir/file_$digest"
-cp "$cachedir/file_$digest" "$outputfile"
+cp --remove-destination --link "$cachedir/file_$digest" "$outputfile" || cp "$cachedir/file_$digest" "$outputfile"


### PR DESCRIPTION
1. Changed the method for copying cached files to the output file from `cp` to `cp --remove-destination --link`.
2. This introduces hard links instead of full copies, significantly improving performance when fetching files from the cache.  A fallback `cp` is included to handle cases where hard linking might fail (e.g., due to filesystem limitations).
3. The `--remove-destination` option ensures that if the destination file already exists, it's removed before creating the hard link, preventing errors.

Log: Improved file fetching performance by utilizing hard links for cached files

Influence:
1. Verify that files fetched from the cache are functionally identical before and after the change.
2. Measure the performance of file fetching (time taken) with and without the hard link optimization.
3. Test the fallback `cp` mechanism by simulating scenarios where hard linking might fail (e.g., by mounting a filesystem that doesn’t support it).
4. Confirm that the fallback `cp` still correctly copies the file in case of hard link failure.

修复: 使用硬链接优化文件获取

1. 将从缓存复制文件的写入方式从 `cp` 改为 `cp --remove-destination --link`。
2. 这样可引入硬链接，而不是完整复制，从而显著提高性能，尤其是在从缓存获 取文件时。  包含一个备用 `cp` 以处理硬链接可能失败的场景（例如，由于文件
系统限制）。
3. `--remove-destination` 选项可确保如果目标文件已存在，则在创建硬链接之 前将其删除，从而防止错误。

Log: 通过使用硬链接来改善文件获取性能

Influence:
1. 验证在更改前后，从缓存获取的文件在功能上是否相同。
2. 测量带和不带硬链接优化时文件获取的性能（耗时）。
3. 测试通过模拟无法进行硬链接的场景（例如，挂载不支持它的文件系统）来测 试备用 `cp` 机制。
4. 确认在硬链接失败时，备用 `cp` 仍然可以正确复制文件。