### PR TITLE
chore: fix linglong test script package name

### DIFF
--- a/tools/test-linglong.sh
+++ b/tools/test-linglong.sh
@@ -53,7 +53,7 @@ ll-cli uninstall org.deepin.demo || true
 ./org.deepin.demo_x86_64_0.0.0.1_main.uab
 
 #安装构建的应用
-ll-cli install org.deepin.demo_x86_64_0.0.0.1_main.uab
+ll-cli install org.deepin.demo_0.0.0.1_x86_64_main.uab
 ll-cli uninstall org.deepin.demo || true
 ll-cli install org.deepin.demo_0.0.0.1_x86_64_binary.layer
 


### PR DESCRIPTION
测试脚本已更新以修正安装命令中的包文件名格式。原来的文件名
模式'org.deepin.demo_x86_64_0.0.0.1_main.uab'不正确，已更改 为'org.deepin.demo_0.0.0.1_x86_64_main.uab'以匹配后续二进制层安装中使用 的实际包命名约定。这确保了测试过程中UAB包和二进制层包名称的一致性。