### PR TITLE
fix: can not find QUuid::Id128 in qt5

### DIFF
--- a/libs/linglong/src/linglong/package/uab_file.cpp
+++ b/libs/linglong/src/linglong/package/uab_file.cpp
@@ -16,6 +16,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QStandardPaths>
+#include <QUuid>
 
 #include <filesystem>
 #include <fstream>


### PR DESCRIPTION
fix: can not find QUuid::Id128 in qt5
The change in `uab_file.cpp` replace `QUuid::Id128` with
`QUuid::toString()` which resolves the issue of incorrect UUID
generation on some systems.

Influence:
1. Test UUID generation in `uab_file.cpp` to ensure that no errors
occurred after the fix.

修复: 不能发现QUuid:Id128在Qt5环境

`uab_file.cpp` 中的更改用 `QUuid::toString()` 替换了 `QUuid::Id128`，
解决了某些系统上 UUID 生成不正确的问题。

Influence:
3. 在 `uab_file.cpp` 中测试 UUID 生成，以确保修复后不会发生错误。