### PR TITLE
fix: correct list command logic and logging

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -17,6 +17,7 @@
 #include "linglong/utils/finally/finally.h"
 #include "linglong/utils/gettext.h"
 #include "linglong/utils/global/initialize.h"
+#include "linglong/utils/log/log.h"
 #include "ocppi/cli/crun/Crun.hpp"
 
 #include <CLI/CLI.hpp>
@@ -703,6 +704,10 @@ You can report bugs to the linyaps team under this project: https://github.com/O
             std::cout << _("linyaps CLI version ") << LINGLONG_VERSION << std::endl;
         }
         return 0;
+    }
+    // set log level if --verbose flag is set
+    if (globalOptions.verbose) {
+        linglong::utils::log::setLogLevel(linglong::utils::log::LogLevel::Debug);
     }
 
     // check lock

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -18,6 +18,7 @@
 #include "linglong/package/reference.h"
 #include "linglong/package_manager/package_task.h"
 #include "linglong/repo/config.h"
+#include "linglong/utils/log/log.h"
 #include "linglong/utils/command/cmd.h"
 #include "linglong/utils/command/env.h"
 #include "linglong/utils/error/error.h"
@@ -1397,7 +1398,7 @@ void OSTreeRepo::pull(service::PackageTask &taskContext,
 
     auto sizes = this->getCommitSize(pullRepo.alias.value_or(pullRepo.name), refString);
     if (!sizes.has_value()) {
-        qWarning() << "get commit size error: " << sizes.error().message();
+        LogD("get commit size error: {}", sizes.error().message());
     } else if (sizes->size() >= 3) {
         data.needed_archived = sizes->at(0);
         data.needed_unpacked = sizes->at(1);


### PR DESCRIPTION
1. Fixed inverted logic in list command for showing upgrade list vs regular package list
2. Added sorting by package ID for both regular list and upgrade list outputs
3. Replaced Qt logging with linglong's custom logging in ostree repository
4. Maintained existing filtering functionality by package type

Log: Fixed package list display logic and improved sorting

Influence:
1. Test ll-cli list command without parameters to show installed packages
2. Test ll-cli list --upgradable to show available upgrades
3. Verify package sorting by ID in both list modes
4. Test package type filtering with --type parameter
5. Verify installation time display in package list
6. Confirm error handling for repository access issues

fix: 修复列表命令逻辑和日志记录

1. 修复了显示升级列表与常规包列表的反向逻辑
2. 为常规列表和升级列表输出添加了按包ID排序功能
3. 在ostree仓库中将Qt日志替换为linglong自定义日志
4. 保持了按包类型过滤的现有功能

Log: 修复包列表显示逻辑并改进排序功能

Influence:
1. 测试不带参数的 ll-cli list 命令以显示已安装的包
2. 测试 ll-cli list --upgradable 以显示可用升级
3. 验证两种列表模式下的包ID排序
4. 测试使用 --type 参数的包类型过滤功能
5. 验证包列表中的安装时间显示
6. 确认仓库访问错误的处理机制