### PR TITLE
refactor: Rework repository client and search logic

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -1084,15 +1084,13 @@ You can report bugs to the linyaps team under this project: https://github.com/O
         }
     }
 
-    const auto defaultRepo = linglong::repo::getDefaultRepo(*repoCfg);
-    linglong::repo::ClientFactory clientFactory(defaultRepo.url);
     auto repoRoot = QDir{ QString::fromStdString(builderCfg->repo) };
     if (!repoRoot.exists() && !repoRoot.mkpath(".")) {
         qCritical() << "failed to create the repository of builder.";
         return -1;
     }
 
-    linglong::repo::OSTreeRepo repo(repoRoot, *repoCfg, clientFactory);
+    linglong::repo::OSTreeRepo repo(repoRoot, *repoCfg);
 
     if (buildRepo->parsed()) {
         return handleRepo(repo,

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -616,11 +616,6 @@ linglong::utils::error::Result<linglong::repo::OSTreeRepo *> initOSTreeRepo()
         return LINGLONG_ERR("load repo config failed", repoConfig);
     }
 
-    // get default repo
-    auto defaultRepo = linglong::repo::getDefaultRepo(*repoConfig);
-    auto clientFactory = new linglong::repo::ClientFactory(std::move(defaultRepo.url));
-    clientFactory->setParent(QCoreApplication::instance());
-
     // check repo root
     auto repoRoot = QDir(LINGLONG_ROOT);
     if (!repoRoot.exists()) {
@@ -628,7 +623,7 @@ linglong::utils::error::Result<linglong::repo::OSTreeRepo *> initOSTreeRepo()
     }
 
     // create repo
-    auto repo = new linglong::repo::OSTreeRepo(repoRoot, std::move(*repoConfig), *clientFactory);
+    auto repo = new linglong::repo::OSTreeRepo(repoRoot, std::move(*repoConfig));
     repo->setParent(QCoreApplication::instance());
     return repo;
 }

--- a/apps/ll-package-manager/src/main.cpp
+++ b/apps/ll-package-manager/src/main.cpp
@@ -32,10 +32,6 @@ void withDBusDaemon(ocppi::cli::CLI &cli)
         QCoreApplication::exit(-1);
         return;
     }
-    const auto defaultRepo = linglong::repo::getDefaultRepo(*config);
-    qWarning() << "server" << defaultRepo.url.c_str();
-    auto *clientFactory = new linglong::repo::ClientFactory(defaultRepo.url);
-    clientFactory->setParent(QCoreApplication::instance());
 
     auto repoRoot = QDir(LINGLONG_ROOT);
     if (!repoRoot.exists() && !repoRoot.mkpath(".")) {
@@ -48,7 +44,7 @@ void withDBusDaemon(ocppi::cli::CLI &cli)
         qCritical() << "failed to migrate repository";
         QCoreApplication::exit(-1);
     }
-    auto *ostreeRepo = new linglong::repo::OSTreeRepo(repoRoot, *config, *clientFactory);
+    auto *ostreeRepo = new linglong::repo::OSTreeRepo(repoRoot, *config);
     ostreeRepo->setParent(QCoreApplication::instance());
     auto result = ostreeRepo->fixExportAllEntries();
     if (!result.has_value()) {
@@ -101,17 +97,13 @@ void withoutDBusDaemon(ocppi::cli::CLI &cli)
         return;
     }
 
-    const auto defaultRepo = linglong::repo::getDefaultRepo(*config);
-    auto *clientFactory = new linglong::repo::ClientFactory(defaultRepo.url);
-    clientFactory->setParent(QCoreApplication::instance());
-
     auto repoRoot = QDir(LINGLONG_ROOT);
     if (!repoRoot.exists() && !repoRoot.mkpath(".")) {
         qCritical() << "failed to create repository directory" << repoRoot.absolutePath();
         std::abort();
     }
 
-    auto *ostreeRepo = new linglong::repo::OSTreeRepo(repoRoot, *config, *clientFactory);
+    auto *ostreeRepo = new linglong::repo::OSTreeRepo(repoRoot, *config);
     ostreeRepo->setParent(QCoreApplication::instance());
     auto result = ostreeRepo->fixExportAllEntries();
     if (!result.has_value()) {

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -17,6 +17,7 @@
 #include "linglong/package/layer_packager.h"
 #include "linglong/package/reference.h"
 #include "linglong/package/uab_packager.h"
+#include "linglong/repo/config.h"
 #include "linglong/repo/ostree_repo.h"
 #include "linglong/runtime/container.h"
 #include "linglong/utils/command/cmd.h"
@@ -131,7 +132,7 @@ utils::error::Result<void> pullDependency(const package::Reference &ref,
     printReplacedText(
       fmt::format("{:<35}{:<15}{:<15}waiting ...", ref.id, ref.version.toString(), module),
       2);
-    repo.pull(tmpTask, ref, module);
+    repo.pull(tmpTask, ref, module, repo.getDefaultRepo());
     if (tmpTask.state() == linglong::api::types::v1::State::Failed) {
         return LINGLONG_ERR(("pull " + ref.toString() + " failed").data(),
                             std::move(tmpTask).takeError());

--- a/libs/linglong/src/linglong/package_manager/package_manager.h
+++ b/libs/linglong/src/linglong/package_manager/package_manager.h
@@ -117,6 +117,13 @@ public
     void pullDependency(PackageTask &taskContext,
                         const api::types::v1::PackageInfoV2 &info,
                         const std::string &module) noexcept;
+    void InstallRef(PackageTask &taskContext,
+                    const package::Reference &ref,
+                    std::vector<std::string> modules,
+                    const api::types::v1::Repo &repo) noexcept;
+    void UninstallRef(PackageTask &taskContext,
+                      const package::Reference &ref,
+                      const std::vector<std::string> &modules) noexcept;
 
 Q_SIGNALS:
     void TaskAdded(QDBusObjectPath object_path);
@@ -142,16 +149,9 @@ private:
                  std::optional<package::Reference> oldRef,
                  const std::vector<std::string> &modules,
                  const std::optional<api::types::v1::Repo> &repo) noexcept;
-    void InstallRef(PackageTask &taskContext,
-                    const package::Reference &ref,
-                    std::vector<std::string> modules,
-                    const api::types::v1::Repo &repo) noexcept;
     void Update(PackageTask &taskContext,
                 const package::Reference &ref,
                 const package::ReferenceWithRepo &newRef) noexcept;
-    void UninstallRef(PackageTask &taskContext,
-                      const package::Reference &ref,
-                      const std::vector<std::string> &modules) noexcept;
     QVariantMap installFromLayer(const QDBusUnixFileDescriptor &fd,
                                  const api::types::v1::CommonOptions &options) noexcept;
 

--- a/libs/linglong/src/linglong/package_manager/package_task.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_task.cpp
@@ -202,6 +202,12 @@ void PackageTask::run() noexcept
     m_job(*this);
 }
 
+bool PackageTask::isTaskDone() const noexcept
+{
+    return m_subState == static_cast<int>(linglong::api::types::v1::SubState::AllDone)
+      || m_subState == static_cast<int>(linglong::api::types::v1::SubState::PackageManagerDone);
+}
+
 PackageTaskQueue::PackageTaskQueue(QObject *parent)
     : QObject(parent)
 {

--- a/libs/linglong/src/linglong/package_manager/package_task.h
+++ b/libs/linglong/src/linglong/package_manager/package_task.h
@@ -120,7 +120,9 @@ public:
         return m_totalPercentage
           + (m_curStagePercentage
              * m_subStateMap[static_cast<api::types::v1::SubState>(m_subState)]);
-    };
+    }
+
+    bool isTaskDone() const noexcept;
 
 public Q_SLOTS:
     void Cancel() noexcept;

--- a/libs/linglong/src/linglong/repo/client_factory.cpp
+++ b/libs/linglong/src/linglong/repo/client_factory.cpp
@@ -9,34 +9,19 @@
 #include "api/ClientAPI.h"
 
 #include <string>
-#include <utility>
 
 namespace linglong::repo {
-
-ClientFactory::ClientFactory(const QString &server)
-    : m_server(server.toStdString())
-{
-}
 
 ClientFactory::ClientFactory(std::string server)
     : m_server(std::move(server))
 {
 }
 
-std::shared_ptr<apiClient_t> ClientFactory::createClientV2()
+std::unique_ptr<ClientAPIWrapper> ClientFactory::createClientV2()
 {
     auto *client = apiClient_create_with_base_path(m_server.c_str(), nullptr, nullptr);
     client->userAgent = m_user_agent.c_str();
-    return { client, apiClient_free };
+    return std::make_unique<ClientAPIWrapper>(client);
 }
 
-void ClientFactory::setServer(const QString &server)
-{
-    m_server = server.toStdString();
-}
-
-void ClientFactory::setServer(const std::string &server)
-{
-    m_server = server;
-}
 } // namespace linglong::repo

--- a/libs/linglong/src/linglong/repo/client_factory.h
+++ b/libs/linglong/src/linglong/repo/client_factory.h
@@ -12,26 +12,92 @@ extern "C" {
 
 #include "configure.h"
 
-#include <QObject>
-#include <QPoint>
+#include <QEventLoop>
 
 #include <memory>
+#include <thread>
+
+#define SYNCREQ(type, func, ...) \
+    syncRun<type##_t, decltype(&type##_free)>(func, type##_free, __VA_ARGS__)
 
 namespace linglong::repo {
 
-class ClientFactory : public QObject
+class ClientAPIWrapper
 {
-    Q_OBJECT
 public:
-    explicit ClientFactory(const QString &server);
+    explicit ClientAPIWrapper(apiClient_t *client)
+        : client(client)
+    {
+    }
+
+    virtual ~ClientAPIWrapper() { apiClient_free(client); }
+
+    template <typename R, typename D, typename T, typename... Args>
+    auto syncRun(T func, D deleter, Args... args) -> std::unique_ptr<R, D>
+    {
+        QEventLoop loop;
+        R *response = nullptr;
+        std::thread t(
+          [&loop, &func, &response](apiClient_t *client, Args... args) {
+              response = func(client, args...);
+              loop.exit();
+          },
+          client,
+          args...);
+        loop.exec();
+        if (t.joinable()) {
+            t.join();
+        }
+        return std::unique_ptr<R, D>(response, deleter);
+    }
+
+    virtual auto fuzzySearch(request_fuzzy_search_req_t *req)
+      -> std::unique_ptr<fuzzy_search_app_200_response_t,
+                         decltype(&fuzzy_search_app_200_response_free)>
+    {
+        return SYNCREQ(fuzzy_search_app_200_response, ClientAPI_fuzzySearchApp, req);
+    }
+
+    virtual auto signIn(request_auth_t *req)
+      -> std::unique_ptr<sign_in_200_response_t, decltype(&sign_in_200_response_free)>
+    {
+        return SYNCREQ(sign_in_200_response, ClientAPI_signIn, req);
+    }
+
+    virtual auto newUploadTaskID(char *token, schema_new_upload_task_req_t *req)
+      -> std::unique_ptr<new_upload_task_id_200_response_t,
+                         decltype(&new_upload_task_id_200_response_free)>
+    {
+        return SYNCREQ(new_upload_task_id_200_response, ClientAPI_newUploadTaskID, token, req);
+    }
+
+    virtual auto uploadTaskFile(char *token, char *taskID, binary_t *binary)
+      -> std::unique_ptr<api_upload_task_file_resp_t, decltype(&api_upload_task_file_resp_free)>
+    {
+        return SYNCREQ(api_upload_task_file_resp, ClientAPI_uploadTaskFile, token, taskID, binary);
+    }
+
+    virtual auto uploadTaskInfo(char *token, char *taskID)
+      -> std::unique_ptr<upload_task_info_200_response_t,
+                         decltype(&upload_task_info_200_response_free)>
+    {
+        return SYNCREQ(upload_task_info_200_response, ClientAPI_uploadTaskInfo, token, taskID);
+    }
+
+private:
+    apiClient_t *client;
+};
+
+class ClientFactory
+{
+public:
     explicit ClientFactory(std::string server);
 
-    std::shared_ptr<apiClient_t> createClientV2();
-    void setServer(const QString &server);
-    void setServer(const std::string &server);
+    std::unique_ptr<ClientAPIWrapper> createClientV2();
 
 private:
     std::string m_server;
     std::string m_user_agent = "linglong/" LINGLONG_VERSION;
 };
+
 } // namespace linglong::repo

--- a/libs/linglong/src/linglong/repo/config.h
+++ b/libs/linglong/src/linglong/repo/config.h
@@ -20,7 +20,11 @@ utils::error::Result<void> saveConfig(const api::types::v1::RepoConfigV2 &cfg,
                                       const QString &path) noexcept;
 int64_t getRepoMinPriority(const api::types::v1::RepoConfigV2 &cfg) noexcept;
 int64_t getRepoMaxPriority(const api::types::v1::RepoConfigV2 &cfg) noexcept;
-api::types::v1::Repo getDefaultRepo(const api::types::v1::RepoConfigV2 &cfg) noexcept;
+const api::types::v1::Repo &getDefaultRepo(const api::types::v1::RepoConfigV2 &cfg) noexcept;
+
+std::vector<api::types::v1::Repo> getPrioritySortedRepos(api::types::v1::RepoConfigV2 cfg) noexcept;
+std::vector<std::vector<api::types::v1::Repo>>
+getPriorityGroupedRepos(api::types::v1::RepoConfigV2 cfg) noexcept;
 
 api::types::v1::RepoConfigV2 convertToV2(const api::types::v1::RepoConfig &cfg) noexcept;
 

--- a/libs/linglong/src/linglong/repo/migrate.cpp
+++ b/libs/linglong/src/linglong/repo/migrate.cpp
@@ -207,7 +207,7 @@ int dispatchMigrations(const Version &from,
     int ret{ std::numeric_limits<int>::max() };
     auto version_1_7_0 = parseVersion("1.7.0");
     if (from < *version_1_7_0) {
-        const auto defaultRepo = linglong::repo::getDefaultRepo(cfg);
+        const auto &defaultRepo = linglong::repo::getDefaultRepo(cfg);
         ret = migrateRef(repo, MigrateRefData{ .root = root, .repoName = defaultRepo.name });
     }
 

--- a/libs/linglong/tests/ll-tests/src/linglong/mocks/linglong_builder_mock.h
+++ b/libs/linglong/tests/ll-tests/src/linglong/mocks/linglong_builder_mock.h
@@ -20,13 +20,10 @@ public:
 private:
     static linglong::repo::OSTreeRepo &initTempRepo()
     {
-        linglong::repo::ClientFactory tempClientFactory(std::string("http://127.0.0.1"));
         auto tempRepoConfig = api::types::v1::RepoConfigV2{};
         char tempPath[] = "/tmp/linglong-builder-test-XXXXXX";
         std::string testDir = mkdtemp(tempPath);
-        static linglong::repo::OSTreeRepo repo(QDir(testDir.c_str()),
-                                               tempRepoConfig,
-                                               tempClientFactory);
+        static linglong::repo::OSTreeRepo repo(QDir(testDir.c_str()), tempRepoConfig);
         return repo;
     }
 

--- a/libs/linglong/tests/ll-tests/src/linglong/mocks/ostree_repo_mock.h
+++ b/libs/linglong/tests/ll-tests/src/linglong/mocks/ostree_repo_mock.h
@@ -17,10 +17,8 @@ using namespace linglong;
 class MockOstreeRepo : public repo::OSTreeRepo
 {
 public:
-    MockOstreeRepo(const QDir &path,
-                   api::types::v1::RepoConfigV2 cfg,
-                   repo::ClientFactory &clientFactory) noexcept
-        : OSTreeRepo(path, cfg, clientFactory)
+    MockOstreeRepo(const QDir &path, api::types::v1::RepoConfigV2 cfg) noexcept
+        : OSTreeRepo(path, cfg)
     {
     }
 

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/uab_installation_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/uab_installation_test.cpp
@@ -24,11 +24,10 @@ using ::testing::Return;
 class MockOSTreeRepo : public repo::OSTreeRepo
 {
 public:
-    MockOSTreeRepo(const std::filesystem::path &path, repo::ClientFactory &clientFactory)
+    MockOSTreeRepo(const std::filesystem::path &path)
         : repo::OSTreeRepo(
             QDir(path.c_str()),
-            api::types::v1::RepoConfigV2{ .defaultRepo = "", .repos = {}, .version = 2 },
-            clientFactory)
+            api::types::v1::RepoConfigV2{ .defaultRepo = "", .repos = {}, .version = 2 })
     {
     }
 
@@ -67,8 +66,7 @@ api::types::v1::UabLayer create_layer(const std::string &id,
 TEST(CheckUABLayersConstrain, EmptyLayers)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     EXPECT_CALL(mockRepo, clearReference(_, _, _, _)).Times(0);
     std::vector<api::types::v1::UabLayer> layers;
@@ -79,8 +77,7 @@ TEST(CheckUABLayersConstrain, EmptyLayers)
 TEST(CheckUABLayersConstrain, ArchMismatch)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers;
     api::types::v1::UabLayer layer;
@@ -98,8 +95,7 @@ TEST(CheckUABLayersConstrain, ArchMismatch)
 TEST(CheckUABLayersConstrain, DifferentIds)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers;
     auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
@@ -123,8 +119,7 @@ TEST(CheckUABLayersConstrain, DifferentIds)
 TEST(CheckUABLayersConstrain, DifferentVersions)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers;
     auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
@@ -152,8 +147,7 @@ TEST(CheckUABLayersConstrain, ExtraModuleNoBinaryAndNotInstalled)
     LINGLONG_TRACE("ExtraModuleNoBinaryAndNotInstalled");
 
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers;
     auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
@@ -176,8 +170,7 @@ TEST(CheckUABLayersConstrain, ExtraModuleNoBinaryAndNotInstalled)
 TEST(CheckUABLayersConstrain, ExtraModuleNoBinaryAndWrongVersionInstalled)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers;
     auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
@@ -203,8 +196,7 @@ TEST(CheckUABLayersConstrain, ExtraModuleNoBinaryAndWrongVersionInstalled)
 TEST(CheckUABLayersConstrain, ExtraModuleNoBinaryButInstalled)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers;
     auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
@@ -230,8 +222,7 @@ TEST(CheckUABLayersConstrain, ExtraModuleNoBinaryButInstalled)
 TEST(CheckUABLayersConstrain, ExtraModuleWithBinary)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers;
     auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
@@ -263,8 +254,7 @@ TEST(GetTaskAction, InstallNewApp)
     LINGLONG_TRACE("InstallNewApp");
 
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
 
     std::vector<api::types::v1::UabLayer> appLayers = {
@@ -283,8 +273,7 @@ TEST(GetTaskAction, InstallNewApp)
 TEST(GetTaskAction, OverwriteApp)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
 
@@ -306,8 +295,7 @@ TEST(GetTaskAction, OverwriteApp)
 TEST(GetTaskAction, UpgradeApp)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
 
@@ -329,8 +317,7 @@ TEST(GetTaskAction, UpgradeApp)
 TEST(GetTaskAction, DowngradeApp)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
 
@@ -352,8 +339,7 @@ TEST(GetTaskAction, DowngradeApp)
 TEST(GetTaskAction, InstallLowVersionRuntime)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
 
@@ -375,8 +361,7 @@ TEST(GetTaskAction, InstallLowVersionRuntime)
 TEST(GetTaskAction, InstallHighVersionRuntime)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
 
@@ -399,8 +384,7 @@ TEST(GetTaskAction, InstallHighVersionRuntime)
 TEST(CheckExecModeUABLayers, NoAppLayers)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers = {
         create_layer("id1", "1.0.0", "main", "runtime")
@@ -412,8 +396,7 @@ TEST(CheckExecModeUABLayers, NoAppLayers)
 TEST(CheckExecModeUABLayers, AppLayerNoRuntime)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     auto layer = create_layer("id1", "1.0.0", "main", "app");
     layer.info.packageInfoV2Module = "binary";
@@ -425,8 +408,7 @@ TEST(CheckExecModeUABLayers, AppLayerNoRuntime)
 TEST(CheckExecModeUABLayers, AppLayerWithRuntimeNoRuntimeLayer)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     auto layer = create_layer("id1", "1.0.0", "main", "app");
     layer.info.runtime = "runtime.id/1.0.0";
@@ -438,8 +420,7 @@ TEST(CheckExecModeUABLayers, AppLayerWithRuntimeNoRuntimeLayer)
 TEST(CheckExecModeUABLayers, AppLayerWithRuntimeIdMismatch)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     auto app_layer = create_layer("id1", "1.0.0", "main", "app");
     app_layer.info.runtime = "runtime.id/1.0.0";
@@ -452,8 +433,7 @@ TEST(CheckExecModeUABLayers, AppLayerWithRuntimeIdMismatch)
 TEST(CheckExecModeUABLayers, AppLayerWithRuntimeChannelMismatch)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     auto app_layer = create_layer("id1", "1.0.0", "main", "app");
     app_layer.info.runtime = "runtime.id/1.0.0";
@@ -466,8 +446,7 @@ TEST(CheckExecModeUABLayers, AppLayerWithRuntimeChannelMismatch)
 TEST(CheckExecModeUABLayers, AppLayerWithRuntimeVersionMismatch)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     auto app_layer = create_layer("id1", "1.0.0", "main", "app");
     app_layer.info.runtime = "runtime.id/2.0.0";
@@ -480,8 +459,7 @@ TEST(CheckExecModeUABLayers, AppLayerWithRuntimeVersionMismatch)
 TEST(CheckExecModeUABLayers, AppLayerWithRuntimeOk)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     auto app_layer = create_layer("id1", "1.0.0", "main", "app");
     app_layer.info.runtime = "runtime.id/1.0";
@@ -496,8 +474,7 @@ TEST(CheckExecModeUABLayers, AppLayerWithRuntimeOk)
 TEST(CheckExecModeUABLayers, ConstrainFailOnAppLayers)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers = { create_layer("id1", "1.0.0", "main", "app"),
                                                      create_layer("id2", "1.0.0", "main", "app") };
@@ -508,8 +485,7 @@ TEST(CheckExecModeUABLayers, ConstrainFailOnAppLayers)
 TEST(CheckExecModeUABLayers, ConstrainFailOnOtherLayers)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     auto app_layer = create_layer("app_id", "1.0.0", "main", "app");
     app_layer.info.runtime = "main:runtime.id/1.0.0";
@@ -530,8 +506,7 @@ TEST(CheckExecModeUABLayers, ConstrainFailOnOtherLayers)
 TEST(CheckDistributionModeUABLayers, NoLayers)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers;
     auto result = UabInstallationAction::checkDistributionModeUABLayers(repo, layers);
@@ -541,8 +516,7 @@ TEST(CheckDistributionModeUABLayers, NoLayers)
 TEST(CheckDistributionModeUABLayers, BothAppAndOtherLayers)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers = {
         create_layer("id1", "1.0.0", "main", "app"),
@@ -555,8 +529,7 @@ TEST(CheckDistributionModeUABLayers, BothAppAndOtherLayers)
 TEST(CheckDistributionModeUABLayers, OnlyAppLayers)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     auto layer = create_layer("id1", "1.0.0", "main", "app");
     layer.info.packageInfoV2Module = "binary";
@@ -568,8 +541,7 @@ TEST(CheckDistributionModeUABLayers, OnlyAppLayers)
 TEST(CheckDistributionModeUABLayers, OnlyOtherLayers)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     auto layer = create_layer("id1", "1.0.0", "main", "runtime");
     layer.info.packageInfoV2Module = "runtime";
@@ -581,8 +553,7 @@ TEST(CheckDistributionModeUABLayers, OnlyOtherLayers)
 TEST(CheckDistributionModeUABLayers, ConstrainFailOnAppLayers)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers = { create_layer("id1", "1.0.0", "main", "app"),
                                                      create_layer("id2", "1.0.0", "main", "app") };
@@ -593,8 +564,7 @@ TEST(CheckDistributionModeUABLayers, ConstrainFailOnAppLayers)
 TEST(CheckDistributionModeUABLayers, ConstrainFailOnOtherLayers)
 {
     TempDir tempDir;
-    repo::ClientFactory clientFactory(std::string("http://localhost"));
-    MockOSTreeRepo mockRepo(tempDir.path(), clientFactory);
+    MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers = {
         create_layer("id1", "1.0.0", "main", "runtime"),

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/client_factory_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/client_factory_test.cpp
@@ -20,32 +20,9 @@ protected:
     void TearDown() override { }
 };
 
-TEST_F(ClientFactoryTest, CreateWithQString)
-{
-    ClientFactory factory(QString("http://localhost:8081"));
-    auto client = factory.createClientV2();
-    EXPECT_NE(client, nullptr);
-}
-
 TEST_F(ClientFactoryTest, CreateWithStdString)
 {
     ClientFactory factory(std::string("http://localhost:8081"));
-    auto client = factory.createClientV2();
-    EXPECT_NE(client, nullptr);
-}
-
-TEST_F(ClientFactoryTest, SetServerWithQString)
-{
-    ClientFactory factory(QString("http://localhost:8080"));
-    factory.setServer(QString("http://localhost:8084"));
-    auto client = factory.createClientV2();
-    EXPECT_NE(client, nullptr);
-}
-
-TEST_F(ClientFactoryTest, SetServerWithStdString)
-{
-    ClientFactory factory(std::string("http://localhost:8080"));
-    factory.setServer(std::string("http://localhost:8083"));
     auto client = factory.createClientV2();
     EXPECT_NE(client, nullptr);
 }

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/config_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/config_test.cpp
@@ -88,3 +88,50 @@ TEST(Repo, ConventToV2)
     EXPECT_EQ(configV2.repos[1].url, "http://example.com/repo1");
     EXPECT_EQ(configV2.repos[1].priority, -100);
 }
+
+TEST(Repo, GetPrioritySortedRepos)
+{
+    RepoConfigV2 cfg;
+    EXPECT_TRUE(getPrioritySortedRepos(cfg).empty());
+
+    cfg.repos = { { std::nullopt, false, "repo2", 100, "http://example.com/repo2" },
+                  { std::nullopt, false, "repo3", 300, "http://example.com/repo3" },
+                  { std::nullopt, false, "repo1", 200, "http://example.com/repo1" } };
+
+    auto sortedRepos = getPrioritySortedRepos(cfg);
+    ASSERT_EQ(sortedRepos.size(), 3);
+    EXPECT_EQ(sortedRepos[0].name, "repo3");
+    EXPECT_EQ(sortedRepos[0].priority, 300);
+    EXPECT_EQ(sortedRepos[1].name, "repo1");
+    EXPECT_EQ(sortedRepos[1].priority, 200);
+    EXPECT_EQ(sortedRepos[2].name, "repo2");
+    EXPECT_EQ(sortedRepos[2].priority, 100);
+}
+
+TEST(Repo, GetPriorityGroupedRepos)
+{
+    RepoConfigV2 cfg;
+    EXPECT_TRUE(getPriorityGroupedRepos(cfg).empty());
+
+    cfg.repos = { { std::nullopt, false, "repo2", 100, "http://example.com/repo2" },
+                  { std::nullopt, false, "repo4", 200, "http://example.com/repo4" },
+                  { std::nullopt, false, "repo3", 300, "http://example.com/repo3" },
+                  { std::nullopt, false, "repo1", 200, "http://example.com/repo1" } };
+
+    auto groupedRepos = getPriorityGroupedRepos(cfg);
+    ASSERT_EQ(groupedRepos.size(), 3);
+
+    ASSERT_EQ(groupedRepos[0].size(), 1);
+    EXPECT_EQ(groupedRepos[0][0].name, "repo3");
+    EXPECT_EQ(groupedRepos[0][0].priority, 300);
+
+    ASSERT_EQ(groupedRepos[1].size(), 2);
+    EXPECT_EQ(groupedRepos[1][0].name, "repo4");
+    EXPECT_EQ(groupedRepos[1][0].priority, 200);
+    EXPECT_EQ(groupedRepos[1][1].name, "repo1");
+    EXPECT_EQ(groupedRepos[1][1].priority, 200);
+
+    ASSERT_EQ(groupedRepos[2].size(), 1);
+    EXPECT_EQ(groupedRepos[2][0].name, "repo2");
+    EXPECT_EQ(groupedRepos[2][0].priority, 100);
+}


### PR DESCRIPTION
Refactors the interaction with remote repositories to clarify the code's intent.

Key changes include:
- Introduce `ClientAPIWrapper` to encapsulate the generated C-style API client.
- The remote package searching function is renamed from `listRemote` to `searchRemote` to better reflect its purpose.
- The `pull` method now requires an explicit repo argument.
- add `getPrioritySortedRepos` and `getPriorityGroupedRepos` helpers.