### PR TITLE
feat: add ll-driver-detect utility for NVIDIA driver detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,7 +327,8 @@ pfl_add_libraries(
   ll-cli
   ll-package-manager
   llpkg
-  ll-session-helper)
+  ll-session-helper
+  ll-driver-detect)
 
 if(ENABLE_LINGLONG_APP_BUILDER_UTILS)
   add_subdirectory(apps/ll-builder-utils)

--- a/apps/ll-driver-detect/CMakeLists.txt
+++ b/apps/ll-driver-detect/CMakeLists.txt
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+pfl_add_executable(
+  OUTPUT_NAME
+  ll-driver-detect
+  LIBEXEC
+  linglong
+  SOURCES
+  ./src/main.cpp
+  ./src/driver_detection_config.cpp
+  ./src/nvidia_driver_detector.cpp
+  ./src/application_singleton.cpp
+  ./src/driver_detection_manager.cpp
+  ./src/dbus_notifier.cpp
+  LINK_LIBRARIES
+  PRIVATE
+  CLI11::CLI11
+  linglong::utils)

--- a/apps/ll-driver-detect/README.md
+++ b/apps/ll-driver-detect/README.md
@@ -1,0 +1,120 @@
+# ll-driver-detect
+
+`ll-driver-detect` 是如意玲珑（Linyaps）的显卡驱动检测工具，用于自动检测系统中的可用显卡驱动，并为用户提供安装选项。
+
+## 功能概述
+
+- **可扩展的驱动检测**: 采用插件式架构 (`DriverDetectionManager`)，可以轻松扩展以支持多种类型的显卡驱动（目前已支持 NVIDIA）。
+- **单例运行保证**: 通过文件锁 (`ApplicationSingleton`) 确保在任何时候只有一个检测进程在运行，避免资源浪费和重复通知。
+- **简化的用户配置**: 提供一个简单的配置选项，允许用户选择“不再提醒”，配置被保存在 `~/.config/linglong/driver_detection.json` 中。
+- **统一的用户通知**: 当检测到一个或多个可安装的驱动时，通过 DBus 向用户发送一个统一的通知。
+- **命令行支持**: 提供多种操作模式，包括全自动检测、仅检查和仅安装。
+
+## 安装
+
+该工具是如意玲珑的内置部分，会随 `linglong-bin` 一同安装。
+
+## 使用方法
+
+### 基本用法
+
+```bash
+# 运行驱动检测（默认进行检测并发送通知）
+ll-driver-detect
+
+# 查看帮助信息
+ll-driver-detect --help
+```
+
+### 命令行选项
+
+```
+用法: ll-driver-detect [选项]
+
+选项:
+  -h,--help         显示帮助信息
+  -v,--version      显示版本信息
+  -f,--force        强制检测和通知，即使配置为“不再提醒”。
+  -c,--check-only   仅检查驱动，不进行安装或通知。
+  -i,--install-only 仅安装驱动，不发送通知。
+```
+
+### 配置管理
+
+本工具的配置非常简单，存储在 `~/.config/linglong/driver_detection.json`。
+
+```json
+{
+  "neverRemind": false
+}
+```
+
+- `neverRemind`: 如果设置为 `true`，`ll-driver-detect` 将不会再发送通知。用户在通知中选择“不再提醒”时，此字段会自动设为 `true`。
+
+## 工作原理
+
+### 检测流程
+
+1. **获取单例锁**: 程序启动时，`ApplicationSingleton` 会尝试在 `$XDG_CONFIG_HOME/linglong/ll-driver-detect.lock`（如果 `XDG_CONFIG_HOME` 未设置，则默认为 `~/.config/linglong/ll-driver-detect.lock`）获取文件锁。如果锁已被另一实例持有，则当前进程会安静地退出。
+2. **初始化驱动管理器**: 创建一个 `DriverDetectionManager` 实例。
+3. **注册与检测**: 管理器的构造函数会注册所有可用的 `DriverDetector` 子类（例如 `NVIDIADriverDetector`）。随后，管理器调用每个检测器的 `detect()` 方法。
+4. **结果聚合**: `detect()` 方法返回驱动信息（如果检测成功），包括驱动标识、版本、玲珑包名和当前安装状态。管理器收集所有成功检测到的驱动信息。
+5. **执行操作**:
+    - 如果没有检测到任何驱动，程序退出。
+    - 默认情况下，它会检查配置文件，并决定是否发送通知。
+    - 如果使用 `-c, --check-only`，程序会打印出检测到的驱动并退出。
+    - 如果使用 `-i, --install-only`，程序会尝试安装所有检测到的驱动并退出。
+
+### 通知机制
+
+- 在默认模式下，如果检测到驱动并且配置文件中的 `neverRemind` 为 `false`（或使用了 `--force` 选项）：
+    1. `DBusNotifier` 会构造一个 DBus 消息。
+    2. 该消息被发送到系统的通知服务（`org.freedesktop.Notifications`）。
+    3. 通知中会包含“立即安装”和“不再提醒”两个选项。
+    4. 如果用户选择“安装”，程序会调用 `ll-cli install` 来安装所有检测到的驱动包。
+    5. 如果用户选择“不再提醒”，程序会将 `neverRemind` 设为 `true`并保存到配置文件。
+
+## 开发信息
+
+### 项目结构
+
+```
+apps/ll-driver-detect/
+├── src/
+│   ├── main.cpp                        # 主程序入口
+│   ├── application_singleton.h/.cpp    # 应用单例管理器
+│   ├── driver_detection_manager.h/.cpp # 驱动检测协调器
+│   ├── driver_detector.h/.cpp          # 驱动检测器基类
+│   ├── nvidia_driver_detector.h/.cpp   # NVIDIA 驱动检测器实现
+│   ├── driver_detection_config.h/.cpp  # 配置管理
+│   └── dbus_notifier.h/.cpp            # DBus 通知实现
+├── README.md                          # 本文档
+└── CMakeLists.txt                     # 构建配置
+```
+
+### 核心类
+
+- **`ApplicationSingleton`**: 通过文件锁确保全局只有一个实例在运行。
+- **`DriverDetectionManager`**: 负责注册和运行所有具体的驱动检测器。
+- **`DriverDetector`**: 驱动检测器的抽象基类，定义了 `detect()` 接口。
+- **`NVIDIADriverDetector`**: `DriverDetector` 的一个实现，专门用于检测 NVIDIA 驱动。
+- **`DriverDetectionConfigManager`**: 负责加载和保存 `driver_detection.json` 配置文件。
+- **`DBusNotifier`**: 封装了通过 DBus 发送通知的逻辑。
+
+### 构建
+
+```bash
+# 切换到项目根目录
+cd ${LINGYAPS_ROOT}
+
+# 创建构建目录
+mkdir build && cd build
+
+# 配置和构建
+cmake ..
+make ll-driver-detect
+```
+
+## 许可证
+
+本项目遵循 LGPL-3.0-or-later 许可证。

--- a/apps/ll-driver-detect/src/application_singleton.cpp
+++ b/apps/ll-driver-detect/src/application_singleton.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "application_singleton.h"
+
+#include "linglong/utils/log/log.h"
+
+#include <filesystem>
+namespace linglong::driver::detect {
+
+ApplicationSingleton::ApplicationSingleton(const std::string &lockFilePath)
+    : lockFilePath_(lockFilePath)
+    , lockHeld_(false)
+{
+}
+
+ApplicationSingleton::~ApplicationSingleton()
+{
+    releaseLock();
+}
+
+utils::error::Result<bool> ApplicationSingleton::tryAcquireLock()
+{
+    LINGLONG_TRACE("Try acquire lock")
+
+    if (lockHeld_) {
+        return true;
+    }
+
+    // Create directory if it doesn't exist
+    std::filesystem::path lockPath(lockFilePath_);
+    std::filesystem::path lockDir = lockPath.parent_path();
+
+    if (!lockDir.empty() && !std::filesystem::exists(lockDir)) {
+        std::error_code ec;
+        std::filesystem::create_directories(lockDir, ec);
+        if (ec) {
+            return LINGLONG_ERR("Failed to create lock directory: " + ec.message());
+        }
+    }
+
+    // Try to create file lock
+    auto fileLock = linglong::utils::filelock::FileLock::create(lockFilePath_, true);
+    if (!fileLock) {
+        return LINGLONG_ERR(fileLock);
+    }
+
+    // Try to acquire write lock (exclusive)
+    auto lockResult = fileLock->tryLock(linglong::utils::filelock::LockType::Write);
+    if (!lockResult) {
+        return LINGLONG_ERR(lockResult);
+    }
+
+    if (*lockResult) {
+        fileLock_ = std::make_unique<linglong::utils::filelock::FileLock>(std::move(*fileLock));
+        lockHeld_ = true;
+        return true;
+    }
+
+    // Another instance is already running
+    return false;
+}
+
+void ApplicationSingleton::releaseLock()
+{
+    if (lockHeld_ && fileLock_) {
+        auto result = fileLock_->unlock();
+        if (!result) {
+            // Log error but don't throw - we're in destructor
+            LogF("Failed to release file lock: {}", result.error().message());
+        }
+        fileLock_.reset();
+        lockHeld_ = false;
+    }
+}
+
+} // namespace linglong::driver::detect

--- a/apps/ll-driver-detect/src/application_singleton.h
+++ b/apps/ll-driver-detect/src/application_singleton.h
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linglong/utils/error/error.h"
+#include "linglong/utils/filelock.h"
+
+#include <string>
+
+namespace linglong::driver::detect {
+
+/**
+ * @brief Application singleton manager
+ *
+ * This class ensures only one instance of the driver detection application
+ * can run at a time, replacing the configuration-based frequency control.
+ */
+class ApplicationSingleton
+{
+public:
+    /**
+     * @brief Constructor
+     * @param lockFilePath Path to the lock file
+     */
+    explicit ApplicationSingleton(const std::string &lockFilePath);
+
+    /**
+     * @brief Destructor - releases the lock
+     */
+    ~ApplicationSingleton();
+
+    /**
+     * @brief Try to acquire the singleton lock
+     * @return true if lock acquired successfully, false if another instance is running
+     */
+    utils::error::Result<bool> tryAcquireLock();
+
+    /**
+     * @brief Release the lock
+     */
+    void releaseLock();
+
+    /**
+     * @brief Check if we currently hold the lock
+     * @return true if we hold the lock, false otherwise
+     */
+    bool isLockHeld() const { return lockHeld_; }
+
+    // Delete copy constructor and assignment operator
+    ApplicationSingleton(const ApplicationSingleton &) = delete;
+    ApplicationSingleton &operator=(const ApplicationSingleton &) = delete;
+
+private:
+    std::string lockFilePath_;
+    std::unique_ptr<linglong::utils::filelock::FileLock> fileLock_;
+    bool lockHeld_;
+};
+
+} // namespace linglong::driver::detect

--- a/apps/ll-driver-detect/src/dbus_notifier.cpp
+++ b/apps/ll-driver-detect/src/dbus_notifier.cpp
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "dbus_notifier.h"
+
+#include "linglong/utils/finally/finally.h"
+#include "linglong/utils/log/log.h"
+
+#include <QDBusReply>
+#include <QEventLoop>
+
+namespace linglong::driver::detect {
+
+DBusNotifier::DBusNotifier(QObject *parent)
+    : QObject(parent)
+    , dbusInterface_("org.freedesktop.Notifications",
+                     "/org/freedesktop/Notifications",
+                     "org.freedesktop.Notifications")
+{
+}
+
+utils::error::Result<void> DBusNotifier::init()
+{
+    LINGLONG_TRACE("init dbus notifier")
+
+    auto connection = dbusInterface_.connection();
+
+    if (!connection.connect(dbusInterface_.service(),
+                            dbusInterface_.path(),
+                            dbusInterface_.interface(),
+                            "ActionInvoked",
+                            this,
+                            SLOT(forwardActionInvoked(quint32, QString)))) {
+        return LINGLONG_ERR("couldn't connect to signal ActionInvoked:"
+                            + connection.lastError().message());
+    }
+
+    if (!connection.connect(dbusInterface_.service(),
+                            dbusInterface_.path(),
+                            dbusInterface_.interface(),
+                            "NotificationClosed",
+                            this,
+                            SLOT(forwardNotificationClosed(quint32, quint32)))) {
+        return LINGLONG_ERR("couldn't connect to signal NotificationClosed:"
+                            + connection.lastError().message());
+    }
+    return LINGLONG_OK;
+}
+
+utils::error::Result<DBusNotifier::NotificationResult>
+DBusNotifier::sendInteractiveNotification(const NotificationRequest &request)
+{
+    LINGLONG_TRACE("send request through dbus notification")
+
+    quint32 notificationID{ 0 };
+    QString choice;
+    auto reason{ CloseReason::NoReason };
+
+    auto invokeCon =
+      QObject::connect(this,
+                       &DBusNotifier::actionInvoked,
+                       [&notificationID, &choice](quint32 ID, const QString &action) {
+                           if (notificationID != 0 && notificationID == ID) {
+                               choice = action;
+                           }
+                       });
+    auto disInvokeCon = utils::finally::finally([&invokeCon] {
+        QObject::disconnect(invokeCon);
+    });
+
+    auto closedCon = QObject::connect(this,
+                                      &DBusNotifier::notificationClosed,
+                                      [&notificationID, &reason](quint32 ID, quint32 newReason) {
+                                          if (notificationID != 0 && notificationID == ID) {
+                                              reason = static_cast<CloseReason>(newReason);
+                                          }
+                                      });
+    auto disClosedCon = utils::finally::finally([&closedCon] {
+        QObject::disconnect(closedCon);
+    });
+
+    auto reply = sendDBusNotification(request.appName,
+                                      0,            // replaceId
+                                      request.icon, // icon
+                                      request.summary,
+                                      request.body,
+                                      request.actions,
+                                      QVariantMap(), // hints
+                                      0);
+
+    if (!reply) {
+        return LINGLONG_ERR(reply.error().message());
+    }
+    notificationID = *reply;
+
+    QEventLoop loop;
+    std::function<void()> checker = std::function{ [&loop, &reason, &checker]() {
+        if (reason != CloseReason::NoReason) {
+            loop.exit();
+        }
+        QMetaObject::invokeMethod(&loop, checker, Qt::QueuedConnection);
+    } };
+
+    QMetaObject::invokeMethod(&loop, checker, Qt::QueuedConnection);
+    loop.exec();
+
+    switch (reason) {
+    case CloseReason::Expired:
+    case CloseReason::Dismissed:
+    case CloseReason::CloseByCall:
+        return NotificationResult(choice, true);
+    case CloseReason::Undefined:
+        return LINGLONG_ERR("server return an undefined reason");
+    case CloseReason::NoReason:
+        break;
+    }
+
+    // This part of the code should not be reachable.
+    // To be safe, return an error instead of aborting.
+    return LINGLONG_ERR("Unhandled notification close reason");
+}
+
+utils::error::Result<void> DBusNotifier::sendSimpleNotification(const NotificationRequest &request)
+{
+    LINGLONG_TRACE("sendSimpleNotification");
+
+    // 发送通知（无动作，简单通知）
+    auto notificationId = sendDBusNotification(request.appName,
+                                               0,            // replaceId
+                                               request.icon, // icon
+                                               request.summary,
+                                               request.body,
+                                               QStringList(), // no actions
+                                               QVariantMap(), // hints
+                                               request.timeout);
+
+    if (!notificationId) {
+        return LINGLONG_ERR(notificationId.error().message());
+    }
+
+    LogD("Simple notification sent with ID: {}", *notificationId);
+    return LINGLONG_OK;
+}
+
+utils::error::Result<quint32> DBusNotifier::sendDBusNotification(const QString &appName,
+                                                                 quint32 replaceId,
+                                                                 const QString &icon,
+                                                                 const QString &summary,
+                                                                 const QString &body,
+                                                                 const QStringList &actions,
+                                                                 const QVariantMap &hints,
+                                                                 qint32 timeout)
+{
+    LINGLONG_TRACE("sendDBusNotification");
+
+    if (!dbusInterface_.isValid()) {
+        return LINGLONG_ERR("DBus interface is not valid");
+    }
+
+    // 调用Notify方法
+    QDBusMessage message =
+      dbusInterface_
+        .call("Notify", appName, replaceId, icon, summary, body, actions, hints, timeout);
+
+    if (message.type() == QDBusMessage::ErrorMessage) {
+        return LINGLONG_ERR(QString("Failed to send notification: %1").arg(message.errorMessage()));
+    }
+
+    if (message.arguments().isEmpty()) {
+        return LINGLONG_ERR("No notification ID returned");
+    }
+
+    quint32 notificationId = message.arguments().first().toUInt();
+    LogD("Notification sent with ID: {}", notificationId);
+
+    return notificationId;
+}
+
+void DBusNotifier::forwardActionInvoked(quint32 ID, QString action)
+{
+    Q_EMIT actionInvoked(ID, action, QPrivateSignal{});
+}
+
+void DBusNotifier::forwardNotificationClosed(quint32 ID, quint32 reason)
+{
+    Q_EMIT notificationClosed(ID, reason, QPrivateSignal{});
+}
+
+} // namespace linglong::driver::detect

--- a/apps/ll-driver-detect/src/dbus_notifier.h
+++ b/apps/ll-driver-detect/src/dbus_notifier.h
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linglong/utils/error/error.h"
+
+#include <QDBusInterface>
+#include <QObject>
+
+namespace linglong::driver::detect {
+
+/**
+ * @brief DBus通知类
+ *
+ * 该类提供DBus通知功能
+ */
+class DBusNotifier final : public QObject
+{
+    Q_OBJECT
+
+public:
+    /**
+     * @brief 通知结果结构
+     */
+    struct NotificationResult
+    {
+        QString action; // 用户选择的动作
+        bool success;   // 通知是否成功发送
+
+        NotificationResult()
+            : success(false)
+        {
+        }
+
+        NotificationResult(const QString &act, bool succ)
+            : action(act)
+            , success(succ)
+        {
+        }
+    };
+
+    /**
+     * @brief 通知请求结构
+     */
+    struct NotificationRequest
+    {
+        QString summary;     // 通知标题
+        QString body;        // 通知内容
+        QStringList actions; // 可用动作按钮文本（成对出现：id, 文本）
+        QString appName;     // 应用名称
+        QString icon;        // 通知图标
+        quint32 timeout;     // 超时时间（毫秒）
+    };
+
+    /**
+     * @brief 构造函数
+     */
+    explicit DBusNotifier(QObject *parent = nullptr);
+
+    /**
+     * @brief Initializes the DBus connection and signals
+     * @return A result object, holding an error if initialization fails
+     */
+    utils::error::Result<void> init();
+
+    /**
+     * @brief 发送交互式通知并等待用户响应
+     * @param request 通知请求
+     * @return 通知结果
+     */
+    utils::error::Result<NotificationResult>
+    sendInteractiveNotification(const NotificationRequest &request);
+
+    /**
+     * @brief 发送简单通知
+     * @param request 通知请求
+     * @return 成功或错误信息
+     */
+    utils::error::Result<void> sendSimpleNotification(const NotificationRequest &request);
+
+Q_SIGNALS:
+    void actionInvoked(quint32 ID, QString action, QPrivateSignal);
+    void notificationClosed(quint32 ID, quint32 reason, QPrivateSignal);
+
+private Q_SLOTS:
+    void forwardActionInvoked(quint32 ID, QString action);
+    void forwardNotificationClosed(quint32 ID, quint32 reason);
+
+private:
+    enum class CloseReason {
+        Expired = 1, // The notification expired.
+        Dismissed,   // The notification was dismissed by the user.
+        CloseByCall, // The notification was closed by a call to CloseNotification.
+        Undefined,   // Undefined/reserved reasons.
+        NoReason     // custom defined for initializing variable
+    };
+
+    /**
+     * @brief 发送通知到DBus服务
+     * @param appName 应用名称
+     * @param replaceId 替换ID
+     * @param icon 图标
+     * @param summary 标题
+     * @param body 内容
+     * @param actions 动作列表
+     * @param hints 提示信息
+     * @param timeout 超时时间
+     * @return 通知ID
+     */
+    utils::error::Result<quint32> sendDBusNotification(const QString &appName,
+                                                       quint32 replaceId,
+                                                       const QString &icon,
+                                                       const QString &summary,
+                                                       const QString &body,
+                                                       const QStringList &actions,
+                                                       const QVariantMap &hints,
+                                                       qint32 timeout);
+
+    QDBusInterface dbusInterface_; ///< DBus接口
+};
+
+} // namespace linglong::driver::detect

--- a/apps/ll-driver-detect/src/driver_detection_config.cpp
+++ b/apps/ll-driver-detect/src/driver_detection_config.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "driver_detection_config.h"
+
+#include "linglong/utils/log/log.h"
+
+#include <nlohmann/json.hpp>
+
+#include <filesystem>
+#include <fstream>
+
+namespace linglong::driver::detect {
+
+DriverDetectionConfigManager::DriverDetectionConfigManager(const std::string &configPath)
+    : configFilePath(configPath)
+{
+    // Try to load existing config, if it fails, use defaults
+    loadConfig();
+}
+
+bool DriverDetectionConfigManager::loadConfig()
+{
+    std::error_code ec;
+    if (!std::filesystem::exists(configFilePath, ec) || ec) {
+        // Config file doesn't exist or error checking, use defaults
+        return true;
+    }
+
+    std::ifstream file(configFilePath);
+    if (!file.is_open()) {
+        return false;
+    }
+
+    nlohmann::json jsonConfig = nlohmann::json::parse(file, nullptr, false);
+    file.close();
+
+    if (jsonConfig.is_discarded()) {
+        LogW("Failed to parse driver detection config, using defaults.");
+        return false;
+    }
+
+    // Parse configuration
+    if (jsonConfig.contains("neverRemind") && jsonConfig["neverRemind"].is_boolean()) {
+        config.neverRemind = jsonConfig["neverRemind"];
+    }
+
+    return true;
+}
+
+bool DriverDetectionConfigManager::saveConfig()
+{
+    nlohmann::json jsonConfig;
+
+    jsonConfig["neverRemind"] = config.neverRemind;
+
+    std::ofstream file(configFilePath);
+    if (!file.is_open()) {
+        return false;
+    }
+
+    file << jsonConfig.dump(4); // Pretty print with 4 spaces
+    file.close();
+
+    return true;
+}
+
+void DriverDetectionConfigManager::recordUserChoice(UserNotificationChoice choice)
+{
+    choice == UserNotificationChoice::InstallNow ? config.neverRemind = false
+                                                 : config.neverRemind = true;
+
+    // Save the updated configuration
+    saveConfig();
+}
+
+} // namespace linglong::driver::detect

--- a/apps/ll-driver-detect/src/driver_detection_config.h
+++ b/apps/ll-driver-detect/src/driver_detection_config.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <string>
+
+namespace linglong::driver::detect {
+
+enum class UserNotificationChoice { InstallNow, NeverRemind };
+
+struct DriverDetectionConfig
+{
+    bool neverRemind = false;
+};
+
+class DriverDetectionConfigManager
+{
+public:
+    explicit DriverDetectionConfigManager(const std::string &configPath);
+    ~DriverDetectionConfigManager() = default;
+
+    // Load configuration from file
+    bool loadConfig();
+
+    // Save configuration to file
+    bool saveConfig();
+
+    // Get current configuration
+    DriverDetectionConfig getConfig() const { return config; }
+
+    // Update configuration
+    void setConfig(const DriverDetectionConfig &newConfig) { config = newConfig; }
+
+    // Check if we should show notification (simplified - no version-specific logic)
+    bool shouldShowNotification() const { return !config.neverRemind; }
+
+    // Record user choice (simplified - no version parameter needed)
+    void recordUserChoice(UserNotificationChoice choice);
+
+private:
+    std::string configFilePath;
+    DriverDetectionConfig config;
+};
+
+} // namespace linglong::driver::detect

--- a/apps/ll-driver-detect/src/driver_detection_manager.cpp
+++ b/apps/ll-driver-detect/src/driver_detection_manager.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "driver_detection_manager.h"
+
+#include "linglong/utils/log/log.h"
+#include "nvidia_driver_detector.h"
+
+namespace linglong::driver::detect {
+
+DriverDetectionManager::DriverDetectionManager()
+{
+    registerDetectors();
+}
+
+utils::error::Result<DriverDetectionResult> DriverDetectionManager::detectAllDrivers()
+{
+    DriverDetectionResult result;
+
+    for (const auto &detector : detectors_) {
+        auto detectionResult = detector->detect();
+        if (!detectionResult) {
+            LogE("Driver detection failed {}: {}",
+                 detector->getDriverIdentify(),
+                 detectionResult.error().message());
+            continue;
+        }
+
+        result.detectedDrivers.emplace_back(*detectionResult);
+        LogD("Detected driver: {} version: {}",
+             detectionResult->packageName,
+             detectionResult->version);
+    }
+
+    return result;
+}
+
+void DriverDetectionManager::registerDetectors()
+{
+    // Register NVIDIA detector
+    detectors_.push_back(std::make_unique<NVIDIADriverDetector>());
+
+    // TODO: Add other driver detector
+
+    LogD("Registered {} driver detectors", detectors_.size());
+}
+
+} // namespace linglong::driver::detect

--- a/apps/ll-driver-detect/src/driver_detection_manager.h
+++ b/apps/ll-driver-detect/src/driver_detection_manager.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "driver_detector.h"
+
+#include <memory>
+#include <vector>
+
+namespace linglong::driver::detect {
+
+// Result of driver detection for all available drivers
+struct DriverDetectionResult
+{
+    std::vector<GraphicsDriverInfo> detectedDrivers;
+
+    bool hasAvailableDrivers() const
+    {
+        return std::any_of(detectedDrivers.begin(),
+                           detectedDrivers.end(),
+                           [](const auto &driver) {
+                               return !driver.isInstalled;
+                           });
+    }
+};
+
+// Manager class that coordinates detection of multiple graphics drivers
+class DriverDetectionManager
+{
+public:
+    DriverDetectionManager();
+    virtual ~DriverDetectionManager() = default;
+
+    // Detect all available graphics drivers on the system
+    // Returns all detected drivers, or empty vector if none found
+    utils::error::Result<DriverDetectionResult> detectAllDrivers();
+
+protected:
+    // Register all available driver detectors
+    virtual void registerDetectors();
+
+    std::vector<std::unique_ptr<DriverDetector>> detectors_;
+};
+
+} // namespace linglong::driver::detect

--- a/apps/ll-driver-detect/src/driver_detector.h
+++ b/apps/ll-driver-detect/src/driver_detector.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linglong/utils/error/error.h"
+
+#include <string>
+
+namespace linglong::driver::detect {
+
+struct GraphicsDriverInfo
+{
+    std::string identify;
+    std::string version;
+    std::string packageName;
+    bool isInstalled = false;
+};
+
+class DriverDetector
+{
+public:
+    virtual ~DriverDetector() = default;
+
+    // Main detection method - returns driver info if detected
+    virtual utils::error::Result<GraphicsDriverInfo> detect() = 0;
+
+    // Check if the driver package is installed
+    virtual utils::error::Result<bool> checkPackageInstalled(const std::string &packageName) = 0;
+
+    // Get the Identify of driver this detector handles
+    virtual std::string getDriverIdentify() const = 0;
+};
+
+} // namespace linglong::driver::detect

--- a/apps/ll-driver-detect/src/main.cpp
+++ b/apps/ll-driver-detect/src/main.cpp
@@ -1,0 +1,303 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "application_singleton.h"
+#include "configure.h"
+#include "dbus_notifier.h"
+#include "driver_detection_config.h"
+#include "driver_detection_manager.h"
+#include "driver_detector.h"
+#include "linglong/utils/command/cmd.h"
+#include "linglong/utils/error/error.h"
+#include "linglong/utils/gettext.h"
+#include "linglong/utils/global/initialize.h"
+#include "tl/expected.hpp"
+
+#include <CLI/CLI.hpp>
+
+#include <QCoreApplication>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace linglong::driver::detect;
+
+constexpr auto kActionInstallNow = "install_now";
+constexpr auto kActionNotRemind = "not_remind";
+constexpr auto kNotificationIcon = "/usr/share/icons/hicolor/scalable/apps/linyaps.svg";
+
+struct DriverDetectOptions
+{
+    std::string driverType;
+    std::string packageName;
+    bool force = false;
+    bool checkOnly = false;
+    bool installOnly = false;
+    int notificationIntervalMinutes = 5; // Kept for backward compatibility, but will be ignored
+};
+
+linglong::utils::error::Result<std::filesystem::path> getDefaultConfigPath()
+{
+    LINGLONG_TRACE("get default config path");
+
+    auto *homeEnv = ::getenv("HOME");
+    if (homeEnv == nullptr) {
+        return LINGLONG_ERR("Couldn't get HOME env.");
+    }
+
+    auto value = getenv("XDG_CONFIG_HOME");
+    auto configDir =
+      value ? std::filesystem::path{ value } : std::filesystem::path{ homeEnv } / ".config";
+    return configDir / "linglong/driver_detection.json";
+}
+
+// Sets up the configuration manager based on command-line options.
+linglong::utils::error::Result<DriverDetectionConfigManager> setupConfigManager()
+{
+    LINGLONG_TRACE("setupConfigManager");
+
+    auto defaultConfigPathResult = getDefaultConfigPath();
+    if (!defaultConfigPathResult) {
+        return LINGLONG_ERR(defaultConfigPathResult.error());
+    }
+
+    // Determine configuration path
+    std::filesystem::path configPath = *defaultConfigPathResult;
+
+    // Ensure configuration directory exists
+    std::error_code ec;
+    std::filesystem::create_directories(configPath.parent_path(), ec);
+    if (ec) {
+        LogW("Failed to create config directory: {}", ec.message());
+    }
+
+    // Create driver detection config manager
+    DriverDetectionConfigManager configManager(configPath.string());
+
+    // Load configuration
+    if (!configManager.loadConfig()) {
+        LogW("Failed to load driver detection config, using defaults");
+    }
+
+    return configManager;
+}
+
+linglong::utils::error::Result<void>
+installDriverPackage(const std::vector<GraphicsDriverInfo> &drivers)
+{
+    LINGLONG_TRACE("installDriverPackage")
+
+    try {
+        for (const auto &driverInfo : drivers) {
+            LogD("Processing driver: Identify={}, Version={}, Package={}, Installed={}",
+                 driverInfo.identify,
+                 driverInfo.version,
+                 driverInfo.packageName,
+                 driverInfo.isInstalled);
+
+            if (driverInfo.isInstalled) {
+                LogD("Driver package is already installed: {}", driverInfo.packageName);
+                continue;
+            }
+
+            // Execute ll-cli install command to install the package
+            auto ret = linglong::utils::command::Cmd("ll-cli").exec(
+              { "install", QString::fromStdString(driverInfo.packageName) });
+            if (!ret) {
+                return LINGLONG_ERR("Installation command failed: " + ret.error().message());
+            }
+
+            LogD("Driver package installation command executed successfully: {}", *ret);
+        }
+
+        return LINGLONG_OK;
+    } catch (const std::exception &e) {
+        return LINGLONG_ERR("Failed to install driver package: " + std::string(e.what()));
+    }
+
+    return LINGLONG_OK;
+}
+
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+
+    bindtextdomain(PACKAGE_LOCALE_DOMAIN, PACKAGE_LOCALE_DIR);
+    textdomain(PACKAGE_LOCALE_DOMAIN);
+
+    linglong::utils::global::applicationInitialize();
+    linglong::utils::global::initLinyapsLogSystem(linglong::utils::log::LogBackend::Console);
+
+    DriverDetectOptions options;
+    CLI::App cliApp{ "Linglong Graphics Driver Detection Tool" };
+
+    // Define command line options
+    cliApp.add_flag("-f,--force", options.force, _("Force installation even if recently reminded"));
+    cliApp.add_flag("-c,--check-only",
+                    options.checkOnly,
+                    _("Check for drivers only without installing or notifying"));
+    cliApp.add_flag("-i,--install-only",
+                    options.installOnly,
+                    _("Only install drivers without notifications"));
+
+    try {
+        cliApp.parse(argc, argv);
+    } catch (const CLI::ParseError &e) {
+        return cliApp.exit(e);
+    }
+
+    LogD("Starting ll-driver-detect application");
+
+    // Initialize application singleton to ensure only one instance runs
+    auto defaultConfigPathResult = getDefaultConfigPath();
+    if (!defaultConfigPathResult) {
+        LogF("Failed to get default config path: {}", defaultConfigPathResult.error().message());
+        return 1;
+    }
+
+    std::filesystem::path lockFilePath = *defaultConfigPathResult;
+    lockFilePath = lockFilePath.parent_path() / "ll-driver-detect.lock";
+
+    ApplicationSingleton singleton(lockFilePath.string());
+    auto lockResult = singleton.tryAcquireLock();
+    if (!lockResult) {
+        LogF("Failed to acquire singleton lock: {}", lockResult.error().message());
+        return 1;
+    }
+
+    if (!*lockResult) {
+        LogW("Another instance of ll-driver-detect is already running. Exiting.");
+        return 0; // Exit gracefully, not an error
+    }
+
+    auto configManagerResult = setupConfigManager();
+    if (!configManagerResult) {
+        LogF("Failed to set up configuration: {}", configManagerResult.error().message());
+        return 1;
+    }
+
+    auto configManager = *configManagerResult;
+    if (!options.force && !configManager.shouldShowNotification()) {
+        LogD("User has chosen not to be reminded about driver installation");
+        return 0;
+    }
+
+    // Create driver detection manager for multi-driver support
+    DriverDetectionManager detectionManager;
+
+    // Run driver detection and handling for all available drivers
+    auto result = detectionManager.detectAllDrivers();
+
+    if (!result) {
+        LogF("Driver detection failed: {}", result.error().message());
+
+        return 1;
+    }
+
+    const auto &detectionResult = *result;
+
+    if (!detectionResult.hasAvailableDrivers()) {
+        std::cout << "No available graphics drivers detected or already installed" << std::endl;
+        return 0;
+    }
+
+    if (options.checkOnly) {
+        std::cout << "CHECK ONLY: only check drivers, no notifications or installations "
+                     "will be performed."
+                  << std::endl;
+        std::cout << "Detected drivers:" << std::endl;
+        for (const auto &driverInfo : detectionResult.detectedDrivers) {
+            std::cout << "----------------------------------------" << std::endl;
+            std::cout << "  Identify: " << driverInfo.identify << std::endl;
+            std::cout << "  Version: " << driverInfo.version << std::endl;
+            std::cout << "  Package: " << driverInfo.packageName << std::endl;
+            std::cout << "  Installed: " << (driverInfo.isInstalled ? "Yes" : "No") << std::endl;
+            std::cout << "----------------------------------------" << std::endl;
+        }
+        return 0;
+    }
+
+    LogD("Detected {} graphics driver(s)", detectionResult.detectedDrivers.size());
+
+    if (options.installOnly) {
+        std::cout << "Install-only: installing detected drivers without notifications" << std::endl;
+        auto installResult = installDriverPackage(detectionResult.detectedDrivers);
+        if (!installResult) {
+            LogW("Failed to install driver package {}: {}",
+                 options.packageName,
+                 installResult.error().message());
+        }
+
+        std::cout << "Successfully installed driver package" << std::endl;
+
+        return 0;
+    }
+
+    // Handle user notifications and installation for each driver
+    // Check if we should show notification for this driver
+    auto notifier = std::make_unique<DBusNotifier>();
+    auto initResult = notifier->init();
+    if (!initResult) {
+        LogF("Failed to initialize DBus notifier: {}", initResult.error().message());
+        return 1;
+    }
+
+    // Create driver-specific notification
+    DBusNotifier::NotificationRequest request;
+    request.appName = "linyaps";
+    request.summary = _("Graphics Driver Available");
+    request.body = QString(_("Graphics driver package is available that can improve performance "
+                             "for some Linyaps applications.\n"
+                             "Would you like to install it?"));
+    request.actions = QStringList()
+      << kActionInstallNow << _("Install Now") << kActionNotRemind << _("Don't Remind");
+    request.icon = kNotificationIcon;
+
+    auto responseResult = notifier->sendInteractiveNotification(request);
+    if (!responseResult) {
+        LogW("Failed to send notification for driver: {}", responseResult.error().message());
+        return 1;
+    }
+
+    // Handle user response
+    const auto &response = *responseResult;
+    if (response.action == kActionInstallNow && response.success) {
+        LogD("User chose to install graphics driver");
+
+        auto installResult = installDriverPackage(detectionResult.detectedDrivers);
+        if (!installResult) {
+            LogW("Failed to install driver package: {}", installResult.error().message());
+            return 1;
+        }
+
+        LogD("Successfully installed driver package");
+
+        // Send success notification
+        DBusNotifier::NotificationRequest successRequest;
+        successRequest.appName = "linyaps";
+        successRequest.summary = _("Graphics Driver Installation Completed");
+        successRequest.body =
+          QString(_("Graphics driver package has been installed.\n"
+                    "Restart the Linyaps app to experience the performance improvement."));
+        successRequest.timeout = 5000; // 5 seconds
+        auto successResult = notifier->sendSimpleNotification(successRequest);
+        if (!successResult) {
+            LogW("Failed to send success notification: {}", successResult.error().message());
+        }
+    } else if (response.action == kActionNotRemind && response.success) {
+        LogD("User chose not to be reminded again");
+        configManager.recordUserChoice(UserNotificationChoice::NeverRemind);
+        configManager.saveConfig();
+    } else {
+        LogD("User dismissed notification or timeout, no action taken");
+    }
+
+    LogD("Driver detection completed successfully");
+    return 0;
+}

--- a/apps/ll-driver-detect/src/nvidia_driver_detector.cpp
+++ b/apps/ll-driver-detect/src/nvidia_driver_detector.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "nvidia_driver_detector.h"
+
+#include "linglong/utils/command/cmd.h"
+#include "linglong/utils/error/error.h"
+#include "linglong/utils/log/log.h"
+
+#include <filesystem>
+#include <fstream>
+
+namespace linglong::driver::detect {
+
+NVIDIADriverDetector::NVIDIADriverDetector(std::string versionFilePath)
+    : versionFilePath_(std::move(versionFilePath))
+{
+}
+
+utils::error::Result<GraphicsDriverInfo> NVIDIADriverDetector::detect()
+{
+    LINGLONG_TRACE("NVIDIA driver detection started");
+
+    // Get driver version
+    auto version = getDriverVersion();
+    if (version.empty()) {
+        return LINGLONG_ERR("Failed to get NVIDIA driver version");
+    }
+
+    auto linglongPackageName = getDriverIdentify() + "." + version;
+
+    // Check if package exists in repo
+    auto existsResult = checkPackageExists(linglongPackageName);
+    if (!existsResult) {
+        return LINGLONG_ERR("Failed to check if package exists: " + existsResult.error().message());
+    }
+
+    // Check if package is installed
+    auto installedResult = checkPackageInstalled(linglongPackageName);
+    if (!installedResult) {
+        return LINGLONG_ERR("Failed to check package installation: "
+                            + installedResult.error().message());
+    }
+
+    return GraphicsDriverInfo{ getDriverIdentify(),
+                               version,
+                               linglongPackageName,
+                               *installedResult };
+}
+
+utils::error::Result<void> NVIDIADriverDetector::checkPackageExists(const std::string &packageName)
+{
+    LINGLONG_TRACE("Check if NVIDIA driver package exists in repository");
+    // Execute ll-cli search command to check driver package existence
+    auto ret = linglong::utils::command::Cmd("ll-cli").exec(
+      { "search", QString::fromStdString(packageName) });
+    if (!ret) {
+        return LINGLONG_ERR("Search command failed: " + ret.error().message());
+    }
+
+    if (!ret->contains(QString::fromStdString(packageName))) {
+        return LINGLONG_ERR("Driver package not found in linglong repo: " + packageName);
+    }
+    return LINGLONG_OK;
+}
+
+utils::error::Result<bool>
+NVIDIADriverDetector::checkPackageInstalled(const std::string &packageName)
+{
+    LINGLONG_TRACE("Check if NVIDIA driver package is installed");
+
+    try {
+        // First execute ll-cli info to get the package info
+        auto listResult =
+          linglong::utils::command::Cmd("ll-cli").exec({ "info", packageName.c_str() });
+
+        if (!listResult) {
+            LogD("Can not get package info with `ll-cli info`, maybe the package is not installed: {}",
+                 listResult.error().message());
+            return false;
+        }
+
+        return true;
+    } catch (const std::exception &e) {
+        return LINGLONG_ERR("Failed to check package installation: " + std::string(e.what()));
+    }
+}
+
+std::string NVIDIADriverDetector::getDriverVersion()
+{
+    std::string version;
+
+    if (!std::filesystem::exists(versionFilePath_)) {
+        LogW("NVIDIA version file not found: {}", versionFilePath_);
+        return version;
+    }
+
+    std::ifstream versionFile(versionFilePath_);
+    if (versionFile) {
+        versionFile >> version;
+
+        std::replace(version.begin(), version.end(), '.', '-');
+    }
+
+    return version;
+}
+
+} // namespace linglong::driver::detect

--- a/apps/ll-driver-detect/src/nvidia_driver_detector.h
+++ b/apps/ll-driver-detect/src/nvidia_driver_detector.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "driver_detector.h"
+
+#include <string>
+
+namespace linglong::driver::detect {
+
+class NVIDIADriverDetector : public DriverDetector
+{
+public:
+    static constexpr auto kNvidiaPackageIdentify = "org.deepin.driver.display.nvidia";
+    static constexpr auto kDefaultNvidiaVersionFile = "/sys/module/nvidia/version";
+
+    explicit NVIDIADriverDetector(std::string versionFilePath = kDefaultNvidiaVersionFile);
+    ~NVIDIADriverDetector() override = default;
+
+    // Main detection method - returns driver info if detected
+    utils::error::Result<GraphicsDriverInfo> detect() override;
+
+    // Check if the driver package is installed
+    utils::error::Result<bool> checkPackageInstalled(const std::string &packageName) override;
+
+    // Check if the driver package exists in repo
+    virtual utils::error::Result<void> checkPackageExists(const std::string &packageName);
+
+    // Get the type of driver this detector handles
+    std::string getDriverIdentify() const override { return kNvidiaPackageIdentify; }
+
+private:
+    // Get driver version from the specified file path
+    std::string getDriverVersion();
+
+    std::string versionFilePath_;
+};
+
+} // namespace linglong::driver::detect

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -50,6 +50,7 @@
 #include <QCryptographicHash>
 #include <QEventLoop>
 #include <QFileInfo>
+#include <QProcess>
 
 #include <algorithm>
 #include <cassert>
@@ -466,6 +467,8 @@ int Cli::run(const RunOptions &options)
     auto uid = getuid();
     auto gid = getgid();
     auto pid = getpid();
+
+    detectDrivers();
 
     auto userContainerDir = std::filesystem::path{ "/run/linglong" } / std::to_string(uid);
     if (auto ret = utils::ensureDirectory(userContainerDir); !ret) {
@@ -2530,6 +2533,19 @@ bool Cli::handleCommonError(const utils::error::Error &error)
     }
 
     return true;
+}
+
+void Cli::detectDrivers()
+{
+    QProcess process;
+    process.setProgram(QString(LINGLONG_LIBEXEC_DIR "/ll-driver-detect"));
+    // 禁用标准输入 (stdin)
+    process.setStandardInputFile("/dev/null");
+    // 禁用标准输出 (stdout)
+    process.setStandardOutputFile("/dev/null");
+    // 禁用标准错误输出 (stderr)
+    process.setStandardErrorFile("/dev/null");
+    process.startDetached();
 }
 
 } // namespace linglong::cli

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -224,6 +224,7 @@ private:
     int getLayerDir(const InspectOptions &options);
     int getBundleDir(const InspectOptions &options);
     utils::error::Result<void> initInteraction();
+    void detectDrivers();
 
     template <typename T>
     utils::error::Result<T> waitDBusReply(QDBusPendingReply<QVariantMap> &reply)

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -56,6 +56,19 @@ pfl_add_executable(
   src/linglong/utils/transaction_test.cpp
   src/linglong/utils/xdg/directory_test.cpp
   src/main.cpp
+
+  # ll-driver-detect tests
+  ${PROJECT_SOURCE_DIR}/apps/ll-driver-detect/src/nvidia_driver_detector.cpp
+  ${PROJECT_SOURCE_DIR}/apps/ll-driver-detect/src/driver_detection_config.cpp
+  ${PROJECT_SOURCE_DIR}/apps/ll-driver-detect/src/dbus_notifier.cpp
+  ${PROJECT_SOURCE_DIR}/apps/ll-driver-detect/src/application_singleton.cpp
+  ${PROJECT_SOURCE_DIR}/apps/ll-driver-detect/src/driver_detection_manager.cpp
+  src/apps/ll-driver-detect/driver_detector_test.cpp
+  src/apps/ll-driver-detect/nvidia_driver_detector_test.cpp
+  src/apps/ll-driver-detect/driver_detection_config_test.cpp
+  src/apps/ll-driver-detect/application_singleton_test.cpp
+  src/apps/ll-driver-detect/driver_detection_manager_test.cpp
+  src/apps/ll-driver-detect/dbus_notifier_test.cpp
   COMPILE_FEATURES
   PUBLIC
   cxx_std_17
@@ -73,3 +86,5 @@ gtest_discover_tests(${tests} WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
 # FIXME: we should'n include header directly
 target_include_directories(${tests}
                            PUBLIC ${PROJECT_SOURCE_DIR}/apps/uab/header/src)
+target_include_directories(${tests}
+                           PUBLIC ${PROJECT_SOURCE_DIR}/apps/ll-driver-detect/src)

--- a/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/application_singleton_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/application_singleton_test.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "application_singleton.h"
+
+#include <filesystem>
+#include <memory>
+
+namespace {
+std::filesystem::path GetTempLockFilePath()
+{
+    return std::filesystem::temp_directory_path() / "ll_driver_detect_singleton_test.lock";
+}
+} // namespace
+
+class ApplicationSingletonTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        lockFilePath = GetTempLockFilePath();
+        // Ensure the file does not exist initially
+        std::filesystem::remove(lockFilePath);
+    }
+
+    void TearDown() override { std::filesystem::remove(lockFilePath); }
+
+    std::filesystem::path lockFilePath;
+};
+
+TEST_F(ApplicationSingletonTest, CanAcquireLockWhenNoOneHasIt)
+{
+    using namespace linglong::driver::detect;
+    ApplicationSingleton singleton(lockFilePath.string());
+
+    auto result = singleton.tryAcquireLock();
+    ASSERT_TRUE(result.has_value())
+      << "Failed to try to acquire lock: " << result.error().message();
+    EXPECT_TRUE(*result);
+    EXPECT_TRUE(singleton.isLockHeld());
+    EXPECT_TRUE(std::filesystem::exists(lockFilePath));
+}
+
+TEST_F(ApplicationSingletonTest, CannotAcquireLockWhenAnotherInstanceHoldsIt)
+{
+    using namespace linglong::driver::detect;
+
+    // First instance acquires the lock
+    ApplicationSingleton singleton1(lockFilePath.string());
+    auto result1 = singleton1.tryAcquireLock();
+    ASSERT_TRUE(result1.has_value());
+    ASSERT_TRUE(*result1);
+    ASSERT_TRUE(singleton1.isLockHeld());
+
+    // Second instance tries to acquire the same lock
+    ApplicationSingleton singleton2(lockFilePath.string());
+    auto result2 = singleton2.tryAcquireLock();
+
+    // It should fail to acquire the lock
+    ASSERT_FALSE(result2);
+}
+
+TEST_F(ApplicationSingletonTest, CanAcquireLockAfterItIsReleased)
+{
+    using namespace linglong::driver::detect;
+
+    // Create a scope for the first singleton
+    {
+        ApplicationSingleton singleton1(lockFilePath.string());
+        auto result1 = singleton1.tryAcquireLock();
+        ASSERT_TRUE(result1.has_value());
+        ASSERT_TRUE(*result1);
+        ASSERT_TRUE(singleton1.isLockHeld());
+    } // singleton1 is destroyed here, releasing the lock
+
+    // A new instance should now be able to acquire the lock
+    ApplicationSingleton singleton2(lockFilePath.string());
+    auto result2 = singleton2.tryAcquireLock();
+    ASSERT_TRUE(result2.has_value())
+      << "tryAcquireLock failed unexpectedly: " << result2.error().message();
+    EXPECT_TRUE(*result2);
+    EXPECT_TRUE(singleton2.isLockHeld());
+}
+
+TEST_F(ApplicationSingletonTest, ReleasingLockManuallyWorks)
+{
+    using namespace linglong::driver::detect;
+    ApplicationSingleton singleton1(lockFilePath.string());
+    auto result1 = singleton1.tryAcquireLock();
+    ASSERT_TRUE(result1.has_value());
+    ASSERT_TRUE(*result1);
+    ASSERT_TRUE(singleton1.isLockHeld());
+
+    singleton1.releaseLock();
+    EXPECT_FALSE(singleton1.isLockHeld());
+
+    // A new instance should now be able to acquire the lock
+    ApplicationSingleton singleton2(lockFilePath.string());
+    auto result2 = singleton2.tryAcquireLock();
+    ASSERT_TRUE(result2.has_value())
+      << "tryAcquireLock failed unexpectedly: " << result2.error().message();
+    EXPECT_TRUE(*result2);
+    EXPECT_TRUE(singleton2.isLockHeld());
+}
+
+TEST_F(ApplicationSingletonTest, CreatesDirectoryForLockFile)
+{
+    using namespace linglong::driver::detect;
+    auto deepLockPath = std::filesystem::temp_directory_path() / "deep_dir_for_test" / "test.lock";
+    std::filesystem::remove(deepLockPath);
+    std::filesystem::remove(deepLockPath.parent_path());
+
+    ASSERT_FALSE(std::filesystem::exists(deepLockPath.parent_path()));
+
+    ApplicationSingleton singleton(deepLockPath.string());
+    auto result = singleton.tryAcquireLock();
+    ASSERT_TRUE(result.has_value())
+      << "Failed to try to acquire lock: " << result.error().message();
+    EXPECT_TRUE(*result);
+    EXPECT_TRUE(singleton.isLockHeld());
+    EXPECT_TRUE(std::filesystem::exists(deepLockPath));
+
+    // Cleanup
+    std::filesystem::remove(deepLockPath);
+    std::filesystem::remove(deepLockPath.parent_path());
+}

--- a/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/dbus_notifier_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/dbus_notifier_test.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "dbus_notifier.h"
+
+#include <QCoreApplication>
+
+using namespace linglong::driver::detect;
+
+class DBusNotifierTest : public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        // QCoreApplication is required for Qt D-Bus to work
+        int argc = 1;
+        const char *argv[] = { "test" };
+        app = new QCoreApplication(argc, const_cast<char **>(argv));
+    }
+
+    static void TearDownTestSuite()
+    {
+        delete app;
+        app = nullptr;
+    }
+
+    static QCoreApplication *app;
+};
+
+QCoreApplication *DBusNotifierTest::app = nullptr;
+
+TEST_F(DBusNotifierTest, InitDoesNotCrash)
+{
+    DBusNotifier notifier;
+
+    // We call init() and primarily test that it does not crash and returns a
+    // valid Result object. On systems with a running D-Bus session bus,
+    // this is expected to succeed. On systems without one, it is expected
+    // to fail gracefully by returning an error.
+    auto result = notifier.init();
+
+    if (!result) {
+        // If it fails, log the error but don't fail the test.
+        // This is an expected outcome if no session bus is available.
+        SUCCEED() << "DBusNotifier::init() failed gracefully as expected on this system: "
+                  << result.error().message();
+    } else {
+        // If it succeeds, that's also a valid outcome.
+        SUCCEED() << "DBusNotifier::init() succeeded as expected on this system.";
+    }
+}

--- a/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/driver_detection_config_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/driver_detection_config_test.cpp
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gtest/gtest.h>
+
+#include "driver_detection_config.h"
+
+#include <filesystem>
+
+namespace {
+std::filesystem::path GetTempFilePath()
+{
+    return std::filesystem::temp_directory_path() / ("test_config.json");
+}
+} // namespace
+
+class DriverDetectionConfigTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        configFilePath = GetTempFilePath();
+        // Ensure the file does not exist initially
+        std::filesystem::remove(configFilePath);
+        ASSERT_FALSE(configFilePath.empty()) << "Failed to create temporary directory";
+    }
+
+    void TearDown() override { std::filesystem::remove(configFilePath); }
+
+    std::filesystem::path configFilePath;
+};
+
+TEST_F(DriverDetectionConfigTest, DefaultConstruction)
+{
+    using namespace linglong::driver::detect;
+
+    // Test that default construction works
+    DriverDetectionConfig config;
+    EXPECT_FALSE(config.neverRemind);
+}
+
+TEST_F(DriverDetectionConfigTest, ConfigManagerConstruction)
+{
+    using namespace linglong::driver::detect;
+
+    // Test that construction works
+    EXPECT_NO_THROW(DriverDetectionConfigManager manager(configFilePath.string()));
+}
+
+TEST_F(DriverDetectionConfigTest, LoadNonExistentConfig)
+{
+    using namespace linglong::driver::detect;
+
+    DriverDetectionConfigManager manager(configFilePath.string());
+
+    // Should handle non-existent file gracefully
+    EXPECT_NO_THROW(manager.loadConfig());
+}
+
+TEST_F(DriverDetectionConfigTest, SaveAndLoadConfig)
+{
+    using namespace linglong::driver::detect;
+
+    // Create manager and modify config
+    DriverDetectionConfigManager manager(configFilePath.string());
+    auto config = manager.getConfig();
+    config.neverRemind = true;
+    manager.setConfig(config);
+
+    // Save config
+    EXPECT_TRUE(manager.saveConfig());
+
+    // Create new manager with same path
+    DriverDetectionConfigManager manager2(configFilePath.string());
+    EXPECT_TRUE(manager2.loadConfig());
+
+    // Verify config was loaded correctly
+    auto loadedConfig = manager2.getConfig();
+    EXPECT_TRUE(loadedConfig.neverRemind);
+}

--- a/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/driver_detection_manager_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/driver_detection_manager_test.cpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "driver_detection_manager.h"
+#include "driver_detector.h"
+
+#include <memory>
+#include <vector>
+
+using namespace linglong::driver::detect;
+
+// A custom detector that returns a specific driver info for successful detection
+class FakeSuccessDetector : public DriverDetector
+{
+public:
+    FakeSuccessDetector(std::string identify, std::string version, bool installed)
+        : info_{ std::move(identify), std::move(version), "some-package", installed }
+    {
+    }
+
+    linglong::utils::error::Result<GraphicsDriverInfo> detect() override { return info_; }
+
+    linglong::utils::error::Result<bool> checkPackageInstalled(const std::string &) override
+    {
+        return info_.isInstalled;
+    }
+
+    std::string getDriverIdentify() const override { return info_.identify; }
+
+private:
+    GraphicsDriverInfo info_;
+};
+
+// A custom detector that always fails
+class FakeFailureDetector : public DriverDetector
+{
+public:
+    linglong::utils::error::Result<GraphicsDriverInfo> detect() override
+    {
+        LINGLONG_TRACE("Fake detector failed as intended")
+        return LINGLONG_ERR("Fake detector failed as intended");
+    }
+
+    linglong::utils::error::Result<bool> checkPackageInstalled(const std::string &) override
+    {
+        LINGLONG_TRACE("Fake detector failed as intended")
+        return LINGLONG_ERR("Should not be called");
+    }
+
+    std::string getDriverIdentify() const override { return "fake-failure"; }
+};
+
+// A test-specific subclass of DriverDetectionManager to allow for mock injection
+class TestableDriverDetectionManager : public DriverDetectionManager
+{
+public:
+    // Override to prevent registration of real detectors
+    void registerDetectors() override { }
+
+    // Expose a way to add mock/fake detectors for tests
+    void addDetector(std::unique_ptr<DriverDetector> detector)
+    {
+        detectors_.push_back(std::move(detector));
+    }
+};
+
+class DriverDetectionManagerTest : public ::testing::Test
+{
+};
+
+TEST_F(DriverDetectionManagerTest, DetectAllDrivers_NoDetectors)
+{
+    TestableDriverDetectionManager manager;
+    auto result = manager.detectAllDrivers();
+    ASSERT_TRUE(result.has_value());
+}

--- a/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/driver_detector_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/driver_detector_test.cpp
@@ -1,0 +1,175 @@
+/*
+ * SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gtest/gtest.h>
+
+#include "driver_detection_config.h"
+#include "driver_detector.h"
+#include "nvidia_driver_detector.h"
+
+#include <filesystem>
+#include <string>
+
+namespace {
+std::filesystem::path GetTempFilePath()
+{
+    return std::filesystem::temp_directory_path() / ("test_version");
+}
+} // namespace
+
+class DriverDetectorTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        versionFilePath = GetTempFilePath();
+        // Ensure the file does not exist initially
+        std::filesystem::remove(versionFilePath);
+        ASSERT_FALSE(versionFilePath.empty()) << "Failed to create temporary directory";
+    }
+
+    void TearDown() override { std::filesystem::remove(versionFilePath); }
+
+    std::filesystem::path versionFilePath;
+};
+
+TEST_F(DriverDetectorTest, NvidiaDriverDetectorInitialization)
+{
+    linglong::driver::detect::NVIDIADriverDetector nvidiaDetector;
+
+    // Test basic initialization - NVIDIADriverDetector should be properly initialized
+    EXPECT_EQ(nvidiaDetector.getDriverIdentify(), "org.deepin.driver.display.nvidia");
+}
+
+TEST_F(DriverDetectorTest, NvidiaDriverDetectorDetect)
+{
+    linglong::driver::detect::NVIDIADriverDetector nvidiaDetector;
+
+    // Test basic detection functionality
+    auto result = nvidiaDetector.detect();
+    // This may or may not find a driver depending on the system
+    // We're mainly testing that the detection process works without crashing
+    EXPECT_TRUE(result.has_value() || !result.has_value());
+
+    if (result.has_value()) {
+        auto &driverInfo = *result;
+        EXPECT_EQ(driverInfo.identify, "org.deepin.driver.display.nvidia");
+        EXPECT_FALSE(driverInfo.version.empty());
+        EXPECT_FALSE(driverInfo.packageName.empty());
+    }
+}
+
+TEST_F(DriverDetectorTest, NvidiaDriverDetectorPackageCheck)
+{
+    linglong::driver::detect::NVIDIADriverDetector nvidiaDetector;
+
+    // Test package checking with a likely non-existent package name
+    auto result = nvidiaDetector.checkPackageInstalled("nonexistent_package_name_12345");
+    // Should return a valid result (false) rather than error
+    EXPECT_TRUE(result.has_value());
+    if (result.has_value()) {
+        EXPECT_FALSE(*result); // Package should not be found
+    }
+}
+
+TEST_F(DriverDetectorTest, DriverDetectionConfigManagerSave)
+{
+    linglong::driver::detect::DriverDetectionConfigManager configManager(versionFilePath.string());
+
+    // Load default config
+    ASSERT_TRUE(configManager.loadConfig());
+
+    // Modify config
+    linglong::driver::detect::DriverDetectionConfig newConfig;
+    configManager.setConfig(newConfig);
+
+    // Test saving configuration to file
+    bool result = configManager.saveConfig();
+    EXPECT_TRUE(result);
+}
+
+TEST_F(DriverDetectorTest, DriverDetectionConfigManagerRoundTrip)
+{
+    // Create and configure first manager
+    linglong::driver::detect::DriverDetectionConfigManager configManager1(versionFilePath.string());
+    ASSERT_TRUE(configManager1.loadConfig());
+
+    // Modify config
+    linglong::driver::detect::DriverDetectionConfig config;
+    config.neverRemind = true;
+    configManager1.setConfig(config);
+
+    // Save to file
+    ASSERT_TRUE(configManager1.saveConfig());
+
+    // Load from file into new config manager
+    linglong::driver::detect::DriverDetectionConfigManager configManager2(versionFilePath.string());
+    bool loadResult = configManager2.loadConfig();
+    EXPECT_TRUE(loadResult);
+
+    // Verify configs match
+    auto config1 = configManager1.getConfig();
+    auto config2 = configManager2.getConfig();
+    EXPECT_EQ(config1.neverRemind, config2.neverRemind);
+}
+
+TEST_F(DriverDetectorTest, GraphicsDriverInfoStructure)
+{
+    // Test GraphicsDriverInfo structure
+    linglong::driver::detect::GraphicsDriverInfo info;
+    info.identify = "org.deepin.driver.display.nvidia";
+    info.version = "470.161.03";
+    info.packageName = "nvidia-driver-470";
+    info.isInstalled = true;
+
+    EXPECT_EQ(info.identify, "org.deepin.driver.display.nvidia");
+    EXPECT_EQ(info.version, "470.161.03");
+    EXPECT_EQ(info.packageName, "nvidia-driver-470");
+    EXPECT_TRUE(info.isInstalled);
+}
+
+TEST_F(DriverDetectorTest, ConfigManagerUserChoice)
+{
+    linglong::driver::detect::DriverDetectionConfigManager configManager(versionFilePath.string());
+    ASSERT_TRUE(configManager.loadConfig());
+
+    configManager.recordUserChoice(linglong::driver::detect::UserNotificationChoice::InstallNow);
+
+    // Initially should show notification
+    EXPECT_TRUE(configManager.shouldShowNotification());
+
+    // Record user choice to never remind
+    configManager.recordUserChoice(linglong::driver::detect::UserNotificationChoice::NeverRemind);
+
+    // Should not show notification anymore
+    EXPECT_FALSE(configManager.shouldShowNotification());
+}
+
+TEST_F(DriverDetectorTest, MemoryManagement)
+{
+    // Test that detector properly manages memory
+    for (int i = 0; i < 100; ++i) {
+        linglong::driver::detect::NVIDIADriverDetector detector;
+        auto result = detector.detect();
+        // Just ensure no crashes occur
+        EXPECT_TRUE(result.has_value() || !result.has_value());
+    }
+    // If we get here without crashes, memory management is working
+}
+
+TEST_F(DriverDetectorTest, ConcurrentDetection)
+{
+    // Test that multiple detectors can be created and used
+    linglong::driver::detect::NVIDIADriverDetector detector1;
+    linglong::driver::detect::NVIDIADriverDetector detector2;
+
+    auto result1 = detector1.detect();
+    auto result2 = detector2.detect();
+
+    // Both should complete without issues
+    EXPECT_TRUE(result1.has_value() || !result1.has_value());
+    EXPECT_TRUE(result2.has_value() || !result2.has_value());
+}

--- a/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/nvidia_driver_detector_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/nvidia_driver_detector_test.cpp
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "nvidia_driver_detector.h"
+
+#include <filesystem>
+#include <fstream>
+
+using namespace linglong::driver::detect;
+using ::testing::_;
+using ::testing::Return;
+
+namespace {
+std::filesystem::path GetTempVersionFilePath()
+{
+    return std::filesystem::temp_directory_path() / "nvidia_test_version_file.txt";
+}
+} // namespace
+
+// A mock class that only mocks checkPackageInstalled, as getDriverVersion is no longer virtual
+class TestableNVIDIADriverDetector : public NVIDIADriverDetector
+{
+public:
+    explicit TestableNVIDIADriverDetector(std::string versionFilePath)
+        : NVIDIADriverDetector(std::move(versionFilePath))
+    {
+    }
+
+    MOCK_METHOD(linglong::utils::error::Result<bool>,
+                checkPackageInstalled,
+                (const std::string &),
+                (override));
+    MOCK_METHOD(linglong::utils::error::Result<void>,
+                checkPackageExists,
+                (const std::string &),
+                (override));
+};
+
+class NvidiaDriverDetectorTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        versionFilePath = GetTempVersionFilePath();
+        std::filesystem::remove(versionFilePath); // Ensure clean slate
+    }
+
+    void TearDown() override { std::filesystem::remove(versionFilePath); }
+
+    // Helper to create a mock version file
+    void createMockVersionFile(const std::string &content)
+    {
+        std::ofstream file(versionFilePath);
+        ASSERT_TRUE(file.is_open()) << "Failed to create mock version file: " << versionFilePath;
+        file << content;
+        file.close();
+    }
+
+    std::filesystem::path versionFilePath;
+};
+
+TEST_F(NvidiaDriverDetectorTest, Detect_Success_PackageNotInstalled)
+{
+    createMockVersionFile("510.85.02"); // Simplified version format now
+    TestableNVIDIADriverDetector detector(versionFilePath.string());
+    const std::string expectedVersion = "510-85-02"; // With dots replaced by dashes
+    const std::string expectedPackageName =
+      std::string(detector.getDriverIdentify()) + "." + expectedVersion;
+
+    EXPECT_CALL(detector, checkPackageExists(expectedPackageName))
+      .WillOnce(Return(linglong::utils::error::Result<void>()));
+    EXPECT_CALL(detector, checkPackageInstalled(expectedPackageName)).WillOnce(Return(false));
+
+    auto result = detector.detect();
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->identify, detector.getDriverIdentify());
+    EXPECT_EQ(result->version, expectedVersion);
+    EXPECT_EQ(result->packageName, expectedPackageName);
+    EXPECT_FALSE(result->isInstalled);
+}
+
+TEST_F(NvidiaDriverDetectorTest, Detect_Success_PackageAlreadyInstalled)
+{
+    createMockVersionFile("510.85.02");
+    TestableNVIDIADriverDetector detector(versionFilePath.string());
+    const std::string expectedVersion = "510-85-02";
+    const std::string expectedPackageName =
+      std::string(detector.getDriverIdentify()) + "." + expectedVersion;
+
+    EXPECT_CALL(detector, checkPackageExists(expectedPackageName))
+      .WillOnce(Return(linglong::utils::error::Result<void>()));
+    EXPECT_CALL(detector, checkPackageInstalled(expectedPackageName)).WillOnce(Return(true));
+
+    auto result = detector.detect();
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->identify, detector.getDriverIdentify());
+    EXPECT_EQ(result->version, expectedVersion);
+    EXPECT_EQ(result->packageName, expectedPackageName);
+    EXPECT_TRUE(result->isInstalled);
+}
+
+TEST_F(NvidiaDriverDetectorTest, Detect_Fails_When_VersionFileDoesNotExist)
+{
+    std::filesystem::remove(versionFilePath); // Ensure file does not exist
+    TestableNVIDIADriverDetector detector(versionFilePath.string());
+
+    EXPECT_CALL(detector, checkPackageInstalled(_)).Times(0); // Should not be called
+
+    auto result = detector.detect();
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().message(), "Failed to get NVIDIA driver version");
+}
+
+TEST_F(NvidiaDriverDetectorTest, Detect_Fails_When_VersionFileIsEmpty)
+{
+    createMockVersionFile(""); // Empty file
+    TestableNVIDIADriverDetector detector(versionFilePath.string());
+
+    EXPECT_CALL(detector, checkPackageInstalled(_)).Times(0); // Should not be called
+
+    auto result = detector.detect();
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().message(), "Failed to get NVIDIA driver version");
+}

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -64,6 +64,7 @@ pfl_add_library(
   Qt${QT_VERSION_MAJOR}::Core
   Qt${QT_VERSION_MAJOR}::DBus
   PkgConfig::glib2
+  PkgConfig::systemd
   fmt::fmt
   tl::expected
   ytj::ytj

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -18,8 +18,6 @@ cgg
 cs
 da
 de
-de_CH
-de_DE
 el
 el_GR
 en_AU

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -12,3 +12,6 @@ apps/ll-builder/src/main.cpp
 # ll-dialog
 apps/ll-dialog/src/permissionDialog.cpp
 apps/ll-dialog/src/cache_dialog.cpp
+
+# ll-driver_detection
+apps/ll-driver-detect/src/main.cpp

--- a/po/linyaps.pot
+++ b/po/linyaps.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-21 17:24+0800\n"
+"POT-Creation-Date: 2025-12-11 20:52+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,101 +17,109 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:76
-msgid "Permission denied, please check whether you are running as root."
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:537
-msgid "To install the module, one must first install the app."
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:540
-msgid "Module is already installed."
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:543
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1297
-msgid "Install failed"
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:546
-msgid "The module could not be found remotely."
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:549
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1784
-msgid "Uninstall failed"
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:552
-msgid "Upgrade failed"
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:555
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1765
-msgid "Application is not installed."
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:558
-msgid "Remote application is not found."
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:561
-msgid "Latest version is already installed."
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:796
+#: ../libs/linglong/src/linglong/cli/cli.cpp:640
 msgid "privileged mode requires running as root"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1271
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1570
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1053
+#, c++-format
+msgid "Application {} is not installed."
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1063
+#, c++-format
+msgid "{} is not an application."
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1157
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2520
 msgid ""
 "Network connection failed. Please:\n"
 "1. Check your internet connection\n"
 "2. Verify network proxy settings if used"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1277
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2219
+msgid ""
+"The cache generation failed, please uninstall and reinstall the application."
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2405
+msgid "To install the module, one must first install the app."
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2408
+msgid "Module is already installed."
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2411
+msgid "The module could not be found remotely."
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2415
+#, c++-format
 msgid ""
 "Application already installed, If you want to replace it, try using 'll-cli "
-"install %1 --force'"
+"install {} --force'"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1283
-msgid "Application %1 is not found in remote repo."
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2421
+#, c++-format
+msgid "Application {} is not found in remote repo."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1287
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2424
 msgid "Cannot specify a version when installing a module."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1291
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2428
+#, c++-format
 msgid ""
 "The latest version has been installed. If you want to replace it, try using "
-"'ll-cli install %1/version --force'"
+"'ll-cli install {} --force'"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1769
-msgid ""
-"Multiple versions of the package are installed. Please specify a single "
-"version to uninstall:\n"
-"%1"
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2434
+msgid "Install failed"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1775
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2456
 msgid ""
 "The application is currently running and cannot be uninstalled. Please turn "
 "off the application and try again."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1780
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2464
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2497
+msgid "Application is not installed."
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2468
+#, c++-format
+msgid ""
+"Multiple versions of the package are installed. Please specify a single "
+"version to uninstall:\n"
+"{}"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2474
 msgid "Base or runtime cannot be uninstalled, please use 'll-cli prune'."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2800
-msgid ""
-"The cache generation failed, please uninstall and reinstall the application."
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2478
+msgid "Uninstall failed"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2501
+msgid "Upgrade failed"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2525
+msgid "Package not found"
+msgstr ""
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2528
+msgid "Operation canceled"
 msgstr ""
 
 #: ../apps/ll-cli/src/main.cpp:146 ../apps/ll-builder/src/main.cpp:100
@@ -276,36 +284,44 @@ msgstr ""
 msgid "Uninstall a specify module"
 msgstr ""
 
-#. below options are used for compatibility with old ll-cli
 #: ../apps/ll-cli/src/main.cpp:331
+msgid "Force uninstall base or runtime"
+msgstr ""
+
+#. below options are used for compatibility with old ll-cli
+#: ../apps/ll-cli/src/main.cpp:334
 msgid "Remove all unused modules"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:335
+#: ../apps/ll-cli/src/main.cpp:338
 msgid "Uninstall all modules"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:345
+#: ../apps/ll-cli/src/main.cpp:348
 msgid "Upgrade the application or runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:348
+#: ../apps/ll-cli/src/main.cpp:351
 msgid "Usage: ll-cli upgrade [OPTIONS] [APP]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:352
+#: ../apps/ll-cli/src/main.cpp:355
 msgid ""
 "Specify the application ID. If it not be specified, all applications will be "
 "upgraded"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:364
+#: ../apps/ll-cli/src/main.cpp:360
+msgid "Only upgrade dependencies of application"
+msgstr ""
+
+#: ../apps/ll-cli/src/main.cpp:370
 msgid ""
 "Search the applications/runtimes containing the specified text from the "
 "remote repository"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:368
+#: ../apps/ll-cli/src/main.cpp:374
 msgid ""
 "Usage: ll-cli search [OPTIONS] KEYWORDS\n"
 "\n"
@@ -320,33 +336,33 @@ msgid ""
 "ll-cli search . --type=runtime"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:379
+#: ../apps/ll-cli/src/main.cpp:385
 msgid "Specify the Keywords"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:386 ../apps/ll-cli/src/main.cpp:425
+#: ../apps/ll-cli/src/main.cpp:392 ../apps/ll-cli/src/main.cpp:431
 msgid ""
 "Filter result with specify type. One of \"runtime\", \"base\", \"app\" or "
 "\"all\""
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:390
+#: ../apps/ll-cli/src/main.cpp:396
 msgid "Specify the repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:395
+#: ../apps/ll-cli/src/main.cpp:401
 msgid "Include develop application in result"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:398
+#: ../apps/ll-cli/src/main.cpp:404
 msgid "Show all versions of an application(s), base(s) or runtime(s)"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:406
+#: ../apps/ll-cli/src/main.cpp:412
 msgid "List installed application(s), base(s) or runtime(s)"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:409
+#: ../apps/ll-cli/src/main.cpp:415
 msgid ""
 "Usage: ll-cli list [OPTIONS]\n"
 "\n"
@@ -361,44 +377,44 @@ msgid ""
 "ll-cli list --upgradable\n"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:431
+#: ../apps/ll-cli/src/main.cpp:437
 msgid ""
 "Show the list of latest version of the currently installed application(s), "
 "base(s) or runtime(s)"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:441
+#: ../apps/ll-cli/src/main.cpp:447
 msgid "Display or modify information of the repository currently using"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:443
+#: ../apps/ll-cli/src/main.cpp:449
 msgid "Usage: ll-cli repo SUBCOMMAND [OPTIONS]"
 msgstr ""
 
 #. add repo sub command add
-#: ../apps/ll-cli/src/main.cpp:447 ../apps/ll-builder/src/main.cpp:959
+#: ../apps/ll-cli/src/main.cpp:453 ../apps/ll-builder/src/main.cpp:959
 msgid "Add a new repository"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:448
+#: ../apps/ll-cli/src/main.cpp:454
 msgid "Usage: ll-cli repo add [OPTIONS] NAME URL"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:449 ../apps/ll-cli/src/main.cpp:461
+#: ../apps/ll-cli/src/main.cpp:455 ../apps/ll-cli/src/main.cpp:467
 #: ../apps/ll-builder/src/main.cpp:961
 msgid "Specify the repo name"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:452 ../apps/ll-cli/src/main.cpp:464
-#: ../apps/ll-cli/src/main.cpp:482 ../apps/ll-builder/src/main.cpp:964
+#: ../apps/ll-cli/src/main.cpp:458 ../apps/ll-cli/src/main.cpp:470
+#: ../apps/ll-cli/src/main.cpp:488 ../apps/ll-builder/src/main.cpp:964
 #: ../apps/ll-builder/src/main.cpp:987
 msgid "Url of the repository"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:455 ../apps/ll-cli/src/main.cpp:471
-#: ../apps/ll-cli/src/main.cpp:479 ../apps/ll-cli/src/main.cpp:490
-#: ../apps/ll-cli/src/main.cpp:502 ../apps/ll-cli/src/main.cpp:512
-#: ../apps/ll-cli/src/main.cpp:519 ../apps/ll-builder/src/main.cpp:968
+#: ../apps/ll-cli/src/main.cpp:461 ../apps/ll-cli/src/main.cpp:477
+#: ../apps/ll-cli/src/main.cpp:485 ../apps/ll-cli/src/main.cpp:496
+#: ../apps/ll-cli/src/main.cpp:508 ../apps/ll-cli/src/main.cpp:518
+#: ../apps/ll-cli/src/main.cpp:525 ../apps/ll-builder/src/main.cpp:968
 #: ../apps/ll-builder/src/main.cpp:976 ../apps/ll-builder/src/main.cpp:984
 #: ../apps/ll-builder/src/main.cpp:996 ../apps/ll-builder/src/main.cpp:1005
 #: ../apps/ll-builder/src/main.cpp:1014
@@ -406,156 +422,156 @@ msgid "Alias of the repo name"
 msgstr ""
 
 #. add repo sub command modify
-#: ../apps/ll-cli/src/main.cpp:460
+#: ../apps/ll-cli/src/main.cpp:466
 msgid "Modify repository URL"
 msgstr ""
 
 #. add repo sub command remove
-#: ../apps/ll-cli/src/main.cpp:469 ../apps/ll-builder/src/main.cpp:973
+#: ../apps/ll-cli/src/main.cpp:475 ../apps/ll-builder/src/main.cpp:973
 msgid "Remove a repository"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:470
+#: ../apps/ll-cli/src/main.cpp:476
 msgid "Usage: ll-cli repo remove [OPTIONS] NAME"
 msgstr ""
 
 #. add repo sub command update
 #. TODO: add --repo and --url options
 #. add repo sub command update
-#: ../apps/ll-cli/src/main.cpp:477 ../apps/ll-builder/src/main.cpp:981
+#: ../apps/ll-cli/src/main.cpp:483 ../apps/ll-builder/src/main.cpp:981
 msgid "Update the repository URL"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:478
+#: ../apps/ll-cli/src/main.cpp:484
 msgid "Usage: ll-cli repo update [OPTIONS] NAME URL"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:488 ../apps/ll-builder/src/main.cpp:993
+#: ../apps/ll-cli/src/main.cpp:494 ../apps/ll-builder/src/main.cpp:993
 msgid "Set a default repository name"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:489
+#: ../apps/ll-cli/src/main.cpp:495
 msgid "Usage: ll-cli repo set-default [OPTIONS] NAME"
 msgstr ""
 
 #. add repo sub command show
-#: ../apps/ll-cli/src/main.cpp:495 ../apps/ll-builder/src/main.cpp:1019
+#: ../apps/ll-cli/src/main.cpp:501 ../apps/ll-builder/src/main.cpp:1019
 msgid "Show repository information"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:496
+#: ../apps/ll-cli/src/main.cpp:502
 msgid "Usage: ll-cli repo show [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:500
+#: ../apps/ll-cli/src/main.cpp:506
 msgid "Set the priority of the repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:501
+#: ../apps/ll-cli/src/main.cpp:507
 msgid "Usage: ll-cli repo set-priority ALIAS PRIORITY"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:505
+#: ../apps/ll-cli/src/main.cpp:511
 msgid "Priority of the repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:510 ../apps/ll-builder/src/main.cpp:1002
+#: ../apps/ll-cli/src/main.cpp:516 ../apps/ll-builder/src/main.cpp:1002
 msgid "Enable mirror for the repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:511
+#: ../apps/ll-cli/src/main.cpp:517
 msgid "Usage: ll-cli repo enable-mirror [OPTIONS] ALIAS"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:517 ../apps/ll-builder/src/main.cpp:1011
+#: ../apps/ll-cli/src/main.cpp:523 ../apps/ll-builder/src/main.cpp:1011
 msgid "Disable mirror for the repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:518
+#: ../apps/ll-cli/src/main.cpp:524
 msgid "Usage: ll-cli repo disable-mirror [OPTIONS] ALIAS"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:529
+#: ../apps/ll-cli/src/main.cpp:535
 msgid "Display information about installed apps or runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:532
+#: ../apps/ll-cli/src/main.cpp:538
 msgid "Usage: ll-cli info [OPTIONS] APP"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:536
+#: ../apps/ll-cli/src/main.cpp:542
 msgid "Specify the application ID, and it can also be a .layer file"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:548
+#: ../apps/ll-cli/src/main.cpp:554
 msgid "Display the exported files of installed application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:551
+#: ../apps/ll-cli/src/main.cpp:557
 msgid "Usage: ll-cli content [OPTIONS] APP"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:552
+#: ../apps/ll-cli/src/main.cpp:558
 msgid "Specify the installed application ID"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:560
+#: ../apps/ll-cli/src/main.cpp:566
 msgid "Remove the unused base or runtime"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:562
+#: ../apps/ll-cli/src/main.cpp:568
 msgid "Usage: ll-cli prune [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:573
+#: ../apps/ll-cli/src/main.cpp:579
 msgid "Display the inspect information of the installed application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:575
+#: ../apps/ll-cli/src/main.cpp:581
 msgid "Usage: ll-cli inspect SUBCOMMAND [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:582
+#: ../apps/ll-cli/src/main.cpp:588
 msgid ""
 "Display the data(bundle) directory of the installed(running) application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:583
+#: ../apps/ll-cli/src/main.cpp:589
 msgid "Usage: ll-cli inspect dir [OPTIONS] APP"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:587
+#: ../apps/ll-cli/src/main.cpp:593
 msgid "Specify the application ID, and it can also be reference"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:593
+#: ../apps/ll-cli/src/main.cpp:599
 msgid "Specify the directory type (layer or bundle),the default is layer"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:600
+#: ../apps/ll-cli/src/main.cpp:606
 msgid ""
 "Specify the module type (binary or develop). Only works when type is layer"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:639
+#: ../apps/ll-cli/src/main.cpp:640
 msgid ""
 "linyaps CLI\n"
 "A CLI program to run application and manage application and runtime\n"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:647 ../apps/ll-builder/src/main.cpp:747
+#: ../apps/ll-cli/src/main.cpp:648 ../apps/ll-builder/src/main.cpp:747
 msgid "Print this help message and exit"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:648 ../apps/ll-builder/src/main.cpp:748
+#: ../apps/ll-cli/src/main.cpp:649 ../apps/ll-builder/src/main.cpp:748
 msgid "Expand all help"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:649
+#: ../apps/ll-cli/src/main.cpp:650
 msgid "Usage: ll-cli [OPTIONS] [SUBCOMMAND]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:650
+#: ../apps/ll-cli/src/main.cpp:651
 msgid ""
 "If you found any problems during use,\n"
 "You can report bugs to the linyaps team under this project: https://github."
@@ -563,55 +579,55 @@ msgid ""
 msgstr ""
 
 #. version flag
-#: ../apps/ll-cli/src/main.cpp:657 ../apps/ll-builder/src/main.cpp:772
+#: ../apps/ll-cli/src/main.cpp:658 ../apps/ll-builder/src/main.cpp:772
 msgid "Show version"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:662
+#: ../apps/ll-cli/src/main.cpp:663
 msgid ""
 "Use peer to peer DBus, this is used only in case that DBus daemon is not "
 "available"
 msgstr ""
 
 #. json flag
-#: ../apps/ll-cli/src/main.cpp:667
+#: ../apps/ll-cli/src/main.cpp:668
 msgid "Use json format to output result"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:674
+#: ../apps/ll-cli/src/main.cpp:675
 msgid "Show debug info (verbose logs)"
 msgstr ""
 
 #. groups for subcommands
-#: ../apps/ll-cli/src/main.cpp:691
+#: ../apps/ll-cli/src/main.cpp:692
 msgid "Managing installed applications and runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:692
+#: ../apps/ll-cli/src/main.cpp:693
 msgid "Managing running applications"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:693
+#: ../apps/ll-cli/src/main.cpp:694
 msgid "Finding applications and runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:694
+#: ../apps/ll-cli/src/main.cpp:695
 msgid "Managing remote repositories"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:720
+#: ../apps/ll-cli/src/main.cpp:721
 msgid "linyaps CLI version "
 msgstr ""
 
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:71
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:134
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:329
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:310
 msgid "ID"
 msgstr ""
 
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:72
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:135
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:253
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:247
 msgid "Name"
 msgstr ""
 
@@ -659,27 +675,27 @@ msgstr ""
 msgid "Pid"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:254
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:248
 msgid "Url"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:255
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:249
 msgid "Alias"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:256
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:250
 msgid "Priority"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:317
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:298
 msgid "No apps available for update."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:330
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:311
 msgid "Installed"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:331
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:312
 msgid "New"
 msgstr ""
 
@@ -967,4 +983,45 @@ msgstr ""
 
 #: ../apps/ll-dialog/src/cache_dialog.cpp:54
 msgid "is starting"
+msgstr ""
+
+#. Define command line options
+#: ../apps/ll-driver-detect/src/main.cpp:141
+msgid "Force installation even if recently reminded"
+msgstr ""
+
+#: ../apps/ll-driver-detect/src/main.cpp:144
+msgid "Check for drivers only without installing or notifying"
+msgstr ""
+
+#: ../apps/ll-driver-detect/src/main.cpp:147
+msgid "Only install drivers without notifications"
+msgstr ""
+
+#: ../apps/ll-driver-detect/src/main.cpp:254
+msgid "Graphics Driver Available"
+msgstr ""
+
+#: ../apps/ll-driver-detect/src/main.cpp:256
+msgid ""
+"Graphics driver package is available that can improve performance for some "
+"Linyaps applications. Would you like to install it?"
+msgstr ""
+
+#: ../apps/ll-driver-detect/src/main.cpp:259
+msgid "Install Now"
+msgstr ""
+
+#: ../apps/ll-driver-detect/src/main.cpp:259
+msgid "Don't Remind"
+msgstr ""
+
+#: ../apps/ll-driver-detect/src/main.cpp:284
+msgid "Graphics Driver Installation Completed"
+msgstr ""
+
+#: ../apps/ll-driver-detect/src/main.cpp:286
+msgid ""
+"Graphics driver package has been installed. Restart the Linyaps app to "
+"experience the performance improvement."
 msgstr ""


### PR DESCRIPTION
Introduce a new command-line tool that automatically detects installed NVIDIA graphics drivers, maps them to the corresponding Linglong driver packages, and notifies users of available updates. The utility supports multiple operation modes (auto, check-only, install-only), configurable notification intervals, and persistent user preferences. Integration includes CMake build rules and updated translation strings.