### PR TITLE
fix: fix logging and mergeOutput

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.h
+++ b/libs/linglong/src/linglong/builder/linglong_builder.h
@@ -53,6 +53,12 @@ utils::error::Result<void> cmdRemoveApp(repo::OSTreeRepo &repo,
                                         std::vector<std::string> refs,
                                         bool prune);
 
+namespace detail {
+void mergeOutput(const std::vector<std::filesystem::path> &src,
+                 const std::filesystem::path &dest,
+                 const std::vector<std::string> &targets);
+}
+
 class Builder
 {
 public:
@@ -128,9 +134,6 @@ private:
     auto generateBuildDependsScript() noexcept -> utils::error::Result<bool>;
     auto generateDependsScript() noexcept -> utils::error::Result<bool>;
     void takeTerminalForeground();
-    void mergeOutput(const std::vector<std::filesystem::path> &src,
-                     const std::filesystem::path &dest,
-                     const std::vector<std::string> &targets);
     void printBasicInfo();
     void printRepo();
     bool checkDeprecatedInstallFile();

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/log.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/log.cpp
@@ -224,3 +224,20 @@ TEST_F(LoggerTest, MessageFormattingWorksCorrectly)
     ASSERT_TRUE(mock_journal_data.called);
     EXPECT_EQ(mock_journal_data.fields["MESSAGE"], "Hello, world! The number is 42.");
 }
+
+TEST_F(LoggerTest, LogFormat)
+{
+    logger_.setLogLevel(LogLevel::Debug);
+    logger_.setLogBackend(LogBackend::Console);
+
+    std::string captured_output;
+    {
+        StderrRedirector redirector;
+        EXPECT_TRUE(redirector.init());
+        std::string message = "message is {}";
+        logger_.log(context_, LogLevel::Debug, "Debug: {}", message);
+        captured_output = redirector.getOutput();
+    }
+
+    EXPECT_EQ("Debug: message is {}\n", captured_output);
+}

--- a/libs/utils/src/linglong/utils/log/log.h
+++ b/libs/utils/src/linglong/utils/log/log.h
@@ -97,7 +97,7 @@ public:
         }
 
         if ((logBackend & LogBackend::Console) != LogBackend::None) {
-            fmt::println(stderr, message);
+            fmt::println(stderr, "{}", message);
         }
 
         if ((logBackend & LogBackend::Journal) != LogBackend::None) {


### PR DESCRIPTION
- `fmt::println(stderr, message)` could crash if the message contained format specifiers like `{}`.
- fix the `mergeOutput` logic and extract it from the `Builder` class into a free function within the `detail` namespace. This refactoring allows for easier unit testing.
- Unit tests have been added for both `mergeOutput` function and the logging format fix.