### PR TITLE
feat: add manual extension and env support

### DIFF
--- a/apps/ll-builder/src/command_options.h
+++ b/apps/ll-builder/src/command_options.h
@@ -29,6 +29,7 @@ struct RunCommandOptions
     std::vector<std::string> execModules;
     std::vector<std::string> commands;
     bool debugMode = false;
+    std::vector<std::string> extensions;
 };
 
 struct ListCommandOptions

--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -301,7 +301,7 @@ int handleRun(linglong::builder::Builder &builder, const RunCommandOptions &opti
         }
     }
 
-    auto result = builder.run(modules, options.commands, options.debugMode);
+    auto result = builder.run(modules, options.commands, options.debugMode, options.extensions);
     if (!result) {
         LogE("Run failed: {}", result.error());
         return result.error().code();
@@ -834,6 +834,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
                    runOpts.execModules,
                    _("Run specified module. eg: --modules binary,develop"))
       ->delimiter(',')
+      ->allow_extra_args(false)
       ->type_name("modules");
     buildRun->add_option(
       "COMMAND",
@@ -842,6 +843,14 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     buildRun->add_flag("--debug",
                        runOpts.debugMode,
                        _("Run in debug mode (enable develop module)"));
+    buildRun
+      ->add_option("--extensions",
+                   runOpts.extensions,
+                   _("Specify extension(s) used by the app to run"))
+      ->type_name("REF")
+      ->delimiter(',')
+      ->allow_extra_args(false)
+      ->check(validatorString);
 
     auto buildList = commandParser.add_subcommand("list", _("List built linyaps app"));
     buildList->usage(_("Usage: ll-builder list [OPTIONS]"));

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -200,6 +200,14 @@ ll-cli run org.deepin.demo -- bash -x /path/to/bash/script)"));
                    _("Specify the runtime used by the application to run"))
       ->type_name("REF")
       ->check(validatorString);
+    cliRun
+      ->add_option("--extensions",
+                   runOptions.extensions,
+                   _("Specify extension(s) used by the application to run"))
+      ->type_name("REF")
+      ->delimiter(',')          // 支持以逗号分隔
+      ->allow_extra_args(false) //避免吞掉后面的参数
+      ->check(validatorString);
     cliRun->add_option("COMMAND", runOptions.commands, _("Run commands in a running sandbox"));
 }
 

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -1685,7 +1685,8 @@ utils::error::Result<void> Builder::importLayer(repo::OSTreeRepo &ostree, const 
 
 utils::error::Result<void> Builder::run(std::vector<std::string> modules,
                                         std::vector<std::string> args,
-                                        bool debug)
+                                        bool debug,
+                                        std::vector<std::string> extensions)
 {
     LINGLONG_TRACE("run application");
 
@@ -1703,6 +1704,9 @@ utils::error::Result<void> Builder::run(std::vector<std::string> modules,
     linglong::runtime::ResolveOptions opts;
     opts.depsBinaryOnly = !debug;
     opts.appModules = std::move(modules);
+    if (!extensions.empty()) {
+        opts.extensionRefs = extensions;
+    }
     auto res = runContext.resolve(*curRef, opts);
     if (!res) {
         return LINGLONG_ERR(res);

--- a/libs/linglong/src/linglong/builder/linglong_builder.h
+++ b/libs/linglong/src/linglong/builder/linglong_builder.h
@@ -88,7 +88,7 @@ public:
     static auto importLayer(repo::OSTreeRepo &repo, const QString &path)
       -> utils::error::Result<void>;
 
-    auto run(std::vector<std::string> modules, std::vector<std::string> args, bool debug = false)
+    auto run(std::vector<std::string> modules, std::vector<std::string> args, bool debug = false, std::vector<std::string> extensions = {})
       -> utils::error::Result<void>;
     auto runtimeCheck() -> utils::error::Result<void>;
     auto runFromRepo(const package::Reference &ref, const std::vector<std::string> &args)

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -678,10 +678,18 @@ int Cli::run(const RunOptions &options)
     linglong::runtime::ResolveOptions opts;
     opts.baseRef = options.base;
     opts.runtimeRef = options.runtime;
+    // 处理多个扩展
+    if (!options.extensions.empty()) {
+        opts.extensionRefs = options.extensions;
+    }
 
-    LogD("start resolve run context with base {} and runtime {}",
+    // 调整日志输出，打印扩展列表（用逗号拼接）
+    std::string extStr =
+      opts.extensionRefs ? linglong::common::strings::join(*opts.extensionRefs, ',') : "null";
+    LogD("start resolve run context with base {}, runtime {}, extensions {}",
          opts.baseRef.value_or("null"),
-         opts.runtimeRef.value_or("null"));
+         opts.runtimeRef.value_or("null"),
+         extStr);
 
     auto res = runContext.resolve(*curAppRef, opts);
     if (!res) {

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -47,6 +47,7 @@ struct RunOptions
     std::vector<std::string> commands;
     std::optional<std::string> base;
     std::optional<std::string> runtime;
+    std::vector<std::string> extensions;
 };
 
 struct EnterOptions

--- a/libs/linglong/src/linglong/runtime/run_context.cpp
+++ b/libs/linglong/src/linglong/runtime/run_context.cpp
@@ -154,6 +154,19 @@ utils::error::Result<void> RunContext::resolve(const linglong::package::Referenc
         return LINGLONG_ERR(ret);
     }
 
+    // 手动解析多个扩展
+    if (options.extensionRefs && !options.extensionRefs->empty()) {
+        auto manualExtensionDef = makeManualExtensionDefine(*options.extensionRefs);
+        if (!manualExtensionDef) {
+            return LINGLONG_ERR(manualExtensionDef);
+        }
+
+        auto ret = resolveExtension(*manualExtensionDef);
+        if (!ret) {
+            return LINGLONG_ERR(ret);
+        }
+    }
+
     // all reference are cleard , we can get actual layer directory now
     return resolveLayer(options.depsBinaryOnly,
                         options.appModules.value_or(std::vector<std::string>{}));
@@ -279,30 +292,6 @@ utils::error::Result<void> RunContext::resolveLayer(bool depsBinaryOnly,
         }
     }
 
-    auto replaceSubstring = [](std::string_view str, std::string_view from, std::string_view to) {
-        std::string result;
-        if (from.empty()) {
-            return std::string(str);
-        }
-
-        size_t start = 0;
-        while (true) {
-            size_t pos = str.find(from, start);
-            if (pos == std::string_view::npos) {
-                break;
-            }
-            // Append the part before the match
-            result.append(str.data() + start, pos - start);
-            // Append the replacement
-            result.append(to.data(), to.size());
-            // Move past the matched part
-            start = pos + from.size();
-        }
-        // Append the remaining part of the string
-        result.append(str.data() + start, str.size() - start);
-        return result;
-    };
-
     for (auto &ext : extensionLayers) {
         if (!ext.resolveLayer()) {
             qWarning() << "ignore failed extension layer";
@@ -313,12 +302,8 @@ utils::error::Result<void> RunContext::resolveLayer(bool depsBinaryOnly,
         if (!extensionOf) {
             continue;
         }
-        const auto &[extensionDefine, layer] = *extensionOf;
-        if (!extensionDefine.allowEnv) {
-            continue;
-        }
-        const auto &allowEnv = *extensionDefine.allowEnv;
 
+        const auto &[extensionDefine, layer] = *extensionOf;
         auto extItem = ext.getCachedItem();
         if (!extItem) {
             continue;
@@ -333,24 +318,33 @@ utils::error::Result<void> RunContext::resolveLayer(bool depsBinaryOnly,
             continue;
         }
         for (const auto &env : *extImpl.env) {
-            auto allowed = allowEnv.find(env.first);
-            if (allowed == allowEnv.end()) {
-                qWarning() << "env " << QString::fromStdString(env.first) << " not allowed in "
-                           << layer.get().getReference().toString().c_str();
-                continue;
+            // if allowEnv is not defined, all envs are allowed
+            std::string defaultValue;
+            if (extensionDefine.allowEnv) {
+                const auto &allowEnv = *extensionDefine.allowEnv;
+                auto allowed = allowEnv.find(env.first);
+                if (allowed == allowEnv.end()) {
+                    LogW("env {} not allowed in {}", env.first, ext.getReference().toString());
+                    continue;
+                }
+                defaultValue = allowed->second;
             }
 
             std::string res =
-              replaceSubstring(env.second, "$PREFIX", "/opt/extensions/" + ext.getReference().id);
+              common::strings::replaceSubstring(env.second,
+                                                "$PREFIX",
+                                                "/opt/extensions/" + ext.getReference().id);
             auto &value = environment[env.first];
-            if (!value.empty()) {
-                res = replaceSubstring(res, "$ORIGIN", value);
-            } else if (!allowed->second.empty()) {
-                res = replaceSubstring(res, "$ORIGIN", allowed->second);
+            if (value.empty()) {
+                value = defaultValue;
             }
+            // If $ORIGIN is unset and the default value is empty, the environment variable
+            // may become ":NEW_VALUE" or "NEW_VALUE:". We cannot remove the leading/trailing
+            // colon because the value might represent a non-path element (e.g., a delimiter)
+            res = common::strings::replaceSubstring(res, "$ORIGIN", value);
+
             value = res;
-            qDebug() << "environment[" << QString::fromStdString(env.first)
-                     << "]=" << QString::fromStdString(res);
+            LogD("environment[{}]={}", env.first, res);
         }
     }
 
@@ -359,7 +353,7 @@ utils::error::Result<void> RunContext::resolveLayer(bool depsBinaryOnly,
 
 utils::error::Result<void> RunContext::resolveExtension(RuntimeLayer &layer)
 {
-    LINGLONG_TRACE("resolve extension");
+    LINGLONG_TRACE("resolve RuntimeLayer extension");
 
     auto item = layer.getCachedItem();
     if (!item) {
@@ -368,40 +362,87 @@ utils::error::Result<void> RunContext::resolveExtension(RuntimeLayer &layer)
 
     const auto &info = item->info;
     if (info.extensions) {
-        for (const auto &extension : *info.extensions) {
-            qDebug() << "handle extensions: " << QString::fromStdString(extension.name);
-            qDebug() << "version: " << QString::fromStdString(extension.version);
-            qDebug() << "directory: " << QString::fromStdString(extension.directory);
-            if (extension.allowEnv) {
-                for (const auto &allowEnv : *extension.allowEnv) {
-                    qDebug() << "allowEnv: " << QString::fromStdString(allowEnv.first) << ":"
-                             << QString::fromStdString(allowEnv.second);
-                }
-            }
-
-            std::string name = extension.name;
-            auto ext = extension::ExtensionFactory::makeExtension(name);
-            if (!ext->shouldEnable(name)) {
-                continue;
-            }
-
-            auto fuzzyRef =
-              package::FuzzyReference::create(info.channel, name, extension.version, std::nullopt);
-            auto ref = repo.clearReference(*fuzzyRef,
-                                           { .fallbackToRemote = false, .semanticMatching = true });
-            if (!ref) {
-                // extension is not installed, ignore it
-                qDebug() << "extension is not installed: " << fuzzyRef->toString().c_str();
-                continue;
-            }
-
-            auto &extensionLayer = extensionLayers.emplace_back(*ref, *this);
-            extensionLayer.setExtensionInfo(
-              std::make_pair(extension, std::reference_wrapper<RuntimeLayer>(extensionLayer)));
-        }
+        return resolveExtension(*info.extensions, info.channel, true);
     }
 
     return LINGLONG_OK;
+}
+
+utils::error::Result<void>
+RunContext::resolveExtension(const std::vector<api::types::v1::ExtensionDefine> &extDefs,
+                             std::optional<std::string> channel,
+                             bool skipOnNotFound)
+{
+    LINGLONG_TRACE("resolve extension define");
+
+    for (const auto &extDef : extDefs) {
+        LogD("handle extensions: {}", extDef.name);
+        LogD("version: {}", extDef.version);
+        LogD("directory: {}", extDef.directory);
+        if (extDef.allowEnv) {
+            for (const auto &allowEnv : *extDef.allowEnv) {
+                LogD("allowEnv: {}:{}", allowEnv.first, allowEnv.second);
+            }
+        }
+
+        std::string name = extDef.name;
+        auto ext = extension::ExtensionFactory::makeExtension(name);
+        if (!ext->shouldEnable(name)) {
+            continue;
+        }
+
+        std::optional<std::string> version;
+        if (!extDef.version.empty()) {
+            version = extDef.version;
+        }
+        auto fuzzyRef = package::FuzzyReference::create(channel, name, version, std::nullopt);
+        auto ref =
+          repo.clearReference(*fuzzyRef, { .fallbackToRemote = false, .semanticMatching = true });
+        if (!ref) {
+            LogD("extension is not installed: {}", fuzzyRef->toString());
+            if (skipOnNotFound) {
+                continue;
+            }
+            return LINGLONG_ERR("extension is not installed", ref);
+        }
+
+        RuntimeLayer layer(*ref, *this);
+        auto item = layer.getCachedItem();
+        if (!item) {
+            return LINGLONG_ERR("failed to get layer item", item);
+        }
+        if (item->info.kind != "extension") {
+            return LINGLONG_ERR(fmt::format("{} is not an extension", ref->toString()));
+        }
+
+        auto &extensionLayer = extensionLayers.emplace_back(std::move(layer));
+        extensionLayer.setExtensionInfo(
+          std::make_pair(extDef, std::reference_wrapper<RuntimeLayer>(extensionLayer)));
+    }
+
+    return LINGLONG_OK;
+}
+
+utils::error::Result<std::vector<api::types::v1::ExtensionDefine>>
+RunContext::makeManualExtensionDefine(const std::vector<std::string> &refs)
+{
+    LINGLONG_TRACE("make extension define");
+
+    std::vector<api::types::v1::ExtensionDefine> extDefs;
+    extDefs.reserve(refs.size());
+    for (const auto &ref : refs) {
+        auto fuzzyRef = package::FuzzyReference::parse(ref);
+        if (!fuzzyRef) {
+            return LINGLONG_ERR("failed to parse extension ref", fuzzyRef);
+        }
+
+        extDefs.emplace_back(api::types::v1::ExtensionDefine{
+          .directory = "/opt/extensions/" + fuzzyRef->id,
+          .name = fuzzyRef->id,
+          .version = fuzzyRef->version.value_or(""),
+        });
+    }
+    return extDefs;
 }
 
 void RunContext::detectDisplaySystem(generator::ContainerCfgBuilder &builder) noexcept

--- a/libs/linglong/src/linglong/runtime/run_context.h
+++ b/libs/linglong/src/linglong/runtime/run_context.h
@@ -59,6 +59,7 @@ struct ResolveOptions
     std::optional<std::vector<std::string>> appModules;
     std::optional<std::string> baseRef;
     std::optional<std::string> runtimeRef;
+    std::optional<std::vector<std::string>> extensionRefs;
 };
 
 class RunContext
@@ -103,8 +104,14 @@ private:
     utils::error::Result<void> resolveLayer(bool depsBinaryOnly,
                                             const std::vector<std::string> &appModules);
     utils::error::Result<void> resolveExtension(RuntimeLayer &layer);
+    utils::error::Result<void>
+    resolveExtension(const std::vector<api::types::v1::ExtensionDefine> &extDefs,
+                     std::optional<std::string> channel = std::nullopt,
+                     bool skipOnNotFound = false);
     utils::error::Result<void> fillExtraAppMounts(generator::ContainerCfgBuilder &builder);
     void detectDisplaySystem(generator::ContainerCfgBuilder &builder) noexcept;
+    utils::error::Result<std::vector<api::types::v1::ExtensionDefine>>
+    makeManualExtensionDefine(const std::vector<std::string> &refs);
 
     repo::OSTreeRepo &repo;
     std::unordered_map<SecurityContextType, std::unique_ptr<SecurityContext>> securityContexts;


### PR DESCRIPTION
# 使用指定的扩展包运行应用
`ll-cli run org.deepin.demo --extensions org.deepin.driver.display.nvidia`
# 使用环境变量指定的扩展包运行应用
`export LL_FORCE_EXTENSION=org.deepin.driver.display.nvidia`
`ll-cli run org.deepin.demo`

背景
- 现有运行时仅解析包内声明的 extension，无法手动指定多个扩展。
- 需要支持通过 CLI/环境变量临时启用扩展，并按扩展定义注入环境变量。

变更
- ll-cli/ll-builder 新增 --extensions 选项（支持逗号分隔）。
- Builder/Cli 将 extensions 传入 RunContext::ResolveOptions。
- RunContext 支持手动解析并挂载 extension；读取 extImpl->env，
  自动构造 allowEnv（以系统环境为默认值）；解析失败的扩展将被忽略并告警。
- 当旧值与默认值都为空时，$ORIGIN 替换会移除多余的结尾冒号。
- 日志新增 extensions 输出，便于排查。

用法
- CLI：ll-cli run <app> --extensions ext1,ext2 -- <command>
- 环境变量：LL_FORCE_EXTENSION=ext1,ext2 ll-cli run <app> -- <command>

兼容性
- 无破坏性；未指定 --extensions 且未设置 LL_FORCE_EXTENSION 时行为不变。

测试
- 验证指定多个扩展的挂载顺序与 env 注入。
- 验证仅设置 LL_FORCE_EXTENSION 的回退逻辑。
- 示例：LL_FORCE_EXTENSION=org.example.ext1 ll-cli run org.demo -- bash -lc 'env | grep ...'

Refs: #1458
