### PR TITLE
feat: Let "qdbusxml2cpp" path being set manually

### DIFF
--- a/libs/dbus-api/CMakeLists.txt
+++ b/libs/dbus-api/CMakeLists.txt
@@ -37,7 +37,7 @@ function(linglong_add_dbus_interface target xml basename) # include
   if("${QT_VERSION_MAJOR}" STREQUAL "6")
     qt6_add_dbus_interface(INTERFACE_SOURCES ${xml} ${basename})
   else()
-    set(Qt5DBus_QDBUSXML2CPP_EXECUTABLE qdbusxml2cpp)
+    set(Qt5DBus_QDBUSXML2CPP_EXECUTABLE "${Qt5DBus_QDBUSXML2CPP_EXECUTABLE}")
     qt5_add_dbus_interface(INTERFACE_SOURCES ${xml} ${basename})
   endif()
   target_sources(${target} PRIVATE ${INTERFACE_SOURCES})


### PR DESCRIPTION
在这个patch提交前,玲珑编译时依赖宿主系统的qdbusxml2cpp在$PATH下,否则编译过程就会因为找不到哦啊qdbusxml2cpp命令报错而失败。
然而在一些发行版里**比如Fedora代表的RPM系**,Qt5及以后的Qt版本打包中qdbusxml2cpp命令放在了/usr/lib64/qt5/bin下并没透传到$PATH,而导致在Fedora上用Qt5编译玲珑产生错误,因此这个PR将Qdbusxml2cpp的路径设置为手动,由发行版编译时在debian/rules或者spec文件里通过指定Qt5DBus_QDBUSXML2CPP_EXECUTABLE变量让发行版去指定自己发行版下的qdbusxml2cpp命令放在哪里,比如RPM系就这么设置:
<img width="757" height="30" alt="图片" src="https://github.com/user-attachments/assets/1886f95b-465e-4a74-a2f1-68b3f01fb4f0" />
这么设置过之后,在Fedora 42/43/Rawhide,OpenEuler 24.03 LTS和EPEL 9/10下编译都是正常的,希望官方采纳这个,最好能**对这个PR进行更改让其在开发中能跟普适化**