### PR TITLE
feat: add base and runtime options

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -189,7 +189,12 @@ ll-cli run org.deepin.demo -- bash -x /path/to/bash/script)"));
 
           return {};
       });
-
+    cliRun->add_option("--base", runOptions.base, _("Specify the base used by the application to run"))
+      ->type_name("REF")
+      ->check(validatorString);
+    cliRun->add_option("--runtime", runOptions.runtime, _("Specify the runtime used by the application to run"))
+      ->type_name("REF")
+      ->check(validatorString);
     cliRun->add_option("COMMAND", runOptions.commands, _("Run commands in a running sandbox"));
 }
 
@@ -655,19 +660,19 @@ You can report bugs to the linyaps team under this project: https://github.com/O
                            _("Show debug info (verbose logs)"));
 
     // subcommand options
-    RunOptions runOptions;
-    EnterOptions enterOptions;
-    KillOptions killOptions;
-    InstallOptions installOptions;
-    UpgradeOptions upgradeOptions;
-    SearchOptions searchOptions;
-    UninstallOptions uninstallOptions;
-    ListOptions listOptions;
-    InfoOptions infoOptions;
-    ContentOptions contentOptions;
-    RepoOptions repoOptions;
-    InspectOptions inspectOptions;
-    DirOptions dirOptions;
+    RunOptions runOptions{};
+    EnterOptions enterOptions{};
+    KillOptions killOptions{};
+    InstallOptions installOptions{};
+    UpgradeOptions upgradeOptions{};
+    SearchOptions searchOptions{};
+    UninstallOptions uninstallOptions{};
+    ListOptions listOptions{};
+    InfoOptions infoOptions{};
+    ContentOptions contentOptions{};
+    RepoOptions repoOptions{};
+    InspectOptions inspectOptions{};
+    DirOptions dirOptions{};
 
     // groups for subcommands
     auto *CliBuildInGroup = _("Managing installed applications and runtimes");

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -1948,7 +1948,10 @@ utils::error::Result<void> Builder::run(const QStringList &modules,
     }
 
     runtime::RunContext runContext(this->repo);
-    auto res = runContext.resolve(*curRef, !debug, modules);
+    linglong::runtime::ResolveOptions opts;
+    opts.depsBinaryOnly = !debug;
+    opts.appModules = modules;
+    auto res = runContext.resolve(*curRef, opts);
     if (!res) {
         return LINGLONG_ERR(res);
     }

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -45,6 +45,8 @@ struct RunOptions
     std::vector<std::string> fileUrls;
     std::vector<std::string> envs;
     std::vector<std::string> commands;
+    std::optional<std::string> base;
+    std::optional<std::string> runtime;
 };
 
 struct EnterOptions

--- a/libs/linglong/src/linglong/runtime/run_context.h
+++ b/libs/linglong/src/linglong/runtime/run_context.h
@@ -51,6 +51,14 @@ private:
     std::optional<ExtensionRuntimeLayerInfo> extensionOf;
 };
 
+struct ResolveOptions
+{
+    bool depsBinaryOnly{ false };
+    std::optional<QStringList> appModules;
+    std::optional<std::string> baseRef;
+    std::optional<std::string> runtimeRef;
+};
+
 class RunContext
 {
 public:
@@ -62,8 +70,8 @@ public:
     ~RunContext();
 
     utils::error::Result<void> resolve(const linglong::package::Reference &runnable,
-                                       bool depsBinaryOnly = false,
-                                       const QStringList &appModules = {});
+                                       const ResolveOptions &opts = ResolveOptions{});
+
     utils::error::Result<void> resolve(const api::types::v1::BuilderProject &target,
                                        std::filesystem::path buildOutput);
 


### PR DESCRIPTION
1. Add `--base` option to specify the base layer.
2. Add `--runtime` option to specify the runtime.
3. Modify `RunContext::resolve` to utilize the `--base` and `--runtime` options.
4. Update builder resolution to pass base and runtime references.
5. Add logging for base and runtime resolution

Log: Added command-line options to specify the base and runtime for application execution.

Influence:
1. Test application execution with different base layers.
2. Verify that specifying a runtime overrides the default runtime.
3. Ensure that the `--base` and `--runtime` options are respected during application resolution.
4. Check that the logging accurately reflects the used base and runtime.

feat: 为 ll-cli 添加 base 和 runtime 选项

1. 添加 --base 选项来指定基础层
2. 添加 --runtime 选项来指定运行时环境
3. 修改 RunContext::resolve 以使用 --base 和 --runtime 选项
4. 更新构建器解析以传递基础和运行时引用
5. 添加基础和运行时解析的日志记录

Log: 增加了 ll-cli 的命令行选项，用于指定应用程序执行的基础层和运行时
环境。

Influence:
1. 使用不同的基础层测试应用程序执行
2. 验证指定运行时是否会覆盖默认运行时
3. 确保在应用程序解析期间尊重 --base 和 --runtime 选项
4. 检查日志是否准确地反映所使用的基础和运行时