### PR TITLE
fix: clear removableStorageMounts before binding

### DIFF
--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -277,6 +277,7 @@ ContainerCfgBuilder &ContainerCfgBuilder::bindRemovableStorageMounts() noexcept
     std::error_code ec;
 
     std::vector<std::string> propagationPaths{ "/media", "/mnt" };
+    removableStorageMounts = std::vector<Mount>{};
 
     for (const auto &path : propagationPaths) {
         auto mountPath = std::filesystem::path(path);


### PR DESCRIPTION
Clear the `removableStorageMounts` vector before binding removable storage mounts. This ensures that stale mount points from previous configurations are not included, preventing potential issues with incorrect mount configurations. This is crucial for scenarios where the removable storage setup changes between container runs.

Influence:
1. Test with removable storage devices connected and disconnected before/after container startup.
2. Verify that only the currently available removable storage devices are mounted inside the container.
3. Check that stale mount points are correctly removed when a removable device is disconnected.

fix: 在绑定之前清除 removableStorageMounts

在绑定可移动存储挂载点之前，清除 `removableStorageMounts` 向量。 这样可
以确保不包含来自先前配置的陈旧挂载点，从而避免潜在的错误挂载配置问题。这
对于可移动存储设置在容器运行之间发生变化的场景至关重要。

Influence:
1. 测试在容器启动之前/之后连接和断开可移动存储设备的情况。
2. 验证只有当前可用的可移动存储设备才会在容器内挂载。
3. 检查当可移动设备断开连接时，陈旧的挂载点是否已正确删除。