### PR TITLE
feat: Add --force option to uninstall command

### DIFF
--- a/api/schema/v1.json
+++ b/api/schema/v1.json
@@ -1025,11 +1025,15 @@
       "type": "object",
       "description": "package manager uninstall parameters",
       "required": [
-        "package"
+        "package",
+        "options"
       ],
       "properties": {
         "package": {
           "$ref": "#/$defs/PackageManager1Package"
+        },
+        "options": {
+          "$ref": "#/$defs/CommonOptions"
         }
       }
     },

--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -790,9 +790,12 @@ $defs:
     description: package manager uninstall parameters
     required:
       - package
+      - options
     properties:
       package:
         $ref: '#/$defs/PackageManager1Package'
+      options:
+        $ref: '#/$defs/CommonOptions'
   PackageManager1UpdateParameters:
     type: object
     description: package manager update result

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -326,6 +326,9 @@ void addUninstallCommand(CLI::App &commandParser,
     cliUninstall->add_option("--module", uninstallOptions.module, _("Uninstall a specify module"))
       ->type_name("MODULE")
       ->check(validatorString);
+    cliUninstall->add_flag("--force",
+                           uninstallOptions.forceOpt,
+                           _("Force uninstall base or runtime"));
 
     // below options are used for compatibility with old ll-cli
     const auto &pruneDescription = std::string{ _("Remove all unused modules") };

--- a/libs/api/src/linglong/api/types/v1/Generators.hpp
+++ b/libs/api/src/linglong/api/types/v1/Generators.hpp
@@ -1047,11 +1047,13 @@ j["type"] = x.type;
 }
 
 inline void from_json(const json & j, PackageManager1UninstallParameters& x) {
+x.options = j.at("options").get<CommonOptions>();
 x.package = j.at("package").get<PackageManager1Package>();
 }
 
 inline void to_json(json & j, const PackageManager1UninstallParameters & x) {
 j = json::object();
+j["options"] = x.options;
 j["package"] = x.package;
 }
 

--- a/libs/api/src/linglong/api/types/v1/PackageManager1UninstallParameters.hpp
+++ b/libs/api/src/linglong/api/types/v1/PackageManager1UninstallParameters.hpp
@@ -17,6 +17,7 @@
 #include <nlohmann/json.hpp>
 #include "linglong/api/types/v1/helper.hpp"
 
+#include "linglong/api/types/v1/CommonOptions.hpp"
 #include "linglong/api/types/v1/PackageManager1Package.hpp"
 
 namespace linglong {
@@ -33,6 +34,7 @@ using nlohmann::json;
 * package manager uninstall parameters
 */
 struct PackageManager1UninstallParameters {
+CommonOptions options;
 PackageManager1Package package;
 };
 }

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -583,7 +583,7 @@ int Cli::run(const RunOptions &options)
 
     auto res = runContext.resolve(*curAppRef, opts);
     if (!res) {
-        this->printer.printErr(res.error());
+        handleCommonError(res.error());
         return -1;
     }
 
@@ -1360,6 +1360,10 @@ int Cli::uninstall(const UninstallOptions &options)
     }
 
     auto params = api::types::v1::PackageManager1UninstallParameters{};
+    params.options = api::types::v1::CommonOptions{
+        .force = options.forceOpt,
+        .skipInteraction = false,
+    };
     params.package.id = fuzzyRef->id;
     if (fuzzyRef->channel) {
         params.package.channel = fuzzyRef->channel;
@@ -2615,6 +2619,9 @@ bool Cli::handleCommonError(const utils::error::Error &error)
         this->printer.printMessage(_("Network connection failed. Please:"
                                      "\n1. Check your internet connection"
                                      "\n2. Verify network proxy settings if used"));
+        break;
+    case utils::error::ErrorCode::LayerCompatibilityError:
+        this->printer.printMessage(_("Package not found"));
         break;
     default:
         this->printer.printErr(error);

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -98,6 +98,7 @@ struct UninstallOptions
 {
     std::string appid;
     std::string module;
+    bool forceOpt{ false };
 };
 
 struct ListOptions

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -94,10 +94,6 @@ public:
                    const clearReferenceOption &opts,
                    const std::string &module = "binary",
                    const std::optional<std::string> &repo = std::nullopt) const noexcept;
-    [[nodiscard]] utils::error::Result<linglong::package::ReferenceWithRepo>
-    getRemoteReferenceByPriority(const package::FuzzyReference &fuzzy,
-                                 const getRemoteReferenceByPriorityOption &opts,
-                                 const std::string &module = "binary") noexcept;
 
     utils::error::Result<std::vector<api::types::v1::PackageInfoV2>> listLocal() const noexcept;
     utils::error::Result<std::vector<api::types::v1::PackageInfoV2>>


### PR DESCRIPTION
Introduces a `--force` flag to the `ll-cli uninstall` command, allowing users to forcefully uninstall packages that are typically protected, such as base and runtime dependencies.

This commit also includes significant refactoring:
- The dependency pulling logic in `PackageManager::pullDependency` has been refactored to prioritize newer remote packages over existing local ones, ensuring dependencies are kept up-to-date.