### PR TITLE
fix: use TZDIR environment variable to bind localtime directory

### DIFF
--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -1268,8 +1268,14 @@ bool ContainerCfgBuilder::buildMountLocalTime() noexcept
                                             .type = "bind" });
     }
 
-    bindIfExist(*localtimeMount, "/usr/share/zoneinfo");
-    bindIfExist(*localtimeMount, "/etc/timezone");
+    auto *tzdir_env = getenv("TZDIR");
+    if (tzdir_env != nullptr && tzdir_env[0] != '\0')
+    {
+        bindIfExist(*localtimeMount, tzdir_env);
+    } else {
+        bindIfExist(*localtimeMount, "/usr/share/zoneinfo");
+        bindIfExist(*localtimeMount, "/etc/timezone");
+    }
 
     return true;
 }


### PR DESCRIPTION
The change improves portability by finding the localtime directory via the TZDIR environment variable. TZDIR is used by glibc, and on distos like nixos, they set TZDIR to `/etc/zoneinfo`.