### PR TITLE
fix: correct mock function naming from warp to wrap

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/builder/source_fetcher_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/builder/source_fetcher_test.cpp
@@ -34,7 +34,7 @@ TEST_F(SourceFetcherTest, FetchFileSource)
 
     QDir cacheDir("/tmp/cache");
     auto mockCmd = std::make_shared<MockCommand>("mock");
-    mockCmd->warpExecFunc = [&](const QStringList &args) {
+    mockCmd->wrapExecFunc = [&](const QStringList &args) {
         auto argsStr = args.join(" ").toStdString();
         EXPECT_TRUE(args[0].contains("fetch-file-source")) << argsStr;
         EXPECT_EQ(args[1].toStdString(), "/tmp/dest/" + source.name.value()) << argsStr;
@@ -62,7 +62,7 @@ TEST_F(SourceFetcherTest, FetchGitSource)
 
     QDir cacheDir("/tmp/cache");
     auto mockCmd = std::make_shared<MockCommand>("mock");
-    mockCmd->warpExecFunc = [&](const QStringList &args) {
+    mockCmd->wrapExecFunc = [&](const QStringList &args) {
         auto argsStr = args.join(" ").toStdString();
         EXPECT_TRUE(args[0].contains("fetch-git-source")) << argsStr;
         EXPECT_EQ(args[1].toStdString(), "/tmp/dest/" + source.name.value()) << argsStr;
@@ -92,10 +92,10 @@ TEST_F(SourceFetcherTest, gitSubmodules)
     {
         QDir cacheDir("/tmp/cache");
         auto mockCmd = std::make_shared<MockCommand>("mock");
-        mockCmd->warpExecFunc = [&](const QStringList &args) {
+        mockCmd->wrapExecFunc = [&](const QStringList &args) {
             return utils::error::Result<QString>("ok");
         };
-        mockCmd->warpSetEnvFunc = [&](const QString &name,
+        mockCmd->wrapSetEnvFunc = [&](const QString &name,
                                       const QString &value) -> linglong::utils::command::Cmd & {
             EXPECT_EQ(name, "GIT_SUBMODULES");
             EXPECT_EQ(value, "true");
@@ -111,10 +111,10 @@ TEST_F(SourceFetcherTest, gitSubmodules)
     {
         QDir cacheDir("/tmp/cache");
         auto mockCmd = std::make_shared<MockCommand>("mock");
-        mockCmd->warpExecFunc = [&](const QStringList &args) {
+        mockCmd->wrapExecFunc = [&](const QStringList &args) {
             return utils::error::Result<QString>("ok");
         };
-        mockCmd->warpSetEnvFunc = [&](const QString &name,
+        mockCmd->wrapSetEnvFunc = [&](const QString &name,
                                       const QString &value) -> linglong::utils::command::Cmd & {
             EXPECT_TRUE(value.isEmpty()) << name.toStdString();
             return *mockCmd;
@@ -184,7 +184,7 @@ TEST_F(SourceFetcherTest, FetchInvalidGitCommit)
     source.commit = "invalid_commit";
     SourceFetcher fetcher(source, cacheDir);
     auto mockCmd = std::make_shared<MockCommand>("mock");
-    mockCmd->warpExecFunc = [&](const QStringList &args) {
+    mockCmd->wrapExecFunc = [&](const QStringList &args) {
         LINGLONG_TRACE("FetchInvalidGitCommit");
         return LINGLONG_ERR("Invalid commit", -2);
     };
@@ -214,7 +214,7 @@ TEST_F(SourceFetcherTest, FetchInvalidFileDigest)
     source.digest = "invalid_digest";
     SourceFetcher fetcher(source, cacheDir);
     auto mockCmd = std::make_shared<MockCommand>("mock");
-    mockCmd->warpExecFunc = [&](const QStringList &args) {
+    mockCmd->wrapExecFunc = [&](const QStringList &args) {
         LINGLONG_TRACE("FetchInvalidFileDigest");
         return LINGLONG_ERR("Invalid digest", -3);
     };
@@ -236,7 +236,7 @@ TEST_F(SourceFetcherTest, FetchNoSetName)
 
     QDir cacheDir("/tmp/cache");
     auto mockCmd = std::make_shared<MockCommand>("mock");
-    mockCmd->warpExecFunc = [&](const QStringList &args) {
+    mockCmd->wrapExecFunc = [&](const QStringList &args) {
         return utils::error::Result<QString>("ok");
     };
     SourceFetcher fetcher(source, cacheDir);

--- a/libs/linglong/tests/ll-tests/src/linglong/mocks/command_mock.h
+++ b/libs/linglong/tests/ll-tests/src/linglong/mocks/command_mock.h
@@ -21,26 +21,26 @@ public:
     }
 
     // mock exec
-    std::function<linglong::utils::error::Result<QString>(const QStringList &)> warpExecFunc;
+    std::function<linglong::utils::error::Result<QString>(const QStringList &)> wrapExecFunc;
 
     linglong::utils::error::Result<QString> exec(const QStringList &args) noexcept override
     {
-        return warpExecFunc ? warpExecFunc(args) : Cmd::exec(args);
+        return wrapExecFunc ? wrapExecFunc(args) : Cmd::exec(args);
     }
 
     // mock exists
-    std::function<linglong::utils::error::Result<bool>()> warpExistsFunc;
+    std::function<linglong::utils::error::Result<bool>()> wrapExistsFunc;
 
     linglong::utils::error::Result<bool> exists() noexcept override
     {
-        return warpExistsFunc ? warpExistsFunc() : Cmd::exists();
+        return wrapExistsFunc ? wrapExistsFunc() : Cmd::exists();
     }
 
     // mock setEnv
-    std::function<linglong::utils::command::Cmd &(const QString &, const QString &)> warpSetEnvFunc;
+    std::function<linglong::utils::command::Cmd &(const QString &, const QString &)> wrapSetEnvFunc;
 
     Cmd &setEnv(const QString &name, const QString &value) noexcept override
     {
-        return warpSetEnvFunc ? warpSetEnvFunc(name, value) : Cmd::setEnv(name, value);
+        return wrapSetEnvFunc ? wrapSetEnvFunc(name, value) : Cmd::setEnv(name, value);
     }
 };

--- a/libs/linglong/tests/ll-tests/src/linglong/mocks/ostree_repo_mock.h
+++ b/libs/linglong/tests/ll-tests/src/linglong/mocks/ostree_repo_mock.h
@@ -34,13 +34,13 @@ public:
     }
 
     // mock getOverlayShareDir
-    std::function<QDir()> warpGetOverlayShareDirFunc;
+    std::function<QDir()> wrapGetOverlayShareDirFunc;
 
 protected:
     QDir getOverlayShareDir() const noexcept override
     {
-        if (warpGetOverlayShareDirFunc) {
-            return warpGetOverlayShareDirFunc();
+        if (wrapGetOverlayShareDirFunc) {
+            return wrapGetOverlayShareDirFunc();
         }
         return OSTreeRepo::getOverlayShareDir();
     }

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/ostree_repo_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/ostree_repo_test.cpp
@@ -114,6 +114,9 @@ TEST_F(RepoTest, exportDir)
 
     // 测试exportDir功能
     fs::path destDirPath = tempDir / "entries";
+    ostreeRepo->wrapGetOverlayShareDirFunc = [destDirPath]() {
+        return QDir(QString((destDirPath / "share").string().c_str()));
+    };
     {
         // 测试目标目录已存在同名文件的情况
         created = fs::create_directories(destDirPath / "share" / "applications", ec);
@@ -146,7 +149,7 @@ TEST_F(RepoTest, exportDir)
           << "exportDir failed: " << result.error().message().toStdString();
         EXPECT_FALSE(ec) << "Unexpected error code: " << ec.message();
     }
-    ostreeRepo->warpGetOverlayShareDirFunc = [destDirPath]() {
+    ostreeRepo->wrapGetOverlayShareDirFunc = [destDirPath]() {
         return QDir(QString((destDirPath / "apps/share").string().c_str()));
     };
     // 如果defaultShareDir已存在desktop, 则优先导出到defaultShareDir目录


### PR DESCRIPTION
1. Fixed typo in mock function naming from 'warp' to 'wrap' across multiple test files
2. Changed variable names including warpExecFunc to wrapExecFunc
3. Updated warpSetEnvFunc to wrapSetEnvFunc
4. Modified warpGetOverlayShareDirFunc to wrapGetOverlayShareDirFunc
5. All changes are in test files and mock headers, no production code affected

Influence:
1. Verify all test cases still pass with the renamed mock functions
2. Check test coverage remains the same
3. Ensure no impact on actual command execution functionality
4. Confirm mock behavior remains consistent with previous implementation

fix: 修正模拟函数命名从warp到wrap

1. 修复了多个测试文件中模拟函数命名从'warp'到'wrap'的拼写错误
2. 将变量名warpExecFunc改为wrapExecFunc
3. 更新warpSetEnvFunc为wrapSetEnvFunc
4. 修改warpGetOverlayShareDirFunc为wrapGetOverlayShareDirFunc
5. 所有更改都在测试文件和模拟头文件中，不影响生产代码

Influence:
1. 验证所有测试用例在重命名模拟函数后仍能通过
2. 检查测试覆盖率保持不变
3. 确保不影响实际命令执行功能
4. 确认模拟行为与之前实现保持一致