### PR TITLE
refactor: Centralize runtime directory management

### DIFF
--- a/libs/common/CMakeLists.txt
+++ b/libs/common/CMakeLists.txt
@@ -9,6 +9,8 @@ pfl_add_library(
   STATIC
   SOURCES
   # find -regex '\.\/*.+\.[ch]\(pp\)?\(.in\)?' -type f -printf '%P\n'| sort
+  src/linglong/common/dir.cpp
+  src/linglong/common/dir.h
   src/linglong/common/display.cpp
   src/linglong/common/display.h
   src/linglong/common/strings.cpp

--- a/libs/common/src/linglong/common/dir.cpp
+++ b/libs/common/src/linglong/common/dir.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linglong/common/dir.h"
+
+#include "linglong/common/xdg.h"
+
+namespace linglong::common::dir {
+
+std::filesystem::path getRuntimeDir() noexcept
+{
+    return xdg::getXDGRuntimeDir() / "linglong";
+}
+
+std::filesystem::path getAppRuntimeDir(const std::string &appId) noexcept
+{
+    return getRuntimeDir() / "apps" / appId;
+}
+
+std::filesystem::path getBundleDir(const std::string &containerId) noexcept
+{
+    return getRuntimeDir() / containerId;
+}
+
+} // namespace linglong::common::dir

--- a/libs/common/src/linglong/common/dir.h
+++ b/libs/common/src/linglong/common/dir.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <filesystem>
+
+namespace linglong::common::dir {
+
+// linglong Runtime directory is $XDG_RUNTIME_DIR/linglong, for example:
+// /run/user/$UID/linglong
+// /tmp/linglong-runtime-$UID/linglong
+std::filesystem::path getRuntimeDir() noexcept;
+
+std::filesystem::path getAppRuntimeDir(const std::string &appId) noexcept;
+
+std::filesystem::path getBundleDir(const std::string &containerId) noexcept;
+
+} // namespace linglong::common::dir

--- a/libs/common/src/linglong/common/xdg.cpp
+++ b/libs/common/src/linglong/common/xdg.cpp
@@ -16,12 +16,8 @@ std::filesystem::path getXDGRuntimeDir() noexcept
     }
 
     // fallback to default
-    return std::filesystem::path{ "/tmp" } / "linglong" / std::to_string(::getuid());
-}
-
-std::filesystem::path getAppXDGRuntimeDir(const std::string &appId) noexcept
-{
-    return getXDGRuntimeDir() / "linglong/apps" / appId;
+    // /tmp/linglong-runtime-$UID
+    return std::filesystem::path{ "/tmp" } / ("linglong-runtime-" + std::to_string(::getuid()));
 }
 
 } // namespace linglong::common::xdg

--- a/libs/common/src/linglong/common/xdg.h
+++ b/libs/common/src/linglong/common/xdg.h
@@ -11,6 +11,5 @@
 namespace linglong::common::xdg {
 
 std::filesystem::path getXDGRuntimeDir() noexcept;
-std::filesystem::path getAppXDGRuntimeDir(const std::string &appId) noexcept;
 
 } // namespace linglong::common::xdg

--- a/libs/linglong/src/linglong/builder/config.h
+++ b/libs/linglong/src/linglong/builder/config.h
@@ -9,7 +9,6 @@
 #include "linglong/api/types/v1/BuilderConfig.hpp"
 #include "linglong/utils/error/error.h"
 
-#include <QStandardPaths>
 #include <QString>
 
 namespace linglong::builder {

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -26,6 +26,7 @@
 #include "linglong/api/types/v1/SubState.hpp"
 #include "linglong/api/types/v1/UpgradeListResult.hpp"
 #include "linglong/cli/printer.h"
+#include "linglong/common/dir.h"
 #include "linglong/oci-cfg-generators/container_cfg_builder.h"
 #include "linglong/package/layer_file.h"
 #include "linglong/package/reference.h"
@@ -261,7 +262,7 @@ bool delegateToContainerInit(const std::string &containerID,
     struct sockaddr_un addr{};
     addr.sun_family = AF_UNIX;
 
-    auto bundleDir = linglong::runtime::getBundleDir(containerID);
+    auto bundleDir = linglong::common::dir::getBundleDir(containerID);
     const std::string socketPath = bundleDir / "init/socket";
 
     std::copy(socketPath.begin(), socketPath.end(), &addr.sun_path[0]);

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -13,7 +13,7 @@
 #include "linglong/api/types/v1/PackageManager1PruneResult.hpp"
 #include "linglong/api/types/v1/Repo.hpp"
 #include "linglong/api/types/v1/State.hpp"
-#include "linglong/common/xdg.h"
+#include "linglong/common/dir.h"
 #include "linglong/extension/extension.h"
 #include "linglong/package/layer_file.h"
 #include "linglong/package/layer_packager.h"
@@ -39,7 +39,6 @@
 #include <QEventLoop>
 #include <QJsonArray>
 #include <QMetaObject>
-#include <QStandardPaths>
 #include <QTimer>
 #include <QUuid>
 
@@ -2514,7 +2513,7 @@ utils::error::Result<void> PackageManager::generateCache(const package::Referenc
 #endif
 
     process.args = std::move(ldGenerateCmd);
-    auto XDGRuntimeDir = common::xdg::getAppXDGRuntimeDir(ref.id);
+    auto XDGRuntimeDir = common::dir::getAppRuntimeDir(ref.id);
     auto containerStateRoot = XDGRuntimeDir / "ll-box";
 
     ocppi::runtime::RunOption opt;

--- a/libs/linglong/src/linglong/runtime/container_builder.cpp
+++ b/libs/linglong/src/linglong/runtime/container_builder.cpp
@@ -6,7 +6,30 @@
 
 #include "linglong/runtime/container_builder.h"
 
+#include "linglong/common/dir.h"
+
 namespace linglong::runtime {
+
+utils::error::Result<std::filesystem::path> makeBundleDir(const std::string &containerID)
+{
+    LINGLONG_TRACE("get bundle dir");
+    auto bundle = common::dir::getBundleDir(containerID);
+    std::error_code ec;
+    if (std::filesystem::exists(bundle, ec)) {
+        std::filesystem::remove_all(bundle, ec);
+        if (ec) {
+            qWarning() << QString("failed to remove bundle directory %1: %2")
+                            .arg(bundle.c_str(), ec.message().c_str());
+        }
+    }
+
+    if (!std::filesystem::create_directories(bundle, ec) && ec) {
+        return LINGLONG_ERR(QString("failed to create bundle directory %1: %2")
+                              .arg(bundle.c_str(), ec.message().c_str()));
+    }
+
+    return bundle;
+}
 
 ContainerBuilder::ContainerBuilder(ocppi::cli::CLI &cli)
     : cli(cli)

--- a/libs/linglong/src/linglong/runtime/container_builder.h
+++ b/libs/linglong/src/linglong/runtime/container_builder.h
@@ -14,10 +14,11 @@
 #include "ocppi/cli/CLI.hpp"
 
 #include <QCryptographicHash>
-#include <QDir>
-#include <QStandardPaths>
 
 namespace linglong::runtime {
+
+// Used to obtain a clean container bundle directory.
+utils::error::Result<std::filesystem::path> makeBundleDir(const std::string &containerID);
 
 inline std::string genContainerID(const package::Reference &ref) noexcept
 {
@@ -36,36 +37,6 @@ inline std::string genContainerID(const package::Reference &ref) noexcept
       .toStdString();
 }
 
-// Used to obtain a clean container bundle directory.
-
-inline std::filesystem::path getBundleDir(const std::string &containerID) noexcept
-{
-    const std::filesystem::path runtimeDir =
-      QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation).toStdString();
-    return runtimeDir / "linglong" / containerID;
-}
-
-inline utils::error::Result<std::filesystem::path> makeBundleDir(const std::string &containerID)
-{
-    LINGLONG_TRACE("get bundle dir");
-    auto bundle = getBundleDir(containerID);
-    std::error_code ec;
-    if (std::filesystem::exists(bundle, ec)) {
-        std::filesystem::remove_all(bundle, ec);
-        if (ec) {
-            qWarning() << QString("failed to remove bundle directory %1: %2")
-                            .arg(bundle.c_str(), ec.message().c_str());
-        }
-    }
-
-    if (!std::filesystem::create_directories(bundle, ec) && ec) {
-        return LINGLONG_ERR(QString("failed to create bundle directory %1: %2")
-                              .arg(bundle.c_str(), ec.message().c_str()));
-    }
-
-    return bundle;
-}
-
 class ContainerBuilder : public QObject
 {
     Q_OBJECT
@@ -79,4 +50,4 @@ private:
     ocppi::cli::CLI &cli;
 };
 
-}; // namespace linglong::runtime
+} // namespace linglong::runtime

--- a/libs/linglong/src/linglong/runtime/wayland_security_ctx.cpp
+++ b/libs/linglong/src/linglong/runtime/wayland_security_ctx.cpp
@@ -4,7 +4,7 @@
 
 #include "linglong/runtime/wayland_security_ctx.h"
 
-#include "linglong/common/xdg.h"
+#include "linglong/common/dir.h"
 #include "linglong/utils/finally/finally.h"
 #include "linglong/utils/log/log.h"
 #include "wayland-security-context-v1.h"
@@ -115,7 +115,7 @@ WaylandSecurityContextManagerV1::createSecurityContext(
         }
     });
 
-    auto runtimeDir = linglong::common::xdg::getAppXDGRuntimeDir(builder.getAppId());
+    auto runtimeDir = linglong::common::dir::getAppRuntimeDir(builder.getAppId());
     auto waylandSocket = runtimeDir / "wayland-socket";
 
     std::error_code ec;

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -12,6 +12,7 @@ pfl_add_executable(
   DISABLE_INSTALL
   SOURCES
   # find -regex '\./src/.+\.[ch]\(pp\)?' -type f -printf '%P\n'| sort
+  src/linglong/common/xdg_test.cpp
   src/linglong/package/architecture_test.cpp
   src/linglong/package/fallback_version_test.cpp
   src/linglong/package/reference_test.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/common/xdg_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/common/xdg_test.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "linglong/common/xdg.h"
+#include "linglong/utils/command/env.h"
+
+#include <filesystem>
+
+class XDGTest : public ::testing::Test
+{
+protected:
+    void SetUp() override { }
+
+    void TearDown() override { }
+};
+
+TEST_F(XDGTest, GetXDGRuntimeDir)
+{
+    auto checkRuntimeDir = [](const std::filesystem::path &runtimeDir) {
+        if (std::filesystem::exists(runtimeDir)) {
+            // 1. if dir exists, it should be writable for the owner.
+            auto perms = std::filesystem::status(runtimeDir).permissions();
+            ASSERT_NE((perms & std::filesystem::perms::owner_write), std::filesystem::perms::none)
+              << "runtimeDir is not writable for owner: " << runtimeDir;
+        } else {
+            // 2. if dir does not exist, its parent dir should be writable by all users.
+            auto parentDir = runtimeDir.parent_path();
+            ASSERT_TRUE(std::filesystem::exists(parentDir))
+              << "parent of runtimeDir does not exist: " << parentDir;
+            auto perms = std::filesystem::status(parentDir).permissions();
+            ASSERT_NE((perms & std::filesystem::perms::others_write), std::filesystem::perms::none)
+              << "parent of runtimeDir is not writable by others: " << parentDir;
+        }
+    };
+
+    {
+        auto runtimeDir = linglong::common::xdg::getXDGRuntimeDir();
+        checkRuntimeDir(runtimeDir);
+    }
+
+    {
+        linglong::utils::command::EnvironmentVariableGuard env("XDG_RUNTIME_DIR", "/tmp");
+        auto runtimeDir = linglong::common::xdg::getXDGRuntimeDir();
+        ASSERT_EQ(runtimeDir, "/tmp");
+    }
+
+    {
+        linglong::utils::command::EnvironmentVariableGuard env("XDG_RUNTIME_DIR", "");
+        auto runtimeDir = linglong::common::xdg::getXDGRuntimeDir();
+        checkRuntimeDir(runtimeDir);
+    }
+}

--- a/libs/linglong/tests/ll-tests/src/linglong/mocks/linglong_builder_mock.h
+++ b/libs/linglong/tests/ll-tests/src/linglong/mocks/linglong_builder_mock.h
@@ -32,7 +32,7 @@ private:
 
     static linglong::runtime::ContainerBuilder &initTempContainerBuilder()
     {
-        auto tempCLI = ocppi::cli::crun::Crun::New("/usr/bin/sh");
+        auto static tempCLI = ocppi::cli::crun::Crun::New(std::filesystem::current_path());
         static linglong::runtime::ContainerBuilder cb(**tempCLI);
         return cb;
     }

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -9,6 +9,7 @@
 #include "configure.h"
 #include "linglong/api/types/v1/Generators.hpp"
 #include "linglong/api/types/v1/OciConfigurationPatch.hpp"
+#include "linglong/common/dir.h"
 #include "linglong/common/display.h"
 #include "linglong/common/xdg.h"
 #include "ocppi/runtime/config/types/Generators.hpp"
@@ -254,7 +255,7 @@ bool ContainerCfgBuilder::buildXDGRuntime() noexcept
         return false;
     }
 
-    auto hostXDGRuntimeMountPoint = common::xdg::getAppXDGRuntimeDir(appId);
+    auto hostXDGRuntimeMountPoint = common::dir::getAppRuntimeDir(appId);
     std::error_code ec;
     std::filesystem::create_directories(hostXDGRuntimeMountPoint, ec);
     if (ec) {


### PR DESCRIPTION
Introduce `common::dir` to provide a single source for all runtime directory paths, and adds unit tests for the XDG runtime directory retrieval.