### PR TITLE
refactor: using std::filesystem for file operations

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -287,33 +287,27 @@ int handleBuild(linglong::builder::Builder &builder, const BuildCommandOptions &
 
 int handleRun(linglong::builder::Builder &builder, const RunCommandOptions &options)
 {
-    qInfo() << "Handling run command";
+    LogI("Handling run command");
 
-    QStringList modules = { "binary" };
+    std::vector<std::string> modules = { "binary" };
     if (options.debugMode) {
-        modules.push_back("develop");
+        modules.emplace_back("develop");
     }
     if (!options.execModules.empty()) {
-        for (const std::string &module : options.execModules) {
-            modules.append(QString::fromStdString(module));
-        }
-    }
-    modules.removeDuplicates(); // Ensure modules are unique
-
-    QStringList commandList;
-    if (!options.commands.empty()) {
-        for (const auto &command : options.commands) {
-            commandList.append(QString::fromStdString(command));
+        for (const auto &module : options.execModules) {
+            if (std::find(modules.begin(), modules.end(), module) == modules.end()) {
+                modules.emplace_back(module);
+            }
         }
     }
 
-    auto result = builder.run(modules, commandList, options.debugMode);
+    auto result = builder.run(modules, options.commands, options.debugMode);
     if (!result) {
-        qCritical() << "Run failed: " << result.error();
+        LogE("Run failed: {}", result.error());
         return result.error().code();
     }
 
-    qInfo() << "Run completed successfully.";
+    LogI("Run completed successfully.");
     return 0;
 }
 

--- a/libs/linglong/src/linglong/builder/linglong_builder.h
+++ b/libs/linglong/src/linglong/builder/linglong_builder.h
@@ -8,7 +8,6 @@
 
 #include "linglong/api/types/v1/BuilderConfig.hpp"
 #include "linglong/api/types/v1/BuilderProject.hpp"
-#include "linglong/oci-cfg-generators/container_cfg_builder.h"
 #include "linglong/repo/ostree_repo.h"
 #include "linglong/runtime/container_builder.h"
 #include "linglong/runtime/run_context.h"
@@ -45,6 +44,10 @@ struct BuilderBuildOptions
     bool isolateNetWork{ false };
 };
 
+utils::error::Result<std::vector<std::filesystem::path>>
+installModule(const std::filesystem::path &buildOutput,
+              const std::filesystem::path &moduleOutput,
+              const std::unordered_set<std::string> &rules);
 utils::error::Result<void> cmdListApp(repo::OSTreeRepo &repo);
 utils::error::Result<void> cmdRemoveApp(repo::OSTreeRepo &repo,
                                         std::vector<std::string> refs,
@@ -85,7 +88,7 @@ public:
     static auto importLayer(repo::OSTreeRepo &repo, const QString &path)
       -> utils::error::Result<void>;
 
-    auto run(const QStringList &modules, const QStringList &args, bool debug = false)
+    auto run(std::vector<std::string> modules, std::vector<std::string> args, bool debug = false)
       -> utils::error::Result<void>;
     auto runtimeCheck() -> utils::error::Result<void>;
     auto runFromRepo(const package::Reference &ref, const std::vector<std::string> &args)
@@ -123,6 +126,7 @@ private:
                      const std::vector<std::string> &targets);
     void printBasicInfo();
     void printRepo();
+    bool checkDeprecatedInstallFile();
 
 private:
     repo::OSTreeRepo &repo;
@@ -137,10 +141,10 @@ private:
     int64_t gid;
 
     std::optional<package::Reference> projectRef;
-    QStringList packageModules;
+    std::vector<std::string> packageModules;
     std::unique_ptr<utils::OverlayFS> baseOverlay;
     std::unique_ptr<utils::OverlayFS> runtimeOverlay;
-    QDir buildOutput;
+    std::filesystem::path buildOutput;
     std::string installPrefix;
     runtime::RunContext buildContext;
 

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -2738,7 +2738,7 @@ utils::error::Result<package::LayerDir> OSTreeRepo::getMergedModuleDir(
 }
 
 utils::error::Result<package::LayerDir> OSTreeRepo::getMergedModuleDir(
-  const package::Reference &ref, const QStringList &loadModules) const noexcept
+  const package::Reference &ref, const std::vector<std::string> &loadModules) const noexcept
 {
     LINGLONG_TRACE("merge modules");
     QDir mergedDir = this->repoDir.absoluteFilePath("merged");
@@ -2757,7 +2757,8 @@ utils::error::Result<package::LayerDir> OSTreeRepo::getMergedModuleDir(
             || arch != ref.arch.toStdString()) {
             continue;
         }
-        if (!loadModules.contains(layer.info.packageInfoV2Module.c_str())) {
+        if (std::find(loadModules.begin(), loadModules.end(), layer.info.packageInfoV2Module)
+            == loadModules.end()) {
             continue;
         }
         commits.push_back(QString::fromStdString(layer.commit));

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -136,8 +136,8 @@ public:
     getMergedModuleDir(const package::Reference &ref, bool fallbackLayerDir = true) const noexcept;
     // 将指定的modules合并到临时目录，并返回合并后的layerDir，供打包者调试应用
     // 临时目录由调用者负责删除
-    [[nodiscard]] utils::error::Result<package::LayerDir>
-    getMergedModuleDir(const package::Reference &ref, const QStringList &modules) const noexcept;
+    [[nodiscard]] utils::error::Result<package::LayerDir> getMergedModuleDir(
+      const package::Reference &ref, const std::vector<std::string> &modules) const noexcept;
     std::vector<std::string> getModuleList(const package::Reference &ref) noexcept;
     [[nodiscard]] utils::error::Result<std::vector<std::string>>
     getRemoteModuleList(const package::Reference &ref,

--- a/libs/linglong/src/linglong/runtime/run_context.h
+++ b/libs/linglong/src/linglong/runtime/run_context.h
@@ -30,8 +30,9 @@ public:
     using ExtensionRuntimeLayerInfo =
       std::pair<api::types::v1::ExtensionDefine, std::reference_wrapper<RuntimeLayer>>;
 
-    utils::error::Result<void> resolveLayer(
-      const QStringList &modules = {}, const std::optional<std::string> &subRef = std::nullopt);
+    utils::error::Result<void>
+    resolveLayer(const std::vector<std::string> &modules = {},
+                 const std::optional<std::string> &subRef = std::nullopt);
 
     utils::error::Result<api::types::v1::RepositoryCacheLayersItem> getCachedItem();
 
@@ -55,7 +56,7 @@ private:
 struct ResolveOptions
 {
     bool depsBinaryOnly{ false };
-    std::optional<QStringList> appModules;
+    std::optional<std::vector<std::string>> appModules;
     std::optional<std::string> baseRef;
     std::optional<std::string> runtimeRef;
 };
@@ -74,7 +75,7 @@ public:
                                        const ResolveOptions &opts = ResolveOptions{});
 
     utils::error::Result<void> resolve(const api::types::v1::BuilderProject &target,
-                                       std::filesystem::path buildOutput);
+                                       const std::filesystem::path &buildOutput);
 
     utils::error::Result<void> fillContextCfg(generator::ContainerCfgBuilder &builder);
     api::types::v1::ContainerProcessStateInfo stateInfo();
@@ -99,7 +100,8 @@ public:
     bool hasRuntime() const { return !!runtimeLayer; }
 
 private:
-    utils::error::Result<void> resolveLayer(bool depsBinaryOnly, const QStringList &appModules);
+    utils::error::Result<void> resolveLayer(bool depsBinaryOnly,
+                                            const std::vector<std::string> &appModules);
     utils::error::Result<void> resolveExtension(RuntimeLayer &layer);
     utils::error::Result<void> fillExtraAppMounts(generator::ContainerCfgBuilder &builder);
     void detectDisplaySystem(generator::ContainerCfgBuilder &builder) noexcept;

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -24,6 +24,7 @@ pfl_add_executable(
   src/linglong/package/semver_version_test.cpp
   src/linglong/package/uab_file_test.cpp
   src/linglong/package/layer_packager_test.cpp
+  src/linglong/builder/linglong_builder.cpp
   src/linglong/builder/source_fetcher_test.cpp
   src/linglong/mocks/command_mock.h
   src/linglong/mocks/ostree_repo_mock.h

--- a/libs/linglong/tests/ll-tests/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/builder/linglong_builder.cpp
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#include "linglong/builder/linglong_builder.h"
+
+#include <gtest/gtest.h>
+
+#include "linglong/utils/error/error.h"
+#include "linglong/utils/global/initialize.h"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <unistd.h>
+
+// A RAII wrapper for a temporary directory created with mkdtemp.
+class TempDir
+{
+public:
+    TempDir(const std::string &prefix = "linglong-test-")
+    {
+        std::string tmppath_template =
+          (std::filesystem::temp_directory_path() / (prefix + "XXXXXX")).string();
+        std::vector<char> tmppath_c(tmppath_template.begin(), tmppath_template.end());
+        tmppath_c.push_back('\0');
+
+        char *result = mkdtemp(tmppath_c.data());
+        if (result != nullptr) {
+            _path = result;
+        }
+    }
+
+    ~TempDir()
+    {
+        if (!_path.empty()) {
+            std::error_code ec;
+            std::filesystem::remove_all(_path, ec);
+        }
+    }
+
+    TempDir(const TempDir &) = delete;
+    TempDir &operator=(const TempDir &) = delete;
+    TempDir(TempDir &&) = delete;
+    TempDir &operator=(TempDir &&) = delete;
+
+    const std::filesystem::path &path() const { return _path; }
+
+    bool isValid() const { return !_path.empty(); }
+
+private:
+    std::filesystem::path _path;
+};
+
+TEST(LinglongBuilder, installModule)
+{
+    linglong::utils::global::initLinyapsLogSystem("");
+
+    TempDir buildOutput;
+    ASSERT_TRUE(buildOutput.isValid());
+    TempDir moduleOutput;
+    ASSERT_TRUE(moduleOutput.isValid());
+
+    // Create test files and directories
+    const auto &buildPath = buildOutput.path();
+    std::filesystem::create_directories(buildPath / "include");
+    std::filesystem::create_directories(buildPath / "lib/debug");
+    std::filesystem::create_directories(buildPath / "bin");
+    std::filesystem::create_directories(buildPath / "share/icons/hicolor/48x48/apps");
+
+    std::ofstream(buildPath / "include/header.h");
+    std::ofstream(buildPath / "lib/libfoo.a");
+    std::ofstream(buildPath / "lib/libfoo.so");
+    std::ofstream(buildPath / "lib/debug/libfoo.so.debug");
+    std::ofstream(buildPath / "bin/tool");
+    std::ofstream(buildPath / "share/app.desktop");
+    std::ofstream(buildPath / "share/icons/hicolor/48x48/apps/app.png");
+
+    // Define install rules
+    std::unordered_set<std::string> rules = {
+        "^/include/.+",  // regex rule
+        "/lib/libfoo.a", // normal path rule
+        "/bin/tool",
+        "^/share/icons/.+", // regex rule for icons
+        "# a comment",      // comment rule
+        ""                  // empty rule
+    };
+
+    auto result = linglong::builder::installModule(buildOutput.path(), moduleOutput.path(), rules);
+    ASSERT_TRUE(result.has_value());
+
+    const auto &modulePath = moduleOutput.path();
+    // check files are moved
+    EXPECT_TRUE(std::filesystem::exists(modulePath / "include/header.h"));
+    EXPECT_TRUE(std::filesystem::exists(modulePath / "lib/libfoo.a"));
+    EXPECT_TRUE(std::filesystem::exists(modulePath / "bin/tool"));
+    EXPECT_TRUE(std::filesystem::exists(modulePath / "share/icons/hicolor/48x48/apps/app.png"));
+
+    // check files are NOT moved
+    EXPECT_FALSE(std::filesystem::exists(modulePath / "lib/libfoo.so"));
+    EXPECT_FALSE(std::filesystem::exists(modulePath / "lib/debug/libfoo.so.debug"));
+    EXPECT_FALSE(std::filesystem::exists(modulePath / "share/app.desktop"));
+
+    // check original files are removed (because they are moved)
+    EXPECT_FALSE(std::filesystem::exists(buildPath / "include/header.h"));
+    EXPECT_FALSE(std::filesystem::exists(buildPath / "lib/libfoo.a"));
+    EXPECT_FALSE(std::filesystem::exists(buildPath / "bin/tool"));
+    EXPECT_FALSE(std::filesystem::exists(buildPath / "share/icons/hicolor/48x48/apps/app.png"));
+
+    // check files that should not be moved are still there
+    EXPECT_TRUE(std::filesystem::exists(buildPath / "lib/libfoo.so"));
+    EXPECT_TRUE(std::filesystem::exists(buildPath / "lib/debug/libfoo.so.debug"));
+    EXPECT_TRUE(std::filesystem::exists(buildPath / "share/app.desktop"));
+
+    // Check returned installed file list
+    std::vector<std::string> expectedFiles = { "bin",
+                                               "bin/tool",
+                                               "include",
+                                               "include/header.h",
+                                               "lib",
+                                               "lib/libfoo.a",
+                                               "share",
+                                               "share/icons",
+                                               "share/icons/hicolor",
+                                               "share/icons/hicolor/48x48",
+                                               "share/icons/hicolor/48x48/apps",
+                                               "share/icons/hicolor/48x48/apps/app.png" };
+    std::vector<std::string> installedFiles;
+    for (const auto &p : *result) {
+        installedFiles.emplace_back(p);
+    }
+    std::sort(installedFiles.begin(), installedFiles.end());
+
+    std::sort(expectedFiles.begin(), expectedFiles.end());
+
+    EXPECT_EQ(installedFiles, expectedFiles);
+}

--- a/libs/utils/src/linglong/utils/file.h
+++ b/libs/utils/src/linglong/utils/file.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <string>
+#include <unordered_set>
 
 namespace linglong::utils {
 
@@ -22,8 +23,16 @@ calculateDirectorySize(const std::filesystem::path &dir) noexcept;
 linglong::utils::error::Result<void>
 copyDirectory(const std::filesystem::path &src,
               const std::filesystem::path &dest,
-              std::function<bool(const std::filesystem::path &)> matcher,
+              std::function<bool(const std::filesystem::path &)> matcher = {},
               std::filesystem::copy_options options = std::filesystem::copy_options::copy_symlinks
                 | std::filesystem::copy_options::skip_existing);
+
+linglong::utils::error::Result<void>
+moveFiles(const std::filesystem::path &src,
+          const std::filesystem::path &dest,
+          std::function<bool(const std::filesystem::path &)> matcher);
+
+linglong::utils::error::Result<std::vector<std::filesystem::path>>
+getFiles(const std::filesystem::path &dir);
 
 } // namespace linglong::utils


### PR DESCRIPTION
Refactors file and directory handling within the builder, replacing Qt-based implementations with the modern C++ standard library.

Key changes include:
- Removed support for the deprecated `$appid.install` file. Its presence now causes a build error to enforce the `modules` definition in the project configuration.
- Introduced `utils::moveFiles`, a new utility function that centralizes the logic for moving directory contents based on a flexible matcher predicate.
- Simplified the handling of the default `binary` and `develop` modules. The `binary` module now defaults to a "catch-all" rule (`/`) if not explicitly defined by the user.
- Added unit tests for the new `utils::moveFiles` function and the refactored `installModule` logic.