### PR TITLE
fix: improve test compatibility with older gtest versions

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/package/layer_packager_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/layer_packager_test.cpp
@@ -119,7 +119,11 @@ TEST_F(LayerPackagerTest, LayerPackagerUnpackFuse)
         auto ret = utils::command::Cmd("erofsfuse").exists();
         ASSERT_TRUE(ret.has_value()) << ret.error().message().toStdString();
         if (!*ret) {
+#ifdef GTEST_SKIP
             GTEST_SKIP() << "Skipping this test.";
+#else
+            return;
+#endif
         }
     }
     auto layerFileRet = package::LayerFile::New((layerFilePath).string().c_str());

--- a/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
@@ -149,7 +149,11 @@ TEST_F(UabFileTest, UnpackFuse)
         auto ret = utils::command::Cmd("erofsfuse").exists();
         ASSERT_TRUE(ret.has_value()) << ret.error().message().toStdString();
         if (!*ret) {
+#ifdef GTEST_SKIP
             GTEST_SKIP() << "Skipping this test.";
+#else
+            return;
+#endif
         }
     }
     auto uab = MockUabFile(uabFile);


### PR DESCRIPTION
1. Added conditional compilation to support both GTEST_SKIP and simple return for test skipping
2. This change makes the tests compatible with older versions of Google Test that don't support GTEST_SKIP
3. The modification ensures tests can be properly skipped when erofsfuse is not available, regardless of gtest version

Influence:
1. Verify tests can run on systems with older gtest versions
2. Check test skipping behavior when erofsfuse is not available
3. Ensure no test failures occur due to missing GTEST_SKIP macro

fix: 改进测试对旧版gtest的兼容性

1. 添加条件编译以同时支持GTEST_SKIP和简单返回的测试跳过方式
2. 此更改使测试兼容不支持GTEST_SKIP的旧版Google Test
3. 修改确保无论gtest版本如何，当erofsfuse不可用时都能正确跳过测试

Influence:
1. 验证测试能在使用旧版gtest的系统上运行
2. 检查当erofsfuse不可用时的测试跳过行为
3. 确保不会因缺少GTEST_SKIP宏导致测试失败