### PR TITLE
feat: Disable backtrace by default

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/utils/error/error_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/error/error_test.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "linglong/common/strings.h"
+#include "linglong/utils/command/env.h"
 #include "linglong/utils/error/error.h"
 
 #include <filesystem>
@@ -14,9 +15,11 @@
 using namespace linglong::utils::error;
 
 using namespace linglong::common;
+using linglong::utils::command::EnvironmentVariableGuard;
 
 TEST(Error, New)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     auto res = []() -> Result<void> {
         LINGLONG_TRACE("test LINGLONG_ERR");
         return LINGLONG_ERR("message", -1);
@@ -31,6 +34,7 @@ TEST(Error, New)
 
 TEST(Error, WrapResult)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     auto res = []() -> Result<void> {
         LINGLONG_TRACE("test LINGLONG_ERR");
         auto res = []() -> Result<void> {
@@ -59,6 +63,7 @@ TEST(Error, WrapResult)
 
 TEST(Error, WrapError)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     auto res = []() -> Result<void> {
         LINGLONG_TRACE("test LINGLONG_ERR");
         auto res = []() -> Result<void> {
@@ -82,6 +87,7 @@ TEST(Error, WrapError)
 
 TEST(Error, WarpErrorCode)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     auto res = []() -> Result<void> {
         LINGLONG_TRACE("test LINGLONG_ERR");
         return LINGLONG_ERR("app install failed", ErrorCode::AppInstallFailed);
@@ -95,6 +101,7 @@ TEST(Error, WarpErrorCode)
 
 TEST(Error, WarpStdErrorCode)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     auto res = []() -> Result<void> {
         LINGLONG_TRACE("test LINGLONG_ERR");
         std::error_code ec;
@@ -112,6 +119,7 @@ TEST(Error, WarpStdErrorCode)
 
 TEST(Error, WarpQtFile)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     auto res = []() -> Result<void> {
         LINGLONG_TRACE("test LINGLONG_ERR");
         QFile file("/not_exists_file");
@@ -127,10 +135,9 @@ TEST(Error, WarpQtFile)
     ASSERT_TRUE(strings::contains(msg, "No such file or directory")) << msg;
 }
 
-// 在现有的 error_test.cpp 文件末尾添加以下测试
-
 TEST(Error, WarpGError)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     auto res = []() -> Result<void> {
         LINGLONG_TRACE("test LINGLONG_ERR with GError");
         g_autoptr(GError) gErr =
@@ -147,6 +154,7 @@ TEST(Error, WarpGError)
 
 TEST(Error, WarpSystemError)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     auto res = []() -> Result<void> {
         LINGLONG_TRACE("test LINGLONG_ERR with std::system_error");
         try {
@@ -166,6 +174,7 @@ TEST(Error, WarpSystemError)
 
 TEST(Error, WarpExceptionPtr)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     auto res = []() -> Result<void> {
         LINGLONG_TRACE("test LINGLONG_ERR with std::exception_ptr");
         std::exception_ptr eptr;
@@ -202,6 +211,7 @@ TEST(Error, WarpExceptionPtr)
 
 TEST(Error, WarpStdException)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     auto res = []() -> Result<void> {
         LINGLONG_TRACE("test LINGLONG_ERR with std::exception");
         std::invalid_argument e("Invalid argument provided");
@@ -217,6 +227,7 @@ TEST(Error, WarpStdException)
 
 TEST(Error, WarpNestedError)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     auto res = []() -> Result<void> {
         auto innerFn = []() -> Result<void> {
             LINGLONG_TRACE("inner function");
@@ -242,6 +253,7 @@ TEST(Error, WarpNestedError)
 
 TEST(Error, WarpErrorWithCustomCode)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     auto res = []() -> Result<void> {
         LINGLONG_TRACE("test LINGLONG_ERR with custom error code");
         return LINGLONG_ERR("Custom error occurred", 12345);
@@ -256,6 +268,7 @@ TEST(Error, WarpErrorWithCustomCode)
 
 TEST(Error, WarpQStringMessage)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     auto res = []() -> Result<void> {
         LINGLONG_TRACE("test LINGLONG_ERR with QString message");
         QString errorMsg = QString("Error occurred at line %1").arg(__LINE__);
@@ -271,6 +284,7 @@ TEST(Error, WarpQStringMessage)
 
 TEST(Error, WarpStdStringMessage)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     auto res = []() -> Result<void> {
         LINGLONG_TRACE("test LINGLONG_ERR with std::string message");
         std::string errorMsg = "Standard string error message";
@@ -286,6 +300,7 @@ TEST(Error, WarpStdStringMessage)
 
 TEST(Error, WarpEmptyFile)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     auto res = []() -> Result<void> {
         LINGLONG_TRACE("test LINGLONG_ERR with empty QFile");
         QFile emptyFile;
@@ -301,6 +316,7 @@ TEST(Error, WarpEmptyFile)
 
 TEST(Error, SuccessCase)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     auto res = []() -> Result<void> {
         LINGLONG_TRACE("test successful operation");
         // 模拟成功操作
@@ -312,6 +328,7 @@ TEST(Error, SuccessCase)
 
 TEST(Error, ErrorCodeEnumValues)
 {
+    EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
     // 测试各种错误码枚举值
     auto testErrorCode = [](ErrorCode code, const std::string &description) -> Result<void> {
         LINGLONG_TRACE("test error code : " + description);
@@ -330,4 +347,46 @@ TEST(Error, ErrorCodeEnumValues)
     auto res3 = testErrorCode(ErrorCode::Success, "This should not happen");
     ASSERT_FALSE(res3.has_value());
     ASSERT_EQ(res3.error().code(), 0); // Success 错误码为0
+}
+
+TEST(Error, NoBacktrace)
+{
+    auto res = []() -> Result<void> {
+        LINGLONG_TRACE("trace");
+        return LINGLONG_ERR("error");
+    }();
+
+    ASSERT_FALSE(res.has_value());
+    auto msg = res.error().message();
+    ASSERT_FALSE(strings::contains(msg, "trace")) << msg;
+    ASSERT_TRUE(strings::contains(msg, "error")) << msg;
+}
+
+TEST(Error, DefaultError)
+{
+    auto res1 = []() -> Result<void> {
+        LINGLONG_TRACE("trace 1");
+        return LINGLONG_ERR("error 1", 1);
+    };
+
+    auto res2 = [&res1]() -> Result<void> {
+        LINGLONG_TRACE("trace 2");
+        return LINGLONG_ERR(res1());
+    }();
+
+    ASSERT_FALSE(res2.has_value());
+    auto msg = res2.error().message();
+    ASSERT_FALSE(strings::contains(msg, "trace")) << msg;
+    ASSERT_TRUE(strings::contains(msg, "error 1")) << msg;
+    ASSERT_EQ(res2.error().code(), 1);
+
+    auto res3 = [&res1]() -> Result<void> {
+        LINGLONG_TRACE("trace 3");
+        return LINGLONG_ERR("error 3", res1());
+    }();
+    ASSERT_FALSE(res3.has_value());
+    msg = res3.error().message();
+    ASSERT_FALSE(strings::contains(msg, "trace")) << msg;
+    ASSERT_TRUE(strings::contains(msg, "error 3")) << msg;
+    ASSERT_EQ(res3.error().code(), 1);
 }

--- a/libs/utils/src/linglong/utils/error/error.h
+++ b/libs/utils/src/linglong/utils/error/error.h
@@ -83,7 +83,8 @@ public:
         return Error(std::make_unique<details::ErrorImpl>(file,
                                                           line,
                                                           static_cast<int>(code),
-                                                          trace_msg + ": " + msg.toStdString(),
+                                                          trace_msg,
+                                                          msg.toStdString(),
                                                           nullptr));
     }
 
@@ -96,7 +97,8 @@ public:
         return Error(std::make_unique<details::ErrorImpl>(file,
                                                           line,
                                                           static_cast<int>(code),
-                                                          trace_msg + ": " + msg,
+                                                          trace_msg,
+                                                          msg,
                                                           nullptr));
     }
 
@@ -109,7 +111,8 @@ public:
         return Error(std::make_unique<details::ErrorImpl>(file,
                                                           line,
                                                           static_cast<int>(code),
-                                                          trace_msg + ": " + msg,
+                                                          trace_msg,
+                                                          msg,
                                                           nullptr));
     }
 
@@ -120,7 +123,8 @@ public:
         return Error(std::make_unique<details::ErrorImpl>(file,
                                                           line,
                                                           code,
-                                                          trace_msg + ": " + msg.toStdString(),
+                                                          trace_msg,
+                                                          msg.toStdString(),
                                                           nullptr));
     }
 
@@ -131,7 +135,7 @@ public:
                     int code = -1) -> Error
     {
         return Error(
-          std::make_unique<details::ErrorImpl>(file, line, code, trace_msg + ": " + msg, nullptr));
+          std::make_unique<details::ErrorImpl>(file, line, code, trace_msg, msg, nullptr));
     }
 
     static auto
@@ -139,7 +143,7 @@ public:
       -> Error
     {
         return Error(
-          std::make_unique<details::ErrorImpl>(file, line, code, trace_msg + ": " + msg, nullptr));
+          std::make_unique<details::ErrorImpl>(file, line, code, trace_msg, msg, nullptr));
     }
 
     static auto Err(const char *file,
@@ -148,12 +152,13 @@ public:
                     const QString &msg,
                     const QFile &qfile) -> Error
     {
-        return Error(std::make_unique<details::ErrorImpl>(
-          file,
-          line,
-          qfile.error(),
-          trace_msg + ": " + msg.toStdString() + ": " + qfile.errorString().toStdString(),
-          nullptr));
+        return Error(std::make_unique<details::ErrorImpl>(file,
+                                                          line,
+                                                          qfile.error(),
+                                                          trace_msg,
+                                                          msg.toStdString() + ": "
+                                                            + qfile.errorString().toStdString(),
+                                                          nullptr));
     }
 
     static auto Err(const char *file, int line, const std::string &trace_msg, const QFile &qfile)
@@ -162,8 +167,8 @@ public:
         return Error(std::make_unique<details::ErrorImpl>(file,
                                                           line,
                                                           qfile.error(),
-                                                          trace_msg + ": "
-                                                            + qfile.fileName().toStdString() + ": "
+                                                          trace_msg,
+                                                          qfile.fileName().toStdString() + ": "
                                                             + qfile.errorString().toStdString(),
                                                           nullptr));
     }
@@ -174,16 +179,17 @@ public:
                     std::exception_ptr err,
                     int code = -1) -> Error
     {
-        std::string what = trace_msg + ": ";
+        std::string what;
         try {
             std::rethrow_exception(std::move(err));
         } catch (const std::exception &e) {
-            what += e.what();
+            what = e.what();
         } catch (...) {
-            what += "unknown";
+            what = "unknown";
         }
 
-        return Error(std::make_unique<details::ErrorImpl>(file, line, code, what, nullptr));
+        return Error(
+          std::make_unique<details::ErrorImpl>(file, line, code, trace_msg, what, nullptr));
     }
 
     static auto Err(const char *file,
@@ -193,7 +199,7 @@ public:
                     std::exception_ptr err,
                     int code = -1) -> Error
     {
-        std::string what = trace_msg + ": " + msg.toStdString() + ": ";
+        std::string what = msg.toStdString() + ": ";
         try {
             std::rethrow_exception(std::move(err));
         } catch (const std::exception &e) {
@@ -202,18 +208,15 @@ public:
             what += "unknown";
         }
 
-        return Error(std::make_unique<details::ErrorImpl>(file, line, code, what, nullptr));
+        return Error(
+          std::make_unique<details::ErrorImpl>(file, line, code, trace_msg, what, nullptr));
     }
 
     static auto
     Err(const char *file, int line, const std::string &trace_msg, const std::exception &e) -> Error
     {
-        return Error(std::make_unique<details::ErrorImpl>(file,
-                                                          line,
-
-                                                          -1,
-                                                          trace_msg + ": " + e.what(),
-                                                          nullptr));
+        return Error(
+          std::make_unique<details::ErrorImpl>(file, line, -1, trace_msg, e.what(), nullptr));
     }
 
     static auto Err(const char *file,
@@ -223,9 +226,10 @@ public:
                     const std::exception &e,
                     int code = -1) -> Error
     {
-        std::string what = trace_msg + ": " + msg.toStdString() + ": " + e.what();
+        std::string what = msg.toStdString() + ": " + e.what();
 
-        return Error(std::make_unique<details::ErrorImpl>(file, line, code, what, nullptr));
+        return Error(
+          std::make_unique<details::ErrorImpl>(file, line, code, trace_msg, what, nullptr));
     }
 
     static auto Err(const char *file,
@@ -281,7 +285,8 @@ public:
         return Error(std::make_unique<details::ErrorImpl>(file,
                                                           line,
                                                           cause.error().code(),
-                                                          trace_msg + ": " + msg.toStdString(),
+                                                          trace_msg,
+                                                          msg.toStdString(),
                                                           std::move(cause.error().pImpl)));
     }
 
@@ -297,7 +302,8 @@ public:
         return Error(std::make_unique<details::ErrorImpl>(file,
                                                           line,
                                                           cause.error().code(),
-                                                          trace_msg + ": " + msg,
+                                                          trace_msg,
+                                                          msg,
                                                           std::move(cause.error().pImpl)));
     }
 
@@ -313,7 +319,8 @@ public:
         return Error(std::make_unique<details::ErrorImpl>(file,
                                                           line,
                                                           cause.error().code(),
-                                                          trace_msg + ": " + msg,
+                                                          trace_msg,
+                                                          msg,
                                                           std::move(cause.error().pImpl)));
     }
 
@@ -329,6 +336,7 @@ public:
                                                           line,
                                                           cause.error().code(),
                                                           trace_msg,
+                                                          std::nullopt,
                                                           std::move(cause.error().pImpl)));
     }
 
@@ -341,7 +349,8 @@ public:
         return Error(std::make_unique<details::ErrorImpl>(file,
                                                           line,
                                                           cause.code(),
-                                                          trace_msg + ": " + msg,
+                                                          trace_msg,
+                                                          msg,
                                                           std::move(cause.pImpl)));
     }
 
@@ -353,6 +362,7 @@ public:
                                                           line,
                                                           cause.code(),
                                                           trace_msg,
+                                                          std::nullopt,
                                                           std::move(cause.pImpl)));
     }
 


### PR DESCRIPTION
The LINYAPS_BACKTRACE environment variable now controls the verbosity of error messages, including file paths, line numbers, and backtrace details.