### PR TITLE
fix: use Qt5DBusMacros to auto-locate qdbusxml2cpp

### DIFF
--- a/libs/dbus-api/CMakeLists.txt
+++ b/libs/dbus-api/CMakeLists.txt
@@ -37,7 +37,7 @@ function(linglong_add_dbus_interface target xml basename) # include
   if("${QT_VERSION_MAJOR}" STREQUAL "6")
     qt6_add_dbus_interface(INTERFACE_SOURCES ${xml} ${basename})
   else()
-    set(Qt5DBus_QDBUSXML2CPP_EXECUTABLE qdbusxml2cpp)
+    include(${Qt5DBus_DIR}/Qt5DBusMacros.cmake)
     qt5_add_dbus_interface(INTERFACE_SOURCES ${xml} ${basename})
   endif()
   target_sources(${target} PRIVATE ${INTERFACE_SOURCES})


### PR DESCRIPTION
use Qt5DBusMacros to auto-locate qdbusxml2cpp
让Qt5通过Qt5DBusMacros检测qdbusxml2cpp”