### PR TITLE
fix: add missing headers

### DIFF
--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -38,6 +38,7 @@
 
 #include <QCryptographicHash>
 #include <QDateTime>
+#include <QDebug>
 #include <QDir>
 #include <QDirIterator>
 #include <QEventLoop>


### PR DESCRIPTION
fix forward declaration of 'class QDebug'