### PR TITLE
feat: add --no-progress option to suppress progress output

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -669,10 +669,13 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     auto *jsonFlag = commandParser.add_flag("--json", jsonDescription);
 
     // verbose flag
-    GlobalOptions globalOptions{ .verbose = false };
+    GlobalOptions globalOptions{ .verbose = false, .noProgress = false };
     commandParser.add_flag("-v,--verbose",
                            globalOptions.verbose,
                            _("Show debug info (verbose logs)"));
+    commandParser.add_flag("--no-progress",
+                           globalOptions.noProgress,
+                           _("Don't output progress information"));
 
     // subcommand options
     RunOptions runOptions{};

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -394,7 +394,9 @@ void Cli::handleTaskState() noexcept
         return;
     }
 
-    this->printer.printProgress(taskState.percentage, taskState.message);
+    if (!this->globalOptions.noProgress) {
+        this->printer.printProgress(taskState.percentage, taskState.message);
+    }
 }
 
 void Cli::printOnTaskFailed()

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -41,6 +41,7 @@ class Printer;
 struct GlobalOptions
 {
     bool verbose{ false };
+    bool noProgress{ false };
 };
 
 // 各subcommand的独立选项结构体


### PR DESCRIPTION
Add a new command-line flag `--no-progress` to allow users to suppress progress info. This is useful for scripting or environments where clean output is required.

#1537 