### PR TITLE
fix: clean code

### DIFF
--- a/libs/linglong/src/linglong/builder/source_fetcher.cpp
+++ b/libs/linglong/src/linglong/builder/source_fetcher.cpp
@@ -10,6 +10,7 @@
 #include "linglong/utils/command/cmd.h"
 #include "linglong/utils/error/error.h"
 #include "linglong/utils/global/initialize.h"
+#include "linglong/utils/log/log.h"
 
 #include <QDir>
 #include <QTemporaryDir>
@@ -51,7 +52,7 @@ auto SourceFetcher::fetch(QDir destination) noexcept -> utils::error::Result<voi
         // 便于在执行失败时进行调试
         dir->setAutoRemove(false);
         scriptFile = dir->filePath(scriptName);
-        qDebug() << "Dumping " << scriptName << "from qrc to" << scriptFile;
+        LogD("Dumping {} from qrc to {}", scriptName, scriptFile);
         QFile::copy(":/scripts/" + scriptName, scriptFile);
     }
     auto output =
@@ -64,7 +65,7 @@ auto SourceFetcher::fetch(QDir destination) noexcept -> utils::error::Result<voi
           this->cacheDir.absolutePath(),
         });
     if (!output.has_value()) {
-        qDebug() << "output error:" << output.error();
+        LogE("output error: {}", output.error());
         return LINGLONG_ERR("stderr:", output);
     }
 

--- a/libs/linglong/src/linglong/package/layer_packager.cpp
+++ b/libs/linglong/src/linglong/package/layer_packager.cpp
@@ -10,6 +10,7 @@
 #include "linglong/api/types/v1/LayerInfo.hpp"
 #include "linglong/utils/command/cmd.h"
 #include "linglong/utils/command/env.h"
+#include "linglong/utils/log/log.h"
 
 #include <QDataStream>
 #include <QSysInfo>
@@ -91,7 +92,7 @@ LayerPackager::~LayerPackager()
         }
     }
     if (!std::filesystem::remove_all(this->workDir)) {
-        qCritical() << "remove" << this->workDir.c_str() << "failed";
+        LogE("failed to remove {}", this->workDir);
         Q_ASSERT(false);
     }
 }

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/ostree_repo_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/ostree_repo_test.cpp
@@ -36,7 +36,6 @@ protected:
 
 TEST_F(RepoTest, exportDir)
 {
-    linglong::utils::global::initLinyapsLogSystem("");
     // 准备测试环境
     fs::path tempDir = fs::temp_directory_path() / "repo_test";
     std::error_code ec;

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/file.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/file.cpp
@@ -20,8 +20,6 @@ class FileTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        linglong::utils::global::initLinyapsLogSystem("");
-
         char src_template[] = "/tmp/linglong-file-test-src-XXXXXX";
         src_dir = mkdtemp(src_template);
         ASSERT_FALSE(src_dir.empty());
@@ -248,4 +246,24 @@ TEST_F(FileTest, GetFiles)
     std::sort(expected_files.begin(), expected_files.end());
 
     EXPECT_EQ(files, expected_files);
+}
+
+TEST_F(FileTest, EnsureDirectory)
+{
+    // Test creating a new directory
+    fs::path new_dir = dest_dir / "new_dir";
+    auto result = linglong::utils::ensureDirectory(new_dir);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(fs::is_directory(new_dir));
+
+    // Test with an existing directory
+    result = linglong::utils::ensureDirectory(new_dir);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(fs::is_directory(new_dir));
+
+    // Test with an existing file
+    fs::path file_path = dest_dir / "file.txt";
+    std::ofstream(file_path) << "test";
+    result = linglong::utils::ensureDirectory(file_path);
+    EXPECT_FALSE(result.has_value());
 }

--- a/libs/linglong/tests/ll-tests/src/main.cpp
+++ b/libs/linglong/tests/ll-tests/src/main.cpp
@@ -14,6 +14,7 @@ int main(int argc, char **argv)
 {
     qputenv("QT_FORCE_STDERR_LOGGING", QByteArray("1"));
     linglong::utils::global::installMessageHandler();
+    linglong::utils::global::initLinyapsLogSystem(argv[0]);
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/libs/utils/src/linglong/utils/command/cmd.cpp
+++ b/libs/utils/src/linglong/utils/command/cmd.cpp
@@ -6,6 +6,8 @@
 
 #include "cmd.h"
 
+#include "linglong/utils/log/log.h"
+
 #include <fmt/format.h>
 
 #include <QProcess>
@@ -31,7 +33,7 @@ linglong::utils::error::Result<QString> Cmd::exec(const QStringList &args) noexc
 {
     LINGLONG_TRACE(
       fmt::format("exec {} {}", m_command.toStdString(), args.join(" ").toStdString()));
-    qDebug() << "exec" << m_command << args;
+    LogD("exec {} {}", m_command, args);
     QProcess process;
     process.setProgram(m_command);
     if (!m_envs.isEmpty()) {

--- a/libs/utils/src/linglong/utils/file.cpp
+++ b/libs/utils/src/linglong/utils/file.cpp
@@ -235,4 +235,16 @@ getFiles(const std::filesystem::path &dir)
     return files;
 }
 
+linglong::utils::error::Result<void> ensureDirectory(const std::filesystem::path &dir)
+{
+    LINGLONG_TRACE(fmt::format("ensure directory {}", dir));
+
+    std::error_code ec;
+    if (!std::filesystem::create_directory(dir, ec) && ec) {
+        return LINGLONG_ERR("failed to create directory", ec);
+    }
+
+    return LINGLONG_OK;
+}
+
 } // namespace linglong::utils

--- a/libs/utils/src/linglong/utils/file.h
+++ b/libs/utils/src/linglong/utils/file.h
@@ -5,10 +5,8 @@
 #pragma once
 #include "linglong/utils/error/error.h"
 
-#include <cstdint>
 #include <filesystem>
 #include <string>
-#include <unordered_set>
 
 namespace linglong::utils {
 
@@ -34,5 +32,7 @@ moveFiles(const std::filesystem::path &src,
 
 linglong::utils::error::Result<std::vector<std::filesystem::path>>
 getFiles(const std::filesystem::path &dir);
+
+linglong::utils::error::Result<void> ensureDirectory(const std::filesystem::path &dir);
 
 } // namespace linglong::utils


### PR DESCRIPTION
- Replaced Qt logging calls with linyaps log system.
- Centralized log system initialization for tests.
- Remove the unused `isChildProcess` helper function.
- Remove permission notify, it's not used for a while.
- move `ensureDirectory` to file utils.