### PR TITLE
feat: add jmgpu device node to container bind list

### DIFF
--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -190,7 +190,7 @@ ContainerCfgBuilder::bindDevNode(std::function<bool(const std::string &)> ifBind
 {
     if (!ifBind) {
         ifBind = [](const std::string &name) -> bool {
-            if (name == "snd" || name == "dri" || name.rfind("video", 0) == 0
+            if (name == "snd" || name == "dri" || name == "jmgpu" || name.rfind("video", 0) == 0
                 || name.rfind("nvidia", 0) == 0) {
                 return true;
             }


### PR DESCRIPTION
Include jmgpu in the list of automatically bound device nodes to support applications that require access to JM GPU devices.