### PR TITLE
fix: Remove hardcoded color diagnostics

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,8 +12,7 @@
             "description": "Configure linglong for installing from source.",
             "binaryDir": "${sourceDir}/build-release",
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "-Wall -Wextra -Wpedantic -Wno-c++20-extensions -Wno-pessimizing-move -O2",
-                "CMAKE_COLOR_DIAGNOSTICS": true
+                "CMAKE_CXX_FLAGS": "-Wall -Wextra -Wpedantic -Wno-c++20-extensions -Wno-pessimizing-move -O2"
             }
         },
         {
@@ -24,7 +23,6 @@
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "-Wall -Wextra -Wpedantic -Wno-c++20-extensions -Wno-pessimizing-move -Og -g -fsanitize=undefined",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": true,
-                "CMAKE_COLOR_DIAGNOSTICS": true,
                 "ENABLE_TESTING": true,
                 "CMAKE_INSTALL_PREFIX": "/usr"
             }
@@ -36,8 +34,7 @@
             "binaryDir": "${sourceDir}/build-clang-tidy",
             "cacheVariables": {
                 "CMAKE_CXX_CLANG_TIDY": "clang-tidy",
-                "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_COLOR_DIAGNOSTICS": true
+                "CMAKE_CXX_COMPILER": "clang++"
             }
         }
     ],


### PR DESCRIPTION
1. Removed the `CMAKE_COLOR_DIAGNOSTICS` variable from all CMakePresets.json configurations.
2. The intention is to allow the terminal environment to dictate whether color is used for diagnostic output. Linglong should not enforce a specific color scheme.
3. This change improves compatibility and avoids potential issues where color output is undesirable or unsupported in certain environments. It aligns with best practices for CMake configuration by allowing the environment to control this aspect.

Log: Removed forced color diagnostics

Influence:
1. Verify build and diagnostic output in environments with and without color support.
2. Ensure that diagnostic messages are readable regardless of whether color is enabled.
3. Confirm that the build process is not negatively impacted by the removal of this variable.
4. Test across a variety of terminals and operating systems.

fix: 移除强制颜色诊断

1. 从所有 CMakePresets.json 配置中删除了 `CMAKE_COLOR_DIAGNOSTICS` 变 量。
2. 意图是允许终端环境决定是否使用颜色显示诊断输出。 Linglong 不应强制执 行特定的颜色方案。
3. 此更改提高了兼容性，并避免了在某些环境（其中颜色输出不受欢迎或不受支 持）中出现潜在问题。 它符合 CMake 配置的最佳实践，允许环境控制此方面。

Log: 移除了强制颜色诊断

Influence:
1. 验证在具有和不具有颜色支持的环境中构建和诊断输出。
2. 确保诊断消息无论是否启用颜色，都能被读取。
3. 确认构建过程不会因为删除此变量而受到负面影响。
4. 在各种终端和操作系统上进行测试。