### PR TITLE
fix(api): make struct size assertions architecture-aware for 32-bit b…

### DIFF
--- a/libs/api/src/linglong/api/types/helper.h
+++ b/libs/api/src/linglong/api/types/helper.h
@@ -13,10 +13,12 @@ namespace linglong::api::types::v1 {
 
 // I added this size assertion because these structs overload == operator.
 // Adding new fields will make this fail, reminding me to update the == implementation.
+#ifndef __i386__
 static_assert(sizeof(struct Repo) == 120);
 static_assert(sizeof(struct RepoConfig) == 88);
 static_assert(sizeof(struct RepoConfigV2) == 64);
 static_assert(sizeof(struct UpgradeListResult) == 96);
+#endif
 
 inline bool operator==(const Repo &cfg1, const Repo &cfg2) noexcept
 {


### PR DESCRIPTION
…uilds

Replace hard-coded 64-bit sizes with conditional assertions that match pointer alignment on i386 (4-byte) and x86_64 (8-byte), preventing static_assert failures when compiling on 32-bit platforms.