### PR TITLE
test: add client factory unit tests

### DIFF
--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -36,6 +36,7 @@ pfl_add_executable(
   src/linglong/utils/bash_command_helper_test.cpp
   src/linglong/repo/config_test.cpp
   src/linglong/repo/ostree_repo_test.cpp
+  src/linglong/repo/client_factory_test.cpp
   src/main.cpp
   COMPILE_FEATURES
   PUBLIC

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/client_factory_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/client_factory_test.cpp
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gtest/gtest.h>
+
+#include "linglong/repo/client_factory.h"
+
+#include <QString>
+
+using namespace linglong::repo;
+
+class ClientFactoryTest : public ::testing::Test
+{
+protected:
+    void SetUp() override { }
+
+    void TearDown() override { }
+};
+
+TEST_F(ClientFactoryTest, CreateWithQString)
+{
+    ClientFactory factory(QString("http://localhost:8081"));
+    auto client = factory.createClientV2();
+    EXPECT_NE(client, nullptr);
+}
+
+TEST_F(ClientFactoryTest, CreateWithStdString)
+{
+    ClientFactory factory(std::string("http://localhost:8081"));
+    auto client = factory.createClientV2();
+    EXPECT_NE(client, nullptr);
+}
+
+TEST_F(ClientFactoryTest, SetServerWithQString)
+{
+    ClientFactory factory(QString("http://localhost:8080"));
+    factory.setServer(QString("http://localhost:8084"));
+    auto client = factory.createClientV2();
+    EXPECT_NE(client, nullptr);
+}
+
+TEST_F(ClientFactoryTest, SetServerWithStdString)
+{
+    ClientFactory factory(std::string("http://localhost:8080"));
+    factory.setServer(std::string("http://localhost:8083"));
+    auto client = factory.createClientV2();
+    EXPECT_NE(client, nullptr);
+}


### PR DESCRIPTION
1. Added new test file client_factory_test.cpp to test ClientFactory functionality
2. Includes tests for creating clients with both QString and std::string parameters
3. Tests server URL setting functionality with both string types
4. Verifies client creation succeeds in all cases
5. Added test file to CMakeLists.txt for compilation

Influence:
1. Run the new unit tests to verify ClientFactory behavior
2. Check client creation with different server URLs
3. Verify server URL modification works correctly
4. Test with both QString and std::string parameters

test: 添加客户端工厂单元测试

1. 新增client_factory_test.cpp测试文件用于测试ClientFactory功能
2. 包含使用QString和std::string参数创建客户端的测试
3. 测试使用两种字符串类型设置服务器URL的功能
4. 验证所有情况下客户端创建成功
5. 将测试文件添加到CMakeLists.txt中进行编译

Influence:
1. 运行新单元测试验证ClientFactory行为
2. 检查使用不同服务器URL创建客户端
3. 验证服务器URL修改功能正常工作
4. 测试QString和std::string两种参数类型