### PR TITLE
fix(utils): compilation error due to missing header file

### DIFF
--- a/apps/uab/header/src/main.cpp
+++ b/apps/uab/header/src/main.cpp
@@ -9,12 +9,12 @@
 
 #include <gelf.h>
 #include <getopt.h>
-#include <linux/limits.h>
 #include <nlohmann/json.hpp>
 #include <sys/mount.h>
 
 #include <array>
 #include <atomic>
+#include <climits>
 #include <cstring>
 #include <filesystem>
 #include <iomanip>

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -15,9 +15,9 @@
 #include "sha256.h"
 
 #include <fmt/format.h>
-#include <linux/limits.h>
 
 #include <algorithm>
+#include <climits>
 #include <fstream>
 #include <iomanip>
 #include <iostream>

--- a/libs/utils/src/linglong/utils/hooks.cpp
+++ b/libs/utils/src/linglong/utils/hooks.cpp
@@ -15,6 +15,7 @@
 #include <fmt/format.h>
 
 #include <array>
+#include <climits>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>


### PR DESCRIPTION
1. Add climits header to Ensures proper definition of PATH_MAX.
2. Replace Linux-specific header <linux/limits.h> with standard C++ header
<climits> to improve code portability and follow C++ best practices.
This change ensures better cross-platform compatibility while maintaining
the same functionality.