### PR TITLE
refactor: Extract UAB installation logic into action class

### DIFF
--- a/libs/linglong/CMakeLists.txt
+++ b/libs/linglong/CMakeLists.txt
@@ -53,6 +53,8 @@ pfl_add_library(
   src/linglong/package_manager/package_manager.h
   src/linglong/package_manager/package_task.cpp
   src/linglong/package_manager/package_task.h
+  src/linglong/package_manager/uab_installation.cpp
+  src/linglong/package_manager/uab_installation.h
   src/linglong/package/reference.cpp
   src/linglong/package/reference.h
   src/linglong/package/semver.hpp

--- a/libs/linglong/src/linglong/package/uab_file.cpp
+++ b/libs/linglong/src/linglong/package/uab_file.cpp
@@ -28,17 +28,7 @@
 
 namespace linglong::package {
 
-/**
- * In the package_manager.cpp file, the method installFromUAB attempts to move a lambda to
- * QCoreApplication::instance() via QMetaObject::invokeMethod, which has a object of type
- * std::unique_ptr<uabFile> that created from this method. However, when compiling this project with
- * Qt 5.11, the type of lambda (rvalue reference) is lost during parameter passing to Qt's internal
- * method, so the compiler tries to call the copy constructor of this lambda. std::unique_ptr has a
- * deleted copy constructor, so it compiles failed. The temporary resolution is that returning a
- * std::shared_pointer<UABFile>, if linglong depends on a minimal version of Qt above 5.11, change
- * the type of returned value to std::unique_ptr<UABFile>.
- **/
-utils::error::Result<std::shared_ptr<UABFile>> UABFile::loadFromFile(int fd) noexcept
+utils::error::Result<std::unique_ptr<UABFile>> UABFile::loadFromFile(int fd) noexcept
 {
     LINGLONG_TRACE("load uab file from fd")
 
@@ -47,7 +37,7 @@ utils::error::Result<std::shared_ptr<UABFile>> UABFile::loadFromFile(int fd) noe
         using UABFile::UABFile;
     };
 
-    auto file = std::make_shared<EnableMaker>();
+    auto file = std::make_unique<EnableMaker>();
 
     if (!file->open(fd, QIODevice::ReadOnly, FileHandleFlag::AutoCloseHandle)) {
         return LINGLONG_ERR(QString{ "open uab failed: %1" }.arg(file->errorString()));

--- a/libs/linglong/src/linglong/package/uab_file.h
+++ b/libs/linglong/src/linglong/package/uab_file.h
@@ -24,7 +24,7 @@ class UABFile : public QFile
     friend class MockUabFile;
 
 public:
-    static utils::error::Result<std::shared_ptr<UABFile>> loadFromFile(int fd) noexcept;
+    static utils::error::Result<std::unique_ptr<UABFile>> loadFromFile(int fd) noexcept;
     UABFile(UABFile &&) = delete;
     UABFile &operator=(UABFile &&) = delete;
     ~UABFile() override;

--- a/libs/linglong/src/linglong/package_manager/uab_installation.cpp
+++ b/libs/linglong/src/linglong/package_manager/uab_installation.cpp
@@ -1,0 +1,558 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "uab_installation.h"
+
+#include "linglong/utils/log/log.h"
+
+namespace linglong::service {
+
+std::shared_ptr<UabInstallationAction> UabInstallationAction::create(
+  int uabFD, PackageManager &pm, repo::OSTreeRepo &repo, api::types::v1::CommonOptions opts)
+{
+    auto p = new UabInstallationAction(uabFD, pm, repo, std::move(opts));
+    return std::shared_ptr<UabInstallationAction>(p);
+}
+
+UabInstallationAction::CheckedLayers
+splitUABLayers(std::vector<linglong::api::types::v1::UabLayer> layers)
+{
+    auto it =
+      std::partition(layers.begin(), layers.end(), [](const api::types::v1::UabLayer &layer) {
+          return layer.info.kind == "app";
+      });
+    std::vector<api::types::v1::UabLayer> otherLayers{ it, layers.end() };
+    layers.erase(it, layers.end());
+
+    return std::make_pair(std::move(layers), std::move(otherLayers));
+}
+
+// executable mode includes app layers and optional runtime layers
+utils::error::Result<UabInstallationAction::CheckedLayers>
+UabInstallationAction::checkExecModeUABLayers(
+  repo::OSTreeRepo &repo, const std::vector<linglong::api::types::v1::UabLayer> &layers)
+{
+    LINGLONG_TRACE("check exec mode uab layers");
+
+    auto splitLayers = splitUABLayers(layers);
+    const auto &appLayers = splitLayers.first;
+    const auto &otherLayers = splitLayers.second;
+
+    if (appLayers.empty()) {
+        return LINGLONG_ERR("no app layers found");
+    }
+
+    const auto &appInfo = appLayers.front().info;
+    if (appInfo.runtime) {
+        if (otherLayers.empty()) {
+            return LINGLONG_ERR("runtime layer not found");
+        }
+
+        auto runtimeRef = package::Reference::fromPackageInfo(otherLayers.front().info);
+        if (!runtimeRef) {
+            return LINGLONG_ERR(runtimeRef);
+        }
+
+        auto fuzzyRef = package::FuzzyReference::parse(*appInfo.runtime);
+        if (!fuzzyRef) {
+            return LINGLONG_ERR(fuzzyRef);
+        }
+
+        if (fuzzyRef->id != runtimeRef->id || appInfo.channel != runtimeRef->channel) {
+            return LINGLONG_ERR("runtime layer not matched");
+        }
+
+        if (fuzzyRef->version) {
+            if (!runtimeRef->version.semanticMatch(*fuzzyRef->version)) {
+                return LINGLONG_ERR("runtime layer version not matched");
+            }
+        }
+    }
+
+    if (auto res = checkUABLayersConstrain(repo, appLayers); !res) {
+        return LINGLONG_ERR(res);
+    }
+
+    if (auto res = checkUABLayersConstrain(repo, otherLayers); !res) {
+        return LINGLONG_ERR(res);
+    }
+
+    return splitLayers;
+}
+
+// distribution mode includes one or more module layers from a single package
+utils::error::Result<UabInstallationAction::CheckedLayers>
+UabInstallationAction::checkDistributionModeUABLayers(
+  repo::OSTreeRepo &repo, const std::vector<linglong::api::types::v1::UabLayer> &layers)
+{
+    LINGLONG_TRACE("check distribution mode uab layers");
+
+    auto splitLayers = splitUABLayers(layers);
+    const auto &appLayers = splitLayers.first;
+    const auto &otherLayers = splitLayers.second;
+
+    if (appLayers.empty() && otherLayers.empty()) {
+        return LINGLONG_ERR("no layers found");
+    }
+
+    if (!appLayers.empty() && !otherLayers.empty()) {
+        return LINGLONG_ERR("layers from multiple packages found");
+    }
+
+    if (auto res = checkUABLayersConstrain(repo, appLayers); !res) {
+        return LINGLONG_ERR(res);
+    }
+    if (auto res = checkUABLayersConstrain(repo, otherLayers); !res) {
+        return LINGLONG_ERR(res);
+    }
+
+    return splitLayers;
+}
+
+utils::error::Result<void> UabInstallationAction::checkUABLayersConstrain(
+  repo::OSTreeRepo &repo, const std::vector<linglong::api::types::v1::UabLayer> &layers)
+{
+    LINGLONG_TRACE("check uab layers constrain");
+
+    auto currentArch = package::Architecture::currentCPUArchitecture();
+    if (!currentArch) {
+        return LINGLONG_ERR(currentArch);
+    }
+
+    if (layers.empty()) {
+        return LINGLONG_OK;
+    }
+
+    const auto &front = layers.front().info;
+    bool hasBinary = false;
+    bool extraModule = false;
+    for (const auto &layer : layers) {
+        auto arch = package::Architecture::parse(layer.info.arch[0]);
+        if (!arch) {
+            return LINGLONG_ERR(arch);
+        }
+        if (*arch != *currentArch) {
+            return LINGLONG_ERR(
+              fmt::format("uab arch: {} not match host architecture", layer.info.arch[0]));
+        }
+
+        if (layer.info.id != front.id) {
+            return LINGLONG_ERR("more than one layers with different id");
+        }
+
+        if (layer.info.version != front.version) {
+            return LINGLONG_ERR("modules have different version");
+        }
+
+        const auto &module = layer.info.packageInfoV2Module;
+        if (module == "binary" || module == "runtime") {
+            hasBinary = true;
+        } else {
+            extraModule = true;
+        }
+    }
+
+    auto fuzzyRef =
+      package::FuzzyReference::create(front.channel, front.id, front.version, std::nullopt);
+    if (!fuzzyRef) {
+        return LINGLONG_ERR(fuzzyRef);
+    }
+    if (extraModule && !hasBinary) {
+        auto localRef = repo.clearReference(*fuzzyRef,
+                                            {
+                                              .forceRemote = false,
+                                              .fallbackToRemote = false,
+                                              .semanticMatching = false,
+                                            });
+
+        auto version = package::Version::parse(front.version);
+        if (!version) {
+            return LINGLONG_ERR(version);
+        }
+        if (!localRef || localRef->version != version) {
+            return LINGLONG_ERR("no matched binary module found");
+        }
+    }
+
+    return LINGLONG_OK;
+}
+
+utils::error::Result<TaskAction>
+UabInstallationAction::getTaskAction(repo::OSTreeRepo &repo, const CheckedLayers &checkedLayers)
+{
+    LINGLONG_TRACE("get task action");
+
+    const api::types::v1::UabLayer &toCheck =
+      checkedLayers.first.empty() ? checkedLayers.second.front() : checkedLayers.first.front();
+
+    auto fuzzyRef = package::FuzzyReference::create(toCheck.info.channel,
+                                                    toCheck.info.id,
+                                                    std::nullopt,
+                                                    std::nullopt);
+    if (!fuzzyRef) {
+        return LINGLONG_ERR(fuzzyRef);
+    }
+
+    auto checkRef = package::Reference::fromPackageInfo(toCheck.info);
+    if (!checkRef) {
+        return LINGLONG_ERR(checkRef);
+    }
+
+    const auto &kind = toCheck.info.kind;
+    TaskAction action;
+    action.additionalMessage.remoteRef = checkRef->toString();
+    auto installedRef = repo.latestLocalReference(*fuzzyRef);
+    if (installedRef) {
+        action.additionalMessage.localRef = installedRef->toString();
+        if (checkRef->version == installedRef->version) {
+            action.policy = TaskAction::Policy::Overwrite;
+        } else if (checkRef->version > installedRef->version) {
+            if (kind == "app") {
+                action.policy = TaskAction::Policy::Upgrade;
+                action.msgType = api::types::v1::InteractionMessageType::Upgrade;
+            } else {
+                action.policy = TaskAction::Policy::Install;
+            }
+        } else {
+            if (kind == "app") {
+                action.policy = TaskAction::Policy::Downgrade;
+            } else {
+                action.policy = TaskAction::Policy::Install;
+            }
+        }
+    } else {
+        action.policy = TaskAction::Policy::Install;
+    }
+
+    action.kind = kind;
+    action.newRef = std::move(checkRef).value();
+    if (installedRef) {
+        action.oldRef = std::move(installedRef).value();
+    }
+
+    return action;
+}
+
+UabInstallationAction::UabInstallationAction(int uabFD,
+                                             PackageManager &pm,
+                                             repo::OSTreeRepo &repo,
+                                             api::types::v1::CommonOptions opts)
+    : fd(dup(uabFD))
+    , pm(pm)
+    , repo(repo)
+    , options(std::move(opts))
+{
+}
+
+UabInstallationAction::~UabInstallationAction()
+{
+    close(fd);
+}
+
+utils::error::Result<void> UabInstallationAction::prepare()
+{
+    LINGLONG_TRACE("uab installation prepare");
+
+    if (this->uabFile) {
+        return LINGLONG_OK;
+    }
+
+    auto uabFileRet = package::UABFile::loadFromFile(fd);
+    if (!uabFileRet) {
+        return LINGLONG_ERR(fmt::format("failed to load uab file from fd {}", fd), uabFileRet);
+    }
+    auto uabFile = std::move(uabFileRet).value();
+
+    auto res = uabFile->verify();
+    if (!res) {
+        return LINGLONG_ERR(res);
+    }
+    if (!*res) {
+        return LINGLONG_ERR("failed to verify uab file");
+    }
+
+    auto metaInfoRet = uabFile->getMetaInfo();
+    if (!metaInfoRet) {
+        return LINGLONG_ERR(metaInfoRet);
+    }
+    const auto &metaInfo = metaInfoRet->get();
+
+    if (metaInfo.onlyApp && *metaInfo.onlyApp) {
+        auto res = checkExecModeUABLayers(repo, metaInfo.layers);
+        if (!res) {
+            return LINGLONG_ERR(res);
+        }
+        checkedLayers = std::move(res).value();
+    } else {
+        auto res = checkDistributionModeUABLayers(repo, metaInfo.layers);
+        if (!res) {
+            return LINGLONG_ERR(res);
+        }
+        checkedLayers = std::move(res).value();
+    }
+
+    auto action = getTaskAction(repo, checkedLayers);
+    if (!action) {
+        return LINGLONG_ERR(action);
+    }
+
+    if (action->policy == TaskAction::Policy::Overwrite) {
+        return LINGLONG_ERR("package already installed",
+                            utils::error::ErrorCode::AppInstallAlreadyInstalled);
+    }
+
+    if (action->policy == TaskAction::Policy::Downgrade && !options.force) {
+        return LINGLONG_ERR("latest version already installed",
+                            utils::error::ErrorCode::AppInstallNeedDowngrade);
+    }
+
+    this->action = std::move(action).value();
+    this->taskName = fmt::format("Installing {}", uabFile->symLinkTarget());
+    this->uabFile = std::move(uabFile);
+
+    return LINGLONG_OK;
+}
+
+utils::error::Result<void> UabInstallationAction::doAction(PackageTask &task)
+{
+    LINGLONG_TRACE("uab installation action");
+
+    if (!uabFile) {
+        return LINGLONG_ERR("action not prepared");
+    }
+
+    auto ret = preInstall(task);
+    if (!ret) {
+        return ret;
+    }
+
+    ret = install(task);
+    if (!ret) {
+        return ret;
+    }
+
+    return postInstall(task);
+}
+
+utils::error::Result<void> UabInstallationAction::preInstall(PackageTask &task)
+{
+    LINGLONG_TRACE("uab installation preInstall");
+
+    task.updateState(linglong::api::types::v1::State::Processing, "installing uab");
+    task.updateSubState(linglong::api::types::v1::SubState::PreAction, "prepare environment");
+
+    if (action.policy == TaskAction::Policy::Upgrade && !options.skipInteraction) {
+        if (!pm.waitConfirm(task, action.msgType, action.additionalMessage)) {
+            return LINGLONG_ERR("action canceled");
+        }
+    }
+
+    return LINGLONG_OK;
+}
+
+utils::error::Result<void> UabInstallationAction::install([[maybe_unused]] PackageTask &task)
+{
+    LINGLONG_TRACE("uab installation install");
+
+    auto mountPoint = uabFile->unpack();
+    if (!mountPoint) {
+        return LINGLONG_ERR(mountPoint);
+    }
+    uabMountPoint = std::move(mountPoint).value();
+
+    const auto &metaInfo = uabFile->getMetaInfo()->get();
+    if (metaInfo.onlyApp && *metaInfo.onlyApp) {
+        return installExecModeUAB(task);
+    } else {
+        return installDistributionModeUAB();
+    }
+}
+
+utils::error::Result<void> UabInstallationAction::postInstall(PackageTask &task)
+{
+    LINGLONG_TRACE("uab installation postInstall");
+
+    const auto &newRef = action.newRef;
+    const auto &oldRef = action.oldRef;
+
+    if (!oldRef) {
+        auto mergeRet = repo.mergeModules();
+        if (!mergeRet) {
+            LogE("merge modules failed: {}", mergeRet.error());
+        }
+    }
+
+    // only app should:
+    // 1. replace installed version
+    // 2. export entries
+    // 3. generate cache
+    if (action.kind == "app") {
+        if (oldRef) {
+            auto ret = pm.removeAfterInstall(*oldRef, *newRef, repo.getModuleList(*oldRef));
+            if (!ret) {
+                LogE("remove old reference after install newer version failed: {}", ret.error());
+                return LINGLONG_ERR(ret);
+            }
+        } else {
+            // export directly
+            this->repo.exportReference(*newRef);
+            auto result = pm.tryGenerateCache(*newRef);
+            if (!result) {
+                auto msg =
+                  fmt::format("Failed to generate some cache: {}", result.error().message());
+                task.updateState(linglong::api::types::v1::State::Failed, msg);
+                return LINGLONG_ERR(msg, result);
+            }
+        }
+    }
+
+    auto ret = pm.executePostInstallHooks(*newRef);
+    if (!ret) {
+        task.reportError(std::move(ret).error());
+        return LINGLONG_ERR("failed to execute post install hooks");
+    }
+
+    transaction.commit();
+    task.updateState(linglong::api::types::v1::State::Succeed, "install uab successfully");
+
+    return LINGLONG_OK;
+}
+
+utils::error::Result<void> UabInstallationAction::installUabLayer(
+  const std::vector<api::types::v1::UabLayer> &layers, std::optional<std::string> subRef)
+{
+    LINGLONG_TRACE("install uab layers from single package");
+
+    for (const auto &layer : layers) {
+        std::error_code ec;
+        auto layerDirPath =
+          uabMountPoint / "layers" / layer.info.id / layer.info.packageInfoV2Module;
+        if (!std::filesystem::exists(layerDirPath, ec)) {
+            if (ec) {
+                auto msg = fmt::format("get status of {} failed: {}", layerDirPath, ec.message());
+                return LINGLONG_ERR(msg);
+            }
+
+            auto msg = fmt::format("layer directory {} doesn't exist", layerDirPath);
+            return LINGLONG_ERR(msg);
+        }
+
+        std::vector<std::filesystem::path> overlays;
+        auto signPath = uabFile->extractSignData();
+        if (!signPath) {
+            return LINGLONG_ERR(signPath);
+        }
+        if (!signPath->empty()) {
+            overlays.emplace_back(std::move(signPath).value());
+        }
+
+        auto ref = package::Reference::fromPackageInfo(layer.info);
+        if (!ref) {
+            return LINGLONG_ERR(ref);
+        }
+
+        auto ret =
+          this->repo.importLayerDir(package::LayerDir{ layerDirPath.c_str() }, overlays, subRef);
+        if (!ret) {
+            return LINGLONG_ERR(ret);
+        }
+
+        std::for_each(overlays.begin(), overlays.end(), [](const std::filesystem::path &dir) {
+            std::error_code ec;
+            if (std::filesystem::remove_all(dir, ec) == static_cast<std::uintmax_t>(-1) && ec) {
+                LogW("failed to remove temporary directory {}", dir);
+            }
+        });
+
+        transaction.addRollBack([this,
+                                 ref = std::move(ref).value(),
+                                 module = layer.info.packageInfoV2Module,
+                                 subRef]() noexcept {
+            auto ret = this->repo.remove(ref, module, subRef);
+            if (!ret) {
+                LogE("rollback importLayerDir failed: {}", ret.error());
+            }
+        });
+    }
+
+    return LINGLONG_OK;
+}
+
+utils::error::Result<void> UabInstallationAction::installExecModeUAB(PackageTask &task)
+{
+    LINGLONG_TRACE("install exec mode uab");
+
+    const auto &appLayers = checkedLayers.first;
+    const auto &appInfo = appLayers.front().info;
+    if (appInfo.runtime) {
+        const auto &otherLayers = checkedLayers.second;
+        auto fuzzyRef = package::FuzzyReference::parse(*appInfo.runtime);
+        if (!fuzzyRef) {
+            return LINGLONG_ERR(fuzzyRef);
+        }
+
+        bool installRuntime = false;
+        auto satisfiedRef = repo.latestLocalReference(*fuzzyRef);
+        // can't find satisfied runtime in local repo
+        if (!satisfiedRef) {
+            const auto runtimeInfo = otherLayers.front().info;
+            auto toInstallVersion = package::Version::parse(runtimeInfo.version);
+            if (!toInstallVersion) {
+                return LINGLONG_ERR(toInstallVersion);
+            }
+
+            auto candidateRef = repo.latestRemoteReference(*fuzzyRef);
+            if (candidateRef) {
+                // runtime in remote repo has higher version than runtime in uab file or
+                if (candidateRef->reference.version >= *toInstallVersion) {
+                    pm.pullDependency(task, appInfo, "binary");
+                    // failed to fetch runtime from remote repo
+                    if (!repo.getLayerItem(candidateRef->reference)) {
+                        installRuntime = true;
+                    }
+                }
+            } else {
+                installRuntime = true;
+            }
+        }
+
+        if (installRuntime) {
+            auto metaInfo = uabFile->getMetaInfo()->get();
+            auto res = installUabLayer(otherLayers, metaInfo.uuid);
+            if (!res) {
+                return LINGLONG_ERR(res);
+            }
+        }
+    }
+
+    auto res = installUabLayer(appLayers);
+    if (!res) {
+        return LINGLONG_ERR(res);
+    }
+
+    return LINGLONG_OK;
+}
+
+utils::error::Result<void> UabInstallationAction::installDistributionModeUAB()
+{
+    LINGLONG_TRACE("install distribution mode uab");
+
+    if (!checkedLayers.first.empty()) {
+        auto res = installUabLayer(checkedLayers.first);
+        if (!res) {
+            return LINGLONG_ERR(res);
+        }
+    }
+
+    if (!checkedLayers.second.empty()) {
+        auto res = installUabLayer(checkedLayers.second);
+        if (!res) {
+            return LINGLONG_ERR(res);
+        }
+    }
+
+    return LINGLONG_OK;
+}
+
+} // namespace linglong::service

--- a/libs/linglong/src/linglong/package_manager/uab_installation.h
+++ b/libs/linglong/src/linglong/package_manager/uab_installation.h
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linglong/api/types/v1/InteractionMessageType.hpp"
+#include "linglong/api/types/v1/PackageManager1RequestInteractionAdditionalMessage.hpp"
+#include "linglong/api/types/v1/UabLayer.hpp"
+#include "linglong/package/uab_file.h"
+#include "linglong/package_manager/package_manager.h"
+#include "linglong/package_manager/package_task.h"
+#include "linglong/repo/ostree_repo.h"
+#include "linglong/utils/transaction.h"
+
+#include <optional>
+#include <vector>
+
+namespace linglong::service {
+
+struct TaskAction
+{
+    enum Policy {
+        Upgrade,
+        Install,
+        Remove,
+        Overwrite,
+        Downgrade,
+    } policy;
+
+    api::types::v1::InteractionMessageType msgType;
+    api::types::v1::PackageManager1RequestInteractionAdditionalMessage additionalMessage;
+
+    std::string kind;
+    std::optional<package::Reference> oldRef;
+    std::optional<package::Reference> newRef;
+};
+
+class UabInstallationAction
+{
+public:
+    static std::shared_ptr<UabInstallationAction> create(int uabFD,
+                                                         PackageManager &pm,
+                                                         repo::OSTreeRepo &repo,
+                                                         api::types::v1::CommonOptions options);
+
+    using CheckedLayers = std::pair<std::vector<linglong::api::types::v1::UabLayer>,
+                                    std::vector<linglong::api::types::v1::UabLayer>>;
+    static utils::error::Result<CheckedLayers> checkExecModeUABLayers(
+      repo::OSTreeRepo &repo, const std::vector<linglong::api::types::v1::UabLayer> &layers);
+    static utils::error::Result<CheckedLayers> checkDistributionModeUABLayers(
+      repo::OSTreeRepo &repo, const std::vector<linglong::api::types::v1::UabLayer> &layers);
+    static utils::error::Result<void> checkUABLayersConstrain(
+      repo::OSTreeRepo &repo, const std::vector<api::types::v1::UabLayer> &layers);
+    static utils::error::Result<TaskAction> getTaskAction(repo::OSTreeRepo &repo,
+                                                          const CheckedLayers &checkedLayers);
+
+    virtual ~UabInstallationAction();
+
+    virtual utils::error::Result<void> prepare();
+    virtual utils::error::Result<void> doAction(PackageTask &task);
+
+    virtual std::string getTaskName() const { return taskName; }
+
+protected:
+    virtual utils::error::Result<void> preInstall(PackageTask &task);
+    virtual utils::error::Result<void> install(PackageTask &task);
+    virtual utils::error::Result<void> postInstall(PackageTask &task);
+
+private:
+    UabInstallationAction(int uabFD,
+                          PackageManager &pm,
+                          repo::OSTreeRepo &repo,
+                          api::types::v1::CommonOptions options);
+
+    utils::error::Result<void> installExecModeUAB(PackageTask &task);
+    utils::error::Result<void> installDistributionModeUAB();
+    utils::error::Result<void> installUabLayer(const std::vector<api::types::v1::UabLayer> &layers,
+                                               std::optional<std::string> subRef = std::nullopt);
+
+    int fd;
+    PackageManager &pm;
+    repo::OSTreeRepo &repo;
+    api::types::v1::CommonOptions options;
+
+    TaskAction action;
+    std::string taskName;
+    CheckedLayers checkedLayers;
+    std::unique_ptr<package::UABFile> uabFile;
+    utils::Transaction transaction;
+    std::filesystem::path uabMountPoint;
+};
+
+} // namespace linglong::service

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -1011,10 +1011,6 @@ OSTreeRepo::importLayerDir(const package::LayerDir &dir,
         return LINGLONG_ERR(reference);
     }
 
-    if (this->getLayerDir(*reference, info->packageInfoV2Module, subRef)) {
-        return LINGLONG_ERR(reference->toString() + " exists.", 0);
-    }
-
     overlays.insert(overlays.begin(), dir.absolutePath().toStdString());
 
     std::vector<GFile *> dirs;
@@ -3249,6 +3245,18 @@ OSTreeRepo::latestRemoteReference(package::FuzzyReference &fuzzyRef) noexcept
 
     fuzzyRef.version.reset();
     auto ref = this->getRemoteReferenceByPriority(fuzzyRef, { .semanticMatching = false });
+    if (!ref) {
+        return LINGLONG_ERR(ref);
+    }
+    return ref;
+}
+
+utils::error::Result<package::Reference>
+OSTreeRepo::latestLocalReference(const package::FuzzyReference &fuzzyRef) const noexcept
+{
+    LINGLONG_TRACE("get latest local reference");
+
+    auto ref = clearReferenceLocal(*cache, fuzzyRef, true );
     if (!ref) {
         return LINGLONG_ERR(ref);
     }

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -54,7 +54,7 @@ public:
                api::types::v1::RepoConfigV2 cfg,
                ClientFactory &clientFactory) noexcept;
 
-    ~OSTreeRepo() override;
+    virtual ~OSTreeRepo() override;
 
     [[nodiscard]] const api::types::v1::RepoConfigV2 &getConfig() const noexcept;
     [[nodiscard]] api::types::v1::RepoConfigV2 getOrderedConfig() noexcept;
@@ -87,7 +87,7 @@ public:
               const std::string &module = "binary",
               const std::optional<api::types::v1::Repo> &repo = std::nullopt) noexcept;
 
-    [[nodiscard]] utils::error::Result<package::Reference>
+    [[nodiscard]] virtual utils::error::Result<package::Reference>
     clearReference(const package::FuzzyReference &fuzzy,
                    const clearReferenceOption &opts,
                    const std::string &module = "binary",
@@ -151,6 +151,8 @@ public:
       const std::optional<api::types::v1::Repo> &repo = std::nullopt) noexcept;
     utils::error::Result<package::ReferenceWithRepo>
     latestRemoteReference(package::FuzzyReference &fuzzyRef) noexcept;
+    virtual utils::error::Result<package::Reference>
+    latestLocalReference(const package::FuzzyReference &fuzzyRef) const noexcept;
 
     [[nodiscard]] utils::error::Result<api::types::v1::RepositoryCacheLayersItem>
     getLayerItem(const package::Reference &ref,
@@ -163,11 +165,7 @@ private:
 
     struct OstreeRepoDeleter
     {
-        void operator()(OstreeRepo *repo)
-        {
-            qDebug() << "delete OstreeRepo" << repo;
-            g_clear_object(&repo);
-        }
+        void operator()(OstreeRepo *repo) { g_clear_object(&repo); }
     };
 
     std::unique_ptr<OstreeRepo, OstreeRepoDeleter> ostreeRepo = nullptr;

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -12,41 +12,42 @@ pfl_add_executable(
   DISABLE_INSTALL
   SOURCES
   # find -regex '\./src/.+\.[ch]\(pp\)?' -type f -printf '%P\n'| sort
+  src/linglong/builder/linglong_builder_test.cpp
+  src/linglong/builder/source_fetcher_test.cpp
   src/linglong/common/strings_test.cpp
   src/linglong/common/xdg_test.cpp
+  src/linglong/mocks/command_mock.h
+  src/linglong/mocks/layer_packager_mock.h
+  src/linglong/mocks/linglong_builder_mock.h
+  src/linglong/mocks/ostree_repo_mock.h
+  src/linglong/mocks/uab_file_mock.h
   src/linglong/package/architecture_test.cpp
   src/linglong/package/fallback_version_test.cpp
+  src/linglong/package/layer_packager_test.cpp
   src/linglong/package/reference_test.cpp
-  src/linglong/package/version_test.cpp
-  src/linglong/package/versionv2_test.cpp
   src/linglong/package/semver_compare_test.cpp
   src/linglong/package/semver_increment_test.cpp
   src/linglong/package/semver_prerelease_test.cpp
   src/linglong/package/semver_serialization_test.cpp
   src/linglong/package/semver_version_test.cpp
   src/linglong/package/uab_file_test.cpp
-  src/linglong/package/layer_packager_test.cpp
-  src/linglong/builder/source_fetcher_test.cpp
-  src/linglong/builder/linglong_builder_test.cpp
-  src/linglong/mocks/command_mock.h
-  src/linglong/mocks/ostree_repo_mock.h
-  src/linglong/mocks/linglong_builder_mock.h
-  src/linglong/mocks/layer_packager_mock.h
-  src/linglong/mocks/uab_file_mock.h
-  src/linglong/utils/error/error_test.cpp
-  src/linglong/utils/file.cpp
-  src/linglong/utils/namespce.cpp
-  src/linglong/utils/log.cpp
-  src/linglong/utils/sha256_test.cpp
-  src/linglong/utils/transaction_test.cpp
-  src/linglong/utils/command_test.cpp
-  src/linglong/utils/bash_command_helper_test.cpp
-  src/linglong/utils/packageinfo_handler_test.cpp
-  src/linglong/utils/gkeyfile_wrapper_test.cpp
-  src/linglong/utils/xdg/directory_test.cpp
+  src/linglong/package/version_test.cpp
+  src/linglong/package/versionv2_test.cpp
+  src/linglong/package_manager/uab_installation_test.cpp
+  src/linglong/repo/client_factory_test.cpp
   src/linglong/repo/config_test.cpp
   src/linglong/repo/ostree_repo_test.cpp
-  src/linglong/repo/client_factory_test.cpp
+  src/linglong/utils/bash_command_helper_test.cpp
+  src/linglong/utils/command_test.cpp
+  src/linglong/utils/error/error_test.cpp
+  src/linglong/utils/file.cpp
+  src/linglong/utils/gkeyfile_wrapper_test.cpp
+  src/linglong/utils/log.cpp
+  src/linglong/utils/namespce.cpp
+  src/linglong/utils/packageinfo_handler_test.cpp
+  src/linglong/utils/sha256_test.cpp
+  src/linglong/utils/transaction_test.cpp
+  src/linglong/utils/xdg/directory_test.cpp
   src/main.cpp
   COMPILE_FEATURES
   PUBLIC
@@ -54,6 +55,7 @@ pfl_add_executable(
   LINK_LIBRARIES
   PRIVATE
   GTest::gtest
+  GTest::gmock
   linglong::linglong
   PkgConfig::CRYPTO)
 

--- a/libs/linglong/tests/ll-tests/src/common/tempdir.h
+++ b/libs/linglong/tests/ll-tests/src/common/tempdir.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+// A RAII wrapper for a temporary directory created with mkdtemp.
+class TempDir
+{
+public:
+    TempDir(const std::string &prefix = "linglong-test-")
+    {
+        std::string tmppath_template =
+          (std::filesystem::temp_directory_path() / (prefix + "XXXXXX")).string();
+        std::vector<char> tmppath_c(tmppath_template.begin(), tmppath_template.end());
+        tmppath_c.push_back('\0');
+
+        char *result = mkdtemp(tmppath_c.data());
+        if (result != nullptr) {
+            _path = result;
+        }
+    }
+
+    ~TempDir()
+    {
+        if (!_path.empty()) {
+            std::error_code ec;
+            std::filesystem::remove_all(_path, ec);
+        }
+    }
+
+    TempDir(const TempDir &) = delete;
+    TempDir &operator=(const TempDir &) = delete;
+    TempDir(TempDir &&) = delete;
+    TempDir &operator=(TempDir &&) = delete;
+
+    const std::filesystem::path &path() const { return _path; }
+
+    bool isValid() const { return !_path.empty(); }
+
+private:
+    std::filesystem::path _path;
+};

--- a/libs/linglong/tests/ll-tests/src/linglong/builder/linglong_builder_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/builder/linglong_builder_test.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include <gtest/gtest.h>
 
+#include "../../common/tempdir.h"
 #include "../mocks/linglong_builder_mock.h"
 #include "linglong/builder/linglong_builder.h"
 #include "linglong/utils/error/error.h"
@@ -16,48 +17,8 @@
 
 #include <unistd.h>
 
-// A RAII wrapper for a temporary directory created with mkdtemp.
-class TempDir
-{
-public:
-    TempDir(const std::string &prefix = "linglong-test-")
-    {
-        std::string tmppath_template =
-          (std::filesystem::temp_directory_path() / (prefix + "XXXXXX")).string();
-        std::vector<char> tmppath_c(tmppath_template.begin(), tmppath_template.end());
-        tmppath_c.push_back('\0');
-
-        char *result = mkdtemp(tmppath_c.data());
-        if (result != nullptr) {
-            _path = result;
-        }
-    }
-
-    ~TempDir()
-    {
-        if (!_path.empty()) {
-            std::error_code ec;
-            std::filesystem::remove_all(_path, ec);
-        }
-    }
-
-    TempDir(const TempDir &) = delete;
-    TempDir &operator=(const TempDir &) = delete;
-    TempDir(TempDir &&) = delete;
-    TempDir &operator=(TempDir &&) = delete;
-
-    const std::filesystem::path &path() const { return _path; }
-
-    bool isValid() const { return !_path.empty(); }
-
-private:
-    std::filesystem::path _path;
-};
-
 TEST(LinglongBuilder, installModule)
 {
-    linglong::utils::global::initLinyapsLogSystem("");
-
     TempDir buildOutput;
     ASSERT_TRUE(buildOutput.isValid());
     TempDir moduleOutput;

--- a/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
@@ -132,8 +132,7 @@ TEST_F(UabFileTest, UnpackFuseOffset)
     // 初始化UABFile对象
     auto uab = linglong::package::UABFile::loadFromFile(fd);
     ASSERT_TRUE(uab.has_value()) << "Failed to load uab file";
-    auto uabValue = *uab;
-    auto unpackRet = uabValue->unpack();
+    auto unpackRet = (*uab)->unpack();
     ASSERT_TRUE(unpackRet.has_value())
       << "Failed to unpack uab file" << unpackRet.error().message();
 

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/uab_installation_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/uab_installation_test.cpp
@@ -1,0 +1,605 @@
+/*
+ * SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../../common/tempdir.h"
+#include "linglong/api/types/v1/PackageInfoV2.hpp"
+#include "linglong/api/types/v1/UabLayer.hpp"
+#include "linglong/package/architecture.h"
+#include "linglong/package/reference.h"
+#include "linglong/package_manager/uab_installation.h"
+#include "linglong/repo/ostree_repo.h"
+#include "linglong/utils/error/error.h"
+
+using namespace linglong;
+using linglong::service::UabInstallationAction;
+using ::testing::_;
+using ::testing::Return;
+
+class MockOSTreeRepo : public repo::OSTreeRepo
+{
+public:
+    MockOSTreeRepo(const std::filesystem::path &path, repo::ClientFactory &clientFactory)
+        : repo::OSTreeRepo(
+            QDir(path.c_str()),
+            api::types::v1::RepoConfigV2{ .defaultRepo = "", .repos = {}, .version = 2 },
+            clientFactory)
+    {
+    }
+
+    MOCK_METHOD(utils::error::Result<package::Reference>,
+                clearReference,
+                (const package::FuzzyReference &fuzzyRef,
+                 const repo::clearReferenceOption &option,
+                 const std::string &module,
+                 const std::optional<std::string> &repo),
+                (override, const, noexcept));
+
+    MOCK_METHOD(utils::error::Result<package::Reference>,
+                latestLocalReference,
+                (const package::FuzzyReference &fuzzyRef),
+                (override, const, noexcept));
+};
+
+namespace {
+api::types::v1::UabLayer create_layer(const std::string &id,
+                                      const std::string &version,
+                                      const std::string &channel,
+                                      const std::string &kind)
+{
+    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+    api::types::v1::UabLayer layer;
+    layer.minified = false;
+    layer.info.id = id;
+    layer.info.version = version;
+    layer.info.channel = channel;
+    layer.info.kind = kind;
+    layer.info.arch = { currentArch };
+    return layer;
+}
+} // namespace
+
+TEST(CheckUABLayersConstrain, EmptyLayers)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    EXPECT_CALL(mockRepo, clearReference(_, _, _, _)).Times(0);
+    std::vector<api::types::v1::UabLayer> layers;
+    auto result = UabInstallationAction::checkUABLayersConstrain(repo, layers);
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST(CheckUABLayersConstrain, ArchMismatch)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    std::vector<api::types::v1::UabLayer> layers;
+    api::types::v1::UabLayer layer;
+    auto currentArch = package::Architecture::currentCPUArchitecture();
+    ASSERT_TRUE(currentArch.has_value());
+    // An arch that doesn't match current arch
+    layer.minified = false;
+    layer.info.arch = { "non-existent-arch" };
+    layers.push_back(layer);
+
+    auto result = UabInstallationAction::checkUABLayersConstrain(repo, layers);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CheckUABLayersConstrain, DifferentIds)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    std::vector<api::types::v1::UabLayer> layers;
+    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+
+    api::types::v1::UabLayer layer1;
+    layer1.minified = false;
+    layer1.info.arch = { currentArch };
+    layer1.info.id = "id1";
+    layers.push_back(layer1);
+
+    api::types::v1::UabLayer layer2;
+    layer2.minified = false;
+    layer2.info.arch = { currentArch };
+    layer2.info.id = "id2";
+    layers.push_back(layer2);
+
+    auto result = UabInstallationAction::checkUABLayersConstrain(repo, layers);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CheckUABLayersConstrain, DifferentVersions)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    std::vector<api::types::v1::UabLayer> layers;
+    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+
+    api::types::v1::UabLayer layer1;
+    layer1.minified = false;
+    layer1.info.arch = { currentArch };
+    layer1.info.id = "id1";
+    layer1.info.version = "1.0.0";
+    layers.push_back(layer1);
+
+    api::types::v1::UabLayer layer2;
+    layer2.minified = false;
+    layer2.info.arch = { currentArch };
+    layer2.info.id = "id1";
+    layer2.info.version = "2.0.0";
+    layers.push_back(layer2);
+
+    auto result = UabInstallationAction::checkUABLayersConstrain(repo, layers);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CheckUABLayersConstrain, ExtraModuleNoBinaryAndNotInstalled)
+{
+    LINGLONG_TRACE("ExtraModuleNoBinaryAndNotInstalled");
+
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    std::vector<api::types::v1::UabLayer> layers;
+    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+
+    api::types::v1::UabLayer layer1;
+    layer1.minified = false;
+    layer1.info.channel = "main";
+    layer1.info.arch = { currentArch };
+    layer1.info.id = "id1";
+    layer1.info.version = "1.0.0";
+    layer1.info.packageInfoV2Module = "extra";
+    layers.push_back(layer1);
+
+    EXPECT_CALL(mockRepo, clearReference(_, _, _, _)).WillOnce(Return(LINGLONG_ERR("")));
+
+    auto result = UabInstallationAction::checkUABLayersConstrain(repo, layers);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CheckUABLayersConstrain, ExtraModuleNoBinaryAndWrongVersionInstalled)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    std::vector<api::types::v1::UabLayer> layers;
+    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+
+    api::types::v1::UabLayer layer1;
+    layer1.minified = false;
+    layer1.info.channel = "main";
+    layer1.info.arch = { currentArch };
+    layer1.info.id = "id1";
+    layer1.info.version = "1.0.0";
+    layer1.info.packageInfoV2Module = "extra";
+    layers.push_back(layer1);
+
+    auto localRef = package::Reference::parse("main:id1/2.0.0/" + currentArch);
+    EXPECT_TRUE(localRef.has_value());
+
+    EXPECT_CALL(mockRepo, clearReference(_, _, _, _)).WillOnce(Return(*localRef));
+
+    auto result = UabInstallationAction::checkUABLayersConstrain(repo, layers);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CheckUABLayersConstrain, ExtraModuleNoBinaryButInstalled)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    std::vector<api::types::v1::UabLayer> layers;
+    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+
+    api::types::v1::UabLayer layer1;
+    layer1.minified = false;
+    layer1.info.channel = "main";
+    layer1.info.arch = { currentArch };
+    layer1.info.id = "id1";
+    layer1.info.version = "1.0.0";
+    layer1.info.packageInfoV2Module = "extra";
+    layers.push_back(layer1);
+
+    auto localRef = package::Reference::parse("main:id1/1.0.0/" + currentArch);
+    EXPECT_TRUE(localRef.has_value());
+
+    EXPECT_CALL(mockRepo, clearReference(_, _, _, _)).WillOnce(Return(*localRef));
+
+    auto result = UabInstallationAction::checkUABLayersConstrain(repo, layers);
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST(CheckUABLayersConstrain, ExtraModuleWithBinary)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    std::vector<api::types::v1::UabLayer> layers;
+    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+
+    api::types::v1::UabLayer layer1;
+    layer1.minified = false;
+    layer1.info.channel = "main";
+    layer1.info.arch = { currentArch };
+    layer1.info.id = "id1";
+    layer1.info.version = "1.0.0";
+    layer1.info.packageInfoV2Module = "extra";
+    layers.push_back(layer1);
+
+    api::types::v1::UabLayer layer2;
+    layer2.minified = false;
+    layer2.info.channel = "main";
+    layer2.info.arch = { currentArch };
+    layer2.info.id = "id1";
+    layer2.info.version = "1.0.0";
+    layer2.info.packageInfoV2Module = "binary";
+    layers.push_back(layer2);
+
+    auto result = UabInstallationAction::checkUABLayersConstrain(repo, layers);
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST(GetTaskAction, InstallNewApp)
+{
+    LINGLONG_TRACE("InstallNewApp");
+
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+
+    std::vector<api::types::v1::UabLayer> appLayers = {
+        create_layer("id1", "1.0.0", "main", "app")
+    };
+    std::vector<api::types::v1::UabLayer> otherLayers;
+
+    EXPECT_CALL(mockRepo, latestLocalReference(_)).WillOnce(Return(LINGLONG_ERR("")));
+
+    auto result =
+      UabInstallationAction::getTaskAction(repo, std::make_pair(appLayers, otherLayers));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->policy, service::TaskAction::Policy::Install);
+}
+
+TEST(GetTaskAction, OverwriteApp)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+
+    std::vector<api::types::v1::UabLayer> appLayers = {
+        create_layer("id1", "1.0.0", "main", "app")
+    };
+    std::vector<api::types::v1::UabLayer> otherLayers;
+
+    auto localRef = package::Reference::parse("main:id1/1.0.0/" + currentArch);
+    ASSERT_TRUE(localRef.has_value());
+    EXPECT_CALL(mockRepo, latestLocalReference(_)).WillOnce(Return(*localRef));
+
+    auto result =
+      UabInstallationAction::getTaskAction(repo, std::make_pair(appLayers, otherLayers));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->policy, service::TaskAction::Policy::Overwrite);
+}
+
+TEST(GetTaskAction, UpgradeApp)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+
+    std::vector<api::types::v1::UabLayer> appLayers = {
+        create_layer("id1", "2.0.0", "main", "app")
+    };
+    std::vector<api::types::v1::UabLayer> otherLayers;
+
+    auto localRef = package::Reference::parse("main:id1/1.0.0/" + currentArch);
+    ASSERT_TRUE(localRef.has_value());
+    EXPECT_CALL(mockRepo, latestLocalReference(_)).WillOnce(Return(*localRef));
+
+    auto result =
+      UabInstallationAction::getTaskAction(repo, std::make_pair(appLayers, otherLayers));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->policy, service::TaskAction::Policy::Upgrade);
+}
+
+TEST(GetTaskAction, DowngradeApp)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+
+    std::vector<api::types::v1::UabLayer> appLayers = {
+        create_layer("id1", "1.0.0", "main", "app")
+    };
+    std::vector<api::types::v1::UabLayer> otherLayers;
+
+    auto localRef = package::Reference::parse("main:id1/2.0.0/" + currentArch);
+    ASSERT_TRUE(localRef.has_value());
+    EXPECT_CALL(mockRepo, latestLocalReference(_)).WillOnce(Return(*localRef));
+
+    auto result =
+      UabInstallationAction::getTaskAction(repo, std::make_pair(appLayers, otherLayers));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->policy, service::TaskAction::Policy::Downgrade);
+}
+
+TEST(GetTaskAction, InstallLowVersionRuntime)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+
+    std::vector<api::types::v1::UabLayer> appLayers;
+    std::vector<api::types::v1::UabLayer> otherLayers = {
+        create_layer("runtime.id1", "2.0.0", "main", "runtime")
+    };
+
+    auto localRef = package::Reference::parse("main:runtime.id1/1.0.0/" + currentArch);
+    ASSERT_TRUE(localRef.has_value());
+    EXPECT_CALL(mockRepo, latestLocalReference(_)).WillOnce(Return(*localRef));
+
+    auto result =
+      UabInstallationAction::getTaskAction(repo, std::make_pair(appLayers, otherLayers));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->policy, service::TaskAction::Policy::Install);
+}
+
+TEST(GetTaskAction, InstallHighVersionRuntime)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+
+    std::vector<api::types::v1::UabLayer> appLayers;
+    std::vector<api::types::v1::UabLayer> otherLayers = {
+        create_layer("runtime.id1", "1.0.0", "main", "runtime")
+    };
+
+    auto localRef = package::Reference::parse("main:runtime.id1/2.0.0/" + currentArch);
+    ASSERT_TRUE(localRef.has_value());
+    EXPECT_CALL(mockRepo, latestLocalReference(_)).WillOnce(Return(*localRef));
+
+    auto result =
+      UabInstallationAction::getTaskAction(repo, std::make_pair(appLayers, otherLayers));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->policy, service::TaskAction::Policy::Install);
+}
+
+// checkExecModeUABLayers tests
+TEST(CheckExecModeUABLayers, NoAppLayers)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    std::vector<api::types::v1::UabLayer> layers = {
+        create_layer("id1", "1.0.0", "main", "runtime")
+    };
+    auto result = UabInstallationAction::checkExecModeUABLayers(repo, layers);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CheckExecModeUABLayers, AppLayerNoRuntime)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    auto layer = create_layer("id1", "1.0.0", "main", "app");
+    layer.info.packageInfoV2Module = "binary";
+    std::vector<api::types::v1::UabLayer> layers = { layer };
+    auto result = UabInstallationAction::checkExecModeUABLayers(repo, layers);
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST(CheckExecModeUABLayers, AppLayerWithRuntimeNoRuntimeLayer)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    auto layer = create_layer("id1", "1.0.0", "main", "app");
+    layer.info.runtime = "runtime.id/1.0.0";
+    std::vector<api::types::v1::UabLayer> layers = { layer };
+    auto result = UabInstallationAction::checkExecModeUABLayers(repo, layers);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CheckExecModeUABLayers, AppLayerWithRuntimeIdMismatch)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    auto app_layer = create_layer("id1", "1.0.0", "main", "app");
+    app_layer.info.runtime = "runtime.id/1.0.0";
+    auto runtime_layer = create_layer("runtime.id_mismatch", "1.0.0", "main", "runtime");
+    std::vector<api::types::v1::UabLayer> layers = { app_layer, runtime_layer };
+    auto result = UabInstallationAction::checkExecModeUABLayers(repo, layers);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CheckExecModeUABLayers, AppLayerWithRuntimeChannelMismatch)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    auto app_layer = create_layer("id1", "1.0.0", "main", "app");
+    app_layer.info.runtime = "runtime.id/1.0.0";
+    auto runtime_layer = create_layer("runtime.id", "1.0.0", "main_mismatch", "runtime");
+    std::vector<api::types::v1::UabLayer> layers = { app_layer, runtime_layer };
+    auto result = UabInstallationAction::checkExecModeUABLayers(repo, layers);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CheckExecModeUABLayers, AppLayerWithRuntimeVersionMismatch)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    auto app_layer = create_layer("id1", "1.0.0", "main", "app");
+    app_layer.info.runtime = "runtime.id/2.0.0";
+    auto runtime_layer = create_layer("runtime.id", "1.0.0", "main", "runtime");
+    std::vector<api::types::v1::UabLayer> layers = { app_layer, runtime_layer };
+    auto result = UabInstallationAction::checkExecModeUABLayers(repo, layers);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CheckExecModeUABLayers, AppLayerWithRuntimeOk)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    auto app_layer = create_layer("id1", "1.0.0", "main", "app");
+    app_layer.info.runtime = "runtime.id/1.0";
+    app_layer.info.packageInfoV2Module = "binary";
+    auto runtime_layer = create_layer("runtime.id", "1.0.1", "main", "runtime");
+    runtime_layer.info.packageInfoV2Module = "runtime";
+    std::vector<api::types::v1::UabLayer> layers = { app_layer, runtime_layer };
+    auto result = UabInstallationAction::checkExecModeUABLayers(repo, layers);
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST(CheckExecModeUABLayers, ConstrainFailOnAppLayers)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    std::vector<api::types::v1::UabLayer> layers = { create_layer("id1", "1.0.0", "main", "app"),
+                                                     create_layer("id2", "1.0.0", "main", "app") };
+    auto result = UabInstallationAction::checkExecModeUABLayers(repo, layers);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CheckExecModeUABLayers, ConstrainFailOnOtherLayers)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    auto app_layer = create_layer("app_id", "1.0.0", "main", "app");
+    app_layer.info.runtime = "main:runtime.id/1.0.0";
+    app_layer.info.packageInfoV2Module = "binary";
+
+    auto runtime_layer1 = create_layer("runtime.id", "1.0.0", "main", "runtime");
+    runtime_layer1.info.packageInfoV2Module = "runtime";
+    auto runtime_layer2 =
+      create_layer("runtime.id", "2.0.0", "main", "runtime"); // different version
+    runtime_layer2.info.packageInfoV2Module = "runtime";
+
+    std::vector<api::types::v1::UabLayer> layers = { app_layer, runtime_layer1, runtime_layer2 };
+    auto result = UabInstallationAction::checkExecModeUABLayers(repo, layers);
+    EXPECT_FALSE(result.has_value());
+}
+
+// checkDistributionModeUABLayers tests
+TEST(CheckDistributionModeUABLayers, NoLayers)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    std::vector<api::types::v1::UabLayer> layers;
+    auto result = UabInstallationAction::checkDistributionModeUABLayers(repo, layers);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CheckDistributionModeUABLayers, BothAppAndOtherLayers)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    std::vector<api::types::v1::UabLayer> layers = {
+        create_layer("id1", "1.0.0", "main", "app"),
+        create_layer("id1", "1.0.0", "main", "runtime")
+    };
+    auto result = UabInstallationAction::checkDistributionModeUABLayers(repo, layers);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CheckDistributionModeUABLayers, OnlyAppLayers)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    auto layer = create_layer("id1", "1.0.0", "main", "app");
+    layer.info.packageInfoV2Module = "binary";
+    std::vector<api::types::v1::UabLayer> layers = { layer };
+    auto result = UabInstallationAction::checkDistributionModeUABLayers(repo, layers);
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST(CheckDistributionModeUABLayers, OnlyOtherLayers)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    auto layer = create_layer("id1", "1.0.0", "main", "runtime");
+    layer.info.packageInfoV2Module = "runtime";
+    std::vector<api::types::v1::UabLayer> layers = { layer };
+    auto result = UabInstallationAction::checkDistributionModeUABLayers(repo, layers);
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST(CheckDistributionModeUABLayers, ConstrainFailOnAppLayers)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    std::vector<api::types::v1::UabLayer> layers = { create_layer("id1", "1.0.0", "main", "app"),
+                                                     create_layer("id2", "1.0.0", "main", "app") };
+    auto result = UabInstallationAction::checkDistributionModeUABLayers(repo, layers);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CheckDistributionModeUABLayers, ConstrainFailOnOtherLayers)
+{
+    TempDir tempDir;
+    repo::ClientFactory clientFactory(std::string("http://localhost"));
+    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    repo::OSTreeRepo &repo = mockRepo;
+    std::vector<api::types::v1::UabLayer> layers = {
+        create_layer("id1", "1.0.0", "main", "runtime"),
+        create_layer("id1", "2.0.0", "main", "runtime")
+    };
+    auto result = UabInstallationAction::checkDistributionModeUABLayers(repo, layers);
+    EXPECT_FALSE(result.has_value());
+}


### PR DESCRIPTION
The `PackageManager::installFromUAB` method was overly complex and handled multiple responsibilities, including validation, user interaction, and the core installation logic. This made the method difficult to maintain, test, and understand.

This commit refactors the UAB installation process by extracting the entire logic into a new `UabInstallationAction` class. This class encapsulates all steps required for a UAB installation, from preparation and validation to execution and cleanup.

We will continue refactoring and abstracting the Task and Action related code in subsequent phases to improve maintainability and testability.