### PR TITLE
fix: fix incorrect removal of re-installed layers during lazy uninstall

### DIFF
--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -107,6 +107,8 @@ public:
     remove(const package::Reference &ref,
            const std::string &module = "binary",
            const std::optional<std::string> &subRef = std::nullopt) noexcept;
+    utils::error::Result<void>
+    remove(const api::types::v1::RepositoryCacheLayersItem &item) noexcept;
 
     utils::error::Result<void> prune();
 
@@ -181,6 +183,8 @@ private:
       QDir layerDir, const api::types::v1::RepositoryCacheLayersItem &layer) noexcept;
     utils::error::Result<void>
     removeOstreeRef(const api::types::v1::RepositoryCacheLayersItem &layer) noexcept;
+    utils::error::Result<void>
+    undeployedLayer(const api::types::v1::RepositoryCacheLayersItem &layer) noexcept;
     [[nodiscard]] utils::error::Result<package::LayerDir>
     getLayerDir(const api::types::v1::RepositoryCacheLayersItem &layer) const noexcept;
 


### PR DESCRIPTION
Previously, the deferred uninstall process removed layers based on their Reference string. If a user uninstalled an app and immediately re-installed the same version (or if an update occurred pending deletion), the lazy uninstall logic would wipe the active OSTree reference, breaking the new installation.

This commit introduces the following changes:
1. In `PackageManager::deferredUninstall`, remove layers by their specific `RepositoryCacheLayersItem` (commit hash) instead of the generic Reference.
2. In `OSTreeRepo::removeOstreeRef`, add a check to ensure the OSTree ref is only removed if it still points to the commit being deleted. This protects the ref if it has moved to a new commit.
3. Refactor `OSTreeRepo::remove` to handle cleanup steps (unset ref, delete from DB, remove files) more robustly, ensuring DB consistency even if file deletion fails.