### PR TITLE
feat: add unit tests for utility components

### DIFF
--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -41,6 +41,9 @@ pfl_add_executable(
   src/linglong/utils/transaction_test.cpp
   src/linglong/utils/command_test.cpp
   src/linglong/utils/bash_command_helper_test.cpp
+  src/linglong/utils/packageinfo_handler_test.cpp
+  src/linglong/utils/gkeyfile_wrapper_test.cpp
+  src/linglong/utils/xdg/directory_test.cpp
   src/linglong/repo/config_test.cpp
   src/linglong/repo/ostree_repo_test.cpp
   src/linglong/repo/client_factory_test.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/gkeyfile_wrapper_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/gkeyfile_wrapper_test.cpp
@@ -1,0 +1,373 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "linglong/utils/error/error.h"
+#include "linglong/utils/gkeyfile_wrapper.h"
+
+#include <QTemporaryFile>
+#include <QTextStream>
+
+#include <filesystem>
+#include <fstream>
+
+class GKeyFileWrapperTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // 创建临时文件用于测试
+        tempFile = std::make_unique<QTemporaryFile>();
+        ASSERT_TRUE(tempFile->open());
+        tempFilePath = tempFile->fileName();
+        tempFile->close();
+    }
+
+    void TearDown() override
+    {
+        // 清理临时文件
+        if (tempFile && tempFile->exists()) {
+            tempFile->remove();
+        }
+    }
+
+    void createTestFile(const QString &content)
+    {
+        QFile file(tempFilePath);
+        ASSERT_TRUE(file.open(QIODevice::WriteOnly | QIODevice::Text));
+        QTextStream stream(&file);
+        stream << content;
+        file.close();
+    }
+
+    std::unique_ptr<QTemporaryFile> tempFile;
+    QString tempFilePath;
+};
+
+TEST_F(GKeyFileWrapperTest, NewWithNonExistentFile)
+{
+    auto result = linglong::utils::GKeyFileWrapper::New("/nonexistent/file.ini");
+    EXPECT_FALSE(result.has_value());
+    EXPECT_TRUE(result.error().message().find("no such file") != std::string::npos);
+}
+
+TEST_F(GKeyFileWrapperTest, NewWithValidFile)
+{
+    const QString content = R"([Desktop Entry]
+Name=Test Application
+Exec=/usr/bin/test-app
+Icon=test-icon
+)";
+
+    createTestFile(content);
+
+    auto result = linglong::utils::GKeyFileWrapper::New(tempFilePath);
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST_F(GKeyFileWrapperTest, NewWithInvalidFile)
+{
+    // 创建无效的文件内容
+    const QString content = R"([Invalid Section
+Name=Test Application
+)";
+
+    createTestFile(content);
+
+    auto result = linglong::utils::GKeyFileWrapper::New(tempFilePath);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(GKeyFileWrapperTest, SetAndGetValue)
+{
+    const QString content = R"([Desktop Entry]
+Name=Test Application
+)";
+
+    createTestFile(content);
+
+    auto result = linglong::utils::GKeyFileWrapper::New(tempFilePath);
+    ASSERT_TRUE(result.has_value());
+
+    auto &wrapper = *result;
+
+    // 设置新值
+    wrapper.setValue("Exec", "/usr/bin/new-app", linglong::utils::GKeyFileWrapper::DesktopEntry);
+
+    // 获取值
+    auto execValue =
+      wrapper.getValue<QString>("Exec", linglong::utils::GKeyFileWrapper::DesktopEntry);
+    EXPECT_TRUE(execValue.has_value());
+    EXPECT_EQ(*execValue, "/usr/bin/new-app");
+
+    // 获取已存在的值
+    auto nameValue =
+      wrapper.getValue<QString>("Name", linglong::utils::GKeyFileWrapper::DesktopEntry);
+    EXPECT_TRUE(nameValue.has_value());
+    EXPECT_EQ(*nameValue, "Test Application");
+}
+
+TEST_F(GKeyFileWrapperTest, GetValueWithNonExistentKey)
+{
+    const QString content = R"([Desktop Entry]
+Name=Test Application
+)";
+
+    createTestFile(content);
+
+    auto result = linglong::utils::GKeyFileWrapper::New(tempFilePath);
+    ASSERT_TRUE(result.has_value());
+
+    auto &wrapper = *result;
+
+    // 获取不存在的键
+    auto nonExistentValue =
+      wrapper.getValue<QString>("NonExistentKey", linglong::utils::GKeyFileWrapper::DesktopEntry);
+    EXPECT_FALSE(nonExistentValue.has_value());
+}
+
+TEST_F(GKeyFileWrapperTest, GetValueWithNonExistentGroup)
+{
+    const QString content = R"([Desktop Entry]
+Name=Test Application
+)";
+
+    createTestFile(content);
+
+    auto result = linglong::utils::GKeyFileWrapper::New(tempFilePath);
+    ASSERT_TRUE(result.has_value());
+
+    auto &wrapper = *result;
+
+    // 获取不存在的组
+    auto nonExistentValue = wrapper.getValue<QString>("Name", "NonExistentGroup");
+    EXPECT_FALSE(nonExistentValue.has_value());
+}
+
+TEST_F(GKeyFileWrapperTest, GetGroups)
+{
+    const QString content = R"([Desktop Entry]
+Name=Test Application
+
+[D-BUS Service]
+Name=com.example.Test
+
+[Service]
+ExecStart=/usr/bin/test-service
+)";
+
+    createTestFile(content);
+
+    auto result = linglong::utils::GKeyFileWrapper::New(tempFilePath);
+    ASSERT_TRUE(result.has_value());
+
+    auto &wrapper = *result;
+
+    auto groups = wrapper.getGroups();
+    EXPECT_EQ(groups.size(), 3);
+    EXPECT_TRUE(groups.contains("Desktop Entry"));
+    EXPECT_TRUE(groups.contains("D-BUS Service"));
+    EXPECT_TRUE(groups.contains("Service"));
+}
+
+TEST_F(GKeyFileWrapperTest, GetKeys)
+{
+    const QString content = R"([Desktop Entry]
+Name=Test Application
+Exec=/usr/bin/test-app
+Icon=test-icon
+)";
+
+    createTestFile(content);
+
+    auto result = linglong::utils::GKeyFileWrapper::New(tempFilePath);
+    ASSERT_TRUE(result.has_value());
+
+    auto &wrapper = *result;
+
+    auto keys = wrapper.getkeys(linglong::utils::GKeyFileWrapper::DesktopEntry);
+    EXPECT_TRUE(keys.has_value());
+    EXPECT_EQ(keys->size(), 3);
+    EXPECT_TRUE(keys->contains("Name"));
+    EXPECT_TRUE(keys->contains("Exec"));
+    EXPECT_TRUE(keys->contains("Icon"));
+}
+
+TEST_F(GKeyFileWrapperTest, GetKeysWithNonExistentGroup)
+{
+    const QString content = R"([Desktop Entry]
+Name=Test Application
+)";
+
+    createTestFile(content);
+
+    auto result = linglong::utils::GKeyFileWrapper::New(tempFilePath);
+    ASSERT_TRUE(result.has_value());
+
+    auto &wrapper = *result;
+
+    auto keys = wrapper.getkeys("NonExistentGroup");
+    EXPECT_FALSE(keys.has_value());
+}
+
+TEST_F(GKeyFileWrapperTest, SaveToFile)
+{
+    const QString content = R"([Desktop Entry]
+Name=Test Application
+)";
+
+    createTestFile(content);
+
+    auto result = linglong::utils::GKeyFileWrapper::New(tempFilePath);
+    ASSERT_TRUE(result.has_value());
+
+    auto &wrapper = *result;
+
+    // 修改内容
+    wrapper.setValue("Exec",
+                     "/usr/bin/modified-app",
+                     linglong::utils::GKeyFileWrapper::DesktopEntry);
+    wrapper.setValue("Icon", "modified-icon", linglong::utils::GKeyFileWrapper::DesktopEntry);
+
+    // 保存到新文件
+    QString newFilePath = tempFilePath + ".new";
+    auto saveResult = wrapper.saveToFile(newFilePath);
+    EXPECT_TRUE(saveResult.has_value());
+
+    // 验证新文件内容
+    auto newWrapper = linglong::utils::GKeyFileWrapper::New(newFilePath);
+    EXPECT_TRUE(newWrapper.has_value());
+
+    auto execValue =
+      newWrapper->getValue<QString>("Exec", linglong::utils::GKeyFileWrapper::DesktopEntry);
+    EXPECT_TRUE(execValue.has_value());
+    EXPECT_EQ(*execValue, "/usr/bin/modified-app");
+
+    auto iconValue =
+      newWrapper->getValue<QString>("Icon", linglong::utils::GKeyFileWrapper::DesktopEntry);
+    EXPECT_TRUE(iconValue.has_value());
+    EXPECT_EQ(*iconValue, "modified-icon");
+
+    // 清理新文件
+    QFile::remove(newFilePath);
+}
+
+TEST_F(GKeyFileWrapperTest, HasKey)
+{
+    const QString content = R"([Desktop Entry]
+Name=Test Application
+Exec=/usr/bin/test-app
+)";
+
+    createTestFile(content);
+
+    auto result = linglong::utils::GKeyFileWrapper::New(tempFilePath);
+    ASSERT_TRUE(result.has_value());
+
+    auto &wrapper = *result;
+
+    // 测试存在的键
+    auto hasName = wrapper.hasKey("Name", linglong::utils::GKeyFileWrapper::DesktopEntry);
+    EXPECT_TRUE(hasName.has_value());
+    EXPECT_TRUE(*hasName);
+
+    auto hasExec = wrapper.hasKey("Exec", linglong::utils::GKeyFileWrapper::DesktopEntry);
+    EXPECT_TRUE(hasExec.has_value());
+    EXPECT_TRUE(*hasExec);
+
+    // 测试不存在的键
+    auto hasNonExistent =
+      wrapper.hasKey("NonExistentKey", linglong::utils::GKeyFileWrapper::DesktopEntry);
+    EXPECT_TRUE(hasNonExistent.has_value());
+    EXPECT_FALSE(*hasNonExistent);
+}
+
+TEST_F(GKeyFileWrapperTest, HasKeyWithNonExistentGroup)
+{
+    const QString content = R"([Desktop Entry]
+Name=Test Application
+)";
+
+    createTestFile(content);
+
+    auto result = linglong::utils::GKeyFileWrapper::New(tempFilePath);
+    ASSERT_TRUE(result.has_value());
+
+    auto &wrapper = *result;
+
+    auto hasKey = wrapper.hasKey("Name", "NonExistentGroup");
+    EXPECT_FALSE(hasKey.has_value());
+}
+
+TEST_F(GKeyFileWrapperTest, Constants)
+{
+    // 测试常量定义
+    EXPECT_EQ(linglong::utils::GKeyFileWrapper::DesktopEntry, "Desktop Entry");
+    EXPECT_EQ(linglong::utils::GKeyFileWrapper::DBusService, "D-BUS Service");
+    EXPECT_EQ(linglong::utils::GKeyFileWrapper::SystemdService, "Service");
+    EXPECT_EQ(linglong::utils::GKeyFileWrapper::ContextMenu, "Menu Entry");
+}
+
+TEST_F(GKeyFileWrapperTest, EmptyFile)
+{
+    // 创建空文件
+    createTestFile("");
+
+    auto result = linglong::utils::GKeyFileWrapper::New(tempFilePath);
+    EXPECT_TRUE(result.has_value());
+
+    auto &wrapper = *result;
+
+    // 空文件应该没有组
+    auto groups = wrapper.getGroups();
+    EXPECT_TRUE(groups.isEmpty());
+}
+
+TEST_F(GKeyFileWrapperTest, MultipleOperations)
+{
+    const QString content = R"([Desktop Entry]
+Name=Original Name
+)";
+
+    createTestFile(content);
+
+    auto result = linglong::utils::GKeyFileWrapper::New(tempFilePath);
+    ASSERT_TRUE(result.has_value());
+
+    auto &wrapper = *result;
+
+    // 执行多个操作
+    wrapper.setValue("Name", "Updated Name", linglong::utils::GKeyFileWrapper::DesktopEntry);
+    wrapper.setValue("Exec",
+                     "/usr/bin/updated-app",
+                     linglong::utils::GKeyFileWrapper::DesktopEntry);
+    wrapper.setValue("Icon", "updated-icon", linglong::utils::GKeyFileWrapper::DesktopEntry);
+
+    // 验证所有更改
+    auto nameValue =
+      wrapper.getValue<QString>("Name", linglong::utils::GKeyFileWrapper::DesktopEntry);
+    EXPECT_TRUE(nameValue.has_value());
+    EXPECT_EQ(*nameValue, "Updated Name");
+
+    auto execValue =
+      wrapper.getValue<QString>("Exec", linglong::utils::GKeyFileWrapper::DesktopEntry);
+    EXPECT_TRUE(execValue.has_value());
+    EXPECT_EQ(*execValue, "/usr/bin/updated-app");
+
+    auto iconValue =
+      wrapper.getValue<QString>("Icon", linglong::utils::GKeyFileWrapper::DesktopEntry);
+    EXPECT_TRUE(iconValue.has_value());
+    EXPECT_EQ(*iconValue, "updated-icon");
+
+    // 验证键的存在
+    auto hasAllKeys = wrapper.hasKey("Name", linglong::utils::GKeyFileWrapper::DesktopEntry);
+    EXPECT_TRUE(hasAllKeys.has_value());
+    EXPECT_TRUE(*hasAllKeys);
+
+    // 验证组中的键数量
+    auto keys = wrapper.getkeys(linglong::utils::GKeyFileWrapper::DesktopEntry);
+    EXPECT_TRUE(keys.has_value());
+    EXPECT_EQ(keys->size(), 3);
+}

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/packageinfo_handler_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/packageinfo_handler_test.cpp
@@ -1,0 +1,425 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "linglong/utils/error/error.h"
+#include "linglong/utils/packageinfo_handler.h"
+#include "linglong/utils/serialize/json.h"
+
+#include <filesystem>
+#include <fstream>
+
+using namespace linglong::utils;
+
+class PackageInfoHandlerTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // 创建临时目录用于测试
+        tempDir = std::filesystem::temp_directory_path() / "packageinfo_test";
+        std::filesystem::create_directories(tempDir);
+    }
+
+    void TearDown() override
+    {
+        // 清理临时目录
+        std::filesystem::remove_all(tempDir);
+    }
+
+    std::filesystem::path tempDir;
+};
+
+TEST_F(PackageInfoHandlerTest, toPackageInfoV2_BasicConversion)
+{
+    // 创建PackageInfo对象
+    linglong::api::types::v1::PackageInfo oldInfo;
+    oldInfo.appid = "com.example.testapp";
+    oldInfo.arch = { "x86_64" };
+    oldInfo.base = "org.deepin.base";
+    oldInfo.channel = "main";
+    oldInfo.command = std::vector<std::string>{ "testapp" };
+    oldInfo.description = "Test application";
+    oldInfo.kind = "app";
+    oldInfo.packageInfoModule = "runtime";
+    oldInfo.name = "TestApp";
+    oldInfo.size = 1024;
+    oldInfo.version = "1.0.0";
+
+    // 转换为PackageInfoV2
+    auto result = linglong::utils::toPackageInfoV2(oldInfo);
+
+    // 验证转换结果
+    EXPECT_EQ(result.id, oldInfo.appid);
+    EXPECT_EQ(result.arch, oldInfo.arch);
+    EXPECT_EQ(result.base, oldInfo.base);
+    EXPECT_EQ(result.channel, "main"); // channel有默认值
+    EXPECT_EQ(result.command, oldInfo.command);
+    EXPECT_EQ(result.description, oldInfo.description);
+    EXPECT_EQ(result.kind, oldInfo.kind);
+    EXPECT_EQ(result.packageInfoV2Module, oldInfo.packageInfoModule);
+    EXPECT_EQ(result.name, oldInfo.name);
+    // 比较permissions - 两者都应该是空值
+    EXPECT_EQ(result.permissions.has_value(), oldInfo.permissions.has_value());
+    EXPECT_EQ(result.runtime, oldInfo.runtime);
+    EXPECT_EQ(result.schemaVersion, PACKAGE_INFO_VERSION);
+    EXPECT_EQ(result.size, oldInfo.size);
+    EXPECT_EQ(result.version, oldInfo.version);
+
+    // 验证可选字段
+    EXPECT_FALSE(result.compatibleVersion.has_value());
+    EXPECT_FALSE(result.uuid.has_value());
+}
+
+TEST_F(PackageInfoHandlerTest, toPackageInfoV2_WithOptionalFields)
+{
+    // 创建包含可选字段的PackageInfo对象
+    linglong::api::types::v1::PackageInfo oldInfo;
+    oldInfo.appid = "com.example.testapp";
+    oldInfo.arch = { "x86_64" };
+    oldInfo.base = "org.deepin.base";
+    oldInfo.channel = std::nullopt;     // 空channel
+    oldInfo.command = std::nullopt;     // 空command
+    oldInfo.description = std::nullopt; // 空description
+    oldInfo.kind = "app";
+    oldInfo.packageInfoModule = "runtime";
+    oldInfo.name = "TestApp";
+    oldInfo.permissions = std::nullopt; // 空permissions
+    oldInfo.runtime = std::nullopt;     // 空runtime
+    oldInfo.size = 2048;
+    oldInfo.version = "2.0.0";
+
+    // 转换为PackageInfoV2
+    auto result = linglong::utils::toPackageInfoV2(oldInfo);
+
+    // 验证转换结果
+    EXPECT_EQ(result.id, oldInfo.appid);
+    EXPECT_EQ(result.arch, oldInfo.arch);
+    EXPECT_EQ(result.base, oldInfo.base);
+    EXPECT_EQ(result.channel, "main");            // 空channel使用默认值
+    EXPECT_FALSE(result.command.has_value());     // 空command保持空
+    EXPECT_FALSE(result.description.has_value()); // 空description保持空
+    EXPECT_EQ(result.kind, oldInfo.kind);
+    EXPECT_EQ(result.packageInfoV2Module, oldInfo.packageInfoModule);
+    EXPECT_EQ(result.name, oldInfo.name);
+    EXPECT_FALSE(result.permissions.has_value()); // 空permissions保持空
+    EXPECT_FALSE(result.runtime.has_value());     // 空runtime保持空
+    EXPECT_EQ(result.schemaVersion, PACKAGE_INFO_VERSION);
+    EXPECT_EQ(result.size, oldInfo.size);
+    EXPECT_EQ(result.version, oldInfo.version);
+}
+
+TEST_F(PackageInfoHandlerTest, parsePackageInfo_FromFileV2)
+{
+    // 创建PackageInfoV2 JSON文件
+    std::string jsonContent = R"({
+        "arch": ["x86_64"],
+        "base": "org.deepin.base",
+        "channel": "main",
+        "command": ["testapp"],
+        "description": "Test application",
+        "id": "com.example.testapp",
+        "kind": "app",
+        "module": "runtime",
+        "name": "TestApp",
+        "schema_version": "1.0",
+        "size": 1024,
+        "version": "1.0.0"
+    })";
+
+    std::string filePath = (tempDir / "package_v2.json").string();
+    std::ofstream file(filePath);
+    ASSERT_TRUE(file.is_open());
+    file << jsonContent;
+    file.close();
+
+    // 解析文件
+    auto result = linglong::utils::parsePackageInfo(QString::fromStdString(filePath));
+
+    // 验证解析结果
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->id, "com.example.testapp");
+    EXPECT_EQ(result->arch, std::vector<std::string>{ "x86_64" });
+    EXPECT_EQ(result->base, "org.deepin.base");
+    EXPECT_EQ(result->channel, "main");
+    EXPECT_EQ(result->command, std::vector<std::string>{ "testapp" });
+    EXPECT_EQ(result->description, "Test application");
+    EXPECT_EQ(result->kind, "app");
+    EXPECT_EQ(result->packageInfoV2Module, "runtime");
+    EXPECT_EQ(result->name, "TestApp");
+    EXPECT_EQ(result->schemaVersion, "1.0");
+    EXPECT_EQ(result->size, 1024);
+    EXPECT_EQ(result->version, "1.0.0");
+}
+
+TEST_F(PackageInfoHandlerTest, parsePackageInfo_FromFileV1)
+{
+    // 创建PackageInfo JSON文件（V1格式）
+    std::string jsonContent = R"({
+        "appid": "com.example.testapp",
+        "arch": ["x86_64"],
+        "base": "org.deepin.base",
+        "channel": "main",
+        "command": ["testapp"],
+        "description": "Test application",
+        "kind": "app",
+        "module": "runtime",
+        "name": "TestApp",
+        "size": 1024,
+        "version": "1.0.0"
+    })";
+
+    std::string filePath = (tempDir / "package_v1.json").string();
+    std::ofstream file(filePath);
+    ASSERT_TRUE(file.is_open());
+    file << jsonContent;
+    file.close();
+
+    // 解析文件
+    auto result = linglong::utils::parsePackageInfo(QString::fromStdString(filePath));
+
+    // 验证解析结果
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    EXPECT_EQ(result->id, "com.example.testapp");
+    EXPECT_EQ(result->arch, std::vector<std::string>{ "x86_64" });
+    EXPECT_EQ(result->base, "org.deepin.base");
+    EXPECT_EQ(result->channel, "main");
+    EXPECT_EQ(result->command, std::vector<std::string>{ "testapp" });
+    EXPECT_EQ(result->description, "Test application");
+    EXPECT_EQ(result->kind, "app");
+    EXPECT_EQ(result->packageInfoV2Module, "runtime");
+    EXPECT_EQ(result->name, "TestApp");
+    EXPECT_EQ(result->schemaVersion, PACKAGE_INFO_VERSION);
+    EXPECT_EQ(result->size, 1024);
+    EXPECT_EQ(result->version, "1.0.0");
+}
+
+TEST_F(PackageInfoHandlerTest, parsePackageInfo_FromFileInvalid)
+{
+    // 创建无效的JSON文件
+    std::string jsonContent = R"({
+        "invalid": "json content"
+    })";
+
+    std::string filePath = (tempDir / "invalid.json").string();
+    std::ofstream file(filePath);
+    ASSERT_TRUE(file.is_open());
+    file << jsonContent;
+    file.close();
+
+    // 解析文件
+    auto result = linglong::utils::parsePackageInfo(QString::fromStdString(filePath));
+
+    // 验证解析失败
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(PackageInfoHandlerTest, parsePackageInfo_FromJSONV2)
+{
+    // 创建PackageInfoV2 JSON对象
+    nlohmann::json jsonData = { { "arch", { "x86_64" } },
+                                { "base", "org.deepin.base" },
+                                { "channel", "main" },
+                                { "command", { "testapp" } },
+                                { "description", "Test application" },
+                                { "id", "com.example.testapp" },
+                                { "kind", "app" },
+                                { "module", "runtime" },
+                                { "name", "TestApp" },
+                                { "schema_version", "1.0" },
+                                { "size", 1024 },
+                                { "version", "1.0.0" } };
+
+    // 解析JSON
+    auto result = linglong::utils::parsePackageInfo(jsonData);
+
+    // 验证解析结果
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->id, "com.example.testapp");
+    EXPECT_EQ(result->arch, std::vector<std::string>{ "x86_64" });
+    EXPECT_EQ(result->base, "org.deepin.base");
+    EXPECT_EQ(result->channel, "main");
+    EXPECT_EQ(result->command, std::vector<std::string>{ "testapp" });
+    EXPECT_EQ(result->description, "Test application");
+    EXPECT_EQ(result->kind, "app");
+    EXPECT_EQ(result->packageInfoV2Module, "runtime");
+    EXPECT_EQ(result->name, "TestApp");
+    EXPECT_EQ(result->schemaVersion, "1.0");
+    EXPECT_EQ(result->size, 1024);
+    EXPECT_EQ(result->version, "1.0.0");
+}
+
+TEST_F(PackageInfoHandlerTest, parsePackageInfo_FromJSONV1)
+{
+    // 创建PackageInfo JSON对象（V1格式）
+    nlohmann::json jsonData = { { "appid", "com.example.testapp" },
+                                { "arch", { "x86_64" } },
+                                { "base", "org.deepin.base" },
+                                { "channel", "main" },
+                                { "command", { "testapp" } },
+                                { "description", "Test application" },
+                                { "kind", "app" },
+                                { "module", "runtime" },
+                                { "name", "TestApp" },
+                                { "size", 1024 },
+                                { "version", "1.0.0" } };
+
+    // 解析JSON
+    auto result = linglong::utils::parsePackageInfo(jsonData);
+
+    // 验证解析结果
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    EXPECT_EQ(result->id, "com.example.testapp");
+    EXPECT_EQ(result->arch, std::vector<std::string>{ "x86_64" });
+    EXPECT_EQ(result->base, "org.deepin.base");
+    EXPECT_EQ(result->channel, "main");
+    EXPECT_EQ(result->command, std::vector<std::string>{ "testapp" });
+    EXPECT_EQ(result->description, "Test application");
+    EXPECT_EQ(result->kind, "app");
+    EXPECT_EQ(result->packageInfoV2Module, "runtime");
+    EXPECT_EQ(result->name, "TestApp");
+    EXPECT_EQ(result->schemaVersion, PACKAGE_INFO_VERSION);
+    EXPECT_EQ(result->size, 1024);
+    EXPECT_EQ(result->version, "1.0.0");
+}
+
+TEST_F(PackageInfoHandlerTest, parsePackageInfo_FromJSONInvalid)
+{
+    // 创建无效的JSON对象
+    nlohmann::json jsonData = { { "invalid", "json content" } };
+
+    // 解析JSON
+    auto result = linglong::utils::parsePackageInfo(jsonData);
+
+    // 验证解析失败
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(PackageInfoHandlerTest, parsePackageInfo_FromGFileV2)
+{
+    // 创建PackageInfoV2 JSON文件
+    std::string jsonContent = R"({
+        "arch": ["x86_64"],
+        "base": "org.deepin.base",
+        "channel": "main",
+        "command": ["testapp"],
+        "description": "Test application",
+        "id": "com.example.testapp",
+        "kind": "app",
+        "module": "runtime",
+        "name": "TestApp",
+        "schema_version": "1.0",
+        "size": 1024,
+        "version": "1.0.0"
+    })";
+
+    std::string filePath = (tempDir / "package_gfile_v2.json").string();
+    std::ofstream file(filePath);
+    ASSERT_TRUE(file.is_open());
+    file << jsonContent;
+    file.close();
+
+    // 创建GFile对象
+    GFile *gfile = g_file_new_for_path(filePath.c_str());
+
+    // 解析GFile
+    auto result = linglong::utils::parsePackageInfo(gfile);
+
+    // 验证解析结果
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    EXPECT_EQ(result->id, "com.example.testapp");
+    EXPECT_EQ(result->arch, std::vector<std::string>{ "x86_64" });
+    EXPECT_EQ(result->base, "org.deepin.base");
+    EXPECT_EQ(result->channel, "main");
+    EXPECT_EQ(result->command, std::vector<std::string>{ "testapp" });
+    EXPECT_EQ(result->description, "Test application");
+    EXPECT_EQ(result->kind, "app");
+    EXPECT_EQ(result->packageInfoV2Module, "runtime");
+    EXPECT_EQ(result->name, "TestApp");
+    EXPECT_EQ(result->schemaVersion, "1.0");
+    EXPECT_EQ(result->size, 1024);
+    EXPECT_EQ(result->version, "1.0.0");
+
+    // 释放GFile
+    g_object_unref(gfile);
+}
+
+TEST_F(PackageInfoHandlerTest, parsePackageInfo_FromGFileV1)
+{
+    // 创建PackageInfo JSON文件（V1格式）
+    std::string jsonContent = R"({
+        "appid": "com.example.testapp",
+        "arch": ["x86_64"],
+        "base": "org.deepin.base",
+        "channel": "main",
+        "command": ["testapp"],
+        "description": "Test application",
+        "kind": "app",
+        "module": "runtime",
+        "name": "TestApp",
+        "size": 1024,
+        "version": "1.0.0"
+    })";
+
+    std::string filePath = (tempDir / "package_gfile_v1.json").string();
+    std::ofstream file(filePath);
+    ASSERT_TRUE(file.is_open());
+    file << jsonContent;
+    file.close();
+
+    // 创建GFile对象
+    GFile *gfile = g_file_new_for_path(filePath.c_str());
+
+    // 解析GFile
+    auto result = linglong::utils::parsePackageInfo(gfile);
+
+    // 验证解析结果
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    EXPECT_EQ(result->id, "com.example.testapp");
+    EXPECT_EQ(result->arch, std::vector<std::string>{ "x86_64" });
+    EXPECT_EQ(result->base, "org.deepin.base");
+    EXPECT_EQ(result->channel, "main");
+    EXPECT_EQ(result->command, std::vector<std::string>{ "testapp" });
+    EXPECT_EQ(result->description, "Test application");
+    EXPECT_EQ(result->kind, "app");
+    EXPECT_EQ(result->packageInfoV2Module, "runtime");
+    EXPECT_EQ(result->name, "TestApp");
+    EXPECT_EQ(result->schemaVersion, PACKAGE_INFO_VERSION);
+    EXPECT_EQ(result->size, 1024);
+    EXPECT_EQ(result->version, "1.0.0");
+
+    // 释放GFile
+    g_object_unref(gfile);
+}
+
+TEST_F(PackageInfoHandlerTest, parsePackageInfo_FromGFileInvalid)
+{
+    // 创建无效的JSON文件
+    std::string jsonContent = R"({
+        "invalid": "json content"
+    })";
+
+    std::string filePath = (tempDir / "invalid_gfile.json").string();
+    std::ofstream file(filePath);
+    ASSERT_TRUE(file.is_open());
+    file << jsonContent;
+    file.close();
+
+    // 创建GFile对象
+    GFile *gfile = g_file_new_for_path(filePath.c_str());
+
+    // 解析GFile
+    auto result = linglong::utils::parsePackageInfo(gfile);
+
+    // 验证解析失败
+    EXPECT_FALSE(result.has_value());
+
+    // 释放GFile
+    g_object_unref(gfile);
+}

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/xdg/directory_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/xdg/directory_test.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "linglong/utils/error/error.h"
+#include "linglong/utils/xdg/directory.h"
+
+#include <cstdlib>
+#include <filesystem>
+
+TEST(XDGDirectory, appDataDirWithHOME)
+{
+    // 保存原始HOME环境变量
+    const char *originalHome = std::getenv("HOME");
+
+    // 设置测试用的HOME环境变量
+    const char *testHome = "/tmp/test_home";
+    setenv("HOME", testHome, 1);
+
+    // 测试appDataDir函数
+    const std::string appID = "com.example.testapp";
+    auto result = linglong::utils::xdg::appDataDir(appID);
+
+    // 验证结果
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(*result, std::filesystem::path{ testHome } / ".linglong" / appID);
+
+    // 恢复原始HOME环境变量
+    if (originalHome != nullptr) {
+        setenv("HOME", originalHome, 1);
+    } else {
+        unsetenv("HOME");
+    }
+}
+
+TEST(XDGDirectory, appDataDirWithoutHOME)
+{
+    // 保存原始HOME环境变量
+    const char *originalHome = std::getenv("HOME");
+
+    // 移除HOME环境变量
+    unsetenv("HOME");
+
+    // 测试appDataDir函数
+    const std::string appID = "com.example.testapp";
+    auto result = linglong::utils::xdg::appDataDir(appID);
+
+    // 验证结果应该是错误
+    EXPECT_FALSE(result.has_value());
+    // 错误消息包含完整的跟踪信息，我们只需要检查是否包含"HOME is not set"
+    EXPECT_TRUE(result.error().message().find("HOME is not set") != std::string::npos);
+
+    // 恢复原始HOME环境变量
+    if (originalHome != nullptr) {
+        setenv("HOME", originalHome, 1);
+    }
+}
+
+TEST(XDGDirectory, appDataDirWithEmptyAppID)
+{
+    // 保存原始HOME环境变量
+    const char *originalHome = std::getenv("HOME");
+
+    // 设置测试用的HOME环境变量
+    const char *testHome = "/tmp/test_home";
+    setenv("HOME", testHome, 1);
+
+    // 测试空appID
+    const std::string appID = "";
+    auto result = linglong::utils::xdg::appDataDir(appID);
+
+    // 验证结果
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(*result, std::filesystem::path{ testHome } / ".linglong" / "");
+
+    // 恢复原始HOME环境变量
+    if (originalHome != nullptr) {
+        setenv("HOME", originalHome, 1);
+    } else {
+        unsetenv("HOME");
+    }
+}
+
+TEST(XDGDirectory, appDataDirWithComplexAppID)
+{
+    // 保存原始HOME环境变量
+    const char *originalHome = std::getenv("HOME");
+
+    // 设置测试用的HOME环境变量
+    const char *testHome = "/tmp/test_home";
+    setenv("HOME", testHome, 1);
+
+    // 测试复杂的appID
+    const std::string appID = "org.deepin.linglong.example";
+    auto result = linglong::utils::xdg::appDataDir(appID);
+
+    // 验证结果
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(*result, std::filesystem::path{ testHome } / ".linglong" / appID);
+
+    // 恢复原始HOME环境变量
+    if (originalHome != nullptr) {
+        setenv("HOME", originalHome, 1);
+    } else {
+        unsetenv("HOME");
+    }
+}


### PR DESCRIPTION
Added comprehensive unit tests for three utility modules:
1. GKeyFileWrapper tests - validate INI file parsing and manipulation functionality including file loading, value setting/getting, group/key operations, and file saving
2. PackageInfoHandler tests - test package information conversion between V1 and V2 formats, JSON parsing from files/GFile objects, and handling of optional fields
3. XDG directory tests - verify application data directory resolution based on HOME environment variable with various app ID scenarios

These tests ensure the reliability of core utility functions used throughout the Linglong system, covering edge cases, error handling, and proper data conversion between different package information formats.

Influence:
1. Run test suite to verify all new unit tests pass
2. Test GKeyFileWrapper with various INI file formats and invalid inputs
3. Verify PackageInfoHandler handles both V1 and V2 package info formats correctly
4. Test XDG directory resolution with different HOME environment settings
5. Confirm error handling works as expected for invalid inputs

feat: 为工具组件添加单元测试

新增了三个工具模块的全面单元测试：
1. GKeyFileWrapper测试 - 验证INI文件解析和操作功能，包括文件加载、值设 置/获取、组/键操作和文件保存
2. PackageInfoHandler测试 - 测试V1和V2格式之间的包信息转换、从文件/GFile 对象解析JSON以及可选字段处理
3. XDG目录测试 - 基于HOME环境变量验证应用程序数据目录解析，涵盖各种应用 ID场景

这些测试确保了Linglong系统中使用的核心工具函数的可靠性，涵盖了边界情况、
错误处理以及不同包信息格式之间的正确数据转换。

Influence:
1. 运行测试套件验证所有新单元测试通过
2. 使用各种INI文件格式和无效输入测试GKeyFileWrapper
3. 验证PackageInfoHandler正确处理V1和V2包信息格式
4. 使用不同的HOME环境设置测试XDG目录解析
5. 确认错误处理对无效输入按预期工作