### PR TITLE
fix: replace unsafe temp-dir creation and fix fmt API usage

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/utils/packageinfo_handler_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/packageinfo_handler_test.cpp
@@ -18,9 +18,9 @@ class PackageInfoHandlerTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        // 创建临时目录用于测试
-        tempDir = std::filesystem::temp_directory_path() / "packageinfo_test";
-        std::filesystem::create_directories(tempDir);
+        char tempPath[] = "/var/tmp/linglong-uab-file-test-XXXXXX";
+        tempDir = mkdtemp(tempPath);
+        ASSERT_FALSE(tempDir.empty()) << "Failed to create temporary directory";
     }
 
     void TearDown() override

--- a/libs/utils/src/linglong/utils/log/log.h
+++ b/libs/utils/src/linglong/utils/log/log.h
@@ -103,10 +103,10 @@ public:
         if ((logBackend & LogBackend::Journal) != LogBackend::None) {
             fmt::memory_buffer fileBuf;
             fmt::memory_buffer lineBuf;
-            fmt::format_to(fileBuf.begin(), "CODE_FILE={}\0", context.file);
-            fmt::format_to(lineBuf.begin(), "CODE_LINE={}\0", context.line);
-            sd_journal_send_with_location(fileBuf.data(),
-                                          lineBuf.data(),
+            fmt::format_to(fmt::appender(fileBuf), "CODE_FILE={}", context.file);
+            fmt::format_to(fmt::appender(lineBuf), "CODE_LINE={}", context.line);
+            sd_journal_send_with_location(fmt::to_string(fileBuf).c_str(),
+                                          fmt::to_string(lineBuf).c_str(),
                                           context.function,
                                           "MESSAGE=%s",
                                           message.c_str(),


### PR DESCRIPTION
- Use mkdtemp for secure temp directory in tests.
- Update fmt::format_to calls to use modern iterator API.