### PR TITLE
chore: fix uab file name in test script

### DIFF
--- a/tools/test-linglong.sh
+++ b/tools/test-linglong.sh
@@ -50,7 +50,7 @@ ll-builder run -- bash -c "export" | grep DBUS_SYSTEM_BUS_ADDRESS | grep test=2
 
 #运行并安装uab
 ll-cli uninstall org.deepin.demo || true
-./org.deepin.demo_x86_64_0.0.0.1_main.uab
+./org.deepin.demo_0.0.0.1_x86_64_main.uab
 
 #安装构建的应用
 ll-cli install org.deepin.demo_0.0.0.1_x86_64_main.uab


### PR DESCRIPTION
更新测试脚本中的 UAB 文件名以匹配实际的文件名格式。文
件名从 'org.deepin.demo_x86_64_0.0.0.1_main.uab' 改为
'org.deepin.demo_0.0.0.1_x86_64_main.uab'，以符合项目中使用的正确命名 约定。