### PR TITLE
i18n: add policy file for translation

### DIFF
--- a/.tx/transifex.yaml
+++ b/.tx/transifex.yaml
@@ -7,5 +7,9 @@ filters:
     file_format: PO
     source_language: en_US
     translation_files_expression: po/<lang>.po
+  - filter_type: file
+    source_file: misc/share/polkit-1/translations/policy.ts
+    file_format: TS
+    source_language: en_US
 settings:
   pr_branch_name: transifex_update_<br_unique_id>

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -172,7 +172,7 @@ SPDX-FileCopyrightText = "2018 Xiphos Development Team"
 SPDX-License-Identifier = "GPL-2.0-or-later"
 
 [[annotations]]
-path = ["po/**.po", "po/**.pot", "po/POTFILES.in", "po/LINGUAS"]
+path = ["po/**.po", "po/**.pot", "po/POTFILES.in", "po/LINGUAS", "misc/share/polkit-1/translations/*.ts"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "UnionTech Software Technology Co., Ltd."
 SPDX-License-Identifier = "LGPL-3.0-only"

--- a/misc/share/polkit-1/actions/org.deepin.linglong.PackageManager1.policy
+++ b/misc/share/polkit-1/actions/org.deepin.linglong.PackageManager1.policy
@@ -1,133 +1,128 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
 "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
-<!-- this file only used to skip DBus security check, it will be removed later -->
 <policyconfig>
-        <vendor />
-        <vendor_url />
-        <icon_name>stock_person</icon_name>
-        <action id="org.deepin.linglong.PackageManager1.checkAuthentication">
-                <description>Check Authentication</description>
-                <message>Authentication is required to perform this action</message>
-                <defaults>
-                        <allow_any>auth_admin</allow_any>
-                        <allow_inactive>auth_admin</allow_inactive>
-                        <allow_active>auth_admin_keep</allow_active>
-                </defaults>
-                <annotate key="org.freedesktop.policykit.exec.path">@CMAKE_INSTALL_FULL_BINDIR@/@LINGLONG_CLI_BIN@</annotate>
-                <description xml:lang="ar">التحقق من المصادقة</description>
-                <message xml:lang="ar">المصادقة مطلوبة لتنفيذ هذا الإجراء</message>
-                <description xml:lang="ast">Comprobar l'autenticación</description>
-                <message xml:lang="ast">Ríquese l'autenticación pa realizar esta aición</message>
-                <description xml:lang="az">Doğrulamaya nəzarət et</description>
-                <message xml:lang="az">Bu əməliyyatı yerinə yetirmək üçün doğrulama tələບ olunur</message>
-                <description xml:lang="bg">Проверете удостоверяването</description>
-                <message xml:lang="bg">Удостоверяването е задължително за извършване на това действие</message>
-                <description xml:lang="bn">প্রমাণীকরণ পরীক্ষা করুন</description>
-                <message xml:lang="bn">এই কাজটি সম্পন্ন করার জন্য প্রমাণীকরণের প্রয়োজন</message>
-                <description xml:lang="bo">ར་ສྤྲོད་བསྐྱར་ཞິບབྱེད་པ།</description>
-                <message xml:lang="bo">ལས་ཀ་འདི་སྒྲུབ་པར་ར་སྤྲོད་བྱེད་དགོས།</message>
-                <description xml:lang="ca">Comprova l'autenticació</description>
-                <message xml:lang="ca">Cal autenticació per a dur a terme aquesta acció.</message>
-                <description xml:lang="cs">Ověřit autentizaci</description>
-                <message xml:lang="cs">Provedení této akce vyžaduje autentizaci</message>
-                <description xml:lang="da">Kontroller godkendelse</description>
-                <message xml:lang="da">Der kræves godkendelse for at udføre denne handling</message>
-                <description xml:lang="de">Authentifizierung prüfen</description>
-                <message xml:lang="de">Zur Durchführung dieser Aktion ist eine Authentifizierung erforderlich</message>
-                <description xml:lang="de_DE">Authentifizierung prüfen</description>
-                <message xml:lang="de_DE">Für diese Aktion ist eine Authentifizierung erforderlich</message>
-                <description xml:lang="el">Έλεγχος ταυτότητας</description>
-                <message xml:lang="el">Απαιτείται πιστοποίηση για την εκτέλεση αυτής της ενέργειας</message>
-                <description xml:lang="en_AU">Check Authentication</description>
-                <message xml:lang="en_AU">Authentication is required to perform this action</message>
-                <description xml:lang="en_GB">Check Authentication</description>
-                <message xml:lang="en_GB">Authentication is required to perform this action</message>
-                <description xml:lang="en_US">Check Authentication</description>
-                <message xml:lang="en_US">Authentication is required to perform this action</message>
-                <description xml:lang="eo">Kontroli Aŭtentigon</description>
-                <message xml:lang="eo">Aŭtentigo bezonatas por plenumi ĉi tiun agon</message>
-                <description xml:lang="es">Comprobar autenticación</description>
-                <message xml:lang="es">Se requiere autenticación para realizar esta acción</message>
-                <description xml:lang="es_419">Comprobar autenticación</description>
-                <message xml:lang="es_419">Se requiere autenticación para realizar esta acción</message>
-                <description xml:lang="fa">بررسی احراز هویت</description>
-                <message xml:lang="fa">احراز هویت برای انجام این عمل لازم است</message>
-                <description xml:lang="fi">Tarkista todennus</description>
-                <message xml:lang="fi">Tämän toiminnon suorittaminen edellyttää todennusta</message>
-                <description xml:lang="fr">Vérifier l'authentification</description>
-                <message xml:lang="fr">L'authentification est requise pour effectuer cette action</message>
-                <description xml:lang="gl_ES">Comprobar autenticación</description>
-                <message xml:lang="gl_ES">Requírese autenticación para realizar esta acción</message>
-                <description xml:lang="hi_IN">प्रमाणीकरण की जाँच करें</description>
-                <message xml:lang="hi_IN">यह कार्य करने हेतु प्रमाणीकरण आवश्यक है</message>
-                <description xml:lang="hr">Provjera ovjere</description>
-                <message xml:lang="hr">Potrebna je ovjera za obavljanje ove radnje</message>
-                <description xml:lang="hu">Hitelesítés ellenőrzése</description>
-                <message xml:lang="hu">A művelet végrehajtásához hitelesítés szükséges</message>
-                <description xml:lang="id">Periksa Otentikasi</description>
-                <message xml:lang="id">Otentikasi diperlukan untuk melakukan tindakan ini</message>
-                <description xml:lang="it">Verifica Autenticazione</description>
-                <message xml:lang="it">Autenticazione richiesta per eseguire questa operazione</message>
-                <description xml:lang="ja">認証を確認</description>
-                <message xml:lang="ja">この操作を実行するには認証が必要です</message>
-                <description xml:lang="kab">Sesteb n usemdu</description>
-                <message xml:lang="kab">Yetwasra usesteb akken ad tbeddeleḍ tazzla-a.</message>
-                <description xml:lang="ko">인증 확인</description>
-                <message xml:lang="ko">이 작업을 수행하려면 인증이 필요합니다</message>
-                <description xml:lang="lo">ກວດສອບການຢັ້ງຢືນຕົວຕົນ</description>
-                <message xml:lang="lo">ຕ້ອງມີການຢັ້ງຢືນຕົວຕົນເພື່ອປະຕິບັດການດຳເນີນການນີ້</message>
-                <description xml:lang="lt">Patikrinti tapatybės nustatymą</description>
-                <message xml:lang="lt">Norint atlikti šį veiksmą, reikalingas tapatybės nustatymas</message>
-                <description xml:lang="lv">Pārbaudīt autentifikāciju</description>
-                <message xml:lang="lv">Lai veiktu šo darbību, nepieciešama autentifikācija</message>
-                <description xml:lang="mn">Баталгаажуулалт шалгах</description>
-                <message xml:lang="mn">Энэ үйлдлийг хийхэд баталгаажуулалт шаардлагатай</message>
-                <description xml:lang="ms">Semak Pengesahihan</description>
-                <message xml:lang="ms">Pengesahihan diperlukan untuk melakukan tindakan ini</message>
-                <description xml:lang="ne">प्रमाणीकरण जाँच गर्नुहोस्</description>
-                <message xml:lang="ne">यो कार्य गर्न प्रमाणीकरण आवश्यक छ</message>
-                <description xml:lang="nl">Authenticatie controleren</description>
-                <message xml:lang="nl">Authenticatie vereist om deze actie uit te voeren</message>
-                <description xml:lang="pa">ਪ੍ਰਮਾਣਕਤਾ ਦੀ ਜਾਂਚ ਕਰੋ</description>
-                <message xml:lang="pa">ਇਹ ਕਾਰਵਾਈ ਕਰਨ ਲਈ ਪ੍ਰਮਾਣਕਤਾ ਦੀ ਲੋੜ ਹੈ</message>
-                <description xml:lang="pl">Sprawdź uwierzytelnienie</description>
-                <message xml:lang="pl">Wymagane jest uwierzytelnienie, aby wykonać tę czynność</message>
-                <description xml:lang="pt">Verificar autenticação</description>
-                <message xml:lang="pt">É necessária a autenticação para efetuar esta ação</message>
-                <description xml:lang="pt_BR">Verificar autenticação</description>
-                <message xml:lang="pt_BR">A autenticação é necessária para realizar esta ação</message>
-                <description xml:lang="ro">Verificare autentificare</description>
-                <message xml:lang="ro">Autentificarea este necesară pentru a efectua această acțiune</message>
-                <description xml:lang="ru">Проверить аутентификацию</description>
-                <message xml:lang="ru">Для выполнения этого действия требуется аутентификация</message>
-                <description xml:lang="si">සත්‍යාපනය පරීක්ෂා කරන්න</description>
-                <message xml:lang="si">මෙම ක්‍රියාව සිදු කිරීමට සත්‍යාපනය අවශ්‍ය වේ</message>
-                <description xml:lang="sk">Skontrolovať overenie totožnosti</description>
-                <message xml:lang="sk">Na vykonanie tejto akcie sa vyžaduje overenie totožnosti</message>
-                <description xml:lang="sl">Preverite avtentikacijo</description>
-                <message xml:lang="sl">Za izvedbo tega dejanja je potrebna avtentikacija</message>
-                <description xml:lang="sq">Kontrollo Mirëfilltësimin</description>
-                <message xml:lang="sq">Për të kryer këtë veprim, lypset mirëfilltësim</message>
-                <description xml:lang="sr">Провери идентификацију</description>
-                <message xml:lang="sr">Идентификација је неопходна за извршење ове радње</message>
-                <description xml:lang="sv">Kontrollera autentisering</description>
-                <message xml:lang="sv">Autentisering krävs för att utföra denna åtgärd</message>
-                <description xml:lang="sw">Angalia Uthibitishaji</description>
-                <message xml:lang="sw">Uthibitishaji unahitajika kutekeleza kitendo hiki</message>
-                <description xml:lang="tr">Kimlik Doğrulamayı Kontrol Et</description>
-                <message xml:lang="tr">Bu eylemi gerçekleştirmek için kimlik doğrulaması gereklidir</message>
-                <description xml:lang="ug">سالاھىيەتنى دەلىللەش</description>
-                <message xml:lang="ug">بۇ ھەرىكەتنى ئىجرا قىلىش ئۈچۈن سالاھىيەتنى دەلىللەش كېرەك</message>
-                <description xml:lang="uk">Перевірити розпізнавання</description>
-                <message xml:lang="uk">Для виконання цієї дії потрібно пройти розпізнавання</message>
-                <description xml:lang="vi">Kiểm tra Xác thực</description>
-                <message xml:lang="vi">Cần xác thực để thực hiện hành động này</message>
-                <description xml:lang="zh_CN">检查认证</description>
-                <message xml:lang="zh_CN">当前操作需要密码认证</message>
-                <description xml:lang="zh_TW">檢查驗證</description>
-                <message xml:lang="zh_TW">執行此操作需要驗證</message>
-                <description xml:lang="zh_HK">檢查認證</description>
-                <message xml:lang="zh_HK">執行此操作需要認證</message>
-        </action>
+	<vendor />
+	<vendor_url />
+	<icon_name>stock_person</icon_name>
+	<action id="org.deepin.linglong.PackageManager1.checkAuthentication">
+		<description>Check Authentication</description>
+		<message>Authentication is required to perform this action</message>
+		<defaults>
+			<allow_any>auth_admin</allow_any>
+			<allow_inactive>auth_admin</allow_inactive>
+			<allow_active>auth_admin_keep</allow_active>
+		</defaults>
+		<annotate key="org.freedesktop.policykit.exec.path">@CMAKE_INSTALL_FULL_BINDIR@/@LINGLONG_CLI_BIN@</annotate>
+		<description xml:lang="ar">التحقق من المصادقة</description>
+		<message xml:lang="ar">المصادقة مطلوبة لتنفيذ هذا الإجراء</message>
+		<description xml:lang="ast">Comprobar l'autenticación</description>
+		<message xml:lang="ast">Ríquese l'autenticación pa realizar esta aición</message>
+		<description xml:lang="az">Doğrulamaya nəzarət et</description>
+		<message xml:lang="az">Bu əməliyyatı yerinə yetirmək üçün doğrulama tələບ olunur</message>
+		<description xml:lang="bg">Проверете удостоверяването</description>
+		<message xml:lang="bg">Удостоверяването е задължително за извършване на това действие</message>
+		<description xml:lang="bn">প্রমাণীকরণ পরীক্ষা করুন</description>
+		<message xml:lang="bn">এই কাজটি সম্পন্ন করার জন্য প্রমাণীকরণের প্রয়োজন</message>
+		<description xml:lang="bo">ར་ສྤྲོད་བསྐྱར་ཞິບབྱེད་པ།</description>
+		<message xml:lang="bo">ལས་ཀ་འདི་སྒྲུབ་པར་ར་སྤྲོད་བྱེད་དགོས།</message>
+		<description xml:lang="ca">Comprova l'autenticació</description>
+		<message xml:lang="ca">Cal autenticació per a dur a terme aquesta acció.</message>
+		<description xml:lang="cs">Ověřit autentizaci</description>
+		<message xml:lang="cs">Provedení této akce vyžaduje autentizaci</message>
+		<description xml:lang="da">Kontroller godkendelse</description>
+		<message xml:lang="da">Der kræves godkendelse for at udføre denne handling</message>
+		<description xml:lang="de">Authentifizierung prüfen</description>
+		<message xml:lang="de">Zur Durchführung dieser Aktion ist eine Authentifizierung erforderlich</message>
+		<description xml:lang="el">Έλεγχος ταυτότητας</description>
+		<message xml:lang="el">Απαιτείται πιστοποίηση για την εκτέλεση αυτής της ενέργειας</message>
+		<description xml:lang="en_AU">Check Authentication</description>
+		<message xml:lang="en_AU">Authentication is required to perform this action</message>
+		<description xml:lang="en_GB">Check Authentication</description>
+		<message xml:lang="en_GB">Authentication is required to perform this action</message>
+		<description xml:lang="en_US">Check Authentication</description>
+		<message xml:lang="en_US">Authentication is required to perform this action</message>
+		<description xml:lang="eo">Kontroli Aŭtentigon</description>
+		<message xml:lang="eo">Aŭtentigo bezonatas por plenumi ĉi tiun agon</message>
+		<description xml:lang="es">Comprobar autenticación</description>
+		<message xml:lang="es">Se requiere autenticación para realizar esta acción</message>
+		<description xml:lang="fa">بررسی احراز هویت</description>
+		<message xml:lang="fa">احراز هویت برای انجام این عمل لازم است</message>
+		<description xml:lang="fi">Tarkista todennus</description>
+		<message xml:lang="fi">Tämän toiminnon suorittaminen edellyttää todennusta</message>
+		<description xml:lang="fr">Vérifier l'authentification</description>
+		<message xml:lang="fr">L'authentification est requise pour effectuer cette action</message>
+		<description xml:lang="gl_ES">Comprobar autenticación</description>
+		<message xml:lang="gl_ES">Requírese autenticación para realizar esta acción</message>
+		<description xml:lang="hi_IN">प्रमाणीकरण की जाँच करें</description>
+		<message xml:lang="hi_IN">यह कार्य करने हेतु प्रमाणीकरण आवश्यक है</message>
+		<description xml:lang="hr">Provjera ovjere</description>
+		<message xml:lang="hr">Potrebna je ovjera za obavljanje ove radnje</message>
+		<description xml:lang="hu">Hitelesítés ellenőrzése</description>
+		<message xml:lang="hu">A művelet végrehajtásához hitelesítés szükséges</message>
+		<description xml:lang="id">Periksa Otentikasi</description>
+		<message xml:lang="id">Otentikasi diperlukan untuk melakukan tindakan ini</message>
+		<description xml:lang="it">Verifica Autenticazione</description>
+		<message xml:lang="it">Autenticazione richiesta per eseguire questa operazione</message>
+		<description xml:lang="ja">認証を確認</description>
+		<message xml:lang="ja">この操作を実行するには認証が必要です</message>
+		<description xml:lang="kab">Sesteb n usemdu</description>
+		<message xml:lang="kab">Yetwasra usesteb akken ad tbeddeleḍ tazzla-a.</message>
+		<description xml:lang="ko">인증 확인</description>
+		<message xml:lang="ko">이 작업을 수행하려면 인증이 필요합니다</message>
+		<description xml:lang="lo">ກວດສອບການກວດສອບຄວາມຖືກຕ້ອງ</description>
+		<message xml:lang="lo">ຕ້ອງການການພິສູດຢືນຢັນຕົວຕົນເພື່ອປະຕິບັດການກະທຳນີ້</message>
+		<description xml:lang="lt">Patikrinti tapatybės nustatymą</description>
+		<message xml:lang="lt">Norint atlikti šį veiksmą, reikalingas tapatybės nustatymas</message>
+		<description xml:lang="lv">Pārbaudīt autentifikāciju</description>
+		<message xml:lang="lv">Lai veiktu šo darbību, nepieciešama autentifikācija</message>
+		<description xml:lang="mn">Баталгаажуулалт шалгах</description>
+		<message xml:lang="mn">Энэ үйлдлийг хийхэд баталгаажуулалт шаардлагатай</message>
+		<description xml:lang="ms">Semak Pengesahihan</description>
+		<message xml:lang="ms">Pengesahihan diperlukan untuk melakukan tindakan ini</message>
+		<description xml:lang="ne">प्रमाणीकरण जाँच गर्नुहोस्</description>
+		<message xml:lang="ne">यो कार्य गर्न प्रमाणीकरण आवश्यक छ</message>
+		<description xml:lang="nl">Authenticatie controleren</description>
+		<message xml:lang="nl">Authenticatie vereist om deze actie uit te voeren</message>
+		<description xml:lang="pa">ਪ੍ਰਮਾਣਕਤਾ ਦੀ ਜਾਂਚ ਕਰੋ</description>
+		<message xml:lang="pa">ਇਹ ਕਾਰਵਾਈ ਕਰਨ ਲਈ ਪ੍ਰਮਾਣਕਤਾ ਦੀ ਲੋੜ ਹੈ</message>
+		<description xml:lang="pl">Sprawdź uwierzytelnienie</description>
+		<message xml:lang="pl">Wymagane jest uwierzytelnienie, aby wykonać tę czynność</message>
+		<description xml:lang="pt">Verificar autenticação</description>
+		<message xml:lang="pt">É necessária a autenticação para efetuar esta ação</message>
+		<description xml:lang="pt_BR">Verificar autenticação</description>
+		<message xml:lang="pt_BR">A autenticação é necessária para realizar esta ação</message>
+		<description xml:lang="ro">Verificare autentificare</description>
+		<message xml:lang="ro">Autentificarea este necesară pentru a efectua această acțiune</message>
+		<description xml:lang="ru">Проверить аутентификацию</description>
+		<message xml:lang="ru">Для выполнения этого действия требуется аутентификация</message>
+		<description xml:lang="si">සත්‍යාපනය පරීක්ෂා කරන්න</description>
+		<message xml:lang="si">මෙම ක්‍රියාව සිදු කිරීමට සත්‍යාපනය අවශ්‍ය වේ</message>
+		<description xml:lang="sk">Skontrolovať overenie totožnosti</description>
+		<message xml:lang="sk">Na vykonanie tejto akcie sa vyžaduje overenie totožnosti</message>
+		<description xml:lang="sl">Preverite avtentikacijo</description>
+		<message xml:lang="sl">Za izvedbo tega dejanja je potrebna avtentikacija</message>
+		<description xml:lang="sq">Kontrollo Mirëfilltësimin</description>
+		<message xml:lang="sq">Për të kryer këtë veprim, lypset mirëfilltësim</message>
+		<description xml:lang="sr">Провери идентификацију</description>
+		<message xml:lang="sr">Идентификација је неопходна за извршење ове радње</message>
+		<description xml:lang="sv">Kontrollera autentisering</description>
+		<message xml:lang="sv">Autentisering krävs för att utföra denna åtgärd</message>
+		<description xml:lang="sw">Angalia Uthibitishaji</description>
+		<message xml:lang="sw">Uthibitishaji unahitajika kutekeleza kitendo hiki</message>
+		<description xml:lang="tr">Kimlik Doğrulamayı Kontrol Et</description>
+		<message xml:lang="tr">Bu eylemi gerçekleştirmek için kimlik doğrulaması gereklidir</message>
+		<description xml:lang="ug">سالاھىيەتنى دەلىللەش</description>
+		<message xml:lang="ug">بۇ ھەرىكەتنى ئىجرا قىلىش ئۈچۈن سالاھىيەتنى دەلىللەش كېرەك</message>
+		<description xml:lang="uk">Перевірити розпізнавання</description>
+		<message xml:lang="uk">Для виконання цієї дії потрібно пройти розпізнавання</message>
+		<description xml:lang="vi">Kiểm tra Xác thực</description>
+		<message xml:lang="vi">Cần xác thực để thực hiện hành động này</message>
+		<description xml:lang="zh_CN">检查认证</description>
+		<message xml:lang="zh_CN">当前操作需要密码认证</message>
+		<description xml:lang="zh_HK">檢查認證</description>
+		<message xml:lang="zh_HK">執行此操作需要認證</message>
+		<description xml:lang="zh_TW">檢查驗證</description>
+		<message xml:lang="zh_TW">執行此操作需要驗證</message>
+	</action>
 </policyconfig>

--- a/misc/share/polkit-1/translations/policy.ts
+++ b/misc/share/polkit-1/translations/policy.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation type="unfinished" />
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation type="unfinished" />
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_ar.ts
+++ b/misc/share/polkit-1/translations/policy_ar.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ar">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>المصادقة مطلوبة لتنفيذ هذا الإجراء</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>التحقق من المصادقة</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_ast.ts
+++ b/misc/share/polkit-1/translations/policy_ast.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ast">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Ríquese l'autenticación pa realizar esta aición</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Comprobar l'autenticación</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_az.ts
+++ b/misc/share/polkit-1/translations/policy_az.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Bu əməliyyatı yerinə yetirmək üçün doğrulama tələບ olunur</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Doğrulamaya nəzarət et</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_bg.ts
+++ b/misc/share/polkit-1/translations/policy_bg.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bg">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Удостоверяването е задължително за извършване на това действие</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Проверете удостоверяването</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_bn.ts
+++ b/misc/share/polkit-1/translations/policy_bn.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bn">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>এই কাজটি সম্পন্ন করার জন্য প্রমাণীকরণের প্রয়োজন</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>প্রমাণীকরণ পরীক্ষা করুন</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_bo.ts
+++ b/misc/share/polkit-1/translations/policy_bo.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bo">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>ལས་ཀ་འདི་སྒྲུབ་པར་ར་སྤྲོད་བྱེད་དགོས།</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>ར་ສྤྲོད་བསྐྱར་ཞິບབྱེད་པ།</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_ca.ts
+++ b/misc/share/polkit-1/translations/policy_ca.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Cal autenticació per a dur a terme aquesta acció.</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Comprova l'autenticació</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_cs.ts
+++ b/misc/share/polkit-1/translations/policy_cs.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="cs">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Provedení této akce vyžaduje autentizaci</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Ověřit autentizaci</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_da.ts
+++ b/misc/share/polkit-1/translations/policy_da.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="da">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Der kræves godkendelse for at udføre denne handling</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Kontroller godkendelse</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_de.ts
+++ b/misc/share/polkit-1/translations/policy_de.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Zur Durchführung dieser Aktion ist eine Authentifizierung erforderlich</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Authentifizierung prüfen</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_el.ts
+++ b/misc/share/polkit-1/translations/policy_el.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="el">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Απαιτείται πιστοποίηση για την εκτέλεση αυτής της ενέργειας</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Έλεγχος ταυτότητας</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_en_AU.ts
+++ b/misc/share/polkit-1/translations/policy_en_AU.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_AU">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Authentication is required to perform this action</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Check Authentication</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_en_GB.ts
+++ b/misc/share/polkit-1/translations/policy_en_GB.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_GB">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Authentication is required to perform this action</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Check Authentication</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_en_US.ts
+++ b/misc/share/polkit-1/translations/policy_en_US.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_US">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Authentication is required to perform this action</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Check Authentication</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_eo.ts
+++ b/misc/share/polkit-1/translations/policy_eo.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="eo">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Aŭtentigo bezonatas por plenumi ĉi tiun agon</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Kontroli Aŭtentigon</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_es.ts
+++ b/misc/share/polkit-1/translations/policy_es.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Se requiere autenticación para realizar esta acción</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Comprobar autenticación</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_fa.ts
+++ b/misc/share/polkit-1/translations/policy_fa.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fa">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>احراز هویت برای انجام این عمل لازم است</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>بررسی احراز هویت</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_fi.ts
+++ b/misc/share/polkit-1/translations/policy_fi.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Tämän toiminnon suorittaminen edellyttää todennusta</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Tarkista todennus</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_fr.ts
+++ b/misc/share/polkit-1/translations/policy_fr.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>L'authentification est requise pour effectuer cette action</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Vérifier l'authentification</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_gl_ES.ts
+++ b/misc/share/polkit-1/translations/policy_gl_ES.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="gl_ES">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Requírese autenticación para realizar esta acción</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Comprobar autenticación</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_hi_IN.ts
+++ b/misc/share/polkit-1/translations/policy_hi_IN.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hi_IN">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>यह कार्य करने हेतु प्रमाणीकरण आवश्यक है</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>प्रमाणीकरण की जाँच करें</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_hr.ts
+++ b/misc/share/polkit-1/translations/policy_hr.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hr">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Potrebna je ovjera za obavljanje ove radnje</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Provjera ovjere</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_hu.ts
+++ b/misc/share/polkit-1/translations/policy_hu.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>A művelet végrehajtásához hitelesítés szükséges</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Hitelesítés ellenőrzése</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_id.ts
+++ b/misc/share/polkit-1/translations/policy_id.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="id">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Otentikasi diperlukan untuk melakukan tindakan ini</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Periksa Otentikasi</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_it.ts
+++ b/misc/share/polkit-1/translations/policy_it.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Autenticazione richiesta per eseguire questa operazione</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Verifica Autenticazione</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_ja.ts
+++ b/misc/share/polkit-1/translations/policy_ja.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>この操作を実行するには認証が必要です</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>認証を確認</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_kab.ts
+++ b/misc/share/polkit-1/translations/policy_kab.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="kab">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Yetwasra usesteb akken ad tbeddeleḍ tazzla-a.</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Sesteb n usemdu</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_ko.ts
+++ b/misc/share/polkit-1/translations/policy_ko.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ko">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>이 작업을 수행하려면 인증이 필요합니다</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>인증 확인</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_lo.ts
+++ b/misc/share/polkit-1/translations/policy_lo.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lo">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>ຕ້ອງການການພິສູດຢືນຢັນຕົວຕົນເພື່ອປະຕິບັດການກະທຳນີ້</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>ກວດສອບການກວດສອບຄວາມຖືກຕ້ອງ</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_lt.ts
+++ b/misc/share/polkit-1/translations/policy_lt.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lt">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Norint atlikti šį veiksmą, reikalingas tapatybės nustatymas</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Patikrinti tapatybės nustatymą</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_lv.ts
+++ b/misc/share/polkit-1/translations/policy_lv.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lv">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Lai veiktu šo darbību, nepieciešama autentifikācija</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Pārbaudīt autentifikāciju</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_mn.ts
+++ b/misc/share/polkit-1/translations/policy_mn.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="mn">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Энэ үйлдлийг хийхэд баталгаажуулалт шаардлагатай</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Баталгаажуулалт шалгах</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_ms.ts
+++ b/misc/share/polkit-1/translations/policy_ms.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ms">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Pengesahihan diperlukan untuk melakukan tindakan ini</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Semak Pengesahihan</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_ne.ts
+++ b/misc/share/polkit-1/translations/policy_ne.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ne">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>यो कार्य गर्न प्रमाणीकरण आवश्यक छ</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>प्रमाणीकरण जाँच गर्नुहोस्</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_nl.ts
+++ b/misc/share/polkit-1/translations/policy_nl.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Authenticatie vereist om deze actie uit te voeren</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Authenticatie controleren</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_pa.ts
+++ b/misc/share/polkit-1/translations/policy_pa.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pa">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>ਇਹ ਕਾਰਵਾਈ ਕਰਨ ਲਈ ਪ੍ਰਮਾਣਕਤਾ ਦੀ ਲੋੜ ਹੈ</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>ਪ੍ਰਮਾਣਕਤਾ ਦੀ ਜਾਂਚ ਕਰੋ</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_pl.ts
+++ b/misc/share/polkit-1/translations/policy_pl.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Wymagane jest uwierzytelnienie, aby wykonać tę czynność</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Sprawdź uwierzytelnienie</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_pt.ts
+++ b/misc/share/polkit-1/translations/policy_pt.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>É necessária a autenticação para efetuar esta ação</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Verificar autenticação</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_pt_BR.ts
+++ b/misc/share/polkit-1/translations/policy_pt_BR.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>A autenticação é necessária para realizar esta ação</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Verificar autenticação</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_ro.ts
+++ b/misc/share/polkit-1/translations/policy_ro.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ro">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Autentificarea este necesară pentru a efectua această acțiune</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Verificare autentificare</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_ru.ts
+++ b/misc/share/polkit-1/translations/policy_ru.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Для выполнения этого действия требуется аутентификация</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Проверить аутентификацию</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_si.ts
+++ b/misc/share/polkit-1/translations/policy_si.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="si">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>මෙම ක්‍රියාව සිදු කිරීමට සත්‍යාපනය අවශ්‍ය වේ</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>සත්‍යාපනය පරීක්ෂා කරන්න</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_sk.ts
+++ b/misc/share/polkit-1/translations/policy_sk.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sk">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Na vykonanie tejto akcie sa vyžaduje overenie totožnosti</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Skontrolovať overenie totožnosti</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_sl.ts
+++ b/misc/share/polkit-1/translations/policy_sl.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sl">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Za izvedbo tega dejanja je potrebna avtentikacija</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Preverite avtentikacijo</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_sq.ts
+++ b/misc/share/polkit-1/translations/policy_sq.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Për të kryer këtë veprim, lypset mirëfilltësim</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Kontrollo Mirëfilltësimin</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_sr.ts
+++ b/misc/share/polkit-1/translations/policy_sr.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sr">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Идентификација је неопходна за извршење ове радње</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Провери идентификацију</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_sv.ts
+++ b/misc/share/polkit-1/translations/policy_sv.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sv">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Autentisering krävs för att utföra denna åtgärd</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Kontrollera autentisering</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_sw.ts
+++ b/misc/share/polkit-1/translations/policy_sw.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sw">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Uthibitishaji unahitajika kutekeleza kitendo hiki</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Angalia Uthibitishaji</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_tr.ts
+++ b/misc/share/polkit-1/translations/policy_tr.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Bu eylemi gerçekleştirmek için kimlik doğrulaması gereklidir</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Kimlik Doğrulamayı Kontrol Et</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_ug.ts
+++ b/misc/share/polkit-1/translations/policy_ug.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ug">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>بۇ ھەرىكەتنى ئىجرا قىلىش ئۈچۈن سالاھىيەتنى دەلىللەش كېرەك</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>سالاھىيەتنى دەلىللەش</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_uk.ts
+++ b/misc/share/polkit-1/translations/policy_uk.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Для виконання цієї дії потрібно пройти розпізнавання</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Перевірити розпізнавання</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_vi.ts
+++ b/misc/share/polkit-1/translations/policy_vi.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="vi">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>Cần xác thực để thực hiện hành động này</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>Kiểm tra Xác thực</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_zh_CN.ts
+++ b/misc/share/polkit-1/translations/policy_zh_CN.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>当前操作需要密码认证</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>检查认证</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_zh_HK.ts
+++ b/misc/share/polkit-1/translations/policy_zh_HK.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>執行此操作需要認證</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>檢查認證</translation>
+		</message>
+	</context>
+</TS>

--- a/misc/share/polkit-1/translations/policy_zh_TW.ts
+++ b/misc/share/polkit-1/translations/policy_zh_TW.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
+	<context>
+		<name>policy</name>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!message" line="0" />
+			<source>Authentication is required to perform this action</source>
+			<translation>執行此操作需要驗證</translation>
+		</message>
+		<message>
+			<location filename="org.deepin.linglong.PackageManager1.checkAuthentication!description" line="0" />
+			<source>Check Authentication</source>
+			<translation>檢查驗證</translation>
+		</message>
+	</context>
+</TS>


### PR DESCRIPTION
Merging translation can be done using deepin-policy-ts-convert utility.

修改内容说明：

1. 增加了 policy 文件的翻译支持，并且对 transifex.yaml 配置中添加了相应的翻译以供翻译平台的人员可以参与翻译的贡献
2. 添加了老挝语（`lo`）的翻译
3. 移除了 `es_419` 与 `de_DE` 的翻译（翻译贡献者反馈：只需要保留 `es` 和 `de` 即可）

`deepin-policy-ts-convert` 用法速览：

- 此工具是 [deepin-gettext-tools](https://github.com/linuxdeepin/deepin-gettext-tools) 的一部分。
- 翻译初始化使用 `deepin-policy-ts-convert init /path/to/filename.policy /path/to/translations`，会根据 policy 文件内的已有文案生成初始化的 ts 文件。此操作只需要进行一次，本 PR 中的 .ts 文件即由此而来
- 翻译从 ts 合回 policy 文件使用 `deepin-policy-ts-convert ts2policy /path/to/filename.policy /path/to/translations /path/to/filename.policy`。
