### PR TITLE
refactor: use std::string for error tracing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,7 @@ if(NOT fmt_FOUND)
   add_library(fmt-lib INTERFACE)
   add_library(fmt::fmt ALIAS fmt-lib)
   target_include_directories(fmt-lib INTERFACE external/fmt/include)
+  target_compile_definitions(fmt-lib INTERFACE FMT_HEADER_ONLY)
 endif()
 
 # NOTE: UOS v20 do not have tl-expected packaged.

--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -105,7 +105,7 @@ std::string validateNonEmptyString(const std::string &parameter)
 linglong::utils::error::Result<linglong::api::types::v1::BuilderProject>
 parseProjectConfig(const std::filesystem::path &filename)
 {
-    LINGLONG_TRACE("parse project config " + QString::fromStdString(filename));
+    LINGLONG_TRACE("parse project config " + filename.string());
     std::cerr << "Using project file " + filename.string() << std::endl;
     auto project =
       linglong::utils::serialize::LoadYAMLFile<linglong::api::types::v1::BuilderProject>(filename);

--- a/libs/linglong/src/linglong/builder/config.cpp
+++ b/libs/linglong/src/linglong/builder/config.cpp
@@ -10,13 +10,15 @@
 #include "linglong/utils/error/error.h"
 #include "linglong/utils/serialize/yaml.h"
 
+#include <fmt/format.h>
+
 #include <fstream>
 
 namespace linglong::builder {
 
 auto loadConfig(const QString &file) noexcept -> utils::error::Result<api::types::v1::BuilderConfig>
 {
-    LINGLONG_TRACE(QString("load build config from %1").arg(file));
+    LINGLONG_TRACE(fmt::format("load build config from {}", file.toStdString()));
 
     try {
         QFile f(file);
@@ -43,7 +45,7 @@ auto loadConfig(const QString &file) noexcept -> utils::error::Result<api::types
 auto loadConfig(const QStringList &files) noexcept
   -> utils::error::Result<api::types::v1::BuilderConfig>
 {
-    LINGLONG_TRACE(QString("load build config from %1").arg(files.join(" ")));
+    LINGLONG_TRACE(fmt::format("load build config from {}", files.join(" ").toStdString()));
 
     for (const auto &file : files) {
         auto config = loadConfig(file);
@@ -62,7 +64,7 @@ auto loadConfig(const QStringList &files) noexcept
 auto saveConfig(const api::types::v1::BuilderConfig &cfg, const QString &path) noexcept
   -> utils::error::Result<void>
 {
-    LINGLONG_TRACE(QString("save config to %1").arg(path));
+    LINGLONG_TRACE(fmt::format("save config to {}", path.toStdString()));
 
     try {
         auto ofs = std::ofstream(path.toLocal8Bit());

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -79,10 +79,10 @@ namespace {
 
 linglong::utils::error::Result<bool> isChildProcess(pid_t parent, pid_t pid) noexcept
 {
-    LINGLONG_TRACE(QString{ "check if %1 is child of %2" }.arg(pid).arg(parent));
+    LINGLONG_TRACE(fmt::format("check if {} is child of {}", pid, parent));
 
     auto getppid = [](pid_t pid) -> Result<pid_t> {
-        LINGLONG_TRACE(QString{ "get ppid of %1" }.arg(pid));
+        LINGLONG_TRACE(fmt::format("get ppid of {}", pid));
         std::error_code ec;
         auto stat = std::filesystem::path("/proc/" + std::to_string(pid) + "/stat");
         auto fd = ::open(stat.c_str(), O_RDONLY);
@@ -1044,7 +1044,7 @@ int Cli::installFromFile(const QFileInfo &fileInfo,
                          const std::string &appid)
 {
     auto filePath = fileInfo.absoluteFilePath();
-    LINGLONG_TRACE(QString{ "install from file %1" }.arg(filePath));
+    LINGLONG_TRACE(fmt::format("install from file {}", filePath.toStdString()));
 
     QDBusReply<QString> authReply = this->authorization();
     if (!authReply.isValid() && authReply.error().type() == QDBusError::AccessDenied) {

--- a/libs/linglong/src/linglong/package/fallback_version.cpp
+++ b/libs/linglong/src/linglong/package/fallback_version.cpp
@@ -10,6 +10,8 @@
 #include "linglong/package/versionv1.h"
 #include "linglong/package/versionv2.h"
 
+#include <fmt/format.h>
+
 #include <charconv>
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
@@ -31,7 +33,7 @@ namespace linglong::package {
 
 utils::error::Result<FallbackVersion> FallbackVersion::parse(const std::string &raw) noexcept
 {
-    LINGLONG_TRACE(QString("parse fallback version %1").arg(raw.c_str()));
+    LINGLONG_TRACE(fmt::format("parse fallback version {}", raw));
     auto list = split(raw, '.', common::strings::splitOption::SkipEmpty);
     if (list.empty()) {
         return LINGLONG_ERR("parse fallback version failed");

--- a/libs/linglong/src/linglong/package/layer_dir.cpp
+++ b/libs/linglong/src/linglong/package/layer_dir.cpp
@@ -9,13 +9,15 @@
 #include "linglong/api/types/v1/Generators.hpp"
 #include "linglong/utils/packageinfo_handler.h"
 
+#include <fmt/format.h>
+
 #include <fstream>
 
 namespace linglong::package {
 
 utils::error::Result<api::types::v1::PackageInfoV2> LayerDir::info() const
 {
-    LINGLONG_TRACE("get layer info from " + this->absolutePath());
+    LINGLONG_TRACE(fmt::format("get layer info from {}", this->absolutePath().toStdString()));
 
     auto info = utils::parsePackageInfo(this->filePath("info.json"));
     if (!info) {

--- a/libs/linglong/src/linglong/package/layer_file.cpp
+++ b/libs/linglong/src/linglong/package/layer_file.cpp
@@ -123,7 +123,7 @@ utils::error::Result<quint32> LayerFile::binaryDataOffset() noexcept
 
 utils::error::Result<void> LayerFile::saveTo(const QString &destination) noexcept
 {
-    LINGLONG_TRACE(QString("save layer file to %1").arg(destination));
+    LINGLONG_TRACE(fmt::format("save layer file to {}", destination.toStdString()));
 
     if (!this->copy(destination)) {
         return LINGLONG_ERR(*this);

--- a/libs/linglong/src/linglong/package/uab_packager.cpp
+++ b/libs/linglong/src/linglong/package/uab_packager.cpp
@@ -105,7 +105,7 @@ utils::error::Result<void> elfHelper::addNewSection(const QByteArray &sectionNam
                                                     const QFileInfo &dataFile,
                                                     const QStringList &flags) const noexcept
 {
-    LINGLONG_TRACE(QString{ "add section:%1" }.arg(QString{ sectionName }))
+    LINGLONG_TRACE(fmt::format("add section:{}", sectionName.toStdString()))
 
     auto args =
       QStringList{ QString{ "--add-section" },

--- a/libs/linglong/src/linglong/package/version.cpp
+++ b/libs/linglong/src/linglong/package/version.cpp
@@ -8,6 +8,8 @@
 #include "linglong/package/fallback_version.h"
 #include "linglong/package/versionv2.h"
 
+#include <fmt/format.h>
+
 #include <QRegularExpression>
 #include <QString>
 
@@ -24,7 +26,7 @@ namespace linglong::package {
 utils::error::Result<Version> Version::parse(const std::string &raw,
                                              const ParseOptions parseOpt) noexcept
 {
-    LINGLONG_TRACE(QString("parse version %1").arg(raw.c_str()));
+    LINGLONG_TRACE(fmt::format("parse version {}", raw));
 
     auto versionV2 = VersionV2::parse(raw, parseOpt.strict);
     if (versionV2) {
@@ -49,7 +51,7 @@ utils::error::Result<Version> Version::parse(const std::string &raw,
 
 utils::error::Result<void> Version::validateDependVersion(const std::string &raw) noexcept
 {
-    LINGLONG_TRACE(QString{ "validate depend version %1" }.arg(raw.c_str()));
+    LINGLONG_TRACE(fmt::format("validate depend version {}", raw));
     static auto regexExp = []() noexcept {
         QRegularExpression regexExp(R"(^(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?$)");
         regexExp.optimize();

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -143,7 +143,7 @@ PackageManager::~PackageManager()
 
 utils::error::Result<bool> PackageManager::isRefBusy(const package::Reference &ref) noexcept
 {
-    LINGLONG_TRACE(QString{ "check if ref[%1] is used by some apps" }.arg(ref.toString().c_str()));
+    LINGLONG_TRACE(fmt::format("check if ref[{}] is used by some apps", ref.toString()));
 
     auto ret = lockRepo();
     if (!ret) {
@@ -2076,7 +2076,7 @@ void PackageManager::pullDependency(PackageTask &taskContext,
         return;
     }
 
-    LINGLONG_TRACE("pull dependencies of " + QString::fromStdString(info.id));
+    LINGLONG_TRACE("pull dependencies of " + info.id);
 
     utils::Transaction transaction;
     if (info.runtime) {

--- a/libs/linglong/src/linglong/repo/config.cpp
+++ b/libs/linglong/src/linglong/repo/config.cpp
@@ -11,13 +11,15 @@
 #include "linglong/utils/serialize/yaml.h"
 #include "ytj/ytj.hpp"
 
+#include <fmt/format.h>
+
 #include <fstream>
 
 namespace linglong::repo {
 
 utils::error::Result<api::types::v1::RepoConfigV2> loadConfig(const QString &file) noexcept
 {
-    LINGLONG_TRACE(QString("load repo config from %1").arg(file));
+    LINGLONG_TRACE(fmt::format("load repo config from {}", file.toStdString()));
 
     try {
         auto ifs = std::ifstream(file.toLocal8Bit());
@@ -46,7 +48,7 @@ utils::error::Result<api::types::v1::RepoConfigV2> loadConfig(const QString &fil
 
 utils::error::Result<api::types::v1::RepoConfigV2> loadConfig(const QStringList &files) noexcept
 {
-    LINGLONG_TRACE(QString("load repo config from %1").arg(files.join(" ")));
+    LINGLONG_TRACE(fmt::format("load repo config from {}", files.join(" ").toStdString()));
 
     for (const auto &file : files) {
         auto config = loadConfig(file);
@@ -65,7 +67,7 @@ utils::error::Result<api::types::v1::RepoConfigV2> loadConfig(const QStringList 
 utils::error::Result<void> saveConfig(const api::types::v1::RepoConfigV2 &cfg,
                                       const QString &path) noexcept
 {
-    LINGLONG_TRACE(QString("save config to %1").arg(path));
+    LINGLONG_TRACE(fmt::format("save config to {}", path.toStdString()));
 
     try {
         auto defaultRepoExists =

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -446,7 +446,8 @@ createOstreeRepo(const QDir &location,
                  const linglong::api::types::v1::RepoConfigV2 &config,
                  const QString &parent = "") noexcept
 {
-    LINGLONG_TRACE("create linglong repository at " + location.absolutePath());
+    LINGLONG_TRACE(
+      fmt::format("create linglong repository at {}", location.absolutePath().toStdString()));
 
     if (!QFileInfo(location.absolutePath()).isWritable()) {
         return LINGLONG_ERR("permission denied");
@@ -631,8 +632,7 @@ utils::error::Result<void> OSTreeRepo::handleRepositoryUpdate(
   QDir layerDir, const api::types::v1::RepositoryCacheLayersItem &layer) noexcept
 {
     std::string refspec = ostreeRefSpecFromLayerItem(layer);
-    LINGLONG_TRACE(QString("checkout %1 from ostree repository to layers dir")
-                     .arg(QString::fromStdString(refspec)));
+    LINGLONG_TRACE(fmt::format("checkout {} from ostree repository to layers dir", refspec));
 
     int root = open("/", O_DIRECTORY);
     auto _ = utils::finally::finally([root]() {
@@ -685,8 +685,7 @@ utils::error::Result<void> OSTreeRepo::handleRepositoryUpdate(
 
 utils::error::Result<QDir> OSTreeRepo::ensureEmptyLayerDir(const std::string &commit) const noexcept
 {
-    LINGLONG_TRACE(
-      QString{ "ensure empty layer dir exist %1" }.arg(QString::fromStdString(commit)));
+    LINGLONG_TRACE(fmt::format("ensure empty layer dir exist {}", commit));
 
     std::filesystem::path dir =
       this->repoDir.absoluteFilePath(QString::fromStdString("layers/" + commit)).toStdString();
@@ -771,7 +770,7 @@ OSTreeRepo::OSTreeRepo(const QDir &path,
     this->repoDir = path;
 
     {
-        LINGLONG_TRACE("use linglong repo at " + path.absolutePath());
+        LINGLONG_TRACE(fmt::format("use linglong repo at {}", path.absolutePath().toStdString()));
 
         repoPath = g_file_new_for_path(this->ostreeRepoDir().absolutePath().toLocal8Bit());
         ostreeRepo = ostree_repo_new(repoPath);
@@ -1082,7 +1081,7 @@ utils::error::Result<void> OSTreeRepo::pushToRemote(const std::string &remoteRep
                                                     const package::Reference &reference,
                                                     const std::string &module) const noexcept
 {
-    LINGLONG_TRACE("push " + reference.toString());
+    LINGLONG_TRACE(fmt::format("push {}", reference.toString()));
     auto layerDir = this->getLayerDir(reference, module);
     if (!layerDir) {
         return LINGLONG_ERR("layer not found", layerDir);
@@ -1188,7 +1187,7 @@ utils::error::Result<void> OSTreeRepo::remove(const package::Reference &ref,
                                               const std::string &module,
                                               const std::optional<std::string> &subRef) noexcept
 {
-    LINGLONG_TRACE("remove " + ref.toString());
+    LINGLONG_TRACE(fmt::format("remove {}", ref.toString()));
 
     if (module.empty()) {
         return LINGLONG_ERR("module is empty");
@@ -1286,7 +1285,7 @@ GVariantBuilder OSTreeRepo::initOStreePullOptions(const std::string &ref) noexce
 utils::error::Result<std::vector<guint64>>
 OSTreeRepo::getCommitSize(const std::string &remote, const std::string &refString) noexcept
 {
-    LINGLONG_TRACE("get commit size " + QString::fromStdString(refString));
+    LINGLONG_TRACE("get commit size " + refString);
 #if OSTREE_CHECK_VERSION(2020, 1)
     g_autoptr(GError) gErr = nullptr;
     GVariantBuilder builder = this->initOStreePullOptions(refString);
@@ -1381,7 +1380,7 @@ void OSTreeRepo::pull(service::PackageTask &taskContext,
     if (repo) {
         pullRepo = repo.value();
     }
-    LINGLONG_TRACE(std::string{ "pull " + refString + " from " + pullRepo.name }.c_str());
+    LINGLONG_TRACE(fmt::format("pull {} from {}", refString, pullRepo.name));
 
     utils::Transaction transaction;
     auto *cancellable = taskContext.cancellable();
@@ -1500,7 +1499,7 @@ OSTreeRepo::clearReference(const package::FuzzyReference &fuzzy,
                            const std::string &module,
                            const std::optional<std::string> &repo) const noexcept
 {
-    LINGLONG_TRACE("clear fuzzy reference " + fuzzy.toString());
+    LINGLONG_TRACE(fmt::format("clear fuzzy reference {}", fuzzy.toString()));
 
     utils::error::Result<package::Reference> reference = LINGLONG_ERR("reference not exists");
 
@@ -1981,7 +1980,7 @@ utils::error::Result<void> OSTreeRepo::exportDir(const std::string &appID,
                                                  const std::filesystem::path &destination,
                                                  const int &max_depth)
 {
-    LINGLONG_TRACE(QString("export %1").arg(source.c_str()));
+    LINGLONG_TRACE(fmt::format("export {}", source.string()));
     if (max_depth <= 0) {
         qWarning() << "ttl reached, skipping export for" << source.c_str();
         return LINGLONG_OK;
@@ -2004,7 +2003,7 @@ utils::error::Result<void> OSTreeRepo::exportDir(const std::string &appID,
         return LINGLONG_ERR("source is not a directory");
     }
     auto forceMkdirDir = [](std::string path) -> utils::error::Result<void> {
-        LINGLONG_TRACE(QString("force mkdir %1").arg(path.c_str()));
+        LINGLONG_TRACE(fmt::format("force mkdir {}", path));
         // 检查目标目录是否存在，如果不存在则创建
         std::error_code ec;
         auto exists = std::filesystem::exists(path, ec);
@@ -2223,7 +2222,7 @@ utils::error::Result<void>
 OSTreeRepo::exportEntries(const std::filesystem::path &rootEntriesDir,
                           const api::types::v1::RepositoryCacheLayersItem &item) noexcept
 {
-    LINGLONG_TRACE(QString("export %1").arg(item.info.id.c_str()));
+    LINGLONG_TRACE(fmt::format("export {}", item.info.id));
     auto layerDir = getLayerDir(item);
     if (!layerDir.has_value()) {
         return LINGLONG_ERR("get layer dir", layerDir);
@@ -2433,7 +2432,7 @@ OSTreeRepo::markDeleted(const package::Reference &ref,
                         const std::string &module,
                         const std::optional<std::string> &subRef) noexcept
 {
-    LINGLONG_TRACE("mark " + ref.toString() + " to deleted");
+    LINGLONG_TRACE(fmt::format("mark {} to deleted", ref.toString()));
 
     auto item = this->getLayerItem(ref, module, subRef);
     if (!item) {
@@ -2469,7 +2468,7 @@ OSTreeRepo::getLayerItem(const package::Reference &ref,
                          std::string module,
                          const std::optional<std::string> &subRef) const noexcept
 {
-    LINGLONG_TRACE("get latest layer of " + ref.toString());
+    LINGLONG_TRACE(fmt::format("get latest layer of {}", ref.toString()));
     if (module == "runtime") {
         module = "binary";
     }
@@ -2537,8 +2536,7 @@ OSTreeRepo::getLayerItem(const package::Reference &ref,
 auto OSTreeRepo::getLayerDir(const api::types::v1::RepositoryCacheLayersItem &layer) const noexcept
   -> utils::error::Result<package::LayerDir>
 {
-    LINGLONG_TRACE("get dir from layer item "
-                   + QString::fromStdString(ostreeRefSpecFromLayerItem(layer)));
+    LINGLONG_TRACE("get dir from layer item " + ostreeRefSpecFromLayerItem(layer));
 
     QDir dir = this->repoDir.absoluteFilePath(QString::fromStdString("layers/" + layer.commit));
     if (!dir.exists()) {
@@ -2552,7 +2550,7 @@ auto OSTreeRepo::getLayerDir(const package::Reference &ref,
                              const std::optional<std::string> &subRef) const noexcept
   -> utils::error::Result<package::LayerDir>
 {
-    LINGLONG_TRACE("get dir from ref " + ref.toString());
+    LINGLONG_TRACE(fmt::format("get dir from ref {}", ref.toString()));
 
     auto layer = this->getLayerItem(ref, module, subRef);
     if (!layer) {
@@ -2686,7 +2684,7 @@ std::vector<std::string> OSTreeRepo::getModuleList(const package::Reference &ref
 utils::error::Result<package::LayerDir>
 OSTreeRepo::getMergedModuleDir(const package::Reference &ref, bool fallbackLayerDir) const noexcept
 {
-    LINGLONG_TRACE("get merge dir from ref " + ref.toString());
+    LINGLONG_TRACE(fmt::format("get merge dir from ref {}", ref.toString()));
     LogD("getMergedModuleDir: {}", ref.toString());
     auto layer = this->getLayerItem(ref, "binary");
     if (!layer) {
@@ -2700,7 +2698,7 @@ OSTreeRepo::getMergedModuleDir(const package::Reference &ref, bool fallbackLayer
 utils::error::Result<package::LayerDir> OSTreeRepo::getMergedModuleDir(
   const api::types::v1::RepositoryCacheLayersItem &layer, bool fallbackLayerDir) const noexcept
 {
-    LINGLONG_TRACE("get merge dir from layer " + QString::fromStdString(layer.info.id));
+    LINGLONG_TRACE("get merge dir from layer " + layer.info.id);
     QDir mergedDir = this->repoDir.absoluteFilePath("merged");
     auto items = this->cache->queryMergedItems();
     // 如果没有merged记录，尝试使用layer
@@ -3027,7 +3025,7 @@ QString buildDesktopExec(QString origin, const QString &appID) noexcept
 
 utils::error::Result<void> desktopFileRewrite(const QString &filePath, const QString &id)
 {
-    LINGLONG_TRACE("rewrite desktop file " + filePath);
+    LINGLONG_TRACE(fmt::format("rewrite desktop file {}", filePath.toStdString()));
 
     auto file = utils::GKeyFileWrapper::New(filePath);
     if (!file) {
@@ -3078,7 +3076,7 @@ utils::error::Result<void> desktopFileRewrite(const QString &filePath, const QSt
 
 utils::error::Result<void> dbusServiceRewrite(const QString &filePath, const QString &id)
 {
-    LINGLONG_TRACE("rewrite dbus service file " + filePath);
+    LINGLONG_TRACE(fmt::format("rewrite dbus service file {}", filePath.toStdString()));
 
     auto file = utils::GKeyFileWrapper::New(filePath);
     if (!file) {
@@ -3119,7 +3117,7 @@ utils::error::Result<void> dbusServiceRewrite(const QString &filePath, const QSt
 
 utils::error::Result<void> systemdServiceRewrite(const QString &filePath, const QString &id)
 {
-    LINGLONG_TRACE("rewrite systemd user service " + filePath);
+    LINGLONG_TRACE(fmt::format("rewrite systemd user service {}", filePath.toStdString()));
 
     // Related doc: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html
     // NOTE: The key is allowed to be repeated in the service group
@@ -3166,7 +3164,7 @@ utils::error::Result<void> systemdServiceRewrite(const QString &filePath, const 
 
 utils::error::Result<void> contextMenuRewrite(const QString &filePath, const QString &id)
 {
-    LINGLONG_TRACE("rewrite context menu" + filePath);
+    LINGLONG_TRACE(fmt::format("rewrite context menu{}", filePath.toStdString()));
 
     auto file = utils::GKeyFileWrapper::New(filePath);
     if (!file) {

--- a/libs/linglong/src/linglong/runtime/container.cpp
+++ b/libs/linglong/src/linglong/runtime/container.cpp
@@ -14,6 +14,8 @@
 #include "ocppi/runtime/RunOption.hpp"
 #include "ocppi/runtime/config/types/Generators.hpp"
 
+#include <fmt/format.h>
+
 #include <fstream>
 #include <utility>
 
@@ -129,7 +131,7 @@ Container::Container(ocppi::runtime::config::types::Config cfg,
 utils::error::Result<void> Container::run(const ocppi::runtime::config::types::Process &process,
                                           ocppi::runtime::RunOption &opt) noexcept
 {
-    LINGLONG_TRACE(QString("run container %1").arg(QString::fromStdString(this->id)));
+    LINGLONG_TRACE(fmt::format("run container {}", this->id));
 
     std::error_code ec;
     std::filesystem::path runtimeDir = common::dir::getRuntimeDir();

--- a/libs/linglong/src/linglong/runtime/run_context.cpp
+++ b/libs/linglong/src/linglong/runtime/run_context.cpp
@@ -162,8 +162,7 @@ utils::error::Result<void> RunContext::resolve(const linglong::package::Referenc
 utils::error::Result<void> RunContext::resolve(const api::types::v1::BuilderProject &target,
                                                const std::filesystem::path &buildOutput)
 {
-    LINGLONG_TRACE("resolve RunContext from builder project "
-                   + QString::fromStdString(target.package.id));
+    LINGLONG_TRACE("resolve RunContext from builder project " + target.package.id);
 
     auto targetRef = package::Reference::fromBuilderProject(target);
     if (!targetRef) {

--- a/libs/utils/src/linglong/utils/command/cmd.cpp
+++ b/libs/utils/src/linglong/utils/command/cmd.cpp
@@ -6,6 +6,8 @@
 
 #include "cmd.h"
 
+#include <fmt/format.h>
+
 #include <QProcess>
 #include <QStandardPaths>
 
@@ -27,7 +29,8 @@ linglong::utils::error::Result<QString> Cmd::exec() noexcept
 
 linglong::utils::error::Result<QString> Cmd::exec(const QStringList &args) noexcept
 {
-    LINGLONG_TRACE(QString("exec %1 %2").arg(m_command, args.join(" ")));
+    LINGLONG_TRACE(
+      fmt::format("exec {} {}", m_command.toStdString(), args.join(" ").toStdString()));
     qDebug() << "exec" << m_command << args;
     QProcess process;
     process.setProgram(m_command);

--- a/libs/utils/src/linglong/utils/error/details/error_impl.h
+++ b/libs/utils/src/linglong/utils/error/details/error_impl.h
@@ -24,11 +24,11 @@ public:
               int line,
               const char *category,
               const int &code,
-              QString msg,
+              const std::string &msg,
               std::unique_ptr<ErrorImpl> cause = nullptr)
         : context(file, line, "unknown", category)
         , _code(code)
-        , msg(std::move(msg))
+        , msg(QString::fromStdString(msg))
         , cause(std::move(cause))
     {
     }

--- a/libs/utils/src/linglong/utils/error/error.h
+++ b/libs/utils/src/linglong/utils/error/error.h
@@ -81,8 +81,22 @@ public:
 
     static auto Err(const char *file,
                     int line,
-                    const QString &trace_msg,
+                    const std::string &trace_msg,
                     const QString &msg,
+                    const ErrorCode &code) -> Error
+    {
+        return Error(std::make_unique<details::ErrorImpl>(file,
+                                                          line,
+                                                          "default",
+                                                          static_cast<int>(code),
+                                                          trace_msg + ": " + msg.toStdString(),
+                                                          nullptr));
+    }
+
+    static auto Err(const char *file,
+                    int line,
+                    const std::string &trace_msg,
+                    const std::string &msg,
                     const ErrorCode &code) -> Error
     {
         return Error(std::make_unique<details::ErrorImpl>(file,
@@ -95,22 +109,7 @@ public:
 
     static auto Err(const char *file,
                     int line,
-                    const QString &trace_msg,
-                    const std::string &msg,
-                    const ErrorCode &code) -> Error
-    {
-        return Error(
-          std::make_unique<details::ErrorImpl>(file,
-                                               line,
-                                               "default",
-                                               static_cast<int>(code),
-                                               trace_msg + ": " + QString::fromStdString(msg),
-                                               nullptr));
-    }
-
-    static auto Err(const char *file,
-                    int line,
-                    const QString &trace_msg,
+                    const std::string &trace_msg,
                     const char *msg,
                     const ErrorCode &code) -> Error
     {
@@ -118,13 +117,27 @@ public:
                                                           line,
                                                           "default",
                                                           static_cast<int>(code),
-                                                          trace_msg + ": " + QString(msg),
+                                                          trace_msg + ": " + msg,
                                                           nullptr));
     }
 
     static auto
-    Err(const char *file, int line, const QString &trace_msg, const QString &msg, int code = -1)
+    Err(const char *file, int line, const std::string &trace_msg, const QString &msg, int code = -1)
       -> Error
+    {
+        return Error(std::make_unique<details::ErrorImpl>(file,
+                                                          line,
+                                                          "default",
+                                                          code,
+                                                          trace_msg + ": " + msg.toStdString(),
+                                                          nullptr));
+    }
+
+    static auto Err(const char *file,
+                    int line,
+                    const std::string &trace_msg,
+                    const std::string &msg,
+                    int code = -1) -> Error
     {
         return Error(std::make_unique<details::ErrorImpl>(file,
                                                           line,
@@ -135,61 +148,52 @@ public:
     }
 
     static auto
-    Err(const char *file, int line, const QString &trace_msg, const std::string &msg, int code = -1)
+    Err(const char *file, int line, const std::string &trace_msg, const char *msg, int code = -1)
       -> Error
-    {
-        return Error(
-          std::make_unique<details::ErrorImpl>(file,
-                                               line,
-                                               "default",
-                                               code,
-                                               trace_msg + ": " + QString::fromStdString(msg),
-                                               nullptr));
-    }
-
-    static auto Err(
-      const char *file, int line, const QString &trace_msg, const char *msg, int code = -1) -> Error
     {
         return Error(std::make_unique<details::ErrorImpl>(file,
                                                           line,
                                                           "default",
                                                           code,
-                                                          trace_msg + ": " + QString(msg),
+                                                          trace_msg + ": " + msg,
                                                           nullptr));
     }
 
     static auto Err(const char *file,
                     int line,
-                    const QString &trace_msg,
+                    const std::string &trace_msg,
                     const QString &msg,
                     const QFile &qfile) -> Error
     {
-        return Error(
-          std::make_unique<details::ErrorImpl>(file,
-                                               line,
-                                               "default",
-                                               qfile.error(),
-                                               trace_msg + ": " + msg + ": " + qfile.errorString(),
-                                               nullptr));
+        return Error(std::make_unique<details::ErrorImpl>(
+          file,
+          line,
+          "default",
+          qfile.error(),
+          trace_msg + ": " + msg.toStdString() + ": " + qfile.errorString().toStdString(),
+          nullptr));
     }
 
-    static auto Err(const char *file, int line, const QString &trace_msg, const QFile &qfile)
+    static auto Err(const char *file, int line, const std::string &trace_msg, const QFile &qfile)
       -> Error
     {
         return Error(std::make_unique<details::ErrorImpl>(file,
                                                           line,
                                                           "default",
                                                           qfile.error(),
-                                                          trace_msg + ": " + qfile.fileName() + ": "
-                                                            + qfile.errorString(),
+                                                          trace_msg + ": "
+                                                            + qfile.fileName().toStdString() + ": "
+                                                            + qfile.errorString().toStdString(),
                                                           nullptr));
     }
 
-    static auto
-    Err(const char *file, int line, const QString &trace_msg, std::exception_ptr err, int code = -1)
-      -> Error
+    static auto Err(const char *file,
+                    int line,
+                    const std::string &trace_msg,
+                    std::exception_ptr err,
+                    int code = -1) -> Error
     {
-        QString what = trace_msg + ": ";
+        std::string what = trace_msg + ": ";
         try {
             std::rethrow_exception(std::move(err));
         } catch (const std::exception &e) {
@@ -204,12 +208,12 @@ public:
 
     static auto Err(const char *file,
                     int line,
-                    const QString &trace_msg,
+                    const std::string &trace_msg,
                     const QString &msg,
                     std::exception_ptr err,
                     int code = -1) -> Error
     {
-        QString what = trace_msg + ": " + msg + ": ";
+        std::string what = trace_msg + ": " + msg.toStdString() + ": ";
         try {
             std::rethrow_exception(std::move(err));
         } catch (const std::exception &e) {
@@ -222,8 +226,8 @@ public:
           std::make_unique<details::ErrorImpl>(file, line, "default", code, what, nullptr));
     }
 
-    static auto Err(const char *file, int line, const QString &trace_msg, const std::exception &e)
-      -> Error
+    static auto
+    Err(const char *file, int line, const std::string &trace_msg, const std::exception &e) -> Error
     {
         return Error(std::make_unique<details::ErrorImpl>(file,
                                                           line,
@@ -235,12 +239,12 @@ public:
 
     static auto Err(const char *file,
                     int line,
-                    const QString &trace_msg,
+                    const std::string &trace_msg,
                     const QString &msg,
                     const std::exception &e,
                     int code = -1) -> Error
     {
-        QString what = trace_msg + ": " + msg + ": " + e.what();
+        std::string what = trace_msg + ": " + msg.toStdString() + ": " + e.what();
 
         return Error(
           std::make_unique<details::ErrorImpl>(file, line, "default", code, what, nullptr));
@@ -248,7 +252,7 @@ public:
 
     static auto Err(const char *file,
                     int line,
-                    const QString &trace_msg,
+                    const std::string &trace_msg,
                     const QString &msg,
                     GError const *const e) -> Error
     {
@@ -262,7 +266,7 @@ public:
 
     static auto Err(const char *file,
                     int line,
-                    const QString &trace_msg,
+                    const std::string &trace_msg,
                     const char *msg,
                     const std::system_error &e) -> Error
     {
@@ -271,7 +275,7 @@ public:
 
     static auto Err(const char *file,
                     int line,
-                    const QString &trace_msg,
+                    const std::string &trace_msg,
                     const QString &msg,
                     const std::system_error &e) -> Error
     {
@@ -280,7 +284,7 @@ public:
 
     static auto Err(const char *file,
                     int line,
-                    const QString &trace_msg,
+                    const std::string &trace_msg,
                     const std::string &msg,
                     const std::system_error &e) -> Error
     {
@@ -290,8 +294,25 @@ public:
     template <typename Value>
     static auto Err(const char *file,
                     int line,
-                    const QString &trace_msg,
+                    const std::string &trace_msg,
                     const QString &msg,
+                    tl::expected<Value, Error> &&cause) -> Error
+    {
+        Q_ASSERT(!cause.has_value());
+
+        return Error(std::make_unique<details::ErrorImpl>(file,
+                                                          line,
+                                                          "default",
+                                                          cause.error().code(),
+                                                          trace_msg + ": " + msg.toStdString(),
+                                                          std::move(cause.error().pImpl)));
+    }
+
+    template <typename Value>
+    static auto Err(const char *file,
+                    int line,
+                    const std::string &trace_msg,
+                    const std::string &msg,
                     tl::expected<Value, Error> &&cause) -> Error
     {
         Q_ASSERT(!cause.has_value());
@@ -307,25 +328,7 @@ public:
     template <typename Value>
     static auto Err(const char *file,
                     int line,
-                    const QString &trace_msg,
-                    const std::string &msg,
-                    tl::expected<Value, Error> &&cause) -> Error
-    {
-        Q_ASSERT(!cause.has_value());
-
-        return Error(
-          std::make_unique<details::ErrorImpl>(file,
-                                               line,
-                                               "default",
-                                               cause.error().code(),
-                                               trace_msg + ": " + QString::fromStdString(msg),
-                                               std::move(cause.error().pImpl)));
-    }
-
-    template <typename Value>
-    static auto Err(const char *file,
-                    int line,
-                    const QString &trace_msg,
+                    const std::string &trace_msg,
                     const char *msg,
                     tl::expected<Value, Error> &&cause) -> Error
     {
@@ -335,14 +338,14 @@ public:
                                                           line,
                                                           "default",
                                                           cause.error().code(),
-                                                          trace_msg + ": " + QString(msg),
+                                                          trace_msg + ": " + msg,
                                                           std::move(cause.error().pImpl)));
     }
 
     template <typename Value>
     static auto Err(const char *file,
                     int line,
-                    const QString &trace_msg,
+                    const std::string &trace_msg,
                     tl::expected<Value, Error> &&cause) -> Error
     {
         Q_ASSERT(!cause.has_value());
@@ -356,18 +359,19 @@ public:
     }
 
     static auto
-    Err(const char *file, int line, const QString &trace_msg, const QString &msg, Error &&cause)
+    Err(const char *file, int line, const std::string &trace_msg, const QString &msg, Error &&cause)
       -> Error
     {
         return Error(std::make_unique<details::ErrorImpl>(file,
                                                           line,
                                                           "default",
                                                           cause.code(),
-                                                          trace_msg + ": " + msg,
+                                                          trace_msg + ": " + msg.toStdString(),
                                                           std::move(cause.pImpl)));
     }
 
-    static auto Err(const char *file, int line, const QString &trace_msg, Error &&cause) -> Error
+    static auto Err(const char *file, int line, const std::string &trace_msg, Error &&cause)
+      -> Error
     {
 
         return Error(std::make_unique<details::ErrorImpl>(file,
@@ -381,7 +385,7 @@ public:
     template <typename Value>
     static auto Err(const char *file,
                     int line,
-                    const QString &trace_msg,
+                    const std::string &trace_msg,
                     tl::expected<Value, std::exception_ptr> &&cause,
                     int code = -1) -> Error
     {
@@ -393,7 +397,7 @@ public:
     template <typename Value>
     static auto Err(const char *file,
                     int line,
-                    const QString &trace_msg,
+                    const std::string &trace_msg,
                     const QString &msg,
                     tl::expected<Value, std::exception_ptr> &&cause) -> Error
     {
@@ -416,17 +420,8 @@ using Result = tl::expected<Value, Error>;
 
 } // namespace linglong::utils::error
 
-// Use this macro to define trace message at the begining of function
-// 支持QString, std::string, const char*
-#define LINGLONG_TRACE(message)                                    \
-    const QString linglong_trace_message = [](auto &&msg) {        \
-        using val_t = decltype(msg);                               \
-        if constexpr (std::is_convertible_v<val_t, std::string>) { \
-            return QString::fromStdString(msg);                    \
-        } else {                                                   \
-            return msg;                                            \
-        }                                                          \
-    }(message);
+// Use this macro to set trace message for the current scope
+#define LINGLONG_TRACE(message) const std::string _linglong_trace_message = message;
 
 // Use this macro to create new error or wrap an existing error
 // LINGLONG_ERR(message, code =-1)
@@ -449,26 +444,26 @@ using Result = tl::expected<Value, Error>;
     (__VA_ARGS__)
 
 // std::move is used for Result<Value>
-#define LINGLONG_ERR_1(_1) /*NOLINT*/                                           \
-    tl::unexpected(::linglong::utils::error::Error::Err(QT_MESSAGELOG_FILE,     \
-                                                        QT_MESSAGELOG_LINE,     \
-                                                        linglong_trace_message, \
+#define LINGLONG_ERR_1(_1) /*NOLINT*/                                            \
+    tl::unexpected(::linglong::utils::error::Error::Err(QT_MESSAGELOG_FILE,      \
+                                                        QT_MESSAGELOG_LINE,      \
+                                                        _linglong_trace_message, \
                                                         std::move((_1)) /*NOLINT*/))
 
 // std::move is used for Result<Value>
-#define LINGLONG_ERR_2(_1, _2) /*NOLINT*/                                       \
-    tl::unexpected(::linglong::utils::error::Error::Err(QT_MESSAGELOG_FILE,     \
-                                                        QT_MESSAGELOG_LINE,     \
-                                                        linglong_trace_message, \
-                                                        (_1),                   \
+#define LINGLONG_ERR_2(_1, _2) /*NOLINT*/                                        \
+    tl::unexpected(::linglong::utils::error::Error::Err(QT_MESSAGELOG_FILE,      \
+                                                        QT_MESSAGELOG_LINE,      \
+                                                        _linglong_trace_message, \
+                                                        (_1),                    \
                                                         std::move((_2)) /*NOLINT*/))
 
-#define LINGLONG_ERR_3(_1, _2, _3) /*NOLINT*/                                   \
-    tl::unexpected(::linglong::utils::error::Error::Err(QT_MESSAGELOG_FILE,     \
-                                                        QT_MESSAGELOG_LINE,     \
-                                                        linglong_trace_message, \
-                                                        (_1),                   \
-                                                        (_2),                   \
+#define LINGLONG_ERR_3(_1, _2, _3) /*NOLINT*/                                    \
+    tl::unexpected(::linglong::utils::error::Error::Err(QT_MESSAGELOG_FILE,      \
+                                                        QT_MESSAGELOG_LINE,      \
+                                                        _linglong_trace_message, \
+                                                        (_1),                    \
+                                                        (_2),                    \
                                                         (_3)))
 
 #define LINGLONG_OK \

--- a/libs/utils/src/linglong/utils/file.cpp
+++ b/libs/utils/src/linglong/utils/file.cpp
@@ -20,7 +20,7 @@ namespace linglong::utils {
 
 linglong::utils::error::Result<std::string> readFile(std::string filepath)
 {
-    LINGLONG_TRACE(QString("read file %1").arg(filepath.c_str()));
+    LINGLONG_TRACE(fmt::format("read file {}", filepath));
     std::error_code ec;
     auto exists = std::filesystem::exists(filepath, ec);
     if (ec) {
@@ -46,7 +46,7 @@ linglong::utils::error::Result<std::string> readFile(std::string filepath)
 linglong::utils::error::Result<void> writeFile(const std::string &filepath,
                                                const std::string &content)
 {
-    LINGLONG_TRACE(QString("write file %1").arg(filepath.c_str()));
+    LINGLONG_TRACE(fmt::format("write file {}", filepath));
 
     std::error_code ec;
     auto exists = std::filesystem::exists(filepath, ec);

--- a/libs/utils/src/linglong/utils/gkeyfile_wrapper.h
+++ b/libs/utils/src/linglong/utils/gkeyfile_wrapper.h
@@ -8,6 +8,7 @@
 
 #include "linglong/utils/error/error.h"
 
+#include <fmt/format.h>
 #include <glib.h>
 #include <tl/expected.hpp>
 
@@ -33,7 +34,7 @@ public:
 
     static auto New(const QString &filePath) -> error::Result<GKeyFileWrapper>
     {
-        LINGLONG_TRACE(QString("create GKeyFileWrapper for %1").arg(filePath));
+        LINGLONG_TRACE(fmt::format("create GKeyFileWrapper for {}", filePath.toStdString()));
 
         auto desktopEntryFile = QFile(filePath);
         if (!desktopEntryFile.exists()) {
@@ -64,7 +65,7 @@ public:
     template <typename Value>
     auto getValue(const QString &key, const GroupName &group) const -> error::Result<Value>
     {
-        LINGLONG_TRACE(QString("get %1 from %2").arg(key, group));
+        LINGLONG_TRACE(fmt::format("get {} from {}", key.toStdString(), group.toStdString()));
 
         g_autoptr(GError) gErr = nullptr;
         g_autofree gchar *value = g_key_file_get_string(this->gKeyFile.get(),
@@ -95,7 +96,7 @@ public:
 
     auto getkeys(const QString &group) -> error::Result<QStringList>
     {
-        LINGLONG_TRACE("get keys from " + group);
+        LINGLONG_TRACE("get keys from " + group.toStdString());
 
         g_autoptr(GError) gErr = nullptr;
         gsize length{ 0 };
@@ -118,7 +119,7 @@ public:
 
     auto saveToFile(const QString &filepath) -> error::Result<void>
     {
-        LINGLONG_TRACE(QString("save to %1").arg(filepath));
+        LINGLONG_TRACE(fmt::format("save to {}", filepath.toStdString()));
 
         g_autoptr(GError) gErr = nullptr;
 
@@ -132,7 +133,8 @@ public:
 
     auto hasKey(const QString &key, const GroupName &group) -> error::Result<bool>
     {
-        LINGLONG_TRACE(QString("check %1 is in %2 or not").arg(key, group));
+        LINGLONG_TRACE(
+          fmt::format("check {} is in {} or not", key.toStdString(), group.toStdString()));
 
         g_autoptr(GError) gErr = nullptr;
         if (g_key_file_has_key(this->gKeyFile.get(),

--- a/libs/utils/src/linglong/utils/log/log.h
+++ b/libs/utils/src/linglong/utils/log/log.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#define FMT_HEADER_ONLY
 #include "linglong/utils/log/formatter.h"
 
 #include <fmt/format.h>

--- a/libs/utils/src/linglong/utils/packageinfo_handler.cpp
+++ b/libs/utils/src/linglong/utils/packageinfo_handler.cpp
@@ -34,7 +34,7 @@ api::types::v1::PackageInfoV2 toPackageInfoV2(const api::types::v1::PackageInfo 
 
 error::Result<api::types::v1::PackageInfoV2> parsePackageInfo(const QString &path)
 {
-    LINGLONG_TRACE("parse package info from file: " + path);
+    LINGLONG_TRACE("parse package info from file: " + path.toStdString());
 
     auto pkgInfo = serialize::LoadJSONFile<api::types::v1::PackageInfoV2>(path);
     if (pkgInfo) {

--- a/libs/utils/src/linglong/utils/serialize/json.h
+++ b/libs/utils/src/linglong/utils/serialize/json.h
@@ -11,6 +11,7 @@
 #include "linglong/utils/error/error.h"
 #include "nlohmann/json.hpp"
 
+#include <fmt/format.h>
 #include <gio/gio.h>
 
 #include <QFileInfo>
@@ -59,7 +60,7 @@ error::Result<T> LoadJSON(const Source &content) noexcept
 template <typename T>
 error::Result<T> LoadJSONFile(GFile *file) noexcept
 {
-    LINGLONG_TRACE("load json from " + QString::fromStdString(g_file_get_path(file)));
+    LINGLONG_TRACE(fmt::format("load json from {}", g_file_get_path(file)));
 
     g_autoptr(GError) gErr = nullptr;
     g_autofree gchar *content = nullptr;
@@ -75,7 +76,7 @@ error::Result<T> LoadJSONFile(GFile *file) noexcept
 template <typename T>
 error::Result<T> LoadJSONFile(const std::filesystem::path &filePath) noexcept
 {
-    LINGLONG_TRACE("load json from " + QString::fromStdString(filePath.string()));
+    LINGLONG_TRACE(fmt::format("load json from {}", filePath.string()));
     std::ifstream file(filePath);
     if (!file.is_open()) {
         return LINGLONG_ERR("failed to open file");
@@ -87,7 +88,7 @@ error::Result<T> LoadJSONFile(const std::filesystem::path &filePath) noexcept
 template <typename T>
 error::Result<T> LoadJSONFile(QFile &file) noexcept
 {
-    LINGLONG_TRACE("load json from file" + QFileInfo(file).absoluteFilePath());
+    LINGLONG_TRACE("load json from file" + QFileInfo(file).absoluteFilePath().toStdString());
 
     if (!file.open(QFile::ReadOnly)) {
         return LINGLONG_ERR("open", file);


### PR DESCRIPTION
Changed error handling system to use std::string instead of QString for trace messages to improve performance and reduce unnecessary string conversions. The LINGLONG_TRACE macro now directly stores the message as std::string without complex type detection logic. All error creation methods have been updated to accept std::string for trace messages and handle string concatenation more efficiently.

This refactoring eliminates the need for QString conversions when working with standard C++ strings, reducing overhead in error handling paths. The changes maintain backward compatibility while improving type consistency throughout the error system.

Influence:
1. Verify error messages are correctly formatted and displayed
2. Test error handling with various string types (QString, std::string, const char*)
3. Confirm trace functionality works correctly in different scenarios
4. Check that existing error reporting mechanisms continue to function properly
5. Validate that no string conversion errors occur during error propagation

refactor: 使用 std::string 进行错误追踪

将错误处理系统中的跟踪消息从 QString 改为 std::string，以提高性能并减少
不必要的字符串转换。LINGLONG_TRACE 宏现在直接以 std::string 存储消息，无 需复杂的类型检测逻辑。所有错误创建方法都已更新为接受 std::string 类型的
跟踪消息，并更高效地处理字符串连接。

此次重构消除了在处理标准 C++ 字符串时进行 QString 转换的需求，减少了错误
处理路径的开销。这些更改在提高类型一致性的同时保持了向后兼容性。

Influence:
1. 验证错误消息格式正确且显示正常
2. 测试使用各种字符串类型（QString、std::string、const char*）的错误处理
3. 确认跟踪功能在不同场景下正常工作
4. 检查现有的错误报告机制是否继续正常运行
5. 验证在错误传播过程中不会发生字符串转换错误