### PR TITLE
refactor: Centralize XDG and display configuration logic

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -804,7 +804,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     }
 
     // check oci runtime
-    auto path = QStandardPaths::findExecutable(ociRuntimeCLI);
+    auto path = QStandardPaths::findExecutable(ociRuntimeCLI, { BINDIR });
     if (path.isEmpty()) {
         qCritical() << ociRuntimeCLI << "not found";
         return -1;

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -2068,7 +2068,6 @@ utils::error::Result<void> Builder::run(const QStringList &modules,
     }
 
     linglong::generator::ContainerCfgBuilder cfgBuilder;
-    const auto XDGRuntimeDir = common::getAppXDGRuntimeDir(curRef->id.toStdString());
 
     cfgBuilder.setAppId(curRef->id.toStdString())
       .setAppCache(appCache)
@@ -2078,7 +2077,7 @@ utils::error::Result<void> Builder::run(const QStringList &modules,
       .bindDefault()
       .bindDevNode()
       .bindCgroup()
-      .bindXDGRuntime(XDGRuntimeDir)
+      .bindXDGRuntime()
       .bindUserGroup()
       .bindRemovableStorageMounts()
       .bindHostRoot()

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -750,8 +750,6 @@ int Cli::run(const RunOptions &options)
         return -1;
     }
 
-    const auto XDGRuntimeDir = common::getAppXDGRuntimeDir(curAppRef->id.toStdString());
-
     runContext.enableSecurityContext(runtime::getDefaultSecurityContexts());
 
     linglong::generator::ContainerCfgBuilder cfgBuilder;
@@ -762,7 +760,7 @@ int Cli::run(const RunOptions &options)
       .bindDefault()
       .bindDevNode()
       .bindCgroup()
-      .bindXDGRuntime(XDGRuntimeDir)
+      .bindXDGRuntime()
       .bindUserGroup()
       .bindRemovableStorageMounts()
       .bindHostRoot()

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -2435,14 +2435,13 @@ utils::error::Result<void> PackageManager::generateCache(const package::Referenc
         return LINGLONG_ERR(res);
     }
 
-    auto XDGRuntimeDir = common::getAppXDGRuntimeDir(ref.id.toStdString());
     cfgBuilder.setAppId(ref.id.toStdString())
       .setAppCache(appCache, false)
       .addUIdMapping(uid, uid, 1)
       .addGIdMapping(gid, gid, 1)
       .bindDefault()
       .bindCgroup()
-      .bindXDGRuntime(XDGRuntimeDir)
+      .bindXDGRuntime()
       .bindUserGroup()
       .forwardDefaultEnv()
       .addExtraMounts(std::vector<ocppi::runtime::config::types::Mount>{
@@ -2506,6 +2505,7 @@ utils::error::Result<void> PackageManager::generateCache(const package::Referenc
 #endif
 
     process.args = std::move(ldGenerateCmd);
+    auto XDGRuntimeDir = common::getAppXDGRuntimeDir(ref.id.toStdString());
     auto containerStateRoot = XDGRuntimeDir / "ll-box";
 
     ocppi::runtime::RunOption opt;

--- a/libs/linglong/src/linglong/runtime/run_context.cpp
+++ b/libs/linglong/src/linglong/runtime/run_context.cpp
@@ -422,7 +422,6 @@ void RunContext::detectDisplaySystem(generator::ContainerCfgBuilder &builder) no
         }
 
         builder.bindXOrgSocket(xOrgDisplay.value());
-        builder.appendEnv("DISPLAY", xOrgDisplayEnv);
         break;
     }
 
@@ -440,7 +439,6 @@ void RunContext::detectDisplaySystem(generator::ContainerCfgBuilder &builder) no
         }
 
         builder.bindXAuthFile(xOrgAuthFile.value());
-        builder.appendEnv("XAUTHORITY", xOrgAuthFileEnv);
         break;
     }
 
@@ -458,7 +456,6 @@ void RunContext::detectDisplaySystem(generator::ContainerCfgBuilder &builder) no
         }
 
         builder.bindWaylandSocket(waylandDisplay.value());
-        builder.appendEnv("WAYLAND_DISPLAY", waylandDisplayEnv);
         break;
     }
 }

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
@@ -126,7 +126,7 @@ public:
     ContainerCfgBuilder &
     bindDevNode(std::function<bool(const std::string &)> ifBind = nullptr) noexcept;
     ContainerCfgBuilder &bindCgroup() noexcept;
-    ContainerCfgBuilder &bindXDGRuntime(const std::filesystem::path &path) noexcept;
+    ContainerCfgBuilder &bindXDGRuntime() noexcept;
     ContainerCfgBuilder &bindRun() noexcept;
     ContainerCfgBuilder &bindTmp() noexcept;
     ContainerCfgBuilder &bindUserGroup() noexcept;
@@ -142,6 +142,10 @@ public:
     ContainerCfgBuilder &bindHostRoot() noexcept;
     ContainerCfgBuilder &bindHostStatics() noexcept;
     ContainerCfgBuilder &bindHome(std::filesystem::path hostHome) noexcept;
+
+    ContainerCfgBuilder &bindXOrgSocket(const std::filesystem::path &socket) noexcept;
+    ContainerCfgBuilder &bindXAuthFile(const std::filesystem::path &authFile) noexcept;
+    ContainerCfgBuilder &bindWaylandSocket(const std::filesystem::path &socket) noexcept;
 
     ContainerCfgBuilder &enablePrivateDir() noexcept;
     ContainerCfgBuilder &mapPrivate(std::string containerPath, bool isDir) noexcept;
@@ -184,12 +188,6 @@ public:
         applyPatchEnabled = false;
         return *this;
     }
-
-    void bindXOrgSocket(const std::filesystem::path &socket) noexcept;
-
-    void bindXAuthFile(const std::filesystem::path &authFile) noexcept;
-
-    void bindWaylandSocket(const std::filesystem::path &socket) noexcept;
 
     std::string ldConf(const std::string &triplet) const;
 
@@ -256,8 +254,7 @@ private:
     std::filesystem::path basePath;
     std::filesystem::path bundlePath;
     std::optional<std::filesystem::path> appCache;
-    std::filesystem::path hostXDGRuntimeMountPoint;
-    std::filesystem::path containerXDGRuntimeDir;
+    std::optional<std::filesystem::path> containerXDGRuntimeDir;
 
     bool runtimePathRo = true;
     bool appPathRo = true;


### PR DESCRIPTION
Key changes:
- `bindXDGRuntime` signature is simplified. The host path is now resolved internally during the build phase.
- `buildDisplaySystem` now handles creating a predictable graphics environment inside the container.
- X11 is configured with a stable socket path (`/tmp/.X11-unix/X0`) and `DISPLAY=:0`.
- Wayland socket path is now `XDG_RUNTIME_DIR/wayland-0` if xdg runtime dir mounted, otherwise is '/run/linglong/wayland-0'.