### PR TITLE
fix: can't rely on ssi_pid when cross pid_namespaces

### DIFF
--- a/apps/ll-init/src/ll-init.cpp
+++ b/apps/ll-init/src/ll-init.cpp
@@ -309,17 +309,11 @@ bool handle_sigevent(const file_descriptor_wrapper &sigfd,
         }
 
         if (info.ssi_signo != SIGCHLD) {
-            if (info.ssi_pid != 0) {
-                auto ret = ::kill(child, info.ssi_signo);
-                if (ret == -1) {
-                    auto msg =
-                      std::string("Failed to forward signal ") + ::strsignal(info.ssi_signo);
-                    print_sys_error(msg);
-                }
+            auto ret = ::kill(child, info.ssi_signo);
+            if (ret == -1) {
+                auto msg = std::string("Failed to forward signal ") + ::strsignal(info.ssi_signo);
+                print_sys_error(msg);
             }
-
-            print_info("Received signal " + std::to_string(info.ssi_signo)
-                       + " from kernel, just ignore it");
             continue;
         }
 


### PR DESCRIPTION
see https://github.com/OpenAtom-Linyaps/linyaps/issues/1513
https://github.com/OpenAtom-Linyaps/linyaps/pull/1514