### PR TITLE
fix: base field is empty when use ll-cli search

### DIFF
--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -1858,6 +1858,7 @@ OSTreeRepo::listRemote(const package::FuzzyReference &fuzzyRef,
         auto *item = (request_register_struct_t *)entry->data;
         pkgInfos.emplace_back(api::types::v1::PackageInfoV2{
           .arch = { item->arch },
+          .base = { item->base },
           .channel = item->channel,
           .description = item->description,
           .id = item->app_id,


### PR DESCRIPTION
1. Added the `base` field from `request_register_struct_t` to `api::types::v1::PackageInfoV2` when listing remote packages.
2. This change ensures that the `base` information, which represents the base package ID that a package is derived from, is now included in the PackageInfoV2 data structure. This provides more comprehensive information about each package available in the repository, allowing clients to understand the lineage and dependencies of packages better.

Influence:
1. Verify that the `base` field is correctly populated in the PackageInfoV2 objects returned by the `listRemote` function.
2. Ensure that the UI displays the `base` information correctly, if the UI utilizes this field.
3. Test scenarios where packages have different `base` values to ensure proper handling and display of this data.
4. Check if filtering or searching by the `base` field works as expected, if such functionality is implemented.

feat: 向 PackageInfoV2 添加 base 字段

1. 在列出远程软件包时，将 `request_register_struct_t` 中的 `base` 字段添 加到 `api::types::v1::PackageInfoV2`。
2. 此更改确保 `base` 信息（表示软件包所基于的基础软件包 ID）现在包含在 PackageInfoV2 数据结构中。这提供了有关存储库中每个可用软件包的更全面的信
息，使客户端能够更好地了解软件包的沿袭和依赖关系。

Influence:
1. 验证 `base` 字段是否在 `listRemote` 函数返回的 PackageInfoV2 对象中正 确填充。
2. 确保 UI 正确显示 `base` 信息（如果 UI 使用此字段）。
3. 测试软件包具有不同 `base` 值的情况，以确保正确处理和显示此数据。
4. 检查按 `base` 字段进行过滤或搜索是否按预期工作（如果实现了此类 功能）。