### PR TITLE
test: add erofsfuse check in fuse-related tests

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/package/layer_packager_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/layer_packager_test.cpp
@@ -7,6 +7,7 @@
 #include "../mocks/layer_packager_mock.h"
 #include "linglong/api/types/v1/Generators.hpp"
 #include "linglong/package/layer_packager.h"
+#include "linglong/utils/command/cmd.h"
 #include "linglong/utils/error/error.h"
 #include "linglong/utils/strings.h"
 
@@ -114,7 +115,13 @@ TEST_F(LayerPackagerTest, LayerPackagerUnpackFuseOffset)
 
 TEST_F(LayerPackagerTest, LayerPackagerUnpackFuse)
 {
-
+    {
+        auto ret = utils::command::Cmd("erofsfuse").exists();
+        ASSERT_TRUE(ret.has_value()) << ret.error().message().toStdString();
+        if (!*ret) {
+            GTEST_SKIP() << "Skipping this test.";
+        }
+    }
     auto layerFileRet = package::LayerFile::New((layerFilePath).string().c_str());
     ASSERT_TRUE(layerFileRet.has_value())
       << "Failed to create layer file" << layerFileRet.error().message().toStdString();

--- a/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
@@ -145,6 +145,13 @@ TEST_F(UabFileTest, UnpackFuseOffset)
 
 TEST_F(UabFileTest, UnpackFuse)
 {
+    {
+        auto ret = utils::command::Cmd("erofsfuse").exists();
+        ASSERT_TRUE(ret.has_value()) << ret.error().message().toStdString();
+        if (!*ret) {
+            GTEST_SKIP() << "Skipping this test.";
+        }
+    }
     auto uab = MockUabFile(uabFile);
     uab.wrapIsFileReadableFunc = [](const std::string &path) {
         return false;
@@ -168,7 +175,7 @@ TEST_F(UabFileTest, UnpackFsck)
 {
     auto uab = MockUabFile(uabFile);
     uab.wrapCheckCommandExistsFunc = [](const std::string &command) {
-        if (command == "erofs-fuse") {
+        if (command == "erofsfuse") {
             return false;
         }
         return true;


### PR DESCRIPTION
1. Added check for erofsfuse command existence in LayerPackagerTest and UabFileTest
2. Skip tests if erofsfuse is not available
3. Updated command name from "erofs-fuse" to "erofsfuse" in UabFileTest::UnpackFsck
4. Added necessary header include for command utilities

These changes ensure tests requiring erofsfuse are only run when the command is actually available on the system, preventing test failures in environments without erofsfuse installed. The command name was also corrected to match the actual executable name.

Influence:
1. Verify tests are skipped when erofsfuse is not installed
2. Check tests run normally when erofsfuse is available
3. Confirm all fuse-related functionality works as expected when tests run

test: 在fuse相关测试中添加erofsfuse检查

1. 在LayerPackagerTest和UabFileTest中添加对erofsfuse命令存在的检查
2. 如果erofsfuse不可用则跳过测试
3. 在UabFileTest::UnpackFsck中将命令名称从"erofs-fuse"更新为"erofsfuse"
4. 添加了命令工具的必要头文件包含

这些更改确保需要erofsfuse的测试仅在系统上实际可用该命令时运行，防止在
没有安装erofsfuse的环境中测试失败。同时修正了命令名称以匹配实际可执行文
件名。

Influence:
1. 验证当erofsfuse未安装时测试是否被跳过
2. 检查当erofsfuse可用时测试是否正常运行
3. 确认当测试运行时所有fuse相关功能是否按预期工作