### PR TITLE
feat: Refactor namespace handling for rootless builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,7 @@ pkg_search_module(glib2 REQUIRED IMPORTED_TARGET glib-2.0)
 pkg_search_module(ostree1 REQUIRED IMPORTED_TARGET ostree-1)
 pkg_search_module(systemd REQUIRED IMPORTED_TARGET libsystemd)
 pkg_search_module(ELF REQUIRED IMPORTED_TARGET libelf)
+pkg_search_module(cap REQUIRED IMPORTED_TARGET libcap)
 
 set(ytj_ENABLE_TESTING NO)
 set(ytj_ENABLE_INSTALL NO)

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -67,6 +67,12 @@
 
 namespace linglong::builder {
 
+std::vector<std::string> Builder::privilegeBuilderCaps = {
+    "CAP_CHOWN",   "CAP_DAC_OVERRIDE",     "CAP_FOWNER",     "CAP_FSETID",
+    "CAP_KILL",    "CAP_NET_BIND_SERVICE", "CAP_SETFCAP",    "CAP_SETGID",
+    "CAP_SETPCAP", "CAP_SETUID",           "CAP_SYS_CHROOT",
+};
+
 namespace {
 
 /*!
@@ -318,49 +324,6 @@ utils::error::Result<void> installModule(QStringList installRules,
     return LINGLONG_OK;
 }
 
-bool runInNamespace()
-{
-    const int innerUid = 0;
-    const int innerGid = 0;
-    int outerUid = getuid();
-    int outerGid = getgid();
-
-    if (-1 == unshare(CLONE_NEWNS | CLONE_NEWUSER)) {
-        perror("unshare");
-        return false;
-    }
-
-    std::ofstream uidMapFile("/proc/self/uid_map");
-    if (!uidMapFile.is_open()) {
-        qCritical() << "failed to open uid_map";
-        return false;
-    }
-    std::ostringstream content;
-    content << innerUid << " " << outerUid << " 1\n";
-    uidMapFile << content.str();
-    uidMapFile.close();
-
-    std::ofstream setgroupsFile("/proc/self/setgroups");
-    if (!setgroupsFile.is_open()) {
-        qCritical() << "failed to open setgroups";
-        return false;
-    }
-    setgroupsFile << "deny";
-    setgroupsFile.close();
-
-    std::ofstream gidMapFile("/proc/self/gid_map");
-    if (!gidMapFile.is_open()) {
-        qCritical() << "failed to open gid_map";
-        return false;
-    }
-    std::ostringstream().swap(content);
-    content << innerGid << " " << outerGid << " 1\n";
-    gidMapFile << content.str();
-    gidMapFile.close();
-
-    return getuid() == innerUid;
-}
-
 } // namespace
 
 utils::error::Result<void> cmdListApp(repo::OSTreeRepo &repo)
@@ -451,18 +414,6 @@ void Builder::setConfig(const api::types::v1::BuilderConfig &cfg) noexcept
 utils::error::Result<void> Builder::buildStagePrepare() noexcept
 {
     LINGLONG_TRACE("build prepare");
-
-    // fuse-overlayfs should run in new user_namespaces and
-    // run with CAP_DAC_OVERRIDE capbilities. So we unshare
-    // process to new user_namespaces, and map root/root in
-    // namespace to current user/group.
-    //
-    // mount needs CAP_SYS_ADMIN capbilities in the
-    // user_namespaces associated with current mount_namespaces,
-    // So we also unshare to new mount_namespaces.
-    if (!runInNamespace()) {
-        return LINGLONG_ERR("failed to run in namespace");
-    }
 
     uid = getuid();
     gid = getgid();
@@ -762,8 +713,6 @@ utils::error::Result<void> Builder::processBuildDepends() noexcept
       .setAppId(this->project->package.id)
       // overwrite base overlay directory
       .setBasePath(baseOverlay->mergedDirPath().toStdString(), false)
-      .addUIdMapping(uid, uid, 1)
-      .addGIdMapping(gid, gid, 1)
       .bindDefault()
       .addExtraMount(ocppi::runtime::config::types::Mount{
         .destination = "/project",
@@ -771,7 +720,9 @@ utils::error::Result<void> Builder::processBuildDepends() noexcept
         .source = this->workingDir.absolutePath().toStdString(),
         .type = "bind" })
       .forwardDefaultEnv()
-      .appendEnv("LINYAPS_INIT_SINGLE_MODE", "1");
+      .appendEnv("LINYAPS_INIT_SINGLE_MODE", "1")
+      .disableUserNamespace()
+      .setCapabilities(privilegeBuilderCaps);
 
     // overwrite runtime overlay directory
     if (cfgBuilder.getRuntimePath() && runtimeOverlay) {
@@ -893,8 +844,6 @@ utils::error::Result<bool> Builder::buildStageBuild(const QStringList &args) noe
     }
     cfgBuilder.setAppId(this->project->package.id)
       .setBasePath(baseOverlay->mergedDirPath().toStdString(), false)
-      .addUIdMapping(uid, uid, 1)
-      .addGIdMapping(gid, gid, 1)
       .bindDefault()
       .setStartContainerHooks(
         std::vector<ocppi::runtime::config::types::Hook>{ ocppi::runtime::config::types::Hook{
@@ -905,7 +854,9 @@ utils::error::Result<bool> Builder::buildStageBuild(const QStringList &args) noe
         "/project/linglong/output",
         "/project/linglong/overlay",
       })
-      .appendEnv("LINYAPS_INIT_SINGLE_MODE", "1");
+      .appendEnv("LINYAPS_INIT_SINGLE_MODE", "1")
+      .disableUserNamespace()
+      .setCapabilities(privilegeBuilderCaps);
 
     if (this->buildOptions.isolateNetWork) {
         cfgBuilder.isolateNetWork();
@@ -1041,8 +992,6 @@ utils::error::Result<void> Builder::buildStagePreCommit() noexcept
     }
     cfgBuilder.setAppId(project.package.id)
       .setBasePath(baseOverlay->mergedDirPath().toStdString(), false)
-      .addUIdMapping(uid, uid, 1)
-      .addGIdMapping(gid, gid, 1)
       .bindDefault()
       .addExtraMount(ocppi::runtime::config::types::Mount{
         .destination = "/project",
@@ -1050,7 +999,9 @@ utils::error::Result<void> Builder::buildStagePreCommit() noexcept
         .source = this->workingDir.absolutePath().toStdString(),
         .type = "bind" })
       .forwardDefaultEnv()
-      .appendEnv("LINYAPS_INIT_SINGLE_MODE", "1");
+      .appendEnv("LINYAPS_INIT_SINGLE_MODE", "1")
+      .disableUserNamespace()
+      .setCapabilities(privilegeBuilderCaps);
 
     if (cfgBuilder.getRuntimePath() && runtimeOverlay) {
         cfgBuilder.setRuntimePath(runtimeOverlay->mergedDirPath().toStdString(), false);

--- a/libs/linglong/src/linglong/builder/linglong_builder.h
+++ b/libs/linglong/src/linglong/builder/linglong_builder.h
@@ -8,6 +8,7 @@
 
 #include "linglong/api/types/v1/BuilderConfig.hpp"
 #include "linglong/api/types/v1/BuilderProject.hpp"
+#include "linglong/oci-cfg-generators/container_cfg_builder.h"
 #include "linglong/repo/ostree_repo.h"
 #include "linglong/runtime/container_builder.h"
 #include "linglong/runtime/run_context.h"
@@ -136,6 +137,9 @@ private:
     QDir buildOutput;
     std::string installPrefix;
     runtime::RunContext buildContext;
+
+    // capabilities for build stage
+    static std::vector<std::string> privilegeBuilderCaps;
 };
 
 } // namespace linglong::builder

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -26,6 +26,7 @@ pfl_add_executable(
   src/linglong/builder/source_fetcher_test.cpp
   src/linglong/mocks/command.h
   src/linglong/utils/error/result_test.cpp
+  src/linglong/utils/namespce.cpp
   src/linglong/utils/log.cpp
   src/linglong/utils/sha256_test.cpp
   src/linglong/utils/transaction_test.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/namespce.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/namespce.cpp
@@ -1,0 +1,65 @@
+
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "linglong/utils/namespace.h"
+
+TEST(NamespaceTest, ParseSubuidRanges)
+{
+    uid_t uid = 0;
+    // multiple ranges for the same user
+    std::string content1 = "user1:100000:65536\n"
+                           "user2:200000:65536\n"
+                           "user1:300000:1000\n";
+    std::stringstream ss1(content1);
+    auto ranges1 = linglong::utils::detail::parseSubuidRanges(ss1, uid, "user1");
+    ASSERT_TRUE(ranges1.has_value());
+    ASSERT_EQ(ranges1->size(), 2);
+    EXPECT_EQ((*ranges1)[0].subuid, "100000");
+    EXPECT_EQ((*ranges1)[0].count, "65536");
+    EXPECT_EQ((*ranges1)[1].subuid, "300000");
+    EXPECT_EQ((*ranges1)[1].count, "1000");
+
+    // user not exists
+    std::stringstream ss2(content1);
+    auto ranges2 = linglong::utils::detail::parseSubuidRanges(ss2, uid, "nonexistent");
+    ASSERT_TRUE(ranges2.has_value());
+    EXPECT_TRUE((*ranges2).empty());
+
+    // missing field
+    std::string content3 = "user1:100000\n";
+    std::stringstream ss3(content3);
+    auto ranges3 = linglong::utils::detail::parseSubuidRanges(ss3, uid, "user1");
+    ASSERT_FALSE(ranges3.has_value());
+
+    // empty input
+    std::stringstream ss4("");
+    auto ranges4 = linglong::utils::detail::parseSubuidRanges(ss4, uid, "user1");
+    ASSERT_TRUE(ranges4.has_value());
+    EXPECT_TRUE((*ranges4).empty());
+
+    // username is prefix of another username
+    std::string content5 = "user1_long:100000:65536\n"
+                           "user1:200000:65536\n";
+    std::stringstream ss5(content5);
+    auto ranges5 = linglong::utils::detail::parseSubuidRanges(ss5, uid, "user1");
+    ASSERT_TRUE(ranges5.has_value());
+    ASSERT_EQ(ranges5->size(), 1);
+    EXPECT_EQ((*ranges5)[0].subuid, "200000");
+    EXPECT_EQ((*ranges5)[0].count, "65536");
+
+    // use uid
+    std::string content6 = "1000:100000:65536\n"
+                           "user1:200000:65536\n";
+    std::stringstream ss6(content6);
+    auto ranges6 = linglong::utils::detail::parseSubuidRanges(ss6, 1000, "user1");
+    ASSERT_TRUE(ranges6.has_value());
+    ASSERT_EQ(ranges6->size(), 2);
+    EXPECT_EQ((*ranges6)[0].subuid, "100000");
+    EXPECT_EQ((*ranges6)[0].count, "65536");
+    EXPECT_EQ((*ranges6)[1].subuid, "200000");
+    EXPECT_EQ((*ranges6)[1].count, "65536");
+}

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
@@ -183,9 +183,21 @@ public:
         return *this;
     }
 
+    ContainerCfgBuilder &disableUserNamespace() noexcept
+    {
+        disableUserNamespaceEnabled = true;
+        return *this;
+    }
+
     ContainerCfgBuilder &disablePatch() noexcept
     {
         applyPatchEnabled = false;
+        return *this;
+    }
+
+    ContainerCfgBuilder &setCapabilities(std::vector<std::string> caps) noexcept
+    {
+        capabilities = std::move(caps);
         return *this;
     }
 
@@ -196,15 +208,6 @@ public:
     const ocppi::runtime::config::types::Config &getConfig() const { return config; }
 
     Error getError() { return error_; }
-
-    // TODO
-    // ContainerCfgBuilder& mountPermission() noexcept;
-
-    // utils::error::Result<void> useBasicConfig() noexcept;
-    // utils::error::Result<void> useHostRootFSConfig() noexcept;
-    // utils::error::Result<void> useHostStaticsConfig() noexcept;
-
-    // utils::error::Result<void> addEnv(std::map<std::string, std::string> env) noexcept;
 
 private:
     bool checkValid() noexcept;
@@ -222,7 +225,6 @@ private:
     bool buildMountLocalTime() noexcept;
     bool buildMountNetworkConf() noexcept;
     bool buildQuirkVolatile() noexcept;
-    // TODO: impl buildXDG()
     bool buildXDGRuntime() noexcept;
     bool buildEnv() noexcept;
     bool applyPatch() noexcept;
@@ -322,6 +324,7 @@ private:
     std::vector<ocppi::runtime::config::types::Mount> mounts;
 
     bool isolateNetWorkEnabled = false;
+    bool disableUserNamespaceEnabled = false;
     bool applyPatchEnabled = true;
     bool isolateTmp{ false };
 
@@ -331,6 +334,7 @@ private:
     std::optional<std::filesystem::path> xAuthFile;
 
     std::vector<std::string> maskedPaths;
+    std::optional<std::vector<std::string>> capabilities;
     ocppi::runtime::config::types::Config config;
     std::string containerId;
 

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -34,6 +34,8 @@ pfl_add_library(
   src/linglong/utils/log/formatter.h
   src/linglong/utils/log/log.cpp
   src/linglong/utils/log/log.h
+  src/linglong/utils/namespace.cpp
+  src/linglong/utils/namespace.h
   src/linglong/utils/overlayfs.cpp
   src/linglong/utils/overlayfs.h
   src/linglong/utils/packageinfo_handler.cpp
@@ -65,4 +67,5 @@ pfl_add_library(
   tl::expected
   ytj::ytj
   linglong::ocppi
-  linglong::api)
+  linglong::api
+  PkgConfig::cap)

--- a/libs/utils/src/linglong/utils/namespace.cpp
+++ b/libs/utils/src/linglong/utils/namespace.cpp
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "namespace.h"
+
+#include "linglong/utils/command/cmd.h"
+#include "linglong/utils/log/log.h"
+
+#include <sys/capability.h>
+
+#include <array>
+#include <fstream>
+
+#include <pwd.h>
+#include <sched.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace linglong::utils {
+
+namespace detail {
+
+utils::error::Result<std::string> getUserName(uid_t uid)
+{
+    LINGLONG_TRACE("get user name");
+
+    auto bufSize = sysconf(_SC_GETPW_R_SIZE_MAX);
+    if (bufSize < 0) {
+        bufSize = 1024;
+    }
+
+    std::vector<char> buf(bufSize);
+    struct passwd pw;
+    struct passwd *result;
+    auto res = getpwuid_r(uid, &pw, buf.data(), buf.size(), &result);
+    if (res != 0) {
+        return LINGLONG_ERR(fmt::format("failed to get user name {}", res).c_str());
+    }
+
+    return result->pw_name;
+}
+
+utils::error::Result<std::vector<detail::SubuidRange>> parseSubuidRanges(std::istream &stream,
+                                                                         uid_t uid,
+                                                                         const std::string &name)
+{
+    LINGLONG_TRACE("parse subuid ranges");
+
+    std::vector<detail::SubuidRange> ranges;
+    std::string line;
+    while (std::getline(stream, line)) {
+        if (line.rfind(name + ":", 0) != 0 && line.rfind(std::to_string(uid) + ":", 0) != 0) {
+            continue;
+        }
+
+        auto pos = line.find(':');
+        if (pos != std::string::npos) {
+            auto end = line.find(':', pos + 1);
+            if (end == std::string::npos) {
+                return LINGLONG_ERR("invalid subuid file");
+            }
+            auto subuid = line.substr(pos + 1, end - pos - 1);
+            auto count = line.substr(end + 1);
+            ranges.push_back({ subuid, count });
+        }
+    }
+
+    return ranges;
+}
+
+utils::error::Result<std::vector<detail::SubuidRange>> getSubuidRange(uid_t uid, bool isUid)
+{
+    LINGLONG_TRACE("get subuid range");
+
+    auto username = detail::getUserName(uid);
+    if (!username) {
+        return LINGLONG_ERR("failed to get user name", username.error());
+    }
+
+    auto filename = isUid ? "/etc/subuid" : "/etc/subgid";
+    std::ifstream file(filename);
+    if (!file.is_open()) {
+        return {};
+    }
+
+    return detail::parseSubuidRanges(file, uid, *username);
+}
+
+} // namespace detail
+
+utils::error::Result<bool> needRunInNamespace()
+{
+    LINGLONG_TRACE("check need run in namespace");
+
+    auto caps = cap_get_proc();
+    if (!caps) {
+        return LINGLONG_ERR("failed to get capabilities");
+    }
+
+    cap_flag_value_t value;
+    if (cap_get_flag(caps, CAP_SYS_ADMIN, CAP_EFFECTIVE, &value) == -1) {
+        cap_free(caps);
+        return LINGLONG_ERR("failed to get capabilities");
+    }
+
+    cap_free(caps);
+
+    return value != CAP_SET;
+}
+
+// run command in namespace
+// try to clone process with new user_namespaces and mount_namespaces
+// and map root/root in namespace to current user/group, /etc/subuid and
+// /etc/subgid file will be considered
+utils::error::Result<int> runInNamespace(int argc, char *argv[])
+{
+    LINGLONG_TRACE("run in namespace");
+
+    auto entry = [](void *args) {
+        LINGLONG_TRACE("run in namespace entry");
+
+        auto *runInNamespaceArgs = static_cast<detail::RunInNamespaceArgs *>(args);
+        const auto &fd = runInNamespaceArgs->fd;
+
+        write(fd, "1", 1);
+
+        LogD("waiting mapping");
+
+        char buf;
+        if (read(fd, &buf, 1) != 1) {
+            return -1;
+        }
+        close(fd);
+
+        LogD("run command");
+
+        execvp(runInNamespaceArgs->argv[0], runInNamespaceArgs->argv);
+
+        LogD("execvp failed");
+        return -1;
+    };
+
+    int pair[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, pair) == -1) {
+        return LINGLONG_ERR("socketpair failed");
+    }
+
+    detail::RunInNamespaceArgs args{ argc, argv, pair[1] };
+    std::vector<char> stack(1024 * 1024);
+    auto pid = clone((int (*)(void *))entry,
+                     stack.data() + stack.size(),
+                     CLONE_NEWNS | CLONE_NEWUSER | SIGCHLD,
+                     &args);
+    if (pid < 0) {
+        return LINGLONG_ERR(fmt::format("clone failed {}", strerror(errno)).c_str(), errno);
+    }
+
+    close(pair[1]);
+
+    LogD("waiting child {}", pid);
+
+    char buf;
+    if (read(pair[0], &buf, 1) != 1) {
+        return LINGLONG_ERR("read failed");
+    }
+
+    auto mappingTool = [](bool isUid, pid_t pid) -> utils::error::Result<void> {
+        LINGLONG_TRACE("mapping tool");
+
+        auto id = isUid ? geteuid() : getegid();
+        LogD("mapping uid and gid, isUid: {}, id: {}", isUid, id);
+
+        auto ranges = detail::getSubuidRange(id, isUid);
+        if (!ranges) {
+            return LINGLONG_ERR("failed to get subuid range", ranges.error());
+        }
+
+        utils::command::Cmd cmd(isUid ? "newuidmap" : "newgidmap");
+        int containerID = 0;
+        QStringList args = { QString::number(pid),
+                             QString::number(containerID),
+                             QString::number(id),
+                             "1" };
+        for (const auto &range : *ranges) {
+            args << QString::number(containerID + 1) << range.subuid.c_str() << range.count.c_str();
+            containerID += std::stoi(range.count);
+        }
+
+        auto res = cmd.exec(args);
+        if (!res) {
+            return LINGLONG_ERR("newuidmap failed", res.error());
+        }
+
+        return LINGLONG_OK;
+    };
+
+    auto res = mappingTool(true, pid);
+    if (!res) {
+        return LINGLONG_ERR("failed to mapping uid", res.error());
+    }
+
+    res = mappingTool(false, pid);
+    if (!res) {
+        return LINGLONG_ERR("failed to mapping gid", res.error());
+    }
+
+    if (write(pair[0], "1", 1) == -1) {
+        return LINGLONG_ERR("write failed");
+    }
+    close(pair[0]);
+
+    int status;
+    while (true) {
+        auto res = waitpid(pid, &status, 0);
+        if (res == -1) {
+            if (errno == EINTR) {
+                continue;
+            }
+
+            return LINGLONG_ERR(fmt::format("waitpid failed {}", strerror(errno)).c_str());
+        }
+
+        if (WIFEXITED(status)) {
+            status = WEXITSTATUS(status);
+        } else if (WIFSIGNALED(status)) {
+            status = 128 + WTERMSIG(status);
+        } else {
+            status = -1;
+        }
+
+        LogD("child exit with status {}", status);
+        break;
+    }
+
+    return status;
+}
+
+} // namespace linglong::utils

--- a/libs/utils/src/linglong/utils/namespace.h
+++ b/libs/utils/src/linglong/utils/namespace.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linglong/utils/error/error.h"
+#include "ocppi/runtime/config/types/IdMapping.hpp"
+
+namespace linglong::utils {
+
+namespace detail {
+
+struct RunInNamespaceArgs
+{
+    int argc;
+    char **argv;
+    int fd;
+};
+
+struct SubuidRange
+{
+    std::string subuid;
+    std::string count;
+};
+
+utils::error::Result<std::string> getUserName(uid_t uid);
+utils::error::Result<std::vector<SubuidRange>> parseSubuidRanges(std::istream &stream,
+                                                                 uid_t uid,
+                                                                 const std::string &name);
+utils::error::Result<std::vector<SubuidRange>> getSubuidRange(uid_t uid, bool isUid);
+
+} // namespace detail
+
+utils::error::Result<bool> needRunInNamespace();
+utils::error::Result<int> runInNamespace(int argc, char *argv[]);
+
+} // namespace linglong::utils


### PR DESCRIPTION
Previously, a simple `unshare` call was made deep within the builder logic. This approach was brittle and has been replaced by a re-execution execution pattern at the application entry point.

The new implementation consists of:
- A check (`needRunInNamespace`) at startup to determine if the process has sufficient capabilities (`CAP_SYS_ADMIN`).
- If not, the application re-launches itself in a new user and mount namespace using `clone(CLONE_NEWNS | CLONE_NEWUSER)`.
- The parent process configures UID and GID mappings for the child using the external `newuidmap` and `newgidmap` tools. This maps the current user to root inside the new namespace and includes any subordinate UIDs/GIDs.
- The container configuration for build stages is updated to run within this parent namespace. It no longer creates a nested user namespace but instead operates with a specific, limited set of capabilities.

This change introduces a runtime dependency on the `newuidmap` and `newgidmap` utilities, which are typically provided by the `uidmap` package.