### PR TITLE
refactor: Use std::filesystem::path instead of QDir

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -1168,7 +1168,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     }
 
     linglong::builder::Builder builder(std::move(project),
-                                       QDir(cwd.c_str()),
+                                       cwd,
                                        repo,
                                        *containerBuilder,
                                        *builderCfg);

--- a/libs/linglong/src/linglong/builder/linglong_builder.h
+++ b/libs/linglong/src/linglong/builder/linglong_builder.h
@@ -15,7 +15,9 @@
 #include "linglong/utils/error/error.h"
 #include "linglong/utils/overlayfs.h"
 
+#include <filesystem>
 #include <string>
+#include <vector>
 
 namespace linglong::builder {
 
@@ -55,7 +57,7 @@ public:
     // 主要用于在构建完成后将linglong.yaml复制到应用中
     std::string projectYamlFile;
     explicit Builder(std::optional<api::types::v1::BuilderProject> project,
-                     const QDir &workingDir,
+                     std::filesystem::path workingDir,
                      repo::OSTreeRepo &repo,
                      runtime::ContainerBuilder &containerBuilder,
                      const api::types::v1::BuilderConfig &cfg);
@@ -105,7 +107,8 @@ private:
     utils::error::Result<void> generateEntries() noexcept;
     utils::error::Result<void> processBuildDepends() noexcept;
     utils::error::Result<void> commitToLocalRepo() noexcept;
-    std::unique_ptr<utils::OverlayFS> makeOverlay(QString lowerdir, QString overlayDir) noexcept;
+    std::unique_ptr<utils::OverlayFS> makeOverlay(const std::filesystem::path &lowerdir,
+                                                  const std::filesystem::path &overlayDir) noexcept;
     void fixLocaltimeInOverlay(std::unique_ptr<utils::OverlayFS> &base);
     utils::error::Result<package::Reference> ensureUtils(const std::string &id) noexcept;
     utils::error::Result<package::Reference> clearDependency(const std::string &ref,
@@ -115,13 +118,16 @@ private:
     auto generateBuildDependsScript() noexcept -> utils::error::Result<bool>;
     auto generateDependsScript() noexcept -> utils::error::Result<bool>;
     void takeTerminalForeground();
-    void mergeOutput(const QList<QDir> &src, const QDir &dest, const QStringList &target);
+    void mergeOutput(const std::vector<std::filesystem::path> &src,
+                     const std::filesystem::path &dest,
+                     const std::vector<std::string> &targets);
     void printBasicInfo();
     void printRepo();
 
 private:
     repo::OSTreeRepo &repo;
-    QDir workingDir;
+    std::filesystem::path workingDir;
+    std::filesystem::path internalDir;
     std::optional<api::types::v1::BuilderProject> project;
     runtime::ContainerBuilder &containerBuilder;
     api::types::v1::BuilderConfig cfg;

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -26,6 +26,7 @@ pfl_add_executable(
   src/linglong/builder/source_fetcher_test.cpp
   src/linglong/mocks/command.h
   src/linglong/utils/error/result_test.cpp
+  src/linglong/utils/file.cpp
   src/linglong/utils/namespce.cpp
   src/linglong/utils/log.cpp
   src/linglong/utils/sha256_test.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/file.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/file.cpp
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linglong/utils/file.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+class FileTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        src_dir = fs::temp_directory_path() / "copyDirectory_test_src";
+        dest_dir = fs::temp_directory_path() / "copyDirectory_test_dest";
+
+        fs::remove_all(src_dir);
+        fs::remove_all(dest_dir);
+
+        fs::create_directories(src_dir / "subdir1");
+        fs::create_directories(dest_dir);
+
+        std::ofstream(src_dir / "file1.txt") << "content1";
+        std::ofstream(src_dir / "subdir1" / "file2.txt") << "content2";
+        std::ofstream(src_dir / "ignored.txt") << "ignored";
+        fs::create_symlink("file1.txt", src_dir / "symlink1");
+        fs::create_symlink(fs::absolute(src_dir / "file1.txt"), src_dir / "symlink_abs");
+    }
+
+    void TearDown() override
+    {
+        fs::remove_all(src_dir);
+        fs::remove_all(dest_dir);
+    }
+
+    fs::path src_dir;
+    fs::path dest_dir;
+};
+
+TEST_F(FileTest, CopyDirectory)
+{
+    auto matcher = [](const fs::path &path) {
+        return path.filename() != "ignored.txt";
+    };
+
+    auto result = linglong::utils::copyDirectory(src_dir, dest_dir, matcher);
+    ASSERT_TRUE(result.has_value());
+
+    EXPECT_TRUE(fs::exists(dest_dir / "file1.txt"));
+    std::ifstream ifs(dest_dir / "file1.txt");
+    std::string content((std::istreambuf_iterator<char>(ifs)),
+                        (std::istreambuf_iterator<char>()));
+    EXPECT_EQ(content, "content1");
+
+    EXPECT_TRUE(fs::is_directory(dest_dir / "subdir1"));
+    EXPECT_TRUE(fs::exists(dest_dir / "subdir1" / "file2.txt"));
+
+    EXPECT_TRUE(fs::is_symlink(dest_dir / "symlink1"));
+    EXPECT_EQ(fs::read_symlink(dest_dir / "symlink1"), "file1.txt");
+
+    EXPECT_TRUE(fs::is_symlink(dest_dir / "symlink_abs"));
+    EXPECT_EQ(fs::read_symlink(dest_dir / "symlink_abs"), fs::absolute(src_dir / "file1.txt"));
+
+    EXPECT_FALSE(fs::exists(dest_dir / "ignored.txt"));
+}
+
+TEST_F(FileTest, CopyDirectory_OverwriteExisting)
+{
+    std::ofstream(dest_dir / "file1.txt") << "existing_content";
+
+    auto matcher = [](const fs::path &path) {
+        return path.filename() != "ignored.txt";
+    };
+
+    auto result = linglong::utils::copyDirectory(src_dir,
+                                               dest_dir,
+                                               matcher,
+                                               fs::copy_options::overwrite_existing
+                                                 | fs::copy_options::copy_symlinks);
+    ASSERT_TRUE(result.has_value());
+
+    EXPECT_TRUE(fs::exists(dest_dir / "file1.txt"));
+    std::ifstream ifs(dest_dir / "file1.txt");
+    std::string content((std::istreambuf_iterator<char>(ifs)),
+                        (std::istreambuf_iterator<char>()));
+    EXPECT_EQ(content, "content1");
+
+    EXPECT_TRUE(fs::is_directory(dest_dir / "subdir1"));
+    EXPECT_TRUE(fs::exists(dest_dir / "subdir1" / "file2.txt"));
+
+    EXPECT_TRUE(fs::is_symlink(dest_dir / "symlink1"));
+    EXPECT_EQ(fs::read_symlink(dest_dir / "symlink1"), "file1.txt");
+
+    EXPECT_TRUE(fs::is_symlink(dest_dir / "symlink_abs"));
+    EXPECT_EQ(fs::read_symlink(dest_dir / "symlink_abs"), fs::absolute(src_dir / "file1.txt"));
+
+    EXPECT_FALSE(fs::exists(dest_dir / "ignored.txt"));
+}
+
+TEST_F(FileTest, CopyDirectory_DestinationExists)
+{
+    std::ofstream(dest_dir / "file1.txt") << "existing_content";
+
+    auto matcher = [](const fs::path &path) {
+        return path.filename() != "ignored.txt";
+    };
+
+    auto result = linglong::utils::copyDirectory(src_dir, dest_dir, matcher);
+    ASSERT_TRUE(result.has_value());
+
+    EXPECT_TRUE(fs::exists(dest_dir / "file1.txt"));
+    std::ifstream ifs(dest_dir / "file1.txt");
+    std::string content((std::istreambuf_iterator<char>(ifs)),
+                        (std::istreambuf_iterator<char>()));
+    EXPECT_EQ(content, "existing_content");
+
+    EXPECT_TRUE(fs::is_directory(dest_dir / "subdir1"));
+    EXPECT_TRUE(fs::exists(dest_dir / "subdir1" / "file2.txt"));
+
+    EXPECT_TRUE(fs::is_symlink(dest_dir / "symlink1"));
+    EXPECT_EQ(fs::read_symlink(dest_dir / "symlink1"), "file1.txt");
+
+    EXPECT_TRUE(fs::is_symlink(dest_dir / "symlink_abs"));
+    EXPECT_EQ(fs::read_symlink(dest_dir / "symlink_abs"), fs::absolute(src_dir / "file1.txt"));
+
+    EXPECT_FALSE(fs::exists(dest_dir / "ignored.txt"));
+}

--- a/libs/utils/src/linglong/utils/file.h
+++ b/libs/utils/src/linglong/utils/file.h
@@ -10,6 +10,7 @@
 #include <string>
 
 namespace linglong::utils {
+
 linglong::utils::error::Result<std::string> readFile(std::string filepath);
 
 linglong::utils::error::Result<void> writeFile(const std::string &filepath,
@@ -17,4 +18,12 @@ linglong::utils::error::Result<void> writeFile(const std::string &filepath,
 
 linglong::utils::error::Result<uintmax_t>
 calculateDirectorySize(const std::filesystem::path &dir) noexcept;
+
+linglong::utils::error::Result<void>
+copyDirectory(const std::filesystem::path &src,
+              const std::filesystem::path &dest,
+              std::function<bool(const std::filesystem::path &)> matcher,
+              std::filesystem::copy_options options = std::filesystem::copy_options::copy_symlinks
+                | std::filesystem::copy_options::skip_existing);
+
 } // namespace linglong::utils

--- a/libs/utils/src/linglong/utils/overlayfs.h
+++ b/libs/utils/src/linglong/utils/overlayfs.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <QString>
+#include <filesystem>
 
 namespace linglong::utils {
 
@@ -15,21 +15,24 @@ public:
     OverlayFS(const OverlayFS &) = delete;
     OverlayFS &operator=(const OverlayFS &) = delete;
 
-    OverlayFS(QString lowerdir, QString upperdir, QString workdir, QString merged);
+    OverlayFS(std::filesystem::path lowerdir,
+              std::filesystem::path upperdir,
+              std::filesystem::path workdir,
+              std::filesystem::path merged);
     ~OverlayFS();
 
     bool mount();
     void unmount(bool clean = false);
 
-    QString upperDirPath() { return upperdir_; }
+    std::filesystem::path upperDirPath() { return upperdir_; }
 
-    QString mergedDirPath() { return merged_; }
+    std::filesystem::path mergedDirPath() { return merged_; }
 
 private:
-    QString lowerdir_;
-    QString upperdir_;
-    QString workdir_;
-    QString merged_;
+    std::filesystem::path lowerdir_;
+    std::filesystem::path upperdir_;
+    std::filesystem::path workdir_;
+    std::filesystem::path merged_;
 };
 
 } // namespace linglong::utils


### PR DESCRIPTION
Key changes include:
- The `Builder` and `OverlayFS` classes now store and operate on `std::filesystem::path` objects.
- A new utility function `utils::copyDirectory` is introduced to handle recursive directory copying with filtering.