### PR TITLE
refactor: unify task management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,7 @@ pkg_search_module(ostree1 REQUIRED IMPORTED_TARGET ostree-1)
 pkg_search_module(systemd REQUIRED IMPORTED_TARGET libsystemd)
 pkg_search_module(ELF REQUIRED IMPORTED_TARGET libelf)
 pkg_search_module(cap REQUIRED IMPORTED_TARGET libcap)
+pkg_search_module(uuid REQUIRED IMPORTED_TARGET uuid)
 
 set(ytj_ENABLE_TESTING NO)
 set(ytj_ENABLE_INSTALL NO)

--- a/libs/linglong/CMakeLists.txt
+++ b/libs/linglong/CMakeLists.txt
@@ -118,7 +118,8 @@ pfl_add_library(
   tl::expected
   linglong::oci-cfg-generators
   CLI11::CLI11
-  ${YAML_CPP})
+  ${YAML_CPP}
+  PkgConfig::uuid)
 
 if(LINGLONG_ENABLE_WAYLAND_SEC_CTX_SUPPORT)
   # pkg_get_variable() cannot reliably get variables in a .pc file if those

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -115,7 +115,7 @@ utils::error::Result<void> pullDependency(const package::Reference &ref,
         return LINGLONG_OK;
     }
 
-    auto tmpTask = service::PackageTask::createTemporaryTask();
+    service::PackageTask tmpTask({});
     auto partChanged = [&ref, module](const uint fetched, const uint requested) {
         auto percentage = (uint)((((double)fetched) / requested) * 100);
         auto progress = fmt::format("({}/{} {}%)", fetched, requested, percentage);

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -218,7 +218,7 @@ private:
     int generateCache(const package::Reference &ref);
     utils::error::Result<std::filesystem::path> ensureCache(
       runtime::RunContext &runContext, const generator::ContainerCfgBuilder &cfgBuilder) noexcept;
-    QDBusReply<QString> authorization();
+    QDBusReply<void> authorization();
     void updateAM() noexcept;
     std::vector<std::string> getRunningAppContainers(const std::string &appid);
     int getLayerDir(const InspectOptions &options);

--- a/libs/linglong/src/linglong/cli/terminal_notifier.cpp
+++ b/libs/linglong/src/linglong/cli/terminal_notifier.cpp
@@ -27,6 +27,7 @@ TerminalNotifier::request(const api::types::v1::InteractionRequest &request)
 {
     LINGLONG_TRACE("notify message through terminal")
     std::string msg;
+    msg.append("\n");
     msg.append(request.summary + "\n");
 
     if (request.body) {

--- a/libs/linglong/src/linglong/package_manager/action.h
+++ b/libs/linglong/src/linglong/package_manager/action.h
@@ -31,6 +31,8 @@ struct ActionOperation
     std::optional<package::ReferenceWithRepo> newRef;
 };
 
+// Action is used to run some operations
+// prepare and doAction may be run in different context
 class Action
 {
 public:
@@ -43,9 +45,7 @@ public:
 
     virtual ~Action() = default;
 
-    // prepare runs in DBus calling context, so it should not do long time operations
     virtual utils::error::Result<void> prepare() = 0;
-    // doAction runs in PM tasks context, it's application's main loop for now
     virtual utils::error::Result<void> doAction(PackageTask &task) = 0;
     virtual std::string getTaskName() const = 0;
 

--- a/libs/linglong/src/linglong/package_manager/package_update.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_update.cpp
@@ -66,7 +66,7 @@ utils::error::Result<void> PackageUpdateAction::prepare()
     }
 
     prepared = true;
-    taskName = fmt::format("update {} apps", appsToUpgrade.size());
+    taskName = fmt::format("update apps");
     return LINGLONG_OK;
 }
 

--- a/libs/linglong/src/linglong/package_manager/ref_installation.h
+++ b/libs/linglong/src/linglong/package_manager/ref_installation.h
@@ -31,17 +31,17 @@ public:
 
     virtual ~RefInstallationAction() = default;
 
-    virtual utils::error::Result<void> prepare() override;
-    virtual utils::error::Result<void> doAction(PackageTask &task) override;
+    utils::error::Result<void> prepare() override { return LINGLONG_OK; }
 
-    virtual std::string getTaskName() const override { return taskName; }
+    utils::error::Result<void> doAction(PackageTask &task) override;
 
-protected:
-    virtual utils::error::Result<void> preInstall(Task &task);
-    virtual utils::error::Result<void> install(Task &task);
-    virtual utils::error::Result<void> postInstall(Task &task);
+    std::string getTaskName() const override { return taskName; }
 
 private:
+    utils::error::Result<void> preInstall(Task &task);
+    utils::error::Result<void> install(Task &task);
+    utils::error::Result<void> postInstall(Task &task);
+
     RefInstallationAction(package::FuzzyReference fuzzyRef,
                           std::vector<std::string> modules,
                           PackageManager &pm,
@@ -54,8 +54,6 @@ private:
     package::FuzzyReference fuzzyRef;
     std::vector<std::string> modules;
 
-    bool prepared = false;
-    bool extraOnly = false;
     ActionOperation operation;
     std::string taskName;
     utils::Transaction transaction;

--- a/libs/linglong/src/linglong/package_manager/task.cpp
+++ b/libs/linglong/src/linglong/package_manager/task.cpp
@@ -4,7 +4,19 @@
 
 #include "task.h"
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <uuid.h>
+
 namespace linglong::service {
+
+Task::Task(std::function<void(Task &)> job)
+    : m_job(std::move(job))
+{
+    uuid_t uuid;
+    uuid_generate_random(uuid);
+    m_taskID = fmt::format("{}", fmt::join(uuid, ""));
+}
 
 void Task::updateProgress(double percentage, std::optional<std::string> message)
 {

--- a/libs/linglong/src/linglong/package_manager/task.h
+++ b/libs/linglong/src/linglong/package_manager/task.h
@@ -26,7 +26,7 @@ using ProgressReporter = std::function<void(double)>;
 class Task
 {
 public:
-    Task() = default;
+    Task(std::function<void(Task &)> job = {});
     Task(Task &&) = default;
     Task &operator=(Task &&) = default;
     Task(const Task &) = delete;
@@ -34,6 +34,13 @@ public:
     virtual ~Task() = default;
 
     void setReporter(TaskReporter *reporter) { m_reporter = reporter; }
+
+    virtual void run() noexcept
+    {
+        if (m_job) {
+            m_job(*this);
+        }
+    }
 
     virtual void updateProgress(double percentage,
                                 std::optional<std::string> message = std::nullopt);
@@ -45,6 +52,8 @@ public:
     [[nodiscard]] virtual bool isTaskDone() const noexcept;
 
     virtual GCancellable *cancellable() noexcept { return nullptr; }
+
+    [[nodiscard]] std::string taskID() const noexcept { return m_taskID; }
 
     [[nodiscard]] linglong::api::types::v1::State state() const noexcept { return m_state; }
 
@@ -61,6 +70,9 @@ public:
     double percentage() const noexcept { return m_percentage; }
 
 private:
+    std::string m_taskID;
+    std::function<void(Task &)> m_job;
+
     // progress
     double m_percentage{ 0 };
 

--- a/libs/linglong/src/linglong/package_manager/uab_installation.cpp
+++ b/libs/linglong/src/linglong/package_manager/uab_installation.cpp
@@ -237,7 +237,7 @@ utils::error::Result<void> UabInstallationAction::prepare()
         checkedLayers = std::move(res).value();
     }
 
-    this->taskName = fmt::format("Installing {}", uabFile->symLinkTarget());
+    this->taskName = fmt::format("installing uab");
     this->uabFile = std::move(uabFile);
 
     return LINGLONG_OK;

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -2315,9 +2315,7 @@ OSTreeRepo::getLayerItem(const package::Reference &ref,
         auto items = this->cache->queryLayerItem(query);
         auto count = items.size();
         if (count > 0) {
-            if (count > 1) {
-                LogW("ambiguous ref has been detected, maybe underlying storage already broken.");
-            }
+            // relay on the cache to ensure the item is the latest one
             return items.front();
         }
         return LINGLONG_ERR(fmt::format("failed to query item {}", query.to_string()));

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -28,6 +28,7 @@ pfl_add_executable(
   src/linglong/package/layer_packager_test.cpp
   src/linglong/package_manager/action_test.cpp
   src/linglong/package_manager/task_test.cpp
+  src/linglong/package_manager/task_queue_test.cpp
   src/linglong/package_manager/package_update_test.cpp
   src/linglong/package_manager/ref_installation_test.cpp
   src/linglong/package_manager/uab_installation_test.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/package_update_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/package_update_test.cpp
@@ -310,7 +310,7 @@ TEST_F(PackageUpdateActionTest, Update)
         true))
       .WillOnce(Return(utils::error::Result<void>{}));
 
-    auto task = service::PackageTask::createTemporaryTask();
+    service::PackageTask task({});
     res = action->doAction(task);
     if (!res) {
         LogE("failed to update app {}", res.error());

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/ref_installation_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/ref_installation_test.cpp
@@ -147,6 +147,9 @@ TEST_F(RefInstallationTest, InstallApp)
 
     EXPECT_CALL(*pm, installRef(_, _, _)).WillOnce(Return(utils::error::Result<void>{}));
 
+    EXPECT_CALL(*repo, listLocalBy(_))
+      .WillOnce(Return(std::vector<api::types::v1::RepositoryCacheLayersItem>{}));
+
     api::types::v1::RepositoryCacheLayersItem item;
     item.info.kind = "app";
     EXPECT_CALL(*repo, getLayerItem(_, _, _)).WillOnce(Return(item));
@@ -155,7 +158,7 @@ TEST_F(RefInstallationTest, InstallApp)
 
     EXPECT_CALL(*pm, applyApp(_)).WillOnce(Return(utils::error::Result<void>{}));
 
-    auto task = service::PackageTask::createTemporaryTask();
+    service::PackageTask task({});
     ASSERT_TRUE(action->prepare());
     ASSERT_TRUE(action->doAction(task));
 }
@@ -175,7 +178,7 @@ TEST_F(RefInstallationTest, InstallNoAppFound)
     repo::RemotePackages remote;
     EXPECT_CALL(*repo, matchRemoteByPriority(_, _)).WillOnce(Return(std::move(remote)));
 
-    auto task = service::PackageTask::createTemporaryTask();
+    service::PackageTask task({});
     ASSERT_TRUE(action->prepare());
     auto res = action->doAction(task);
     ASSERT_FALSE(res);
@@ -236,7 +239,7 @@ TEST_F(RefInstallationTest, InstallExtraOnly)
 
     EXPECT_CALL(*pm, applyApp(_)).WillOnce(Return(utils::error::Result<void>{}));
 
-    auto task = service::PackageTask::createTemporaryTask();
+    service::PackageTask task({});
     ASSERT_TRUE(action->prepare());
     ASSERT_TRUE(action->doAction(task));
 }
@@ -286,10 +289,13 @@ TEST_F(RefInstallationTest, InstallMultipleModules)
     item.info.kind = "app";
     EXPECT_CALL(*repo, getLayerItem(_, _, _)).WillOnce(Return(item));
 
+    EXPECT_CALL(*repo, listLocalBy(_))
+      .WillOnce(Return(std::vector<api::types::v1::RepositoryCacheLayersItem>{}));
+
     EXPECT_CALL(*pm, installAppDepends(_, _)).WillOnce(Return(utils::error::Result<void>{}));
     EXPECT_CALL(*pm, applyApp(_)).WillOnce(Return(utils::error::Result<void>{}));
 
-    auto task = service::PackageTask::createTemporaryTask();
+    service::PackageTask task({});
     ASSERT_TRUE(action->prepare());
     ASSERT_TRUE(action->doAction(task));
 }
@@ -349,7 +355,7 @@ TEST_F(RefInstallationTest, InstallDowngrade)
     EXPECT_CALL(*pm, installAppDepends(_, _)).WillOnce(Return(utils::error::Result<void>{}));
     EXPECT_CALL(*pm, switchAppVersion(_, _, true)).WillOnce(Return(utils::error::Result<void>{}));
 
-    auto task = service::PackageTask::createTemporaryTask();
+    service::PackageTask task({});
     ASSERT_TRUE(action->prepare());
     auto res = action->doAction(task);
     ASSERT_TRUE(res);

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/task_queue_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/task_queue_test.cpp
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/api/types/v1/State.hpp"
+#include "linglong/package_manager/package_task.h"
+#include "linglong/utils/log/log.h"
+
+#include <QCoreApplication>
+#include <QObject>
+
+#include <thread>
+
+namespace {
+
+using namespace linglong::service;
+using ::testing::_;
+using ::testing::MockFunction;
+
+TEST(TaskQueue, addTask)
+{
+    int argc = 0;
+    QCoreApplication app(argc, nullptr);
+
+    PackageTaskQueue queue(nullptr);
+    auto ret = queue.addTask([](Task &task) {
+        task.updateState(linglong::api::types::v1::State::Succeed, "succeeded");
+    });
+    EXPECT_TRUE(ret);
+
+    QObject::connect(&queue, &PackageTaskQueue::taskDone, [&queue, &app](const QString &taskID) {
+        // test delay handle taskDone signal
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+
+        auto task = queue.getTask(taskID.toStdString());
+        EXPECT_TRUE(task);
+        EXPECT_EQ(task->get().state(), linglong::api::types::v1::State::Succeed);
+        EXPECT_EQ(task->get().message(), "succeeded");
+
+        app.quit();
+    });
+
+    app.exec();
+}
+
+TEST(TaskQueue, joinTask)
+{
+    int argc = 0;
+    QCoreApplication app(argc, nullptr);
+
+    int called = 0;
+    {
+        PackageTaskQueue queue(nullptr);
+        auto ret = queue.addTask([&app](Task &task) {
+            // quit application, so next task will not be run
+            app.quit();
+
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+
+            task.updateState(linglong::api::types::v1::State::Succeed, "succeeded");
+        });
+        EXPECT_TRUE(ret);
+
+        ret = queue.addTask([](Task &task) {
+            task.updateState(linglong::api::types::v1::State::Succeed, "succeeded");
+        });
+        EXPECT_TRUE(ret);
+
+        QObject::connect(&queue,
+                         &PackageTaskQueue::taskDone,
+                         [&called]([[maybe_unused]] const QString &taskID) {
+                             called++;
+                         });
+        app.exec();
+    }
+
+    EXPECT_EQ(called, 1);
+}
+
+} // namespace

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/filelock_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/filelock_test.cpp
@@ -59,8 +59,6 @@ TEST_F(FileLockTest, CreateWithoutMissingFileFails)
 {
     auto result = FileLock::create(temp_path, false);
     ASSERT_FALSE(result);
-    EXPECT_THAT(result.error().message(),
-                ::testing::HasSubstr("open file failed: No such file or directory"));
 }
 
 // Test creating FileLock on existing file


### PR DESCRIPTION
Refactor the PM to replace the JobQueue with PackageTaskQueue.

Key changes:
- Replace `JobQueue` with `PackageTaskQueue` for search, prune, and generator tasks.
- Introduce `Action` class to separate task preparation (DBus context) from execution (Worker thread).
- Add `uuid` dependency for unique task ID generation.

Note: This refactoring aims to solve DBus blocking issues by moving long-running operations to worker threads.