### PR TITLE
feat: Add tests and enhance string utilities

### DIFF
--- a/libs/common/src/linglong/common/strings.cpp
+++ b/libs/common/src/linglong/common/strings.cpp
@@ -19,11 +19,15 @@ bool stringEqual(std::string_view str1, std::string_view str2, bool caseSensitiv
     });
 }
 
-std::string trim(const std::string &str) noexcept
+std::string trim(std::string_view str, std::string_view chars) noexcept
 {
-    auto first = str.find_first_not_of(' ');
-    auto last = str.find_last_not_of(' ');
-    return str.substr(first, last - first + 1);
+    auto first = str.find_first_not_of(chars);
+    if (first == std::string_view::npos) {
+        return "";
+    }
+
+    auto last = str.find_last_not_of(chars);
+    return std::string(str.substr(first, last - first + 1));
 }
 
 std::vector<std::string> split(const std::string &str, char delimiter, splitOption option) noexcept
@@ -61,12 +65,27 @@ std::vector<std::string> split(const std::string &str, char delimiter, splitOpti
 
 std::string join(const std::vector<std::string> &strs, char delimiter) noexcept
 {
-    std::string result;
-    for (size_t i = 0; i < strs.size() - 1; ++i) {
-        result += strs[i];
-        result += delimiter;
+    if (strs.empty()) {
+        return "";
     }
-    result += strs[strs.size() - 1];
+
+    if (strs.size() == 1) {
+        return strs[0];
+    }
+
+    size_t total_len = strs.size() - 1;
+    for (const auto &s : strs) {
+        total_len += s.size();
+    }
+
+    std::string result;
+    result.reserve(total_len);
+    result.append(strs[0]);
+    for (size_t i = 1; i < strs.size(); ++i) {
+        result.push_back(delimiter);
+        result.append(strs[i]);
+    }
+
     return result;
 }
 
@@ -97,7 +116,7 @@ std::string replaceSubstring(std::string_view str,
     return result;
 }
 
-bool hasPrefix(std::string_view str, std::string_view prefix) noexcept
+bool starts_with(std::string_view str, std::string_view prefix) noexcept
 {
     if (str.size() < prefix.size()) {
         return false;
@@ -106,11 +125,12 @@ bool hasPrefix(std::string_view str, std::string_view prefix) noexcept
     return str.substr(0, prefix.size()) == prefix;
 }
 
-bool hasSuffix(std::string_view str, std::string_view suffix) noexcept
+bool ends_with(std::string_view str, std::string_view suffix) noexcept
 {
     if (str.size() < suffix.size()) {
         return false;
     }
+
     return str.substr(str.size() - suffix.size()) == suffix;
 }
 

--- a/libs/common/src/linglong/common/strings.h
+++ b/libs/common/src/linglong/common/strings.h
@@ -31,7 +31,7 @@ inline splitOption operator&(splitOption a, splitOption b)
 
 bool stringEqual(std::string_view str1, std::string_view str2, bool caseSensitive = false) noexcept;
 
-std::string trim(const std::string &str) noexcept;
+std::string trim(std::string_view str, std::string_view chars = " ") noexcept;
 
 std::vector<std::string> split(const std::string &str,
                                char delimiter,
@@ -43,9 +43,9 @@ std::string replaceSubstring(std::string_view str,
                              std::string_view from,
                              std::string_view to) noexcept;
 
-bool hasPrefix(std::string_view str, std::string_view prefix) noexcept;
+bool starts_with(std::string_view str, std::string_view prefix) noexcept;
 
-bool hasSuffix(std::string_view str, std::string_view suffix) noexcept;
+bool ends_with(std::string_view str, std::string_view suffix) noexcept;
 
 bool contains(std::string_view str, std::string_view suffix) noexcept;
 

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -2056,7 +2056,7 @@ utils::error::Result<void> OSTreeRepo::exportDir(const std::string &appID,
         }
         if (is_regular_file) {
             // linyaps.original结尾的文件是重写之前的备份文件，不应该被导出
-            if (common::strings::hasSuffix(source_path.string(), ".linyaps.original")) {
+            if (common::strings::ends_with(source_path.string(), ".linyaps.original")) {
                 continue;
             }
             // 在导出桌面文件和dbus服务文件时，需要修改其中的Exec和TryExec字段
@@ -2128,8 +2128,8 @@ utils::error::Result<void> OSTreeRepo::exportDir(const std::string &appID,
                  target_path.string());
             // 如果配置了overlay并且是applications中的desktop文件，执行特殊的逻辑
             if (oldAppDir != newAppDir
-                && common::strings::hasPrefix(target_path.string(), oldAppDir)
-                && common::strings::hasSuffix(target_path.string(), ".desktop")) {
+                && common::strings::starts_with(target_path.string(), oldAppDir)
+                && common::strings::ends_with(target_path.string(), ".desktop")) {
                 auto desktopExists = false;
                 // 如果要导出的desktop已存在，则覆盖导出（无论是在default还是overlay中），避免桌面和任务栏的快捷方式失效
                 const std::string appDirs[] = { oldAppDir, newAppDir };

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -12,6 +12,7 @@ pfl_add_executable(
   DISABLE_INSTALL
   SOURCES
   # find -regex '\./src/.+\.[ch]\(pp\)?' -type f -printf '%P\n'| sort
+  src/linglong/common/strings_test.cpp
   src/linglong/common/xdg_test.cpp
   src/linglong/package/architecture_test.cpp
   src/linglong/package/fallback_version_test.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/common/strings_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/common/strings_test.cpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "linglong/common/strings.h"
+
+namespace linglong::common::strings {
+
+TEST(StringsTest, StringEqual)
+{
+    EXPECT_TRUE(stringEqual("hello", "hello", true));
+    EXPECT_FALSE(stringEqual("hello", "world", true));
+    EXPECT_FALSE(stringEqual("hello", "Hello", true));
+    EXPECT_TRUE(stringEqual("hello", "Hello", false));
+    EXPECT_TRUE(stringEqual("HELLO", "hello", false));
+    EXPECT_FALSE(stringEqual("hello", "world", false));
+    EXPECT_TRUE(stringEqual("", "", true));
+    EXPECT_TRUE(stringEqual("", "", false));
+    EXPECT_FALSE(stringEqual("hello", "", true));
+    EXPECT_FALSE(stringEqual("", "hello", false));
+    EXPECT_FALSE(stringEqual("hello", "hello world", true));
+}
+
+TEST(StringsTest, Trim)
+{
+    EXPECT_EQ(trim("  hello  "), "hello");
+    EXPECT_EQ(trim("hello  "), "hello");
+    EXPECT_EQ(trim("  hello"), "hello");
+    EXPECT_EQ(trim("hello"), "hello");
+    EXPECT_EQ(trim("  "), "");
+    EXPECT_EQ(trim(""), "");
+    EXPECT_EQ(trim("...hello...", "."), "hello");
+    EXPECT_EQ(trim("abchelloabc", "abc"), "hello");
+    EXPECT_EQ(trim("xxxyhelloxyx", "xy"), "hello");
+    EXPECT_EQ(trim("  hello  ", "."), "  hello  ");
+}
+
+TEST(StringsTest, Split)
+{
+    EXPECT_EQ(split("a,b,c", ',', splitOption::None), std::vector<std::string>({ "a", "b", "c" }));
+    EXPECT_EQ(split(" a , b , c ", ',', splitOption::TrimWhitespace),
+              std::vector<std::string>({ "a", "b", "c" }));
+    EXPECT_EQ(split("a,,c", ',', splitOption::SkipEmpty), std::vector<std::string>({ "a", "c" }));
+    EXPECT_EQ(split(" a , , c ", ',', splitOption::TrimWhitespace | splitOption::SkipEmpty),
+              std::vector<std::string>({ "a", "c" }));
+    EXPECT_EQ(split(",a,b,", ',', splitOption::SkipEmpty), std::vector<std::string>({ "a", "b" }));
+    EXPECT_EQ(split("a,b,", ',', splitOption::None), std::vector<std::string>({ "a", "b", "" }));
+    EXPECT_EQ(split("", ',', splitOption::None), std::vector<std::string>({ "" }));
+    EXPECT_EQ(split("", ',', splitOption::SkipEmpty), std::vector<std::string>({}));
+    EXPECT_EQ(split(",,", ',', splitOption::None), std::vector<std::string>({ "", "", "" }));
+    EXPECT_EQ(split(",,", ',', splitOption::SkipEmpty), std::vector<std::string>({}));
+}
+
+TEST(StringsTest, Join)
+{
+    EXPECT_EQ(join({ "a", "b", "c" }, ','), "a,b,c");
+    EXPECT_EQ(join({ "a" }, ','), "a");
+    EXPECT_EQ(join({}, ','), "");
+    EXPECT_EQ(join({ "", "", "" }, ','), ",,");
+}
+
+TEST(StringsTest, ReplaceSubstring)
+{
+    EXPECT_EQ(replaceSubstring("hello world", "world", "linglong"), "hello linglong");
+    EXPECT_EQ(replaceSubstring("abab", "ab", "c"), "cc");
+    EXPECT_EQ(replaceSubstring("hello", "world", "linglong"), "hello");
+    EXPECT_EQ(replaceSubstring("hello world", "world", ""), "hello ");
+    EXPECT_EQ(replaceSubstring("hello", "", "linglong"), "hello");
+    EXPECT_EQ(replaceSubstring("", "a", "b"), "");
+}
+
+TEST(StringsTest, StartsWith)
+{
+    EXPECT_TRUE(starts_with("hello world", "hello"));
+    EXPECT_FALSE(starts_with("hello world", "world"));
+    EXPECT_FALSE(starts_with("hello", "hello world"));
+    EXPECT_TRUE(starts_with("hello", ""));
+    EXPECT_FALSE(starts_with("", "hello"));
+    EXPECT_TRUE(starts_with("", ""));
+}
+
+TEST(StringsTest, EndsWith)
+{
+    EXPECT_TRUE(ends_with("hello world", "world"));
+    EXPECT_FALSE(ends_with("hello world", "hello"));
+    EXPECT_FALSE(ends_with("world", "hello world"));
+    EXPECT_TRUE(ends_with("hello", ""));
+    EXPECT_FALSE(ends_with("", "hello"));
+    EXPECT_TRUE(ends_with("", ""));
+}
+
+TEST(StringsTest, Contains)
+{
+    EXPECT_TRUE(contains("hello world", "lo wo"));
+    EXPECT_FALSE(contains("hello world", "abc"));
+    EXPECT_TRUE(contains("hello", "hello"));
+    EXPECT_TRUE(contains("hello", ""));
+    EXPECT_FALSE(contains("", "hello"));
+    EXPECT_TRUE(contains("", ""));
+}
+
+} // namespace linglong::common::strings

--- a/libs/linglong/tests/ll-tests/src/linglong/package/layer_packager_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/layer_packager_test.cpp
@@ -178,7 +178,7 @@ TEST_F(LayerPackagerTest, InitWorkDir)
     // 测试创建workdir失败时, initWorkDir 应该使用临时目录
     packager.wrapMkdirDirFunc = [](const std::string &path) -> utils::error::Result<void> {
         LINGLONG_TRACE("test workdir not exists");
-        if (common::strings::hasPrefix(path, "/var/tmp")) {
+        if (common::strings::starts_with(path, "/var/tmp")) {
             return LINGLONG_ERR("failed to create work dir");
         }
         return LINGLONG_OK;

--- a/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
@@ -161,7 +161,7 @@ TEST_F(UabFileTest, UnpackFuse)
     };
     uab.wrapMkdirDirFunc = [](const std::string &path) -> utils::error::Result<void> {
         LINGLONG_TRACE("test");
-        if (common::strings::hasPrefix(path, "/var/tmp")) {
+        if (common::strings::starts_with(path, "/var/tmp")) {
             return LINGLONG_ERR("Cannot create directory in /var/tmp");
         }
         std::filesystem::create_directories(path);

--- a/tools/generate-coverage.sh
+++ b/tools/generate-coverage.sh
@@ -32,6 +32,8 @@ mkdir -p "$builddir"/report || exit 255
 
 gcovr \
     --filter "apps/.*" \
+    --filter "libs/common/.*" \
+    --filter "libs/oci-cfg-generators/.*" \
     --filter "libs/utils/.*" \
     --filter "libs/linglong/src/.*" \
     --html-nested "$builddir"/report/index.html \


### PR DESCRIPTION
Add unit tests for the strings utility functions

Key changes include:

- Enhance `trim` to support trimming with a custom set of characters
- `join` function can handle empty vector now
- Rename `hasPrefix` and `hasSuffix` to `starts_with` and `ends_with` respectively.