### PR TITLE
refactor: simplify container entrypoint generation

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -34,6 +34,7 @@
 #include "linglong/runtime/container_builder.h"
 #include "linglong/runtime/run_context.h"
 #include "linglong/utils/bash_quote.h"
+#include "linglong/utils/bash_command_helper.h"
 #include "linglong/utils/error/error.h"
 #include "linglong/utils/finally/finally.h"
 #include "linglong/utils/gettext.h"
@@ -871,9 +872,8 @@ int Cli::enter(const EnterOptions &options)
 
     qInfo() << "select container id" << QString::fromStdString(containerID);
     auto commands = options.commands;
-    if (commands.size() == 0) {
-        commands.emplace_back("bash");
-        commands.emplace_back("--login");
+    if (commands.empty()) {
+        commands = utils::BashCommandHelper::generateDefaultBashCommand();
     }
 
     auto opt = ocppi::runtime::ExecOption{

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -28,6 +28,7 @@ pfl_add_executable(
   src/linglong/utils/sha256_test.cpp
   src/linglong/utils/transaction_test.cpp
   src/linglong/utils/command_test.cpp
+  src/linglong/utils/bash_command_helper_test.cpp
   src/linglong/repo/config_test.cpp
   src/main.cpp
   COMPILE_FEATURES

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/bash_command_helper_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/bash_command_helper_test.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/utils/bash_command_helper.h"
+
+namespace linglong::utils {
+
+TEST(BashCommandHelper, GenerateBashCommandBase)
+{
+    auto cmd = BashCommandHelper::generateBashCommandBase();
+    EXPECT_EQ(cmd.size(), 6);
+    EXPECT_EQ(cmd[0], "env");
+    EXPECT_EQ(cmd[1], "-i");
+    EXPECT_EQ(cmd[2], "/bin/bash");
+    EXPECT_EQ(cmd[3], "--noprofile");
+    EXPECT_EQ(cmd[4], "--norc");
+    EXPECT_EQ(cmd[5], "-c");
+}
+
+TEST(BashCommandHelper, GenerateDefaultBashCommand)
+{
+    auto cmd = BashCommandHelper::generateDefaultBashCommand();
+    EXPECT_EQ(cmd.size(), 7);
+    EXPECT_EQ(cmd[6], "source /etc/profile; bash --norc");
+}
+
+TEST(BashCommandHelper, GenerateExecCommand)
+{
+    auto cmd = BashCommandHelper::generateExecCommand("test-command");
+    EXPECT_EQ(cmd.size(), 8);
+    EXPECT_EQ(cmd[0], "/run/linglong/container-init");
+    EXPECT_EQ(cmd[6], "-c");
+    EXPECT_EQ(cmd[7], "test-command");
+}
+
+TEST(BashCommandHelper, GenerateEntrypointScript)
+{
+    std::vector<std::string> args = { "arg1", "arg2 with space", "arg3" };
+    auto script = BashCommandHelper::generateEntrypointScript(args);
+
+    EXPECT_EQ(script.find("#!/bin/bash\n"), 0);
+    EXPECT_NE(script.find("source /etc/profile\n"), std::string::npos);
+
+    EXPECT_NE(script.find("arg1"), std::string::npos);
+    EXPECT_NE(script.find("arg2 with space"), std::string::npos);
+    EXPECT_NE(script.find("arg3"), std::string::npos);
+    EXPECT_NE(script.find("exec"), std::string::npos);
+}
+
+} // namespace linglong::utils

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -910,20 +910,6 @@ bool ContainerCfgBuilder::buildMountHome() noexcept
                                     .type = "bind" });
     }
 
-    // NOTE:
-    // Running ~/.bashrc from user home is meaningless in linglong container,
-    // and might cause some issues, so we mask it with the default one.
-    // https://github.com/linuxdeepin/linglong/issues/459
-    constexpr auto defaultBashrc = "/etc/skel/.bashrc";
-    if (std::filesystem::exists(defaultBashrc, ec)) {
-        homeMount->push_back(Mount{
-          .destination = *homePath / ".bashrc",
-          .options = string_list{ "ro", "rbind" },
-          .source = defaultBashrc,
-          .type = "bind",
-        });
-    }
-
     return true;
 }
 

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -51,6 +51,8 @@ pfl_add_library(
   src/linglong/utils/gkeyfile_wrapper.h
   src/linglong/utils/hooks.cpp
   src/linglong/utils/hooks.h
+  src/linglong/utils/bash_quote.h
+  src/linglong/utils/bash_command_helper.h
   COMPILE_FEATURES
   PUBLIC
   cxx_std_17

--- a/libs/utils/src/linglong/utils/bash_command_helper.h
+++ b/libs/utils/src/linglong/utils/bash_command_helper.h
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linglong/utils/bash_quote.h"
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace linglong::utils {
+
+class BashCommandHelper
+{
+public:
+    /**
+     * @brief 生成用于启动一个纯净 Bash shell 的基础命令行参数列表。
+     *
+     * 该函数构建一个字符串向量，代表启动一个 Bash 进程所需的基础命令和参数。
+     * 这个进程不继承父进程的环境变量，并且不自动加载任何用户的配置文件。
+     * 它为后续需要在一个可预测、无用户自定义配置影响的环境中执行命令的场景提供基础。
+     *
+     * @return 包含 'env -i bash --noprofile --norc -c' 的字符串向量。
+     */
+    inline static std::vector<std::string> generateBashCommandBase()
+    {
+        return {
+            "env",         // 'env' 命令，用于操作环境变量。
+            "-i",          // 'env' 的参数，用于创建一个空的环境，清除所有从父进程继承的变量。
+            "/bin/bash",   // 在干净环境中执行的 Shell。
+            "--noprofile", // 'bash' 的参数，防止它加载 .profile、.bash_profile 等登录脚本。
+            "--norc",      // 'bash' 的另一个参数，防止它加载 .bashrc 等交互式启动脚本。
+            "-c"           // 'bash' 的参数，用于执行一个单一的命令字符串。
+        };
+    }
+
+    /**
+     * @brief 生成用于启动一个完整的、默认 Bash shell 的命令参数列表。
+     *
+     * 该函数调用 generateBashCommandBase 来获得基础命令参数，
+     * 然后在其后添加一个命令字符串，用于：
+     * 1. 手动加载系统级的 /etc/profile 文件，以确保 PATH 等关键环境变量被正确设置。
+     * 2. 最终启动一个新的、交互式的 Bash shell，并且该 shell 不会加载用户的 .bashrc。
+     *
+     * 这个命令列表可用于启动一个干净但功能完备的 Bash 会话，
+     * 例如在容器或沙盒环境中。
+     *
+     * @return 包含完整命令和参数的字符串向量，其概念上等同于
+     * 'env -i bash --noprofile --norc -c "source /etc/profile; bash --norc"'。
+     */
+    inline static std::vector<std::string> generateDefaultBashCommand()
+    {
+        auto cmd = generateBashCommandBase();
+        cmd.push_back("source /etc/profile; bash --norc"); // 手动加载系统级的 profile
+                                                           // 脚本。这确保了在干净的环境中， 像 PATH
+                                                           // 这样关键的系统变量被正确设置。
+        return cmd;
+    }
+
+    /**
+     * @brief 生成在干净的 Bash 环境中执行命令的命令行参数。
+     *
+     * 该函数构建一个字符串向量，代表子进程的命令及其参数。
+     * 它旨在在 Linglong 容器内启动一个可执行程序，同时确保 Shell 环境是可预测的，
+     * 并且不受用户特定配置的影响。
+     *
+     * @param entrypoint 一个包含将由 Bash Shell 执行的命令的字符串。
+     * 这个命令通常是一个 Shell 脚本或要运行的程序。
+     * @return 包含程序路径及其参数的字符串向量。
+     * 概念上，生成的命令序列是：
+     * `/run/linglong/container-init env -i /bin/bash --noprofile --norc -c "<entrypoint>"`
+     */
+    inline static std::vector<std::string> generateExecCommand(const std::string &entrypoint)
+    {
+        // TODO: maybe we could use a symlink '/usr/bin/ll-init' points to
+        // '/run/linglong/container-init' will be better
+        auto cmd = generateBashCommandBase();
+        cmd.insert(cmd.begin(), "/run/linglong/container-init");
+        cmd.push_back(entrypoint);
+        return cmd;
+    }
+
+    /**
+     * @brief 从参数列表生成一个完整的 Bash 脚本字符串。
+     *
+     * 该函数接收一个字符串向量作为命令行参数，并构建一个可作为入口点的单一 Bash 脚本。
+     * 生成的脚本首先加载 /etc/profile 以建立基准系统环境，然后执行带参数的命令。
+     *
+     * @param args 一个代表命令及其参数的字符串向量。
+     * @return 包含完整 Bash 脚本的单一字符串。
+     */
+    inline static std::string generateEntrypointScript(const std::vector<std::string> &args)
+    {
+        std::stringstream script;
+        script << "#!/bin/bash\n";
+        script << "source /etc/profile\n";
+        script << "exec ";
+        for (const auto &arg : args) {
+            script << quoteBashArg(arg) << " ";
+        }
+        return script.str();
+    }
+};
+
+} // namespace linglong::utils


### PR DESCRIPTION
1. Introduce `BashCommandHelper` to centralize bash command generation.
2. Refactor container entrypoint script generation for better readability and maintainability.
3.  Remove masking of `~/.bashrc` as it's no longer necessary with the new entrypoint setup.

The previous method of generating the entrypoint script and default bash command was scattered and not easily maintainable. This commit introduces `BashCommandHelper` to encapsulate the logic for generating default bash commands, exec commands, and the entrypoint script. This improves code readability and makes it easier to modify these commands in the future.  Also removed the `~/.bashrc` masking, the new entrypoint creation mechanism has already solved the problem.

Influence:
1.  Test container execution with different commands and entrypoints.
2.  Verify that environment variables are correctly set up within the container.
3.  Ensure that the default bash shell is correctly initialized when entering the container without specific commands.

重构: 简化容器入口点生成

1. 引入 `BashCommandHelper` 来集中化 bash 命令的生成。
2. 重构容器入口点脚本的生成，以提高可读性和可维护性。
3. 移除 `~/.bashrc` 的屏蔽，因为使用新的入口点设置后不再需要它。

之前的入口点脚本和默认 bash 命令的生成方法分散且不易于维护。 此提交引入
`BashCommandHelper` 来封装生成默认 bash 命令、exec 命令和入口点脚本的逻 辑。 这提高了代码的可读性，并且更容易在将来修改这些命令。 此外，删除了
`~/.bashrc` 屏蔽，新的入口点创建机制已经解决了该问题。

Influence:
1. 使用不同的命令和入口点测试容器执行。
2. 验证容器内是否正确设置了环境变量。
3. 确保在没有特定命令的情况下进入容器时，正确初始化默认的 bash shell。