### PR TITLE
refactor: Simplifies icon packaging logic in UABPackager

### DIFF
--- a/libs/linglong/src/linglong/package/uab_packager.cpp
+++ b/libs/linglong/src/linglong/package/uab_packager.cpp
@@ -281,14 +281,8 @@ utils::error::Result<void> UABPackager::packIcon() noexcept
 {
     LINGLONG_TRACE("add icon to uab")
 
-    auto iconAchieve = this->uab.parentDir().absoluteFilePath("icon.a");
-    if (auto ret = utils::command::Cmd("ar").exec({ "q", iconAchieve, icon->absoluteFilePath() });
-        !ret) {
-        return LINGLONG_ERR(ret);
-    }
-
     QByteArray iconSection{ "linglong.icon" };
-    if (auto ret = this->uab.addNewSection(iconSection, QFileInfo{ iconAchieve }); !ret) {
+    if (auto ret = this->uab.addNewSection(iconSection, icon.value()); !ret) {
         return LINGLONG_ERR(ret);
     }
 


### PR DESCRIPTION
Refactors the icon packaging process by removing the intermediate step of creating an "icon.a" archive and directly passing the icon value to the `addNewSection` method. Improves code clarity and reduces unnecessary operations.