### PR TITLE
fix: replace SetUpTestSuite with SetUpTestCase for gtest compatibility

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/package/layer_packager_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/layer_packager_test.cpp
@@ -25,7 +25,7 @@ namespace linglong::package {
 class LayerPackagerTest : public ::testing::Test
 {
 public:
-    static void SetUpTestSuite()
+    static void SetUpTestCase()
     {
         char tempPath[] = "/var/tmp/linglong-layer-packager-test-SetUpTestSuite-XXXXXX";
         std::filesystem::path layerDirPath = mkdtemp(tempPath);
@@ -71,7 +71,7 @@ public:
         ASSERT_FALSE(ec) << "Failed to remove layer dir" << ec.message();
     }
 
-    static void TearDownTestSuite()
+    static void TearDownTestCase()
     {
         std::cout << "Cleanup shared resource" << std::endl;
         // 删除layer文件

--- a/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
@@ -27,7 +27,7 @@ namespace linglong::package {
 class UabFileTest : public ::testing::Test
 {
 protected:
-    static void SetUpTestSuite()
+    static void SetUpTestCase()
     {
         char tempPath[] = "/var/tmp/linglong-uab-file-test-XXXXXX";
         testDir = mkdtemp(tempPath);
@@ -107,7 +107,7 @@ protected:
         }
     }
 
-    static void TearDownTestSuite()
+    static void TearDownTestCase()
     {
         std::error_code ec;
         std::filesystem::remove_all(testDir, ec);


### PR DESCRIPTION
Changed SetUpTestSuite/TearDownTestSuite to SetUpTestCase/ TearDownTestCase in test files to maintain compatibility with older versions of Google Test framework. The newer naming convention (SetUpTestSuite) was introduced in more recent versions of gtest, while older versions only support SetUpTestCase.

This change ensures the test suite can run on systems with older gtest installations without requiring framework upgrades. The functionality remains exactly the same, only the method names are updated to match the older API convention.

Influence:
1. Verify all tests still run correctly after the change
2. Check test setup and teardown operations still work as expected
3. Confirm no regression in test coverage or functionality

fix: 将SetUpTestSuite替换为SetUpTestCase以提高gtest兼容性

将测试文件中的SetUpTestSuite/TearDownTestSuite改为SetUpTestCase/ TearDownTestCase，以保持与旧版Google Test框架的兼容性。较新版本的gtest引 入了新的命名约定(SetUpTestSuite)，而旧版本仅支持SetUpTestCase。

此更改确保测试套件可以在装有旧版gtest的系统上运行，而无需升级框架。功能
完全保持不变，只是更新了方法名称以匹配旧版API约定。

Influence:
1. 验证更改后所有测试仍能正确运行
2. 检查测试设置和清理操作是否仍按预期工作
3. 确认测试覆盖率和功能没有退化