### PR TITLE
feat: Introduce cross-architecture build and export support

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -169,18 +169,17 @@ getProjectYAMLPath(const std::filesystem::path &projectDir, const std::string &u
         return path;
     }
 
-    auto arch = linglong::package::Architecture::currentCPUArchitecture();
-    if (arch && *arch != linglong::package::Architecture()) {
-        std::filesystem::path path = projectDir / ("linglong." + arch->toStdString() + ".yaml");
-        if (std::filesystem::exists(path, ec)) {
-            return path;
-        }
-        if (ec) {
-            return LINGLONG_ERR(fmt::format("path {} error: {}", path, ec.message()));
-        }
+    std::filesystem::path path = projectDir
+      / ("linglong." + linglong::package::Architecture::currentCPUArchitecture().toString()
+         + ".yaml");
+    if (std::filesystem::exists(path, ec)) {
+        return path;
+    }
+    if (ec) {
+        return LINGLONG_ERR(fmt::format("path {} error: {}", path, ec.message()));
     }
 
-    std::filesystem::path path = projectDir / "linglong.yaml";
+    path = projectDir / "linglong.yaml";
     if (std::filesystem::exists(path, ec)) {
         return path;
     }

--- a/libs/linglong/CMakeLists.txt
+++ b/libs/linglong/CMakeLists.txt
@@ -39,6 +39,8 @@ pfl_add_library(
   src/linglong/extension/extension.h
   src/linglong/package/architecture.cpp
   src/linglong/package/architecture.h
+  src/linglong/package/elf_handler.cpp
+  src/linglong/package/elf_handler.h
   src/linglong/package/fallback_version.cpp
   src/linglong/package/fallback_version.h
   src/linglong/package/fuzzy_reference.cpp

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -411,24 +411,46 @@ utils::error::Result<void> Builder::buildStageFetchSource() noexcept
     return LINGLONG_OK;
 }
 
-utils::error::Result<package::Reference> Builder::ensureUtils(const std::string &id) noexcept
+utils::error::Result<package::Reference>
+Builder::ensureUtils(const std::string &id, const package::Architecture &arch) noexcept
 {
     LINGLONG_TRACE("ensureUtils");
 
+    auto fuzzyRef = package::FuzzyReference::create(std::nullopt, id, std::nullopt, arch);
+    if (!fuzzyRef) {
+        return LINGLONG_ERR(fuzzyRef);
+    }
+
     // always try to get newest version from remote
-    auto ref = clearDependency(id, true, true);
-    auto localRef = clearDependency(id, false, false);
+    auto ref = repo.clearReference(
+      *fuzzyRef,
+      { .forceRemote = true, .fallbackToRemote = true, .semanticMatching = true });
+    auto localRef = repo.clearReference(
+      *fuzzyRef,
+      { .forceRemote = false, .fallbackToRemote = false, .semanticMatching = true });
     if (localRef) {
         if (!ref || localRef->version > ref->version) {
             ref = std::move(localRef);
+            LogD("use local tools {}", ref->toString());
         }
     }
-    if (ref && pullDependency(*ref, this->repo, "binary")) {
-        auto appLayerDir = this->repo.getMergedModuleDir(*ref);
-        if (!appLayerDir) {
-            return LINGLONG_ERR("failed to get layer dir of " + ref->toString());
-        }
 
+    if (!ref) {
+        return LINGLONG_ERR("failed to find utils " + id, ref);
+    }
+
+    auto res = pullDependency(*ref, this->repo, "binary");
+    if (!res) {
+        return LINGLONG_ERR("failed to get utils " + id, res);
+    }
+
+    auto appLayerDir = this->repo.getMergedModuleDir(*ref);
+    if (!appLayerDir) {
+        return LINGLONG_ERR("failed to get layer dir of " + ref->toString());
+    }
+
+    // pull dependencies only when the target architecture matches the current CPU architecture
+    if (arch == package::Architecture::currentCPUArchitecture()) {
         auto layerItem = this->repo.getLayerItem(*ref);
         if (!layerItem) {
             return LINGLONG_ERR("failed to get layer item of " + ref->toString());
@@ -454,11 +476,9 @@ utils::error::Result<package::Reference> Builder::ensureUtils(const std::string 
                                     + QString::fromStdString(info.runtime.value()));
             }
         }
-
-        return ref;
     }
 
-    return LINGLONG_ERR("failed to get utils " + QString::fromStdString(id));
+    return ref;
 }
 
 utils::error::Result<package::Reference> Builder::clearDependency(const std::string &ref,
@@ -781,7 +801,7 @@ utils::error::Result<bool> Builder::buildStageBuild(const QStringList &args) noe
 
     // write ld.so.conf
     QString ldConfPath = appCache.absoluteFilePath("ld.so.conf");
-    std::string triplet = projectRef->arch.getTriplet();
+    std::string triplet = package::Architecture::currentCPUArchitecture().getTriplet();
     std::string ldRawConf = cfgBuilder.ldConf(triplet);
 
     QFile ldsoconf{ ldConfPath };
@@ -1167,7 +1187,7 @@ utils::error::Result<void> Builder::commitToLocalRepo() noexcept
     auto appIDPrintWidth = -project.package.id.size() + -5;
 
     auto info = api::types::v1::PackageInfoV2{
-        .arch = { projectRef->arch.toStdString() },
+        .arch = { projectRef->arch.toString() },
         .channel = projectRef->channel,
         .command = project.command,
         .description = project.package.description,
@@ -1363,11 +1383,18 @@ utils::error::Result<void> Builder::exportUAB(const ExportOption &option,
 
     const bool distributedOnly = !exportOpts.ref.empty();
 
-    // Try to use uab-header, uab-loader, ll-box and bundling logic from ll-builder-utils if
-    // available. Fallback to defaults if ll-builder-utils is not found or fails.
-    auto ref = ensureUtils("cn.org.linyaps.builder.utils");
+    if (!distributedOnly && package::Architecture::currentCPUArchitecture() != projectRef->arch) {
+        return LINGLONG_ERR(
+          "can't export different architecture UAB in executable mode, if you want to export UAB "
+          "in distributed mode, please use --ref option instead");
+    }
+
+    // Retrieves static files from the ll-builder-utils matching the target architecture if
+    // available, including uab-header, uab-loader, ll-box. Fallback to defaults if ll-builder-utils
+    // is not found or fails.
+    auto ref = ensureUtils("cn.org.linyaps.builder.utils", projectRef->arch);
     if (ref) {
-        LogD("using cn.org.linyaps.builder.utils");
+        LogD("using static files from cn.org.linyaps.builder.utils");
         std::vector<std::string> args{
             "/opt/apps/cn.org.linyaps.builder.utils/files/bin/ll-builder-export",
             "--get-header",
@@ -1396,7 +1423,15 @@ utils::error::Result<void> Builder::exportUAB(const ExportOption &option,
         } else {
             LogW("run builder utils error: {}", res.error());
         }
+    }
 
+    // Using the packdir tools matching current architecture
+    const auto &arch = package::Architecture::currentCPUArchitecture();
+    if (arch != projectRef->arch) {
+        ref = ensureUtils("cn.org.linyaps.builder.utils", arch);
+    }
+
+    if (ref) {
         auto utilsBundler =
           [&ref, &exportOpts, this](const QString &bundleFile,
                                     const QString &bundleDir) -> utils::error::Result<void> {
@@ -1506,7 +1541,7 @@ utils::error::Result<void> Builder::exportUAB(const ExportOption &option,
     }
 
     if (!option.iconPath.empty()) {
-        if (auto ret = packager.setIcon(QFileInfo{ option.iconPath.c_str() }); !ret) {
+        if (auto ret = packager.setIcon(option.iconPath); !ret) {
             return LINGLONG_ERR(ret);
         }
     }
@@ -1831,7 +1866,7 @@ utils::error::Result<void> Builder::run(std::vector<std::string> modules,
           .appendEnv("LINYAPS_INIT_SINGLE_MODE", "1");
 
         // write ld.so.conf
-        std::string triplet = curRef->arch.getTriplet();
+        std::string triplet = package::Architecture::currentCPUArchitecture().getTriplet();
         std::string ldRawConf = cfgBuilder.ldConf(triplet);
 
         QFile ldsoconf{ ldConfPath.c_str() };
@@ -1972,7 +2007,7 @@ utils::error::Result<void> Builder::runFromRepo(const package::Reference &ref,
           .appendEnv("LINYAPS_INIT_SINGLE_MODE", "1");
 
         // write ld.so.conf
-        std::string triplet = ref.arch.getTriplet();
+        std::string triplet = package::Architecture::currentCPUArchitecture().getTriplet();
         std::string ldRawConf = cfgBuilder.ldConf(triplet);
 
         QFile ldsoconf{ ldConfPath.c_str() };
@@ -2055,9 +2090,12 @@ utils::error::Result<void> Builder::runtimeCheck()
     }
     printMessage("Start runtime check", 2);
     // 导出uab时需要使用main-check统计的信息，所以无论是否跳过检查，都需要执行main-check
-    auto ret =
-      this->run(packageModules,
-                { { std::filesystem::path{ LINGLONG_BUILDER_HELPER } / "main-check.sh" } });
+    auto args = std::vector<std::string>{ std::filesystem::path{ LINGLONG_BUILDER_HELPER }
+                                          / "main-check.sh" };
+    if (package::Architecture::currentCPUArchitecture() != projectRef->arch) {
+        args.push_back("--skip-ldd-check");
+    }
+    auto ret = this->run(packageModules, args);
     // ignore runtime check if skipCheckOutput is set
     if (this->buildOptions.skipCheckOutput) {
         printMessage("Runtime check ignored", 2);
@@ -2233,13 +2271,14 @@ void Builder::printBasicInfo()
     printMessage("[Builder info]");
     printMessage(std::string("Linglong Builder Version: ") + LINGLONG_VERSION, 2);
     printMessage("[Build Target]");
-    auto &project = *this->project;
+    const auto &project = *this->project;
     printMessage(project.package.id, 2);
     printMessage("[Project Info]");
     printMessage("Package Name: " + project.package.name, 2);
     printMessage("Version: " + project.package.version, 2);
     printMessage("Package Type: " + project.package.kind, 2);
-    printMessage("Build Arch: " + projectRef->arch.toStdString(), 2);
+    printMessage("Build Arch: " + package::Architecture::currentCPUArchitecture().toString(), 2);
+    printMessage("Target Arch: " + projectRef->arch.toString(), 2);
 }
 
 void Builder::printRepo()
@@ -2268,7 +2307,7 @@ std::string Builder::uabExportFilename(const linglong::package::Reference &ref)
     return fmt::format("{}_{}_{}_{}.uab",
                        ref.id,
                        ref.version.toString(),
-                       ref.arch.toStdString(),
+                       ref.arch.toString(),
                        ref.channel);
 }
 
@@ -2278,7 +2317,7 @@ std::string Builder::layerExportFilename(const linglong::package::Reference &ref
     return fmt::format("{}_{}_{}_{}.layer",
                        ref.id,
                        ref.version.toString(),
-                       ref.arch.toStdString(),
+                       ref.arch.toString(),
                        module);
 }
 } // namespace linglong::builder

--- a/libs/linglong/src/linglong/builder/linglong_builder.h
+++ b/libs/linglong/src/linglong/builder/linglong_builder.h
@@ -126,7 +126,8 @@ private:
     std::unique_ptr<utils::OverlayFS> makeOverlay(const std::filesystem::path &lowerdir,
                                                   const std::filesystem::path &overlayDir) noexcept;
     void fixLocaltimeInOverlay(std::unique_ptr<utils::OverlayFS> &base);
-    utils::error::Result<package::Reference> ensureUtils(const std::string &id) noexcept;
+    utils::error::Result<package::Reference>
+    ensureUtils(const std::string &id, const package::Architecture &arch) noexcept;
     utils::error::Result<package::Reference> clearDependency(const std::string &ref,
                                                              bool forceRemote,
                                                              bool fallbackToRemote) noexcept;

--- a/libs/linglong/src/linglong/package/architecture.cpp
+++ b/libs/linglong/src/linglong/package/architecture.cpp
@@ -21,7 +21,7 @@ Architecture::Architecture(Value value)
 {
 }
 
-std::string Architecture::toStdString() const noexcept
+std::string Architecture::toString() const noexcept
 {
     switch (this->v) {
     case X86_64:
@@ -135,23 +135,28 @@ bool isNewWorldLoongArch()
 }
 } // namespace
 
-utils::error::Result<Architecture> Architecture::currentCPUArchitecture() noexcept
+const Architecture &Architecture::currentCPUArchitecture()
 {
-    auto arch = QSysInfo::currentCpuArchitecture().toStdString();
+    auto currentArch = []() {
+        auto arch = QSysInfo::currentCpuArchitecture().toStdString();
 
-    if (arch == "sw_64") {
-        arch = "sw64";
-    }
-
-    if (arch == "loongarch64" || arch == "loong64") {
-        if (isNewWorldLoongArch()) {
-            arch = "loong64";
-        } else {
-            arch = "loongarch64";
+        if (arch == "sw_64") {
+            arch = "sw64";
         }
-    }
 
-    return Architecture::parse(arch);
-};
+        if (arch == "loongarch64" || arch == "loong64") {
+            if (isNewWorldLoongArch()) {
+                arch = "loong64";
+            } else {
+                arch = "loongarch64";
+            }
+        }
+        return arch;
+    };
+
+    // throw exception if architecture is unknown
+    static Architecture arch(currentArch());
+    return arch;
+}
 
 } // namespace linglong::package

--- a/libs/linglong/src/linglong/package/architecture.h
+++ b/libs/linglong/src/linglong/package/architecture.h
@@ -34,7 +34,7 @@ public:
      * @brief 获取架构名称的字符串表示
      * @return 架构名称的std::string表示
      */
-    [[nodiscard]] std::string toStdString() const noexcept;
+    [[nodiscard]] std::string toString() const noexcept;
     /**
      * @brief 获取架构的gnu路径
      * @return gnu路径的std::string表示
@@ -47,7 +47,7 @@ public:
 
     static utils::error::Result<Architecture> parse(const std::string &raw) noexcept;
 
-    static utils::error::Result<Architecture> currentCPUArchitecture() noexcept;
+    static const Architecture &currentCPUArchitecture();
 
 private:
     Value v;

--- a/libs/linglong/src/linglong/package/elf_handler.cpp
+++ b/libs/linglong/src/linglong/package/elf_handler.cpp
@@ -1,0 +1,372 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "elf_handler.h"
+
+#include "linglong/utils/finally/finally.h"
+
+#include <byteswap.h>
+#include <endian.h>
+#include <gelf.h>
+#include <libelf.h>
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+namespace {
+
+bool is_host_lsb()
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    return true;
+#else
+    return false;
+#endif
+}
+
+template <typename T>
+T swap_val(T val)
+{
+    return val;
+}
+
+template <>
+uint16_t swap_val(uint16_t val)
+{
+    return bswap_16(val);
+}
+
+template <>
+uint32_t swap_val(uint32_t val)
+{
+    return bswap_32(val);
+}
+
+template <>
+uint64_t swap_val(uint64_t val)
+{
+    return bswap_64(val);
+}
+
+struct EndianSwapper
+{
+    bool need_swap;
+
+    EndianSwapper(bool is_file_lsb) { need_swap = (is_file_lsb != is_host_lsb()); }
+
+    template <typename T>
+    T operator()(T val) const
+    {
+        return need_swap ? swap_val(val) : val;
+    }
+
+    template <typename EhdrT>
+    void swap_header(EhdrT &hdr) const
+    {
+        if (!need_swap)
+            return;
+        hdr.e_type = swap_val(hdr.e_type);
+        hdr.e_machine = swap_val(hdr.e_machine);
+        hdr.e_version = swap_val(hdr.e_version);
+        hdr.e_entry = swap_val(hdr.e_entry);
+        hdr.e_phoff = swap_val(hdr.e_phoff);
+        hdr.e_shoff = swap_val(hdr.e_shoff);
+        hdr.e_flags = swap_val(hdr.e_flags);
+        hdr.e_ehsize = swap_val(hdr.e_ehsize);
+        hdr.e_phentsize = swap_val(hdr.e_phentsize);
+        hdr.e_phnum = swap_val(hdr.e_phnum);
+        hdr.e_shentsize = swap_val(hdr.e_shentsize);
+        hdr.e_shnum = swap_val(hdr.e_shnum);
+        hdr.e_shstrndx = swap_val(hdr.e_shstrndx);
+    }
+
+    template <typename ShdrT>
+    void swap_shdr(ShdrT &sh) const
+    {
+        if (!need_swap)
+            return;
+        sh.sh_name = swap_val(sh.sh_name);
+        sh.sh_type = swap_val(sh.sh_type);
+        sh.sh_flags = swap_val(sh.sh_flags);
+        sh.sh_addr = swap_val(sh.sh_addr);
+        sh.sh_offset = swap_val(sh.sh_offset);
+        sh.sh_size = swap_val(sh.sh_size);
+        sh.sh_link = swap_val(sh.sh_link);
+        sh.sh_info = swap_val(sh.sh_info);
+        sh.sh_addralign = swap_val(sh.sh_addralign);
+        sh.sh_entsize = swap_val(sh.sh_entsize);
+    }
+};
+
+bool write_all(int fd, const void *buf, size_t count)
+{
+    const char *ptr = static_cast<const char *>(buf);
+    size_t left = count;
+    while (left > 0) {
+        ssize_t written = write(fd, ptr, left);
+        if (written <= 0) {
+            if (errno == EINTR)
+                continue;
+            return false;
+        }
+        ptr += written;
+        left -= written;
+    }
+    return true;
+}
+
+off_t align_file(int fd, size_t alignment)
+{
+    off_t current = lseek(fd, 0, SEEK_END);
+    if (current == -1) {
+        return -1;
+    }
+    if (current % alignment == 0) {
+        return current;
+    }
+
+    size_t pad_len = alignment - (current % alignment);
+    const char zeros[16] = { 0 };
+    size_t written = 0;
+    while (written < pad_len) {
+        size_t to_write = std::min(pad_len - written, sizeof(zeros));
+        if (!write_all(fd, zeros, to_write)) {
+            return -1;
+        }
+        written += to_write;
+    }
+
+    return lseek(fd, 0, SEEK_END);
+}
+
+template <typename EhdrT, typename ShdrT>
+linglong::utils::error::Result<void>
+addSectionImpl(int fd, Elf *e, const std::string &name, const char *data, size_t size, bool is_lsb)
+{
+    LINGLONG_TRACE("add section impl");
+
+    EndianSwapper swapper(is_lsb);
+
+    auto appended_offset = align_file(fd, 16);
+    if (appended_offset == -1) {
+        return LINGLONG_ERR("failed to align file");
+    }
+
+    if (!write_all(fd, data, size)) {
+        return LINGLONG_ERR("failed to append section data");
+    }
+
+    EhdrT ehdr;
+    if (pread(fd, &ehdr, sizeof(ehdr), 0) != sizeof(ehdr)) {
+        return LINGLONG_ERR("failed to read elf header");
+    }
+    swapper.swap_header(ehdr);
+
+    size_t shstrndx;
+    if (elf_getshdrstrndx(e, &shstrndx) != 0) {
+        return LINGLONG_ERR("failed to get elf section header string index");
+    }
+
+    Elf_Scn *scn_str = elf_getscn(e, shstrndx);
+    if (scn_str == nullptr) {
+        return LINGLONG_ERR("failed to get elf section header string");
+    }
+    GElf_Shdr shdr_str;
+    if (gelf_getshdr(scn_str, &shdr_str) != &shdr_str) {
+        return LINGLONG_ERR("failed to get strtab header");
+    }
+    if (shdr_str.sh_flags & SHF_COMPRESSED) {
+        return LINGLONG_ERR("compressed string table not supported");
+    }
+
+    Elf_Data *data_str = elf_getdata(scn_str, nullptr);
+    if (data_str == nullptr) {
+        return LINGLONG_ERR("failed to get elf section header string data");
+    }
+
+    size_t old_strtable_size = data_str->d_size;
+    size_t new_name_len = name.length() + 1;
+    size_t new_strtable_size = old_strtable_size + new_name_len;
+
+    auto new_strtab_offset = align_file(fd, 1);
+    if (new_strtab_offset == -1) {
+        return LINGLONG_ERR("failed to align file");
+    }
+
+    if (!write_all(fd, data_str->d_buf, old_strtable_size)) {
+        return LINGLONG_ERR("failed to write old strtab");
+    }
+
+    if (!write_all(fd, name.c_str(), new_name_len)) {
+        return LINGLONG_ERR("failed to write new strtab");
+    }
+
+    size_t new_name_idx = old_strtable_size;
+
+    size_t shnum = 0;
+    elf_getshdrnum(e, &shnum);
+
+    size_t old_sht_size = shnum * sizeof(ShdrT);
+    auto sht_buf = std::make_unique<ShdrT[]>(shnum);
+    size_t read = pread(fd, sht_buf.get(), old_sht_size, ehdr.e_shoff);
+    if (read != old_sht_size) {
+        return LINGLONG_ERR("failed to read sht");
+    }
+
+    for (size_t i = 0; i < shnum; ++i) {
+        swapper.swap_shdr(sht_buf[i]);
+    }
+    sht_buf[shstrndx].sh_offset = new_strtab_offset;
+    sht_buf[shstrndx].sh_size = new_strtable_size;
+
+    size_t sht_align = sizeof(
+      typename std::conditional<sizeof(ShdrT) == sizeof(Elf64_Shdr), uint64_t, uint32_t>::type);
+    auto new_sht_offset = align_file(fd, sht_align);
+    if (new_sht_offset == -1) {
+        return LINGLONG_ERR("failed to align file");
+    }
+    for (size_t i = 0; i < shnum; ++i) {
+        swapper.swap_shdr(sht_buf[i]);
+    }
+    if (!write_all(fd, sht_buf.get(), old_sht_size)) {
+        return LINGLONG_ERR("failed to write sht");
+    }
+
+    ShdrT new_shdr;
+    memset(&new_shdr, 0, sizeof(new_shdr));
+
+    new_shdr.sh_name = new_name_idx;
+    new_shdr.sh_type = SHT_PROGBITS;
+    new_shdr.sh_flags = 0;
+    new_shdr.sh_addr = 0;
+    new_shdr.sh_offset = appended_offset;
+    new_shdr.sh_size = size;
+    new_shdr.sh_link = 0;
+    new_shdr.sh_info = 0;
+    new_shdr.sh_addralign = 1;
+    new_shdr.sh_entsize = 0;
+
+    swapper.swap_shdr(new_shdr);
+    if (!write_all(fd, &new_shdr, sizeof(new_shdr))) {
+        return LINGLONG_ERR("failed to write new shdr");
+    }
+
+    ehdr.e_shoff = new_sht_offset;
+    ehdr.e_shnum = shnum + 1;
+    swapper.swap_header(ehdr);
+    lseek(fd, 0, SEEK_SET);
+    if (!write_all(fd, &ehdr, sizeof(ehdr))) {
+        return LINGLONG_ERR("failed to write new ehdr");
+    }
+
+    return LINGLONG_OK;
+}
+
+} // namespace
+
+namespace linglong::package {
+
+utils::error::Result<std::unique_ptr<ElfHandler>> ElfHandler::create(std::filesystem::path file)
+{
+    LINGLONG_TRACE("create elfhandler: " + file.string());
+
+    return std::make_unique<ElfHandler>(file);
+}
+
+ElfHandler::ElfHandler(std::filesystem::path file)
+    : file_(std::move(file))
+{
+}
+
+ElfHandler::~ElfHandler() { }
+
+utils::error::Result<void> ElfHandler::addSection(const std::string &name,
+                                                  const std::filesystem::path &file)
+{
+    LINGLONG_TRACE("add section from file: " + file.string());
+
+    std::error_code ec;
+    const auto size = std::filesystem::file_size(file, ec);
+    if (ec) {
+        return LINGLONG_ERR(fmt::format("failed to get file size for {}", file.string()), ec);
+    }
+
+    if (size == 0) {
+        return LINGLONG_ERR("file is empty: " + file.string());
+    }
+
+    int fd = open(file.c_str(), O_RDONLY);
+    if (fd < 0) {
+        return LINGLONG_ERR("failed to open file: " + file.string());
+    }
+
+    void *data = mmap(nullptr, size, PROT_READ, MAP_PRIVATE, fd, 0);
+
+    if (data == MAP_FAILED) {
+        close(fd);
+        return LINGLONG_ERR("failed to mmap file: " + file.string());
+    }
+
+    auto result = addSection(name, static_cast<const char *>(data), size);
+
+    munmap(data, size);
+    close(fd);
+
+    return result;
+}
+
+utils::error::Result<void> ElfHandler::addSection(const std::string &name,
+                                                  const char *data,
+                                                  size_t size)
+{
+    LINGLONG_TRACE("add section:" + name);
+
+    if (name.length() > 32) {
+        return LINGLONG_ERR("section name too long");
+    }
+
+    if (elf_version(EV_CURRENT) == EV_NONE) {
+        return LINGLONG_ERR("failed to get elf version");
+    }
+
+    int fd = open(file_.c_str(), O_RDWR);
+    if (fd < 0) {
+        return LINGLONG_ERR("failed to open file: " + file_.string());
+    }
+    auto close_fd = utils::finally::finally([fd] {
+        close(fd);
+    });
+
+    Elf *e = elf_begin(fd, ELF_C_READ_MMAP, nullptr);
+    if (e == nullptr) {
+        return LINGLONG_ERR("failed to get elf");
+    }
+    auto clean_elf = utils::finally::finally([e] {
+        elf_end(e);
+    });
+
+    GElf_Ehdr ehdr;
+    if (gelf_getehdr(e, &ehdr) == nullptr) {
+        return LINGLONG_ERR("failed to get elf header");
+    }
+
+    int file_data_encoding = ehdr.e_ident[EI_DATA];
+    if (file_data_encoding != ELFDATA2LSB && file_data_encoding != ELFDATA2MSB) {
+        return LINGLONG_ERR("unknown elf endianness");
+    }
+    bool is_lsb = (file_data_encoding == ELFDATA2LSB);
+
+    int elf_class = gelf_getclass(e);
+
+    if (elf_class == ELFCLASS64) {
+        return addSectionImpl<Elf64_Ehdr, Elf64_Shdr>(fd, e, name, data, size, is_lsb);
+    } else if (elf_class == ELFCLASS32) {
+        return addSectionImpl<Elf32_Ehdr, Elf32_Shdr>(fd, e, name, data, size, is_lsb);
+    } else {
+        return LINGLONG_ERR("unknown elf class");
+    }
+}
+
+} // namespace linglong::package

--- a/libs/linglong/src/linglong/package/elf_handler.h
+++ b/libs/linglong/src/linglong/package/elf_handler.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linglong/utils/error/error.h"
+
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+namespace linglong::package {
+
+class ElfHandler
+{
+public:
+    ElfHandler(std::filesystem::path file);
+    ~ElfHandler();
+    static utils::error::Result<std::unique_ptr<ElfHandler>> create(std::filesystem::path file);
+
+    utils::error::Result<void> addSection(const std::string &name, const char *data, size_t size);
+    utils::error::Result<void> addSection(const std::string &name,
+                                          const std::filesystem::path &file);
+
+private:
+    std::filesystem::path file_;
+};
+
+} // namespace linglong::package

--- a/libs/linglong/src/linglong/package/fuzzy_reference.cpp
+++ b/libs/linglong/src/linglong/package/fuzzy_reference.cpp
@@ -95,7 +95,7 @@ std::string FuzzyReference::toString() const noexcept
                        this->channel.value_or("unknown"),
                        this->id,
                        this->version ? this->version.value() : "unknown",
-                       this->arch ? this->arch->toStdString() : "unknown");
+                       this->arch ? this->arch->toString() : "unknown");
 }
 
 } // namespace linglong::package

--- a/libs/linglong/src/linglong/package/reference.cpp
+++ b/libs/linglong/src/linglong/package/reference.cpp
@@ -111,7 +111,7 @@ Reference::Reference(const std::string &channel,
 
 std::string Reference::toString() const noexcept
 {
-    return fmt::format("{}:{}/{}/{}", channel, id, version.toString(), arch.toStdString());
+    return fmt::format("{}:{}/{}/{}", channel, id, version.toString(), arch.toString());
 }
 
 bool operator!=(const Reference &lhs, const Reference &rhs) noexcept
@@ -137,16 +137,17 @@ Reference::fromBuilderProject(const api::types::v1::BuilderProject &project) noe
 
     auto architecture = package::Architecture::currentCPUArchitecture();
     if (project.package.architecture) {
-        architecture = package::Architecture::parse(*project.package.architecture);
-    }
-    if (!architecture) {
-        return LINGLONG_ERR(architecture);
+        auto targetArch = package::Architecture::parse(*project.package.architecture);
+        if (!targetArch) {
+            return LINGLONG_ERR(targetArch);
+        }
+        architecture = *targetArch;
     }
     std::string channel = "main";
     if (project.package.channel.has_value()) {
         channel = *project.package.channel;
     }
-    auto ref = package::Reference::create(channel, project.package.id, *version, *architecture);
+    auto ref = package::Reference::create(channel, project.package.id, *version, architecture);
     if (!ref) {
         return LINGLONG_ERR(ref);
     }

--- a/libs/linglong/src/linglong/package/reference.h
+++ b/libs/linglong/src/linglong/package/reference.h
@@ -67,7 +67,7 @@ struct std::hash<linglong::package::Reference>
         hash_combine(seed, hasher(ref.channel));
         hash_combine(seed, hasher(ref.id));
         hash_combine(seed, hasher(ref.version.toString()));
-        hash_combine(seed, hasher(ref.arch.toStdString()));
+        hash_combine(seed, hasher(ref.arch.toString()));
         return seed;
     }
 };

--- a/libs/linglong/src/linglong/package/uab_packager.h
+++ b/libs/linglong/src/linglong/package/uab_packager.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "linglong/api/types/v1/UabMetaInfo.hpp"
+#include "linglong/package/elf_handler.h"
 #include "linglong/package/layer_dir.h"
 #include "linglong/utils/error/error.h"
 
@@ -12,53 +13,14 @@
 #include <libelf.h>
 
 #include <QDir>
-#include <QLoggingCategory>
 #include <QString>
 #include <QUuid>
 
 #include <filesystem>
+#include <memory>
 #include <unordered_set>
 
 namespace linglong::package {
-
-Q_DECLARE_LOGGING_CATEGORY(uab_packager)
-
-struct elfHelper
-{
-    elfHelper() = default;
-    elfHelper(const elfHelper &) = delete;
-    elfHelper(elfHelper &&) noexcept;
-    elfHelper &operator=(const elfHelper &) = delete;
-    elfHelper &operator=(elfHelper &&) noexcept;
-
-    friend bool operator==(const elfHelper &lhs, const elfHelper &rhs) noexcept
-    {
-        return lhs.e == rhs.e && lhs.elfFd == rhs.elfFd && lhs.filePath == rhs.filePath;
-    }
-
-    ~elfHelper();
-    static utils::error::Result<elfHelper> create(const QByteArray &filePath) noexcept;
-
-    [[nodiscard]] auto parentDir() const { return QFileInfo{ filePath }.absoluteDir(); }
-
-    [[nodiscard]] auto fd() const { return elfFd; }
-
-    [[nodiscard]] auto elfPath() const { return filePath; }
-
-    [[nodiscard]] auto ElfPtr() const { return e; }
-
-    [[nodiscard]] utils::error::Result<void>
-    addNewSection(const QByteArray &sectionName,
-                  const QFileInfo &dataFile,
-                  const QStringList &flags = {}) const noexcept;
-
-private:
-    elfHelper(QByteArray path, int fd, Elf *ptr);
-
-    QByteArray filePath;
-    int elfFd{ -1 };
-    Elf *e{ nullptr };
-};
 
 class UABPackager
 {
@@ -68,7 +30,7 @@ public:
 
     UABPackager(UABPackager &&) = delete;
 
-    utils::error::Result<void> setIcon(const QFileInfo &icon) noexcept;
+    utils::error::Result<void> setIcon(std::filesystem::path icon) noexcept;
     utils::error::Result<void> appendLayer(const LayerDir &layer) noexcept;
     utils::error::Result<void> pack(const QString &uabFilePath, bool distributedOnly) noexcept;
     utils::error::Result<void> exclude(const std::vector<std::string> &files) noexcept;
@@ -94,13 +56,13 @@ private:
     [[nodiscard]] utils::error::Result<std::pair<bool, std::unordered_set<std::string>>>
     filteringFiles(const LayerDir &layer) const noexcept;
 
-    elfHelper uab;
+    std::unique_ptr<ElfHandler> uab;
     QList<LayerDir> layers;
     std::unordered_set<std::string> excludeFiles;
     std::unordered_set<std::string> includeFiles;
     std::unordered_set<std::string> neededFiles;
     std::unordered_set<std::string> blackList;
-    std::optional<QFileInfo> icon{ std::nullopt };
+    std::optional<std::filesystem::path> icon;
     api::types::v1::UabMetaInfo meta;
     QDir buildDir;
     std::filesystem::path workDir;

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -503,14 +503,9 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
         return toDBusReply(architectureRet);
     }
 
-    auto currentArch = package::Architecture::currentCPUArchitecture();
-    if (!currentArch) {
-        return toDBusReply(currentArch);
-    }
-
-    if (*architectureRet != *currentArch) {
+    if (*architectureRet != package::Architecture::currentCPUArchitecture()) {
         return toDBusReply(utils::error::ErrorCode::Failed,
-                           "app arch:" + architectureRet->toStdString()
+                           "app arch:" + architectureRet->toString()
                              + " not match host architecture");
     }
 
@@ -561,7 +556,7 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
             auto layerName = fmt::format("{}_{}_{}_{}.layer",
                                          packageRef.id,
                                          packageRef.version.toString(),
-                                         architectureRet->toStdString(),
+                                         architectureRet->toString(),
                                          packageInfo.packageInfoV2Module.c_str());
             auto err = fmt::format("The latest version has been installed. If you want to "
                                    "replace it, try using 'll-cli install {} --force'",
@@ -884,7 +879,7 @@ auto PackageManager::Uninstall(const QVariantMap &parameters) noexcept -> QVaria
     auto refSpec = fmt::format("{}/{}/{}/{}",
                                mainRef->channel,
                                mainRef->id,
-                               mainRef->arch.toStdString(),
+                               mainRef->arch.toString(),
                                curModule);
 
     auto taskRet = tasks.addPackageTask(
@@ -963,12 +958,6 @@ auto PackageManager::Update(const QVariantMap &parameters) noexcept -> QVariantM
       parameters);
     if (!paras) {
         return toDBusReply(utils::error::ErrorCode::AppUpgradeFailed, paras.error().message());
-    }
-
-    auto currentArch = package::Architecture::currentCPUArchitecture();
-    if (!currentArch) {
-        return toDBusReply(utils::error::ErrorCode::AppUpgradeFailed,
-                           currentArch.error().message());
     }
 
     auto action = PackageUpdateAction::create(paras->packages, paras->depsOnly, *this, repo);
@@ -1495,10 +1484,6 @@ utils::error::Result<void> PackageManager::generateCache(const package::Referenc
     process.noNewPrivileges = true;
     process.terminal = true;
 
-    auto currentArch = package::Architecture::currentCPUArchitecture();
-    if (!currentArch) {
-        return LINGLONG_ERR(currentArch);
-    }
     auto ldGenerateCmd =
       std::vector<std::string>{ "/sbin/ldconfig", "-X", "-C", appCacheDest + "/ld.so.cache" };
 #ifdef LINGLONG_FONT_CACHE_GENERATOR

--- a/libs/linglong/src/linglong/package_manager/uab_installation.cpp
+++ b/libs/linglong/src/linglong/package_manager/uab_installation.cpp
@@ -115,11 +115,6 @@ utils::error::Result<void> UabInstallationAction::checkUABLayersConstrain(
 {
     LINGLONG_TRACE("check uab layers constrain");
 
-    auto currentArch = package::Architecture::currentCPUArchitecture();
-    if (!currentArch) {
-        return LINGLONG_ERR(currentArch);
-    }
-
     if (layers.empty()) {
         return LINGLONG_OK;
     }
@@ -130,7 +125,7 @@ utils::error::Result<void> UabInstallationAction::checkUABLayersConstrain(
         if (!arch) {
             return LINGLONG_ERR(arch);
         }
-        if (*arch != *currentArch) {
+        if (*arch != package::Architecture::currentCPUArchitecture()) {
             return LINGLONG_ERR(
               fmt::format("uab arch: {} not match host architecture", layer.info.arch[0]));
         }

--- a/libs/linglong/src/linglong/repo/remote_packages.cpp
+++ b/libs/linglong/src/linglong/repo/remote_packages.cpp
@@ -53,7 +53,7 @@ std::vector<std::string> RemotePackages::getReferenceModules(const package::Refe
         for (const auto &package : packages.second) {
             if (package.id == ref.id && package.channel == ref.channel
                 && package.version == ref.version.toString()
-                && package.arch[0] == ref.arch.toStdString()) {
+                && package.arch[0] == ref.arch.toString()) {
                 modules.emplace_back(package.packageInfoV2Module);
             }
         }

--- a/libs/linglong/src/linglong/repo/repo_cache.cpp
+++ b/libs/linglong/src/linglong/repo/repo_cache.cpp
@@ -250,6 +250,10 @@ RepoCache::queryLayerItem(const repoCacheQuery &query) const noexcept
             continue;
         }
 
+        if (query.architecture && query.architecture.value() != layer.info.arch.front()) {
+            continue;
+        }
+
         if (query.deleted) {
             auto layerDeleted = layer.deleted.value_or(false);
             if (query.deleted.value() != layerDeleted) {

--- a/libs/linglong/src/linglong/repo/repo_cache.h
+++ b/libs/linglong/src/linglong/repo/repo_cache.h
@@ -27,15 +27,11 @@ struct repoCacheQuery
     std::optional<std::string> module;
     std::optional<std::string> uuid;
     std::optional<bool> deleted;
+    std::optional<std::string> architecture;
 
-    static auto arch()
+    auto arch() const
     {
-        auto ret = package::Architecture::currentCPUArchitecture();
-        if (ret) {
-            return ret->toStdString();
-        }
-
-        return std::string{ "unknown" };
+        return architecture.value_or(package::Architecture::currentCPUArchitecture().toString());
     }
 
     [[nodiscard]] std::string to_string() const noexcept

--- a/libs/linglong/tests/ll-tests/src/linglong/package/architecture_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/architecture_test.cpp
@@ -42,7 +42,7 @@ TEST(Package, ArchitectureToString)
 {
     // 使用for循环测试所有架构的toString()方法
     for (const auto &data : ARCHITECTURE_TEST_DATA) {
-        EXPECT_EQ(Architecture(data.value).toStdString(), data.name);
+        EXPECT_EQ(Architecture(data.value).toString(), data.name);
     }
 }
 
@@ -60,7 +60,7 @@ TEST(Package, ArchitectureParseValid)
     for (const auto &data : ARCHITECTURE_TEST_DATA) {
         auto result = Architecture::parse(data.name);
         ASSERT_TRUE(result.has_value()) << "Failed to parse: " << data.name;
-        EXPECT_EQ(result->toStdString(), data.name);
+        EXPECT_EQ(result->toString(), data.name);
         EXPECT_EQ(result->getTriplet(), data.triplet);
     }
 }
@@ -79,7 +79,7 @@ TEST(Package, ArchitectureConstructionFromString)
     // 使用for循环测试从字符串构造架构对象
     for (const auto &data : ARCHITECTURE_TEST_DATA) {
         Architecture arch(data.name);
-        EXPECT_EQ(arch.toStdString(), data.name);
+        EXPECT_EQ(arch.toString(), data.name);
     }
 }
 
@@ -134,18 +134,17 @@ TEST(Package, ArchitectureDefaultConstruction)
 {
     // 测试默认构造
     Architecture defaultArch;
-    EXPECT_EQ(defaultArch.toStdString(), "unknown"); // UNKNOW
-    EXPECT_EQ(defaultArch.getTriplet(), "unknown");  // unknow
+    EXPECT_EQ(defaultArch.toString(), "unknown");   // UNKNOW
+    EXPECT_EQ(defaultArch.getTriplet(), "unknown"); // unknow
 }
 
 TEST(Package, ArchitectureCurrentCPUArchitecture)
 {
     // 测试获取当前CPU架构
     auto currentArch = Architecture::currentCPUArchitecture();
-    EXPECT_TRUE(currentArch.has_value()) << "should not fail (unless system problem)";
     // 这不应该失败（除非有系统问题）
     // 我们无法预测确切的架构，但可以验证它是有效的
-    std::string archString = currentArch->toStdString();
+    std::string archString = currentArch.toString();
     // 当前架构应该是支持的类型之一
     bool found = false;
     for (const auto &data : ARCHITECTURE_TEST_DATA) {
@@ -157,7 +156,7 @@ TEST(Package, ArchitectureCurrentCPUArchitecture)
     EXPECT_TRUE(found) << "Unknown architecture: " << archString;
 
     // 三元组不应为空，且应包含"linux-gnu"
-    std::string triplet = currentArch->getTriplet();
+    std::string triplet = currentArch.getTriplet();
     EXPECT_FALSE(triplet.empty());
     EXPECT_TRUE(linglong::common::strings::contains(triplet, "linux-gnu"));
 }

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/uab_installation_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/uab_installation_test.cpp
@@ -51,7 +51,7 @@ api::types::v1::UabLayer create_layer(const std::string &id,
                                       const std::string &channel,
                                       const std::string &kind)
 {
-    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+    auto currentArch = package::Architecture::currentCPUArchitecture().toString();
     api::types::v1::UabLayer layer;
     layer.minified = false;
     layer.info.id = id;
@@ -81,8 +81,6 @@ TEST(CheckUABLayersConstrain, ArchMismatch)
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers;
     api::types::v1::UabLayer layer;
-    auto currentArch = package::Architecture::currentCPUArchitecture();
-    ASSERT_TRUE(currentArch.has_value());
     // An arch that doesn't match current arch
     layer.minified = false;
     layer.info.arch = { "non-existent-arch" };
@@ -98,7 +96,7 @@ TEST(CheckUABLayersConstrain, DifferentIds)
     MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers;
-    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+    auto currentArch = package::Architecture::currentCPUArchitecture().toString();
 
     api::types::v1::UabLayer layer1;
     layer1.minified = false;
@@ -122,7 +120,7 @@ TEST(CheckUABLayersConstrain, DifferentVersions)
     MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers;
-    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+    auto currentArch = package::Architecture::currentCPUArchitecture().toString();
 
     api::types::v1::UabLayer layer1;
     layer1.minified = false;
@@ -150,7 +148,7 @@ TEST(CheckUABLayersConstrain, ExtraModuleNoBinaryAndNotInstalled)
     MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers;
-    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+    auto currentArch = package::Architecture::currentCPUArchitecture().toString();
 
     api::types::v1::UabLayer layer1;
     layer1.minified = false;
@@ -173,7 +171,7 @@ TEST(CheckUABLayersConstrain, ExtraModuleNoBinaryAndWrongVersionInstalled)
     MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers;
-    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+    auto currentArch = package::Architecture::currentCPUArchitecture().toString();
 
     api::types::v1::UabLayer layer1;
     layer1.minified = false;
@@ -199,7 +197,7 @@ TEST(CheckUABLayersConstrain, ExtraModuleNoBinaryButInstalled)
     MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers;
-    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+    auto currentArch = package::Architecture::currentCPUArchitecture().toString();
 
     api::types::v1::UabLayer layer1;
     layer1.minified = false;
@@ -225,7 +223,7 @@ TEST(CheckUABLayersConstrain, ExtraModuleWithBinary)
     MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
     std::vector<api::types::v1::UabLayer> layers;
-    auto currentArch = package::Architecture::currentCPUArchitecture()->toStdString();
+    auto currentArch = package::Architecture::currentCPUArchitecture().toString();
 
     api::types::v1::UabLayer layer1;
     layer1.minified = false;

--- a/misc/libexec/linglong/builder/helper/main-check.sh
+++ b/misc/libexec/linglong/builder/helper/main-check.sh
@@ -8,10 +8,27 @@
 
 #default level is 1
 declare -i check_level=1
+declare -i skip_ldd=0
+declare -i skip_config=0
 
-if [[ $1 != "" ]]; then
-        check_level=$1
-fi
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --skip-ldd-check)
+            skip_ldd=1
+            shift
+            ;;
+        --skip-config-check)
+            skip_config=1
+            shift
+            ;;
+        *)
+            if [[ -n "$1" ]]; then
+                check_level=$1
+            fi
+            shift
+            ;;
+    esac
+done
 
 case $check_level in
 0)
@@ -26,15 +43,23 @@ case $check_level in
         ;;
 esac
 
-echo "start ldd check"
-if ! @CMAKE_INSTALL_FULL_LIBEXECDIR@/linglong/builder/helper/ldd-check.sh "/opt/apps/${LINGLONG_APPID}/files"; then
-        echo "Error: ldd check failed."
-        if [ $check_level -eq 1 ]; then
-                exit 1
-        fi
+if [[ $skip_ldd -eq 0 ]]; then
+    echo "start ldd check"
+    if ! @CMAKE_INSTALL_FULL_LIBEXECDIR@/linglong/builder/helper/ldd-check.sh "/opt/apps/${LINGLONG_APPID}/files"; then
+            echo "Error: ldd check failed."
+            if [ $check_level -eq 1 ]; then
+                    exit 1
+            fi
+    fi
+else
+    echo "Skipping ldd check."
 fi
 
-echo "start application configure check"
-if ! @CMAKE_INSTALL_FULL_LIBEXECDIR@/linglong/builder/helper/config-check.sh; then
-        echo "Warnning: configue check failed."
+if [[ $skip_config -eq 0 ]]; then
+    echo "start application configure check"
+    if ! @CMAKE_INSTALL_FULL_LIBEXECDIR@/linglong/builder/helper/config-check.sh; then
+            echo "Warning: application configure check failed."
+    fi
+else
+    echo "Skipping application configure check."
 fi


### PR DESCRIPTION
This change enables building linglong packages for a target architecture that is different from the host machine's architecture.

Key changes include:
- The build process now distinguishes between the host architecture(for executing build tools) and the target architecture (for the output package).
- `ensureUtils` is updated to fetch dependencies for a specified architecture, allowing the builder to pull architecture-specific tools and assets.
- In the `exportUAB` stage, `builder-utils` is fetched for both the host and target architecture to correctly handle executable tools and static assets during cross-export.
- Modify `main-check.sh` to skip `ldd` and configuration checks when the target architecture differs from the host.
- The repository cache (`repo_cache`) is now architecture-aware, allowing it to correctly query and manage layers for different architectures.
- The ELF file manipulation logic is refactored into a new `ElfHandler` class, which uses libelf(gelf).
- Implement `EndianSwapper` to handle cross-endianness file modification.
- Manually handle file alignment, string table extension, and SHT relocation to ensure the new section is appended safely to the end of the file.