### PR TITLE
fix: correct no-dbus flag logic

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -748,7 +748,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
                                                   pkgManConn,
                                                   QCoreApplication::instance());
     // if --no-dbus flag is set, start package manager in sudo mode
-    if (!noDBusFlag) {
+    if (*noDBusFlag) {
         if (getuid() != 0) {
             qCritical() << "--no-dbus should only be used by root user.";
             return -1;


### PR DESCRIPTION
The logic for handling the `--no-dbus` flag was inverted.  It was checking `!noDBusFlag` which meant the sudo block was executed when `--no-dbus` was *not* set. This meant that the application attempted to use the package manager connection even when the user explicitly requested to not use dbus (and likely intended to run as root).  This commit corrects the logic by checking `*noDBusFlag`. Now the sudo block will only execute when `--no-dbus` is actually set.

Influence:
1. Test ll-cli commands with and without the `--no-dbus` flag as a normal user.  Verify that without `--no-dbus`, the commands fail due to insufficient permissions.
2. Test ll-cli commands with the `--no-dbus` flag as root. Verify that the commands succeed.
3. Test ll-cli commands without the `--no-dbus` flag as root. Verify that the commands succeed as they will connect via DBus.

fix: 修正 no-dbus 标志逻辑

`--no-dbus` 标志的处理逻辑被反转了。 它检查的是 `!noDBusFlag`，这意味着
当 *没有* 设置 `--no-dbus` 时，sudo 代码块会被执行。 这意味着即使当用户
明确要求不使用 dbus (并且可能打算以 root 身份运行) 时，应用程序也会尝试
使用包管理器连接。 此提交通过检查 `*noDBusFlag` 来更正逻辑。 现在，只有
在实际设置 `--no-dbus` 时，sudo 代码块才会执行。

Influence:
1. 作为普通用户，使用和不使用 `--no-dbus` 标志测试 ll-cli 命令。 验证在 没有 `--no-dbus` 的情况下，由于权限不足，命令会失败。
2. 作为 root 用户，使用 `--no-dbus` 标志测试 ll-cli 命令。 验证命令是否 成功。
3. 作为 root 用户，在没有 `--no-dbus` 标志的情况下测试 ll-cli 命令。 验 证命令是否成功，因为它们将通过 DBus 连接。