### PR TITLE
feat: add no-clean-objects option for remove command

### DIFF
--- a/apps/ll-builder/src/command_options.h
+++ b/apps/ll-builder/src/command_options.h
@@ -38,6 +38,7 @@ struct ListCommandOptions
 
 struct RemoveCommandOptions
 {
+    bool noCleanObjects = false;
     std::vector<std::string> removeList; // List of apps to remove
 };
 

--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -378,7 +378,7 @@ int handleList(linglong::repo::OSTreeRepo &repo, [[maybe_unused]] const ListComm
 
 int handleRemove(linglong::repo::OSTreeRepo &repo, const RemoveCommandOptions &options)
 {
-    auto ret = linglong::builder::cmdRemoveApp(repo, options.removeList);
+    auto ret = linglong::builder::cmdRemoveApp(repo, options.removeList, !options.noCleanObjects);
     if (!ret.has_value()) {
         return -1;
     }
@@ -853,6 +853,9 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     buildList->usage(_("Usage: ll-builder list [OPTIONS]"));
     auto buildRemove = commandParser.add_subcommand("remove", _("Remove built linyaps app"));
     buildRemove->usage(_("Usage: ll-builder remove [OPTIONS] [APP...]"));
+    buildRemove->add_flag("--no-clean-objects",
+                          removeOpts.noCleanObjects,
+                          _("Do not clean objects files before remove apps"));
     buildRemove->add_option("APP", removeOpts.removeList);
 
     // build export

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -387,7 +387,9 @@ utils::error::Result<void> cmdListApp(repo::OSTreeRepo &repo)
     return LINGLONG_OK;
 }
 
-utils::error::Result<void> cmdRemoveApp(repo::OSTreeRepo &repo, std::vector<std::string> refs)
+utils::error::Result<void> cmdRemoveApp(repo::OSTreeRepo &repo,
+                                        std::vector<std::string> refs,
+                                        bool prune)
 {
     for (const auto &ref : refs) {
         auto r = package::Reference::parse(QString::fromStdString(ref));
@@ -404,11 +406,13 @@ utils::error::Result<void> cmdRemoveApp(repo::OSTreeRepo &repo, std::vector<std:
             }
         }
     }
-    auto v = repo.prune();
-    if (!v.has_value()) {
-        std::cerr << v.error().message().toStdString();
+    if (prune) {
+        auto v = repo.prune();
+        if (!v.has_value()) {
+            std::cerr << v.error().message().toStdString();
+        }
     }
-    v = repo.mergeModules();
+    auto v = repo.mergeModules();
     if (!v.has_value()) {
         std::cerr << v.error().message().toStdString();
     }

--- a/libs/linglong/src/linglong/builder/linglong_builder.h
+++ b/libs/linglong/src/linglong/builder/linglong_builder.h
@@ -43,7 +43,9 @@ struct BuilderBuildOptions
 };
 
 utils::error::Result<void> cmdListApp(repo::OSTreeRepo &repo);
-utils::error::Result<void> cmdRemoveApp(repo::OSTreeRepo &repo, std::vector<std::string> refs);
+utils::error::Result<void> cmdRemoveApp(repo::OSTreeRepo &repo,
+                                        std::vector<std::string> refs,
+                                        bool prune);
 
 class Builder
 {


### PR DESCRIPTION
1. Add new flag --no-clean-objects to remove command options
2. Modify cmdRemoveApp function signature to accept prune parameter
3. Conditionally execute repo.prune() based on prune flag
4. Maintain repo.mergeModules() execution regardless of prune flag
5. Update command line interface to expose the new flag

This change allows users to control whether object files should be cleaned during app removal. By default, objects are cleaned (previous behavior), but users can now skip this step using --no-clean-objects flag for faster removal operations or when they want to preserve objects for other purposes.

Log: Added --no-clean-objects flag to ll-builder remove command

Influence:
1. Test default remove behavior (should clean objects)
2. Test remove with --no-clean-objects flag (should not clean objects)
3. Verify repo.mergeModules() is always called
4. Test removal of single and multiple apps with both options
5. Verify error handling for invalid app references
6. Test edge cases with empty app list

feat: 为 remove 命令添加 no-clean-objects 选项

1. 为 remove 命令选项添加新的 --no-clean-objects 标志
2. 修改 cmdRemoveApp 函数签名以接受 prune 参数
3. 根据 prune 标志有条件地执行 repo.prune()
4. 无论 prune 标志如何都执行 repo.mergeModules()
5. 更新命令行界面以暴露新标志

此更改允许用户控制在删除应用程序期间是否应清理对象文件。默认情况下，对象
会被清理（之前的行为），但用户现在可以使用 --no-clean-objects 标志跳过此
步骤，以实现更快的删除操作或在他们希望为其他目的保留对象时使用。

Log: 为 ll-builder remove 命令添加 --no-clean-objects 标志

Influence:
1. 测试默认删除行为（应清理对象）
2. 测试使用 --no-clean-objects 标志的删除（不应清理对象）
3. 验证 repo.mergeModules() 是否始终被调用
4. 测试单个和多个应用程序的删除（两种选项）
5. 验证无效应用程序引用的错误处理
6. 测试空应用程序列表的边界情况