### PR TITLE
fix: fix repo config comparison and add debug logs

### DIFF
--- a/libs/api/src/linglong/api/types/helper.h
+++ b/libs/api/src/linglong/api/types/helper.h
@@ -10,10 +10,16 @@
 
 namespace linglong::api::types::v1 {
 
+// I added this size assertion because these structs overload == operator.
+// Adding new fields will make this fail, reminding me to update the == implementation.
+static_assert(sizeof(struct Repo) == 120);
+static_assert(sizeof(struct RepoConfig) == 88);
+static_assert(sizeof(struct RepoConfigV2) == 64);
+
 inline bool operator==(const Repo &cfg1, const Repo &cfg2) noexcept
 {
     return cfg1.alias == cfg2.alias && cfg1.name == cfg2.name && cfg1.url == cfg2.url
-      && cfg1.priority == cfg2.priority;
+      && cfg1.priority == cfg2.priority && cfg1.mirrorEnabled == cfg2.mirrorEnabled;
 }
 
 inline bool operator!=(const Repo &cfg1, const Repo &cfg2) noexcept

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -499,6 +499,7 @@ auto PackageManager::getConfiguration() const noexcept -> QVariantMap
 
 void PackageManager::setConfiguration(const QVariantMap &parameters) noexcept
 {
+    LogI("set configuration for package manager");
     auto cfg = utils::serialize::fromQVariantMap<api::types::v1::RepoConfigV2>(parameters);
     if (!cfg) {
         sendErrorReply(QDBusError::InvalidArgs, QString::fromStdString(cfg.error().message()));
@@ -508,10 +509,12 @@ void PackageManager::setConfiguration(const QVariantMap &parameters) noexcept
     const auto &cfgRef = *cfg;
     const auto &curCfg = repo.getConfig();
 
+    LogD("new config: {}", nlohmann::json(cfgRef).dump());
+    LogD("cur config: {}", nlohmann::json(curCfg).dump());
     if (cfgRef == curCfg) {
+        LogI("configuration not changed, ignore setting.");
         return;
     }
-
     if (const auto &defaultRepo = cfg->defaultRepo;
         std::find_if(cfg->repos.begin(),
                      cfg->repos.end(),

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -946,9 +946,11 @@ OSTreeRepo::updateConfig(const api::types::v1::RepoConfigV2 &newCfg) noexcept
 utils::error::Result<void> OSTreeRepo::setConfig(const api::types::v1::RepoConfigV2 &cfg) noexcept
 {
     LINGLONG_TRACE("set config");
+    LogD("set config: {}", nlohmann::json(cfg).dump());
 
     utils::Transaction transaction;
 
+    LogI("save config to disk");
     auto result = saveConfig(cfg, this->repoDir.absoluteFilePath("config.yaml"));
     if (!result) {
         return LINGLONG_ERR(result);
@@ -960,6 +962,7 @@ utils::error::Result<void> OSTreeRepo::setConfig(const api::types::v1::RepoConfi
             Q_ASSERT(false);
         }
     });
+    LogI("update ostree repo config");
     result = updateOstreeRepoConfig(this->ostreeRepo.get(), cfg);
     if (!result) {
         return LINGLONG_ERR(result);
@@ -971,7 +974,7 @@ utils::error::Result<void> OSTreeRepo::setConfig(const api::types::v1::RepoConfi
             Q_ASSERT(false);
         }
     });
-
+    LogI("rebuild repo cache");
     if (auto ret = this->cache->rebuildCache(cfg, *(this->ostreeRepo)); !ret) {
         return LINGLONG_ERR(ret);
     }


### PR DESCRIPTION
Fixed the equality operator for Repo struct to include the newly added mirrorEnabled field, preventing incorrect comparison results when this field differs between configurations. Added static assertions to ensure future structural changes to Repo-related types will trigger compilation errors if equality operators are not updated accordingly.

Enhanced configuration setting logic with comprehensive debug logging to improve troubleshooting capabilities. Added logging for configuration changes, comparison results, and key operations during config updates to help diagnose issues with repository configuration management.

Log: Improved repository configuration change detection and logging

Influence:
1. Test repository configuration changes with different mirrorEnabled settings
2. Verify configuration comparison works correctly when only mirrorEnabled differs
3. Check debug logs appear during configuration updates
4. Test configuration persistence and cache rebuilding after changes
5. Verify no regression in existing configuration management functionality

fix: 修复仓库配置比较并添加调试日志

修复了 Repo 结构的相等运算符，包含新增的 mirrorEnabled 字段，防止在该字
段不同时产生错误的比较结果。添加了静态断言，确保未来对 Repo 相关类型的结
构更改如果未更新相等运算符实现将触发编译错误。

增强了配置设置逻辑，添加了全面的调试日志以改进故障排除能力。增加了配置变
更、比较结果和配置更新期间关键操作的日志记录，帮助诊断仓库配置管理问题。

Log: 改进仓库配置变更检测和日志记录

Influence:
1. 测试使用不同 mirrorEnabled 设置的仓库配置变更
2. 验证当仅 mirrorEnabled 不同时配置比较正常工作
3. 检查配置更新期间调试日志是否正确出现
4. 测试配置变更后的配置持久化和缓存重建
5. 验证现有配置管理功能无回归问题