### PR TITLE
refactor: move ld cache generation to client side

### DIFF
--- a/api/dbus/org.deepin.linglong.PackageManager1.xml
+++ b/api/dbus/org.deepin.linglong.PackageManager1.xml
@@ -43,12 +43,6 @@ SPDX-License-Identifier: LGPL-3.0-or-later
       <arg direction="out" name="result" type="a{sv}" />
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap" />
     </method>
-    <method name="GenerateCache">
-      <annotation name="org.freedesktop.DBus.Description" value="Generate cache for app if no cache exists." />
-      <arg direction="in" name="reference" type="s" />
-      <arg direction="out" name="result" type="a{sv}" />
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap" />
-    </method>
     <method name="Permissions">
       <annotation name="org.freedesktop.DBus.Description" value="Used by the client to check whether it has permission to call privileged methods" />
     </method>
@@ -61,10 +55,6 @@ SPDX-License-Identifier: LGPL-3.0-or-later
       <arg name="taskID" type="s" />
       <arg name="result" type="a{sv}" />
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap" />
-    </signal>
-    <signal name="GenerateCacheFinished">
-      <arg name="taskID" type="s" />
-      <arg name="status" type="b" />
     </signal>
     <method name="ReplyInteraction">
       <arg name="task" type="o" />

--- a/libs/common/src/linglong/common/dir.cpp
+++ b/libs/common/src/linglong/common/dir.cpp
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#include "linglong/common/dir.h"
+#include "dir.h"
 
+#include "configure.h"
 #include "linglong/common/xdg.h"
 
 namespace linglong::common::dir {
@@ -21,6 +22,18 @@ std::filesystem::path getAppRuntimeDir(const std::string &appId) noexcept
 std::filesystem::path getBundleDir(const std::string &containerId) noexcept
 {
     return getRuntimeDir() / containerId;
+}
+
+std::filesystem::path getUserCacheDir() noexcept
+{
+    auto cacheDir = xdg::getXDGCacheHomeDir();
+    // If neither XDG_CACHE_HOME nor HOME is set, use LINGLONG_ROOT/cache as fallback,
+    // normally it's can only be written by the package manager
+    if (cacheDir.empty()) {
+        return std::filesystem::path{ LINGLONG_ROOT } / "cache";
+    }
+
+    return cacheDir / "linglong";
 }
 
 } // namespace linglong::common::dir

--- a/libs/common/src/linglong/common/dir.h
+++ b/libs/common/src/linglong/common/dir.h
@@ -17,4 +17,9 @@ std::filesystem::path getAppRuntimeDir(const std::string &appId) noexcept;
 
 std::filesystem::path getBundleDir(const std::string &containerId) noexcept;
 
+// user cache directory for linglong in the following order:
+// 1. $XDG_CACHE_HOME/linglong
+// 2. $HOME/.cache/linglong, if $XDG_CACHE_HOME is either not set or empty
+// 3. LINGLONG_ROOT/cache, if $HOME is either not set or empty
+std::filesystem::path getUserCacheDir() noexcept;
 } // namespace linglong::common::dir

--- a/libs/common/src/linglong/common/xdg.cpp
+++ b/libs/common/src/linglong/common/xdg.cpp
@@ -20,4 +20,21 @@ std::filesystem::path getXDGRuntimeDir() noexcept
     return std::filesystem::path{ "/tmp" } / ("linglong-runtime-" + std::to_string(::getuid()));
 }
 
+std::filesystem::path getXDGCacheHomeDir() noexcept
+{
+    auto *cacheHomeEnv = std::getenv("XDG_CACHE_HOME");
+    if (cacheHomeEnv != nullptr && cacheHomeEnv[0] != '\0') {
+        return cacheHomeEnv;
+    }
+
+    // fallback to default
+    // $HOME/.cache
+    auto *homeEnv = std::getenv("HOME");
+    if (homeEnv != nullptr && homeEnv[0] != '\0') {
+        return std::filesystem::path{ homeEnv } / ".cache";
+    }
+
+    return "";
+}
+
 } // namespace linglong::common::xdg

--- a/libs/common/src/linglong/common/xdg.h
+++ b/libs/common/src/linglong/common/xdg.h
@@ -12,4 +12,6 @@ namespace linglong::common::xdg {
 
 std::filesystem::path getXDGRuntimeDir() noexcept;
 
+std::filesystem::path getXDGCacheHomeDir() noexcept;
+
 } // namespace linglong::common::xdg

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -1924,11 +1924,7 @@ utils::error::Result<void> Builder::run(std::vector<std::string> modules,
       .enableSelfAdjustingMount()
       .appendEnv("LINYAPS_INIT_SINGLE_MODE", "1");
 
-#ifdef LINGLONG_FONT_CACHE_GENERATOR
-    cfgBuilder.enableFontCache()
-#endif
-
-      res = runContext.fillContextCfg(cfgBuilder);
+    res = runContext.fillContextCfg(cfgBuilder);
     if (!res) {
         return LINGLONG_ERR(res);
     }

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -216,7 +216,8 @@ private:
     utils::error::Result<void> runningAsRoot();
     utils::error::Result<void> runningAsRoot(const QList<QString> &args);
     utils::error::Result<std::vector<api::types::v1::UpgradeListResult>> listUpgradable();
-    int generateCache(const package::Reference &ref);
+    utils::error::Result<void> generateLDCache(runtime::RunContext &runContext,
+                                               const std::string &ldConf) noexcept;
     utils::error::Result<std::filesystem::path> ensureCache(
       runtime::RunContext &runContext, const generator::ContainerCfgBuilder &cfgBuilder) noexcept;
     QDBusReply<void> authorization();

--- a/libs/linglong/src/linglong/package_manager/package_manager.h
+++ b/libs/linglong/src/linglong/package_manager/package_manager.h
@@ -57,7 +57,6 @@ public
     auto Update(const QVariantMap &parameters) noexcept -> QVariantMap;
     auto Search(const QVariantMap &parameters) noexcept -> QVariantMap;
     auto Prune() noexcept -> QVariantMap;
-    auto GenerateCache(const QString &reference) noexcept -> QVariantMap;
     void ReplyInteraction(QDBusObjectPath object_path, const QVariantMap &replies);
 
     // Nothing to do here, Permissions() will be rejected in org.deepin.linglong.PackageManager.conf
@@ -103,7 +102,6 @@ Q_SIGNALS:
                             QVariantMap additionalMessage);
     void SearchFinished(QString jobID, QVariantMap result);
     void PruneFinished(QString jobID, QVariantMap result);
-    void GenerateCacheFinished(QString jobID, bool status);
     void ReplyReceived(const QVariantMap &replies);
 
 private:
@@ -122,7 +120,6 @@ private:
     void deferredUninstall() noexcept;
     utils::error::Result<void>
     Prune(std::vector<api::types::v1::PackageInfoV2> &removedInfo) noexcept;
-    utils::error::Result<void> generateCache(const package::Reference &ref) noexcept;
     utils::error::Result<void> removeCache(const package::Reference &ref) noexcept;
 
     QVariantMap runActionOnTaskQueue(std::shared_ptr<Action> action);
@@ -130,7 +127,6 @@ private:
     linglong::repo::OSTreeRepo &repo; // NOLINT
     PackageTaskQueue tasks;
     PackageTaskQueue m_search_queue;
-    PackageTaskQueue m_generator_queue;
 
     int lockFd{ -1 };
     linglong::runtime::ContainerBuilder &containerBuilder;

--- a/libs/linglong/src/linglong/runtime/container.h
+++ b/libs/linglong/src/linglong/runtime/container.h
@@ -17,8 +17,8 @@ class Container
 {
 public:
     Container(ocppi::runtime::config::types::Config cfg,
-              std::string appId,
               std::string containerId,
+              std::filesystem::path bundleDir,
               ocppi::cli::CLI &cli);
 
     utils::error::Result<void> run(const ocppi::runtime::config::types::Process &process,
@@ -27,7 +27,7 @@ public:
 private:
     ocppi::runtime::config::types::Config cfg;
     std::string id;
-    std::string appId;
+    std::filesystem::path bundleDir;
     ocppi::cli::CLI &cli;
 };
 

--- a/libs/linglong/src/linglong/runtime/container_builder.cpp
+++ b/libs/linglong/src/linglong/runtime/container_builder.cpp
@@ -10,10 +10,14 @@
 
 namespace linglong::runtime {
 
-utils::error::Result<std::filesystem::path> makeBundleDir(const std::string &containerID)
+utils::error::Result<std::filesystem::path> makeBundleDir(const std::string &containerID,
+                                                          const std::string &bundleSuffix)
 {
     LINGLONG_TRACE("get bundle dir");
     auto bundle = common::dir::getBundleDir(containerID);
+    if (!bundleSuffix.empty()) {
+        bundle += bundleSuffix;
+    }
     std::error_code ec;
     if (std::filesystem::exists(bundle, ec)) {
         std::filesystem::remove_all(bundle, ec);
@@ -42,8 +46,8 @@ auto ContainerBuilder::create(const linglong::generator::ContainerCfgBuilder &cf
     auto config = cfgBuilder.getConfig();
 
     return std::make_unique<Container>(config,
-                                       cfgBuilder.getAppId(),
                                        cfgBuilder.getContainerId(),
+                                       cfgBuilder.getBundlePath(),
                                        this->cli);
 }
 

--- a/libs/linglong/src/linglong/runtime/container_builder.h
+++ b/libs/linglong/src/linglong/runtime/container_builder.h
@@ -18,7 +18,8 @@
 namespace linglong::runtime {
 
 // Used to obtain a clean container bundle directory.
-utils::error::Result<std::filesystem::path> makeBundleDir(const std::string &containerID);
+utils::error::Result<std::filesystem::path> makeBundleDir(const std::string &containerID,
+                                                          const std::string &bundleSuffix = "");
 
 inline std::string genContainerID(const package::Reference &ref) noexcept
 {

--- a/libs/linglong/src/linglong/runtime/run_context.h
+++ b/libs/linglong/src/linglong/runtime/run_context.h
@@ -78,7 +78,8 @@ public:
     utils::error::Result<void> resolve(const api::types::v1::BuilderProject &target,
                                        const std::filesystem::path &buildOutput);
 
-    utils::error::Result<void> fillContextCfg(generator::ContainerCfgBuilder &builder);
+    utils::error::Result<void> fillContextCfg(generator::ContainerCfgBuilder &builder,
+                                              const std::string &bundleSuffix = "");
     api::types::v1::ContainerProcessStateInfo stateInfo();
 
     repo::OSTreeRepo &getRepo() const { return repo; }

--- a/misc/share/dbus-1/system.d/org.deepin.linglong.PackageManager1.conf
+++ b/misc/share/dbus-1/system.d/org.deepin.linglong.PackageManager1.conf
@@ -31,11 +31,6 @@ SPDX-License-Identifier: LGPL-3.0-or-later
     <!-- Allow anyone to invoke method Search -->
     <allow send_destination="org.deepin.linglong.PackageManager1"
            send_interface="org.deepin.linglong.PackageManager1" send_member="Search"/>
-
-    <!-- Allow anyone to invoke method GenerateCache -->
-    <allow send_destination="org.deepin.linglong.PackageManager1"
-           send_interface="org.deepin.linglong.PackageManager1" send_member="GenerateCache"/>
-
   </policy>
   <!-- Allow root to invoke all methods -->
   <policy user="root">


### PR DESCRIPTION
This commit refactors the ld cache generation logic, moving it from the PackageManager daemon to the CLI client. This change allows cache generation to run with user privileges and stores the cache in the user's XDG cache directory.

Changes:
- Remove `GenerateCache` method from PackageManager DBus interface.
- Implement `generateLDCache` in CLI using a transient container.
- Introduce `getUserCacheDir` to resolve cache paths (XDG_CACHE_HOME).
- Remove obsolete `LINGLONG_FONT_CACHE_GENERATOR` logic.
- Update `Container` and `RunContext` to handle bundle directory cleanup safely.
- Fix `makeBundleDir` to support suffixes for cache generation containers.