### PR TITLE
refactor: remove unused XDG integration cleanup method

### DIFF
--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -1883,39 +1883,6 @@ OSTreeRepo::listRemote(const package::FuzzyReference &fuzzyRef,
     return pkgInfos;
 }
 
-void OSTreeRepo::removeDanglingXDGIntergation() noexcept
-{
-    QDir entriesDir = this->repoDir.absoluteFilePath("entries/share");
-    QDirIterator it(entriesDir.absolutePath(),
-                    QDir::AllEntries | QDir::NoDot | QDir::NoDotDot | QDir::System,
-                    QDirIterator::Subdirectories);
-    while (it.hasNext()) {
-        it.next();
-        const auto info = it.fileInfo();
-        if (info.isDir()) {
-            continue;
-        }
-
-        if (!info.isSymLink()) {
-            // NOTE: Everything in entries should be directory or symbol link.
-            // But it can be some cache file, we should not remove it too.
-            qWarning() << "Invalid file detected." << info.absoluteFilePath();
-            qWarning() << "If the file is a cache or something like that, ignore this warning.";
-            continue;
-        }
-
-        if (info.exists()) {
-            continue;
-        }
-
-        if (!entriesDir.remove(it.filePath())) {
-            qCritical() << "Failed to remove" << it.filePath();
-            Q_ASSERT(false);
-        }
-    }
-    this->updateSharedInfo();
-}
-
 void OSTreeRepo::unexportReference(const std::string &layerDir) noexcept
 {
     QString layerDirStr = layerDir.c_str();

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -117,7 +117,6 @@ public:
 
     utils::error::Result<void> prune();
 
-    void removeDanglingXDGIntergation() noexcept;
     // exportReference should be called when LayerDir of ref is existed in local repo
     void exportReference(const package::Reference &ref) noexcept;
     // unexportReference should be called when LayerDir of ref is existed in local repo


### PR DESCRIPTION
1. Removed the removeDanglingXDGIntergation method from OSTreeRepo class
2. This method was responsible for cleaning up dangling symbolic links in the entries/share directory
3. The functionality is no longer needed as the XDG integration handling has been refactored
4. Removed corresponding declaration from the header file
5. This simplifies the codebase by eliminating unused code paths

Influence:
1. Verify that XDG desktop entries and mime types are still properly handled
2. Test application installation and removal to ensure no dangling links remain
3. Confirm that entries/share directory management works correctly
4. Verify that existing symbolic links are properly maintained

refactor: 移除未使用的 XDG 集成清理方法

1. 从 OSTreeRepo 类中移除了 removeDanglingXDGIntergation 方法
2. 该方法负责清理 entries/share 目录中的悬空符号链接
3. 由于 XDG 集成处理已重构，此功能不再需要
4. 从头文件中移除了相应的声明
5. 通过删除未使用的代码路径简化了代码库

Influence:
1. 验证 XDG 桌面条目和 MIME 类型是否仍正确处理
2. 测试应用程序安装和卸载，确保没有残留悬空链接
3. 确认 entries/share 目录管理正常工作
4. 验证现有符号链接是否正确维护