### PR TITLE
feat: enable git submodule fetching with environment variable control

### DIFF
--- a/api/schema/v1.json
+++ b/api/schema/v1.json
@@ -410,6 +410,10 @@
                 "type": "string",
                 "description": "digest of source"
               },
+              "name": {
+                "type": "string",
+                "description": "name of source"
+              },
               "commit": {
                 "type": "string",
                 "description": "commit of source"
@@ -418,9 +422,9 @@
                 "type": "string",
                 "description": "version of source"
               },
-              "name": {
-                "type": "string",
-                "description": "name of source"
+              "submodules": {
+                "type": "boolean",
+                "description": "whether to checkout submodules"
               }
             }
           }

--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -337,15 +337,18 @@ $defs:
             digest:
               type: string
               description: digest of source
+            name:
+              type: string
+              description: name of source
             commit:
               type: string
               description: commit of source
             version:
               type: string
               description: version of source
-            name:
-              type: string
-              description: name of source
+            submodules:
+              type: boolean
+              description: whether to checkout submodules
       build:
         title: BuilderProjectBuildScript
         description: build script of builder project

--- a/libs/api/src/linglong/api/types/v1/BuilderProjectSource.hpp
+++ b/libs/api/src/linglong/api/types/v1/BuilderProjectSource.hpp
@@ -48,6 +48,10 @@ std::string kind;
 */
 std::optional<std::string> name;
 /**
+* whether to checkout submodules
+*/
+std::optional<bool> submodules;
+/**
 * url of source
 */
 std::optional<std::string> url;

--- a/libs/api/src/linglong/api/types/v1/Generators.hpp
+++ b/libs/api/src/linglong/api/types/v1/Generators.hpp
@@ -436,6 +436,7 @@ x.commit = get_stack_optional<std::string>(j, "commit");
 x.digest = get_stack_optional<std::string>(j, "digest");
 x.kind = j.at("kind").get<std::string>();
 x.name = get_stack_optional<std::string>(j, "name");
+x.submodules = get_stack_optional<bool>(j, "submodules");
 x.url = get_stack_optional<std::string>(j, "url");
 x.version = get_stack_optional<std::string>(j, "version");
 }
@@ -451,6 +452,9 @@ j["digest"] = x.digest;
 j["kind"] = x.kind;
 if (x.name) {
 j["name"] = x.name;
+}
+if (x.submodules) {
+j["submodules"] = x.submodules;
 }
 if (x.url) {
 j["url"] = x.url;

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -170,7 +170,7 @@ fetchSources(const std::vector<api::types::v1::BuilderProjectSource> &sources,
                             .arg("downloading ...")
                             .toStdString(),
                           2);
-        SourceFetcher fetcher(sources.at(pos), cfg, cacheDir);
+        SourceFetcher fetcher(sources.at(pos), cacheDir);
         auto result = fetcher.fetch(QDir(destination));
         if (!result) {
             return LINGLONG_ERR(result);

--- a/libs/linglong/src/linglong/builder/source_fetcher.h
+++ b/libs/linglong/src/linglong/builder/source_fetcher.h
@@ -8,6 +8,7 @@
 
 #include "linglong/api/types/v1/BuilderConfig.hpp"
 #include "linglong/api/types/v1/BuilderProjectSource.hpp"
+#include "linglong/utils/command/cmd.h"
 #include "linglong/utils/error/error.h"
 
 #include <QDir>
@@ -20,17 +21,17 @@ namespace linglong::builder {
 class SourceFetcher
 {
 public:
-    explicit SourceFetcher(api::types::v1::BuilderProjectSource source,
-                           api::types::v1::BuilderConfig cfg,
-                           const QDir &cacheDir);
+    explicit SourceFetcher(api::types::v1::BuilderProjectSource source, const QDir &cacheDir);
 
     auto fetch(QDir destination) noexcept -> utils::error::Result<void>;
+
+    void setCommand(std::shared_ptr<utils::command::Cmd> cmd) { this->m_cmd = cmd; }
 
 private:
     QString getSourceName();
     QDir cacheDir;
     api::types::v1::BuilderProjectSource source;
-    api::types::v1::BuilderConfig cfg;
+    std::shared_ptr<utils::command::Cmd> m_cmd = std::make_shared<utils::command::Cmd>("sh");
 };
 
 } // namespace linglong::builder

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -23,6 +23,8 @@ pfl_add_executable(
   src/linglong/package/semver_version_test.cpp
   src/linglong/package/uab_file_test.cpp
   src/linglong/package/layer_packager_test.cpp
+  src/linglong/builder/source_fetcher_test.cpp
+  src/linglong/mocks/command.h
   src/linglong/utils/error/result_test.cpp
   src/linglong/utils/log.cpp
   src/linglong/utils/sha256_test.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/builder/source_fetcher_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/builder/source_fetcher_test.cpp
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#include <gtest/gtest.h>
+
+#include "../mocks/command.h"
+#include "linglong/api/types/v1/Generators.hpp"
+#include "linglong/builder/source_fetcher.h"
+#include "linglong/utils/error/error.h"
+
+#include <QDir>
+#include <QProcessEnvironment>
+
+using namespace linglong;
+using namespace testing;
+
+namespace linglong::builder {
+class SourceFetcherTest : public ::testing::Test
+{
+protected:
+    void SetUp() override { }
+};
+
+// 测试获取文件类型源码的正常流程
+// 场景：提供有效的文件类型source配置，包括url、digest和name
+// 预期：成功获取源码并返回ok
+TEST_F(SourceFetcherTest, FetchFileSource)
+{
+    api::types::v1::BuilderProjectSource source;
+    source.kind = "file";
+    source.url = "https://example.com/repo.git";
+    source.digest = "abcdef123456";
+    source.name = "repo";
+
+    QDir cacheDir("/tmp/cache");
+    auto mockCmd = std::make_shared<MockCommand>("mock");
+    mockCmd->warpExecFunc = [&](const QStringList &args) {
+        auto argsStr = args.join(" ").toStdString();
+        EXPECT_TRUE(args[0].contains("fetch-file-source")) << argsStr;
+        EXPECT_EQ(args[1].toStdString(), "/tmp/dest/" + source.name.value()) << argsStr;
+        EXPECT_EQ(args[2].toStdString(), source.url) << argsStr;
+        EXPECT_EQ(args[3].toStdString(), source.digest) << argsStr;
+        EXPECT_EQ(args[4].toStdString(), "/tmp/cache") << argsStr;
+        return utils::error::Result<QString>("ok");
+    };
+    SourceFetcher fetcher(source, cacheDir);
+    fetcher.setCommand(mockCmd);
+    auto ret = fetcher.fetch(QDir("/tmp/dest"));
+    EXPECT_TRUE(ret.has_value()) << ret.error().message().toStdString();
+}
+
+// 测试获取git类型源码的正常流程
+// 场景：提供有效的git类型source配置，包括url、commit和name
+// 预期：成功获取源码并返回ok
+TEST_F(SourceFetcherTest, FetchGitSource)
+{
+    api::types::v1::BuilderProjectSource source;
+    source.kind = "git";
+    source.url = "https://example.com/repo.git";
+    source.commit = "abcdef123456";
+    source.name = "repo";
+
+    QDir cacheDir("/tmp/cache");
+    auto mockCmd = std::make_shared<MockCommand>("mock");
+    mockCmd->warpExecFunc = [&](const QStringList &args) {
+        auto argsStr = args.join(" ").toStdString();
+        EXPECT_TRUE(args[0].contains("fetch-git-source")) << argsStr;
+        EXPECT_EQ(args[1].toStdString(), "/tmp/dest/" + source.name.value()) << argsStr;
+        EXPECT_EQ(args[2].toStdString(), source.url) << argsStr;
+        EXPECT_EQ(args[3].toStdString(), source.commit) << argsStr;
+        EXPECT_EQ(args[4], "/tmp/cache") << argsStr;
+        return utils::error::Result<QString>("ok");
+    };
+    SourceFetcher fetcher(source, cacheDir);
+    fetcher.setCommand(mockCmd);
+    auto ret = fetcher.fetch(QDir("/tmp/dest"));
+    EXPECT_TRUE(ret.has_value()) << ret.error().message().toStdString();
+}
+
+// 测试git子模块处理功能
+// 场景1：默认启用子模块时，验证环境变量设置正确
+// 场景2：手动禁用子模块时，验证环境变量被清空
+// 预期：两种情况下都能成功获取源码
+TEST_F(SourceFetcherTest, gitSubmodules)
+{
+    api::types::v1::BuilderProjectSource source;
+    source.kind = "git";
+    source.url = "https://example.com/repo.git";
+    source.commit = "abcdef123456";
+    source.name = "repo";
+    // default is true
+    {
+        QDir cacheDir("/tmp/cache");
+        auto mockCmd = std::make_shared<MockCommand>("mock");
+        mockCmd->warpExecFunc = [&](const QStringList &args) {
+            return utils::error::Result<QString>("ok");
+        };
+        mockCmd->warpSetEnvFunc = [&](const QString &name,
+                                      const QString &value) -> linglong::utils::command::Cmd & {
+            EXPECT_EQ(name, "GIT_SUBMODULES");
+            EXPECT_EQ(value, "true");
+            return *mockCmd;
+        };
+        SourceFetcher fetcher(source, cacheDir);
+        fetcher.setCommand(mockCmd);
+        auto ret2 = fetcher.fetch(QDir("/tmp/dest"));
+        EXPECT_TRUE(ret2.has_value()) << ret2.error().message().toStdString();
+    }
+    // manually disable submodules
+    source.submodules = false;
+    {
+        QDir cacheDir("/tmp/cache");
+        auto mockCmd = std::make_shared<MockCommand>("mock");
+        mockCmd->warpExecFunc = [&](const QStringList &args) {
+            return utils::error::Result<QString>("ok");
+        };
+        mockCmd->warpSetEnvFunc = [&](const QString &name,
+                                      const QString &value) -> linglong::utils::command::Cmd & {
+            EXPECT_TRUE(value.isEmpty()) << name.toStdString();
+            return *mockCmd;
+        };
+        SourceFetcher fetcher(source, cacheDir);
+        fetcher.setCommand(mockCmd);
+        auto ret2 = fetcher.fetch(QDir("/tmp/dest"));
+        EXPECT_TRUE(ret2.has_value()) << ret2.error().message().toStdString();
+    }
+}
+
+// 测试无效的source类型
+// 场景：提供无效的source.kind值
+// 预期：返回错误结果，错误码为-1
+TEST_F(SourceFetcherTest, FetchInvalidSourceKind)
+{
+    api::types::v1::BuilderProjectSource source;
+    source.kind = "invalid";
+    source.url = "https://example.com/repo.git";
+    source.name = "repo";
+
+    QDir cacheDir("/tmp/cache");
+    auto mockCmd = std::make_shared<MockCommand>("mock");
+    SourceFetcher fetcher(source, cacheDir);
+    fetcher.setCommand(mockCmd);
+    auto ret = fetcher.fetch(QDir("/tmp/dest"));
+    EXPECT_FALSE(ret.has_value());
+    EXPECT_EQ(ret.error().code(), -1);
+}
+
+// 测试缺失必填字段的情况
+// 场景：缺少url和name字段
+// 预期：返回错误结果，错误码为-1
+TEST_F(SourceFetcherTest, FetchMissingRequiredField)
+{
+    api::types::v1::BuilderProjectSource source;
+    source.kind = "git";
+    // 缺少 url 和 name
+    source.commit = "abcdef123456";
+
+    QDir cacheDir("/tmp/cache");
+    auto mockCmd = std::make_shared<MockCommand>("mock");
+    SourceFetcher fetcher(source, cacheDir);
+    fetcher.setCommand(mockCmd);
+    auto ret = fetcher.fetch(QDir("/tmp/dest"));
+    EXPECT_FALSE(ret.has_value());
+    EXPECT_EQ(ret.error().code(), -1);
+}
+
+// 测试无效的git commit
+// 场景1：未设置commit字段
+// 场景2：设置无效的commit值
+// 预期：两种情况都返回错误结果，场景2的错误码为-2
+TEST_F(SourceFetcherTest, FetchInvalidGitCommit)
+{
+    api::types::v1::BuilderProjectSource source;
+    source.kind = "git";
+    source.url = "https://example.com/repo.git";
+    source.name = "repo";
+
+    QDir cacheDir("/tmp/cache");
+    {
+        SourceFetcher fetcher(source, cacheDir);
+        auto ret = fetcher.fetch(QDir("/tmp/dest"));
+        EXPECT_FALSE(ret.has_value());
+    }
+    source.commit = "invalid_commit";
+    SourceFetcher fetcher(source, cacheDir);
+    auto mockCmd = std::make_shared<MockCommand>("mock");
+    mockCmd->warpExecFunc = [&](const QStringList &args) {
+        LINGLONG_TRACE("FetchInvalidGitCommit");
+        return LINGLONG_ERR("Invalid commit", -2);
+    };
+    fetcher.setCommand(mockCmd);
+    auto ret = fetcher.fetch(QDir("/tmp/dest"));
+    EXPECT_FALSE(ret.has_value());
+    EXPECT_EQ(ret.error().code(), -2);
+}
+
+// 测试无效的文件digest
+// 场景1：未设置digest字段
+// 场景2：设置无效的digest值
+// 预期：两种情况都返回错误结果，场景2的错误码为-3
+TEST_F(SourceFetcherTest, FetchInvalidFileDigest)
+{
+    api::types::v1::BuilderProjectSource source;
+    source.kind = "file";
+    source.url = "https://example.com/repo.git";
+    source.name = "repo";
+    QDir cacheDir("/tmp/cache");
+    {
+        SourceFetcher fetcher(source, cacheDir);
+        auto ret = fetcher.fetch(QDir("/tmp/dest"));
+        EXPECT_FALSE(ret.has_value());
+    }
+
+    source.digest = "invalid_digest";
+    SourceFetcher fetcher(source, cacheDir);
+    auto mockCmd = std::make_shared<MockCommand>("mock");
+    mockCmd->warpExecFunc = [&](const QStringList &args) {
+        LINGLONG_TRACE("FetchInvalidFileDigest");
+        return LINGLONG_ERR("Invalid digest", -3);
+    };
+    fetcher.setCommand(mockCmd);
+    auto ret = fetcher.fetch(QDir("/tmp/dest"));
+    EXPECT_FALSE(ret.has_value());
+    EXPECT_EQ(ret.error().code(), -3);
+}
+
+// 测试未设置name字段的情况
+// 场景：仅设置url和digest字段
+// 预期：仍能成功获取源码
+TEST_F(SourceFetcherTest, FetchNoSetName)
+{
+    api::types::v1::BuilderProjectSource source;
+    source.kind = "file";
+    source.url = "https://example.com/repo.git";
+    source.digest = "digest";
+
+    QDir cacheDir("/tmp/cache");
+    auto mockCmd = std::make_shared<MockCommand>("mock");
+    mockCmd->warpExecFunc = [&](const QStringList &args) {
+        return utils::error::Result<QString>("ok");
+    };
+    SourceFetcher fetcher(source, cacheDir);
+    fetcher.setCommand(mockCmd);
+    auto ret = fetcher.fetch(QDir("/tmp/dest"));
+    EXPECT_TRUE(ret.has_value());
+}
+
+} // namespace linglong::builder

--- a/libs/linglong/tests/ll-tests/src/linglong/mocks/command.h
+++ b/libs/linglong/tests/ll-tests/src/linglong/mocks/command.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#include <gtest/gtest.h>
+
+#include "linglong/utils/command/cmd.h"
+#include "linglong/utils/error/error.h"
+
+#include <QMap>
+#include <QString>
+#include <QStringList>
+
+#include <functional>
+
+class MockCommand : public linglong::utils::command::Cmd
+{
+public:
+    MockCommand(const QString &command)
+        : Cmd(command)
+    {
+    }
+
+    // mock exec
+    std::function<linglong::utils::error::Result<QString>(const QStringList &)> warpExecFunc;
+
+    linglong::utils::error::Result<QString> exec(const QStringList &args) noexcept override
+    {
+        return warpExecFunc ? warpExecFunc(args) : Cmd::exec(args);
+    }
+
+    // mock exists
+    std::function<linglong::utils::error::Result<bool>()> warpExistsFunc;
+
+    linglong::utils::error::Result<bool> exists() noexcept override
+    {
+        return warpExistsFunc ? warpExistsFunc() : Cmd::exists();
+    }
+
+    // mock setEnv
+    std::function<linglong::utils::command::Cmd &(const QString &, const QString &)> warpSetEnvFunc;
+
+    Cmd &setEnv(const QString &name, const QString &value) noexcept override
+    {
+        return warpSetEnvFunc ? warpSetEnvFunc(name, value) : Cmd::setEnv(name, value);
+    }
+};

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/command_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/command_test.cpp
@@ -11,10 +11,12 @@
 class MockCmd : public linglong::utils::command::Cmd
 {
 public:
-    MOCK_METHOD(linglong::utils::error::Result<QString>,
-                exec,
-                (const QStringList &args),
-                (noexcept));
+    MockCmd(const QString &command)
+        : Cmd(command)
+    {
+    }
+
+    MOCK_METHOD(linglong::utils::error::Result<QString>, exec, (const QStringList &), (const));
     MOCK_METHOD(linglong::utils::error::Result<bool>, exists, (), (noexcept));
 };
 
@@ -48,4 +50,14 @@ TEST(command, commandExists)
     ret = linglong::utils::command::Cmd("nonexistent").exists();
     EXPECT_TRUE(ret.has_value()) << ret.error().message().toStdString();
     EXPECT_FALSE(*ret) << "nonexistent should not exist";
+}
+
+TEST(command, setEnv)
+{
+    linglong::utils::command::Cmd cmd("bash");
+    cmd.setEnv("LINGLONG_TEST_SETENV", "OK");
+    auto ret = cmd.exec({ "-c", "export" });
+    EXPECT_TRUE(ret.has_value()) << ret.error().message().toStdString();
+    auto retStr = *ret;
+    EXPECT_TRUE(retStr.contains("LINGLONG_TEST_SETENV=")) << retStr.toStdString();
 }

--- a/libs/utils/src/linglong/utils/command/cmd.cpp
+++ b/libs/utils/src/linglong/utils/command/cmd.cpp
@@ -12,7 +12,7 @@ namespace linglong::utils::command {
 
 Cmd::Cmd(const QString &command) noexcept
 {
-    this->command = command;
+    this->m_command = command;
 }
 
 Cmd::~Cmd() { }
@@ -24,10 +24,18 @@ linglong::utils::error::Result<QString> Cmd::exec() noexcept
 
 linglong::utils::error::Result<QString> Cmd::exec(const QStringList &args) noexcept
 {
-    LINGLONG_TRACE(QString("exec %1 %2").arg(command, args.join(" ")));
-    qDebug() << "exec" << command << args;
+    LINGLONG_TRACE(QString("exec %1 %2").arg(m_command, args.join(" ")));
+    qDebug() << "exec" << m_command << args;
     QProcess process;
-    process.setProgram(command);
+    process.setProgram(m_command);
+    if (!m_envs.isEmpty()) {
+        // Merge system and custom environment variables
+        QStringList envs = QProcess::systemEnvironment();
+        for (const auto &key : m_envs.keys()) {
+            envs.push_back(key + "=" + m_envs[key]);
+        }
+        process.setEnvironment(envs);
+    }
     process.setArguments(args);
     process.setProcessChannelMode(QProcess::MergedChannels);
     process.start();
@@ -45,16 +53,36 @@ linglong::utils::error::Result<QString> Cmd::exec(const QStringList &args) noexc
 
 linglong::utils::error::Result<bool> Cmd::exists() noexcept
 {
-    LINGLONG_TRACE(QString("check command %1 exists").arg(command));
-    qDebug() << "exists" << command;
+    LINGLONG_TRACE(QString("check command %1 exists").arg(m_command));
+    qDebug() << "exists" << m_command;
     QProcess process;
     process.setProgram("sh");
-    process.setArguments({ "-c", QString("command -v %1").arg(command) });
+    if (!m_envs.isEmpty()) {
+        // Merge system and custom environment variables
+        QStringList envs = QProcess::systemEnvironment();
+        for (const auto &key : m_envs.keys()) {
+            envs.push_back(key + "=" + m_envs[key]);
+        }
+        process.setEnvironment(envs);
+    }
+    process.setArguments({ "-c", QString("command -v %1").arg(m_command) });
+    process.setProcessChannelMode(QProcess::MergedChannels);
     process.start();
     if (!process.waitForFinished(-1)) {
         return LINGLONG_ERR(process.errorString(), process.error());
     }
     return process.exitCode() == 0;
+}
+
+// set environment, if value is empty, remove the environment
+Cmd &Cmd::setEnv(const QString &name, const QString &value) noexcept
+{
+    if (value.isEmpty()) {
+        m_envs.remove(name);
+        return *this;
+    }
+    m_envs[name] = value;
+    return *this;
 }
 
 } // namespace linglong::utils::command

--- a/libs/utils/src/linglong/utils/command/cmd.h
+++ b/libs/utils/src/linglong/utils/command/cmd.h
@@ -8,6 +8,10 @@
 
 #include "linglong/utils/error/error.h"
 
+#include <QMap>
+#include <QString>
+#include <QStringList>
+
 namespace linglong::utils::command {
 
 class Cmd
@@ -16,12 +20,14 @@ public:
     Cmd(const QString &command) noexcept;
     ~Cmd();
 
-    linglong::utils::error::Result<bool> exists() noexcept;
-    linglong::utils::error::Result<QString> exec() noexcept;
-    linglong::utils::error::Result<QString> exec(const QStringList &args) noexcept;
+    virtual linglong::utils::error::Result<bool> exists() noexcept;
+    virtual linglong::utils::error::Result<QString> exec() noexcept;
+    virtual linglong::utils::error::Result<QString> exec(const QStringList &args) noexcept;
+    virtual Cmd &setEnv(const QString &name, const QString &value) noexcept;
 
 private:
-    QString command;
+    QString m_command;
+    QMap<QString, QString> m_envs{};
 };
 
 } // namespace linglong::utils::command

--- a/misc/libexec/linglong/fetch-git-source
+++ b/misc/libexec/linglong/fetch-git-source
@@ -34,5 +34,7 @@ git add :/
 git reset --hard FETCH_HEAD
 
 # Fetch submodule
-git submodule update --init --recursive --depth 1
-git submodule foreach git reset --hard HEAD
+if [ -n "$GIT_SUBMODULES" ]; then
+    git submodule update --init --recursive --depth 1
+    git submodule foreach git reset --hard HEAD
+fi

--- a/tools/codegen.sh
+++ b/tools/codegen.sh
@@ -19,8 +19,11 @@ QUICKTYPE=${QUICKTYPE:=$(command -v quicktype || true)}
 if [ -z "$QUICKTYPE" ]; then
         pushd quicktype
         if not npx quicktype --version &>/dev/null; then
+                echo "Installing quicktype"
                 npm i
                 npm run build
+        else
+                echo "quicktype already installed"
         fi
         popd
 fi
@@ -108,6 +111,11 @@ generate() {
 
 # yq should use which written in go instead of python. https://github.com/mikefarah/yq
 YQ=${YQ:=$(command -v yq)}
+
+if [ -z "$YQ" ]; then
+        echo "yq not found"
+        exit 255
+fi
 
 "$YQ" e '.properties = ( [
         .$defs | keys | .[] as $type | {


### PR DESCRIPTION
1. Add environment variable support to Cmd class for process execution
2. Set GIT_SUBMODULES=true when executing source fetch scripts
3. Conditionally execute git submodule commands based on GIT_SUBMODULES env var
4. Fix member variable naming in Cmd class (command -> m_command)
5. Pass environment variables to command existence checking process

This change allows git submodules to be fetched only when explicitly enabled through the GIT_SUBMODULES environment variable, providing better control over the source fetching process. The environment variable mechanism was added to the Cmd utility class to support this feature, and existing command execution logic was updated to use proper member variable naming conventions.

Log: Added conditional git submodule fetching support in source fetcher

Influence:
1. Test git repository fetching with submodules enabled
2. Verify git repository fetching without submodules (default behavior)
3. Test environment variable passing in command execution
4. Verify command existence checking with environment variables
5. Test source fetching for projects with and without submodules
6. Validate that existing git fetch functionality remains unchanged

feat: 通过环境变量控制启用 git 子模块获取

1. 为 Cmd 类添加环境变量支持以执行进程
2. 在执行源码获取脚本时设置 GIT_SUBMODULES=true
3. 基于 GIT_SUBMODULES 环境变量条件性执行 git 子模块命令
4. 修正 Cmd 类中的成员变量命名（command -> m_command）
5. 将环境变量传递给命令存在性检查进程

此变更允许仅在通过 GIT_SUBMODULES 环境变量明确启用时才获取 git 子模块，
从而更好地控制源码获取过程。为支持此功能，向 Cmd 工具类添加了环境变量机
制，并更新了现有命令执行逻辑以使用正确的成员变量命名约定。

Log: 在源码获取器中添加条件性 git 子模块获取支持

Influence:
1. 测试启用子模块的 git 仓库获取
2. 验证不带子模块的 git 仓库获取（默认行为）
3. 测试命令执行中的环境变量传递
4. 验证带环境变量的命令存在性检查
5. 测试带和不带子模块的项目源码获取
6. 验证现有 git 获取功能保持不变