### PR TITLE
fix: the application was abnormally removed due to an error in execut…

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.h
+++ b/libs/linglong/src/linglong/package_manager/package_manager.h
@@ -114,6 +114,7 @@ public
                                                   const std::vector<std::string> &modules) noexcept;
     utils::error::Result<void> tryGenerateCache(const package::Reference &ref) noexcept;
     utils::error::Result<void> executePostInstallHooks(const package::Reference &ref) noexcept;
+    utils::error::Result<void> executePostUninstallHooks(const package::Reference &ref) noexcept;
     void pullDependency(PackageTask &taskContext,
                         const api::types::v1::PackageInfoV2 &info,
                         const std::string &module) noexcept;
@@ -169,7 +170,6 @@ private:
     Prune(std::vector<api::types::v1::PackageInfoV2> &removedInfo) noexcept;
     utils::error::Result<void> generateCache(const package::Reference &ref) noexcept;
     utils::error::Result<void> removeCache(const package::Reference &ref) noexcept;
-    utils::error::Result<void> executePostUninstallHooks(const package::Reference &ref) noexcept;
 
     linglong::repo::OSTreeRepo &repo; // NOLINT
     PackageTaskQueue tasks;


### PR DESCRIPTION
…ing hooks

1. Hook scripts should be executed before exporting and generating caches; otherwise, execution failures may result in the application being removed.
2. Enhances logging for better visibility into hook execution failures and aligns hook handling across installation, upgrade, and dependency management workflows.