### PR TITLE
fix(ll-driver-detect): replace busy-wait with signal-slot for notific…

### DIFF
--- a/apps/ll-driver-detect/src/main.cpp
+++ b/apps/ll-driver-detect/src/main.cpp
@@ -258,6 +258,7 @@ int main(int argc, char *argv[])
     request.actions = QStringList()
       << kActionInstallNow << _("Install Now") << kActionNotRemind << _("Don't Remind");
     request.icon = kNotificationIcon;
+    request.timeout = 25000; // 25 seconds
 
     auto responseResult = notifier->sendInteractiveNotification(request);
     if (!responseResult) {


### PR DESCRIPTION
…ation response

Eliminates CPU-intensive polling by connecting notificationClosed and actionInvoked signals to QEventLoop::quit, ensuring prompt exit when the user interacts or the notification expires.