### PR TITLE
fix: prevent concurrent repository operations

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.h
+++ b/libs/linglong/src/linglong/package_manager/package_manager.h
@@ -172,6 +172,8 @@ private:
 
     int lockFd{ -1 };
     linglong::runtime::ContainerBuilder &containerBuilder;
+
+    bool taskRepoInOperation = false;
 };
 
 } // namespace linglong::service

--- a/libs/utils/src/linglong/utils/error/error.h
+++ b/libs/utils/src/linglong/utils/error/error.h
@@ -28,6 +28,7 @@ enum class ErrorCode : int {
     Unknown = 1000,               // 未知错误
     AppNotFoundFromRemote = 1001, // 从远程找不到对应应用
     AppNotFoundFromLocal = 1002,  // 从本地找不到对应应用
+    RepoInOperation = 1003,
 
     /* 安装 */
     AppInstallFailed = 2001,                // 安装失败

--- a/libs/utils/src/linglong/utils/finally/finally.h
+++ b/libs/utils/src/linglong/utils/finally/finally.h
@@ -25,6 +25,7 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include <memory>
 #include <utility>
 
 namespace linglong::utils::finally {
@@ -73,5 +74,11 @@ template <class F>
 [[nodiscard]] auto finally(F &&f) noexcept
 {
     return final_action<std::decay_t<F>>{ std::forward<F>(f) };
+}
+
+template <class F>
+[[nodiscard]] auto shared_finally(F &&f) noexcept
+{
+    return std::make_shared<final_action<std::decay_t<F>>>(std::forward<F>(f));
 }
 } // namespace linglong::utils::finally


### PR DESCRIPTION
Introduce a flag to reject new package management tasks (install, uninstall, update, prune) when an operation is already in progress.