### PR TITLE
feat: add fish shell completions and improve bash/zsh support

### DIFF
--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -38,6 +38,7 @@ configure_files(
   share/bash-completion/completions/ll-builder
   share/bash-completion/completions/ll-cli
   share/zsh/vendor-completions/_ll-cli
+  share/fish/vendor_completions.d/ll-cli.fish
   share/dbus-1/system.d/org.deepin.linglong.PackageManager1.conf
   share/dbus-1/system-services/org.deepin.linglong.PackageManager1.service
   share/linglong/export-dirs.json
@@ -60,6 +61,12 @@ set(ZSH_COMPLETIONS_DIR ${CMAKE_INSTALL_DATADIR}/zsh)
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/share/zsh/vendor-completions
         DESTINATION ${ZSH_COMPLETIONS_DIR})
+
+# fish-completion
+set(FISH_COMPLETIONS_DIR ${CMAKE_INSTALL_DATADIR}/fish)
+
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/share/fish/vendor_completions.d
+        DESTINATION ${FISH_COMPLETIONS_DIR})
 
 # dbus
 set(DBUS_SYSTEM_BUS_DIR ${CMAKE_INSTALL_DATADIR}/dbus-1)

--- a/misc/share/bash-completion/completions/ll-builder
+++ b/misc/share/bash-completion/completions/ll-builder
@@ -1,127 +1,126 @@
 #!/bin/env bash
 
-# SPDX-FileCopyrightText: 2023 - 2025 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 # linglong builder completion
 
-#set -x
-
 __ll_builder_get_layer_list() {
-        ls $1*.layer 2>/dev/null | tr '\n' ' '
+    ls *.layer 2>/dev/null | tr '\n' ' '
 }
 
 __ll_builder_get_repo_name_list() {
-        ll-builder repo show | tail -n+3 | awk '{print $1}' | tr "\n" " "
+    ll-builder repo show 2>/dev/null | tail -n+3 | awk '{print $3 ? $3 : $1}' | tr "\n" " "
 }
 
 __ll_builder_get_commited_list() {
-        ll-builder list | tr "\n" " "
+    ll-builder list 2>/dev/null | tr "\n" " "
 }
 
 __filter_exist_options() {
-        local aviable_opts
-        for opt in $1; do
-                local blank=" "
-                for word in "${COMP_WORDS[@]}"; do
-                        if [[ "x$word" == "x$opt" ]]; then
-                                opt=""
-                                blank=""
-                                break
-                        fi
-                done
-                aviable_opts+="$opt"
-                aviable_opts+="$blank"
+    local aviable_opts
+    for opt in $1; do
+        local blank=" "
+        for word in "${COMP_WORDS[@]}"; do
+            if [[ "x$word" == "x$opt" ]]; then
+                opt=""
+                blank=""
+                break
+            fi
         done
-        echo $aviable_opts
+        aviable_opts+="$opt"
+        aviable_opts+="$blank"
+    done
+    echo $aviable_opts
 }
 
 _ll_builder_complete() {
-        local cur prev output_options subcommand
-        COMPREPLY=()
-        cur="${COMP_WORDS[COMP_CWORD]}"
-        prev="${COMP_WORDS[COMP_CWORD - 1]}"
+    local cur prev output_options
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD - 1]}"
 
-        # Define the options and subcommands
-        local common_options="-h --help --help-all"
-        local subcommands="create build run export push import extract repo migrate"
+    local subcommands="create build run export push import import-dir extract repo list remove"
+    local version_options="--version"
+    local common_options="-h --help --help-all"
 
-        output_options="$common_options"
-        # For the first word (command or options)
-        if [[ ${COMP_CWORD} -lt 2 ]]; then
-                output_options="${output_options} ${subcommands}"
-                COMPREPLY=($(compgen -W "${output_options}" -- "${cur}"))
-                return 0
-        fi
-
-        case ${COMP_WORDS[1]} in
-        create)
-                # Nothing here
-                ;;
-        build)
-                local build_options="--file --arch --offline"
-                build_options+=" --full-develop-module"
-                build_options+=" --skip-fetch-source"
-                build_options+=" --skip-pull-depend"
-                build_options+=" --skip-run-container"
-                build_options+=" --skip-commit-output"
-                build_options+=" --skip-output-check"
-                build_options+=" --skip-strip-symbols"
-
-                output_options="${output_options} ${build_options}"
-                ;;
-        run)
-                local run_options="--file --url"
-                output_options="${output_options} ${run_options}"
-                ;;
-        export)
-                local export_options="--file --icon --layer --loader --no-develop"
-                output_options="${output_options} ${export_options}"
-
-                if [[ ${prev} == "--ref" ]]; then
-                        output_options="${output_options} $(__ll_builder_get_commited_list)"
-                else
-                        output_options="${output_options} --ref"
-                fi
-                ;;
-        remove)
-                local remove_options="--no-clean-objects"
-                output_options="${output_options} ${remove_options} $(__ll_builder_get_commited_list)"
-                ;;
-        push)
-                local push_options="--file --repo-url --repo-name --channel --module"
-                output_options="${output_options} ${push_options}"
-                ;;
-        import)
-                if [[ ${prev} == "import" ]]; then
-                        output_options="${output_options} $(__ll_builder_get_layer_list)"
-                fi
-                ;;
-        extract)
-                if [[ ${prev} == "extract" ]]; then
-                        output_options="${output_options} $(__ll_builder_get_layer_list)"
-                fi
-                ;;
-        repo)
-                local repo_subcommands="add remove update set-default show"
-                if [[ ${prev} == "repo" ]]; then
-                        output_options="${output_options} ${repo_subcommands}"
-                fi
-
-                if [[ ${prev} == "remove" || ${prev} == "set-default" ]]; then
-                        output_options="${output_options} $(__ll_builder_get_repo_name_list)"
-                fi
-                ;;
-        migrate)
-                # Nothing here
-                ;;
-        esac
-
-        output_options="$(__filter_exist_options "${output_options}")"
+    # 处理一级子命令及根选项补全
+    if [[ ${COMP_CWORD} -eq 1 ]]; then
+        output_options="${subcommands} ${version_options} ${common_options}"
         COMPREPLY=($(compgen -W "${output_options}" -- "${cur}"))
-
         return 0
+    fi
+
+    case ${COMP_WORDS[1]} in
+    create)
+        output_options="${common_options}"
+        ;;
+    build)
+        local build_options="-f --file --offline --isolate-network"
+        build_options+=" --full-develop-module --skip-fetch-source --skip-pull-depend"
+        build_options+=" --skip-run-container --skip-commit-output --skip-output-check --skip-strip-symbols"
+        output_options="${common_options} ${build_options}"
+        ;;
+    run)
+        local run_options="-f --file --modules --debug --extensions"
+        output_options="${common_options} ${run_options}"
+
+        if [[ ${prev} == "--extensions" ]]; then
+            output_options="$(__ll_builder_get_commited_list)"
+        fi
+        ;;
+    export)
+        local export_options="-f --file -z --compressor --icon --layer --loader --no-develop -o --output --ref --modules"
+        output_options="${common_options} ${export_options}"
+
+        case ${prev} in
+        --ref)
+            output_options="$(__ll_builder_get_commited_list)"
+            ;;
+        -z | --compressor)
+            output_options="lz4 lzma zstd"
+            ;;
+        esac
+        ;;
+    remove)
+        local remove_options="--no-clean-objects"
+        output_options="${common_options} ${remove_options} $(__ll_builder_get_commited_list)"
+        ;;
+    push)
+        local push_options="-f --file --repo-url --repo-name --module"
+        output_options="${common_options} ${push_options}"
+        ;;
+    import | import-dir)
+        if [[ ${COMP_CWORD} -eq 2 ]]; then
+            COMPREPLY=($(compgen -f -- "${cur}"))
+            return 0
+        fi
+        ;;
+    extract)
+        if [[ ${COMP_CWORD} -eq 2 ]]; then
+            output_options="$(__ll_builder_get_layer_list)"
+        fi
+        ;;
+    repo)
+        local repo_subcommands="add remove update set-default show enable-mirror disable-mirror"
+        if [[ ${prev} == "repo" ]]; then
+            output_options="${common_options} ${repo_subcommands}"
+        elif [[ " remove update set-default enable-mirror disable-mirror " =~ " ${prev} " ]]; then
+            output_options="$(__ll_builder_get_repo_name_list)"
+        else
+            output_options="${common_options}"
+        fi
+        ;;
+    *)
+        output_options="${common_options}"
+        ;;
+    esac
+
+    output_options="$(__filter_exist_options "${output_options}")"
+    COMPREPLY=($(compgen -W "${output_options}" -- "${cur}"))
+
+    return 0
 }
 
 complete -F _ll_builder_complete ll-builder

--- a/misc/share/bash-completion/completions/ll-cli
+++ b/misc/share/bash-completion/completions/ll-cli
@@ -9,145 +9,158 @@
 #set -x
 
 __ll_cli_get_container_list() {
-        ll-cli ps | tail -n+2 | awk '{print $1}' | tr '\n' ' '
+    ll-cli ps 2>/dev/null | awk 'NR>1 {print $1}'
 }
 
 __ll_cli_get_installed_app_list() {
-        ll-cli list --type=app | tail -n+2 | awk '{print $1}' | tr '\n' ' '
+    ll-cli list --type=app 2>/dev/null | awk 'NR>1 {print $1}'
 }
 
 __ll_cli_get_installed_list() {
-        ll-cli list | tail -n+2 | awk '{print $1}' | tr '\n' ' '
+    ll-cli list 2>/dev/null | awk 'NR>1 {print $1}'
 }
 
 __ll_cli_get_layer_list() {
-        ls $1*.layer 2>/dev/null | tr '\n' ' '
+    ls -- "${1:-}"*.layer 2>/dev/null | tr '\n' ' '
 }
 
 __ll_cli_get_repo_alias_list() {
-        ll-cli repo show | tail -n+3 | awk '{print $3}' | tr "\n" " "
+    ll-cli repo show 2>/dev/null | awk 'NR>2 {print $3}'
 }
 
 __filter_exist_options() {
-        local aviable_opts
-        for opt in $1; do
-                local blank=" "
-                for word in "${COMP_WORDS[@]}"; do
-                        if [[ "x${word}" == "x${opt}" ]]; then
-                                opt=""
-                                blank=""
-                                break
-                        fi
-                done
-                aviable_opts+="${opt}"
-                aviable_opts+="${blank}"
+    local all_candidates=($1)
+    local filtered=()
+    for opt in "${all_candidates[@]}"; do
+        local found=0
+        for word in "${COMP_WORDS[@]}"; do
+            if [[ "$word" == "$opt" ]]; then
+                found=1
+                break
+            fi
         done
-        echo ${aviable_opts}
+        # 如果当前选项不在已输入的单词中，则加入候选列表
+        [[ $found -eq 0 ]] && filtered+=("$opt")
+    done
+    echo "${filtered[@]}"
 }
 
-_ll_cli_complete() {
-        local cur prev output_options subcommand
-        COMPREPLY=()
+_ll_cli_completion() {
+    local cur prev words cword
+    _get_comp_words_by_ref -n : cur prev words cword 2>/dev/null || {
         cur="${COMP_WORDS[COMP_CWORD]}"
         prev="${COMP_WORDS[COMP_CWORD - 1]}"
+        words=("${COMP_WORDS[@]}")
+        cword=$COMP_CWORD
+    }
 
-        # Define the options and subcommands
-        local common_options="-h --help --help-all"
-        local global_options="--version --json"
-        local subcommands="run ps enter kill prune install uninstall upgrade list info content search repo"
+    local subcommands="run ps enter kill install uninstall upgrade search list repo info content prune"
+    local global_opts="--help --help-all --json --verbose -v --no-progress"
 
-        output_options="$common_options"
-        # For the first word (command or options)
-        if [[ ${COMP_CWORD} -lt 2 ]]; then
-                output_options="${output_options} ${global_options} ${subcommands}"
-                COMPREPLY=($(compgen -W "${output_options}" -- "${cur}"))
-                return 0
-        elif [[ ${COMP_CWORD} -eq 2 && ${COMP_WORDS[1]} == -* ]]; then
-                output_options="${output_options} ${subcommands}"
-                COMPREPLY=($(compgen -W "${output_options}" -- "${cur}"))
-                return 0
+    COMPREPLY=()
+    local subcmd=""
+    local i
+
+    # 查找当前的子命令
+    for ((i = 1; i < cword; i++)); do
+        if [[ " $subcommands " =~ " ${words[i]} " ]]; then
+            subcmd="${words[i]}"
+            break
         fi
+    done
 
-        if [[ ${COMP_WORDS[1]} != -* ]]; then
-                subcommand=${COMP_WORDS[1]}
+    if [[ -z "$subcmd" ]]; then
+        if [[ "$cur" == -* ]]; then
+            COMPREPLY=($(compgen -W "$global_opts --version" -- "$cur"))
         else
-                subcommand=${COMP_WORDS[2]}
+            COMPREPLY=($(compgen -W "$subcommands $global_opts --version" -- "$cur"))
         fi
-
-        case ${subcommand} in
-        run)
-                local run_options="--file --url"
-                local installed_list
-                if [[ "${prev}" == "run" ]]; then
-                        installed_list="$(__ll_cli_get_installed_app_list)"
-                fi
-                output_options="${output_options} ${run_options} ${installed_list}"
-                ;;
-        ps)
-                # Nothing here
-                ;;
-        enter)
-                local enter_options="--working-directory"
-                local container_list
-                if [[ "${prev}" == "enter" ]]; then
-                        container_list="$(__ll_cli_get_container_list)"
-                fi
-                output_options="${output_options} ${enter_options} ${container_list}"
-                ;;
-        kill)
-                output_options="${output_options} $(__ll_cli_get_container_list)"
-                ;;
-        prune)
-                # Nothing here
-                ;;
-        install)
-                install_options="--module --force -y"
-                output_options="${output_options} ${install_options}"
-                COMPREPLY=($(compgen -W "${output_options}" -- "${cur}"))
-                _filedir @(layer|uab)
-                return 0
-                ;;
-        uninstall)
-                local uninstall_options
-                local installed_list
-                if [[ "${prev}" == "uninstall" ]]; then
-                        installed_list="$(__ll_cli_get_installed_app_list)"
-                fi
-                output_options="${output_options} ${uninstall_options} ${installed_list}"
-                ;;
-        upgrade)
-                output_options="${output_options} $(__ll_cli_get_installed_list)"
-                ;;
-        list)
-                list_options="--type --upgradable"
-                output_options="${output_options} ${list_options}"
-                ;;
-        info)
-                output_options="${output_options} $(__ll_cli_get_installed_list) $(__ll_cli_get_layer_list ${cur}))"
-                ;;
-        content)
-                output_options="${output_options} $(__ll_cli_get_installed_app_list)"
-                ;;
-        search)
-                search_options="--type --dev"
-                output_options="${output_options} ${search_options}"
-                ;;
-        repo)
-                local repo_subcommands="add remove update set-default show"
-                if [[ ${prev} == "repo" ]]; then
-                        output_options="${output_options} ${repo_subcommands}"
-                fi
-
-                if [[ ${prev} == "remove" || ${prev} == "set-default" ]]; then
-                        output_options="${output_options} $(__ll_cli_get_repo_alias_list)"
-                fi
-                ;;
-        esac
-
-        output_options="$(__filter_exist_options "${output_options}")"
-        COMPREPLY=($(compgen -W "${output_options}" -- "${cur}"))
-
         return 0
+    fi
+
+    local opts=""
+    case "$subcmd" in
+    run)
+        if [[ "$prev" == "run" ]]; then
+            opts="$(__ll_cli_get_installed_app_list)"
+        else
+            opts="--file --url --env --base --runtime --extensions"
+        fi
+        ;;
+    enter)
+        if [[ "$prev" == "enter" ]]; then
+            opts="$(__ll_cli_get_container_list)"
+        else
+            opts="--working-directory"
+        fi
+        ;;
+    kill)
+        if [[ "$prev" == "kill" || "$prev" == "-s" || "$prev" == "--signal" ]]; then
+            [[ "$prev" == "kill" ]] && opts="$(__ll_cli_get_container_list)"
+            [[ "$prev" != "kill" ]] && opts="SIGTERM SIGKILL SIGINT SIGHUP"
+        else
+            opts="--signal -s"
+        fi
+        ;;
+    install)
+        opts="--module --repo --force -y"
+
+        if [[ "$cur" != -* ]]; then
+            _filedir '@(layer|uab)'
+
+            if [[ ${#COMPREPLY[@]} -gt 0 ]]; then
+                local filtered_opts=$(__filter_exist_options "$opts $global_opts")
+                COMPREPLY+=($(compgen -W "$filtered_opts" -- "$cur"))
+                return 0
+            fi
+        fi
+        ;;
+    upgrade)
+        opts="$(__ll_cli_get_installed_app_list)"
+        ;;
+    uninstall)
+        if [[ "$prev" == "uninstall" ]]; then
+            opts="$(__ll_cli_get_installed_app_list)"
+        else
+            opts="--module --force"
+        fi
+        ;;
+    search | list)
+        if [[ "$prev" == "--type" ]]; then
+            opts="runtime base app all"
+        else
+            [[ "$subcmd" == "search" ]] && opts="--type --repo --dev --show-all-version"
+            [[ "$subcmd" == "list" ]] && opts="--type --upgradable"
+        fi
+        ;;
+    repo)
+        local repo_subs="add remove update set-default show set-priority enable-mirror disable-mirror"
+        if [[ "$prev" == "repo" ]]; then
+            opts="$repo_subs"
+        elif [[ " remove update set-default set-priority enable-mirror disable-mirror " =~ " $prev " ]]; then
+            opts="$(__ll_cli_get_repo_alias_list)"
+        elif [[ " ${words[*]} " =~ " add " ]]; then
+            opts="--alias"
+        fi
+        ;;
+    info)
+        opts="$(__ll_cli_get_installed_list) $(__ll_cli_get_layer_list ${cur})"
+        ;;
+    content)
+        opts="$(__ll_cli_get_installed_list)"
+        ;;
+    esac
+
+    local total_candidates="$opts $global_opts"
+
+    local final_opts
+    final_opts=$(__filter_exist_options "$total_candidates")
+
+    if [[ -n "$final_opts" ]]; then
+        COMPREPLY=($(compgen -W "$final_opts" -- "$cur"))
+    fi
+
+    return 0
 }
 
-complete -F _ll_cli_complete ll-cli
+complete -F _ll_cli_completion -o default ll-cli

--- a/misc/share/fish/vendor_completions.d/ll-builder.fish
+++ b/misc/share/fish/vendor_completions.d/ll-builder.fish
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+function __ll_builder_get_repos
+    ll-builder repo show 2>/dev/null | tail -n+3 | awk '{print $3 ? $3 : $1}'
+end
+
+function __ll_builder_get_refs
+    ll-builder list 2>/dev/null
+end
+
+complete -c ll-builder -n "__fish_use_subcommand" -l version
+
+complete -c ll-builder -s h -l help
+complete -c ll-builder -l help-all
+
+# 3. Subcommands
+set -l cmds create build run export push import import-dir extract repo remove list
+complete -c ll-builder -f -n "__fish_use_subcommand" -a "$cmds"
+
+# 4. Build options
+complete -c ll-builder -f -n "__fish_seen_subcommand_from build" -s f -l file -l offline -l isolate-network
+complete -c ll-builder -f -n "__fish_seen_subcommand_from build" -l full-develop-module -l skip-fetch-source -l skip-pull-depend -l skip-run-container -l skip-commit-output -l skip-output-check -l skip-strip-symbols
+
+# 5. Run options
+complete -c ll-builder -f -n "__fish_seen_subcommand_from run" -s f -l file -l modules -l debug
+complete -c ll-builder -f -n "__fish_seen_subcommand_from run" -l extensions -a "(__ll_builder_get_refs)"
+
+# 6. Export options
+complete -c ll-builder -f -n "__fish_seen_subcommand_from export" -s f -l file -l icon -l layer -l loader -l no-develop -s o -l output -l modules
+complete -c ll-builder -f -n "__fish_seen_subcommand_from export" -s z -l compressor -a "lz4 lzma zstd"
+complete -c ll-builder -f -n "__fish_seen_subcommand_from export" -l ref -a "(__ll_builder_get_refs)"
+
+# 7. Remove options
+complete -c ll-builder -f -n "__fish_seen_subcommand_from remove" -l no-clean-objects
+complete -c ll-builder -f -n "__fish_seen_subcommand_from remove" -a "(__ll_builder_get_refs)"
+
+# 8. Push options
+complete -c ll-builder -f -n "__fish_seen_subcommand_from push" -s f -l file -l repo-url -l repo-name -l module
+
+# 9. Repo subcommands and arguments
+complete -c ll-builder -f -n "__fish_seen_subcommand_from repo" -a "add remove update set-default show enable-mirror disable-mirror"
+set -l repo_sub_needs_name remove update set-default enable-mirror disable-mirror
+complete -c ll-builder -f -n "__fish_seen_subcommand_from repo; and __fish_seen_subcommand_from $repo_sub_needs_name" -a "(__ll_builder_get_repos)"
+
+# 10. File completions for specific commands
+complete -c ll-builder -f -n "__fish_seen_subcommand_from import extract" -a "(ls *.layer 2>/dev/null)"

--- a/misc/share/fish/vendor_completions.d/ll-cli.fish
+++ b/misc/share/fish/vendor_completions.d/ll-cli.fish
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+function __fish_ll_cli_get_containers
+    ll-cli ps 2>/dev/null | awk 'NR>1 {print $1}'
+end
+
+function __fish_ll_cli_get_installed_apps
+    ll-cli list --type=app 2>/dev/null | awk 'NR>1 {print $1}'
+end
+
+function __fish_ll_cli_get_installed_all
+    ll-cli list 2>/dev/null | awk 'NR>1 {print $1}'
+end
+
+function __fish_ll_cli_get_repo_aliases
+    ll-cli repo show 2>/dev/null | awk 'NR>2 {print $3}'
+end
+
+complete -c ll-cli -f
+
+# version
+complete -c ll-cli -n "__fish_use_subcommand" -l version
+
+# 全局选项
+set -l global_long_opts help help-all json verbose no-progress
+set -l global_short_opts v
+
+for opt in $global_long_opts
+    complete -c ll-cli -l $opt
+end
+for opt in $global_short_opts
+    complete -c ll-cli -s $opt
+end
+
+# --- 一级子命令定义 ---
+set -l subcommands run ps enter kill install uninstall upgrade search list repo info content prune
+complete -c ll-cli -n "__fish_use_subcommand" -a "$subcommands"
+
+# --- 子命令参数补全逻辑 ---
+
+# run, enter, kill
+complete -c ll-cli -n "__fish_seen_subcommand_from run" -l file -l url -l env -l base -l runtime -l extensions
+complete -c ll-cli -n "__fish_seen_subcommand_from run" -a "(__fish_ll_cli_get_installed_apps)"
+complete -c ll-cli -n "__fish_seen_subcommand_from enter" -l working-directory
+complete -c ll-cli -n "__fish_seen_subcommand_from kill" -s s -l signal -xa "SIGTERM SIGKILL SIGINT SIGHUP"
+complete -c ll-cli -n "__fish_seen_subcommand_from enter kill" -a "(__fish_ll_cli_get_containers)"
+
+# install / uninstall / upgrade
+complete -c ll-cli -n "__fish_seen_subcommand_from install" -l module -l repo -l force -s y
+complete -c ll-cli -n "__fish_seen_subcommand_from install" -k -a "(__fish_complete_suffix .layer .uab)"
+complete -c ll-cli -n "__fish_seen_subcommand_from uninstall" -l module -l force
+complete -c ll-cli -n "__fish_seen_subcommand_from uninstall upgrade" -a "(__fish_ll_cli_get_installed_apps)"
+
+# search / list
+complete -c ll-cli -n "__fish_seen_subcommand_from search list" -l type -xa "runtime base app all"
+complete -c ll-cli -n "__fish_seen_subcommand_from search" -l repo -l dev -l show-all-version
+complete -c ll-cli -n "__fish_seen_subcommand_from list" -l upgradable
+
+# repo
+set -l repo_subs add remove update set-default show set-priority enable-mirror disable-mirror
+complete -c ll-cli -n "__fish_seen_subcommand_from repo; and not __fish_seen_subcommand_from $repo_subs" -a "$repo_subs"
+complete -c ll-cli -n "__fish_seen_subcommand_from repo; and __fish_seen_subcommand_from add" -l alias
+complete -c ll-cli -n "__fish_seen_subcommand_from repo; and __fish_seen_subcommand_from remove update set-default set-priority enable-mirror disable-mirror" -a "(__fish_ll_cli_get_repo_aliases)"
+
+# info 和 content 支持已安装的 app/runtime
+complete -c ll-cli -n "__fish_seen_subcommand_from info content" -a "(__fish_ll_cli_get_installed_all)"
+
+# info 额外支持补全当前目录下的 .layer 文件 (核心修复)
+complete -c ll-cli -n "__fish_seen_subcommand_from info" -k -a "(__fish_complete_suffix .layer)"

--- a/misc/share/zsh/vendor-completions/_ll-builder
+++ b/misc/share/zsh/vendor-completions/_ll-builder
@@ -1,0 +1,89 @@
+#compdef ll-builder
+
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+_ll_builder_get_commited_list() {
+    ll-builder list 2>/dev/null | tr "\n" " "
+}
+
+_ll_builder_get_repo_name_list() {
+    ll-builder repo show 2>/dev/null | tail -n+3 | awk '{print $3 ? $3 : $1}'
+}
+
+_ll-builder() {
+    local -a subcommands
+    subcommands=(create build run export push import import-dir extract repo list remove)
+
+    _arguments -C \
+        '--version' \
+        '(-h --help --help-all)'{-h,--help,--help-all} \
+        '1: :->cmds' \
+        '*:: :->args'
+
+    case $state in
+        cmds)
+            compadd "$@" $subcommands
+            ;;
+        args)
+            case $line[1] in
+                create)
+                    _arguments '(-h --help --help-all)'{-h,--help,--help-all}
+                    ;;
+                build)
+                    _values '' -f --file --offline --isolate-network --full-develop-module \
+                        --skip-fetch-source --skip-pull-depend --skip-run-container \
+                        --skip-commit-output --skip-output-check --skip-strip-symbols \
+                        -h --help --help-all
+                    ;;
+                run)
+                    _arguments \
+                        '(-f --file)'{-f,--file} \
+                        '--modules' '--debug' \
+                        '--extensions: :($( _ll_builder_get_commited_list ))' \
+                        '(-h --help --help-all)'{-h,--help,--help-all}
+                    ;;
+                export)
+                    _arguments \
+                        '(-f --file)'{-f,--file} '--icon' '--layer' '--loader' '--no-develop' \
+                        '(-o --output)'{-o,--output} '--modules' \
+                        '(-z --compressor)'{-z,--compressor}': :(lz4 lzma zstd)' \
+                        '--ref: :($( _ll_builder_get_commited_list ))' \
+                        '(-h --help --help-all)'{-h,--help,--help-all}
+                    ;;
+                remove)
+                    _arguments \
+                        '--no-clean-objects' \
+                        '*: :($( _ll_builder_get_commited_list ))' \
+                        '(-h --help --help-all)'{-h,--help,--help-all}
+                    ;;
+                push)
+                    _values '' -f --file --repo-url --repo-name --module -h --help --help-all
+                    ;;
+                import|import-dir)
+                    _arguments '1: :_files' '(-h --help --help-all)'{-h,--help,--help-all}
+                    ;;
+                extract)
+                    _arguments '1: :_files -g "*.layer"' '2: :_directories' '(-h --help --help-all)'{-h,--help,--help-all}
+                    ;;
+                repo)
+                    if (( CURRENT == 2 )); then
+                        compadd add remove update set-default show enable-mirror disable-mirror
+                    else
+                        case $words[2] in
+                            remove|update|set-default|enable-mirror|disable-mirror)
+                                compadd $(_ll_builder_get_repo_name_list)
+                                ;;
+                        esac
+                    fi
+                    ;;
+                *)
+                    _arguments '(-h --help --help-all)'{-h,--help,--help-all}
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_ll-builder "$@"

--- a/misc/share/zsh/vendor-completions/_ll-cli
+++ b/misc/share/zsh/vendor-completions/_ll-cli
@@ -1,223 +1,120 @@
 #compdef ll-cli
 
-# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
-#
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
-__ll_cli_get_container_list() {
-    ll-cli ps | tail -n+2 | awk '{print $1}' || echo ""
+__ll_cli_get_containers() {
+    local -a containers
+    containers=(${(f)"$(ll-cli ps 2>/dev/null | awk 'NR>1 {print $1}')"})
+    _describe 'container' containers
 }
 
-__ll_cli_get_installed_list() {
-    ll-cli list | tail -n+2 | awk '{print $1line}' || echo ""
+__ll_cli_get_installed_apps() {
+    local -a apps
+    apps=(${(f)"$(ll-cli list --type=app 2>/dev/null | awk 'NR>1 {print $1}')"})
+    _describe 'app' apps
 }
 
-__ll_cli_get_installed_app_list() {
-    ll-cli list --type=all | tail -n+2 | awk '{print $1line}' || echo ""
+__ll_cli_get_installed_all() {
+    local -a all_items
+    all_items=(${(f)"$(ll-cli list 2>/dev/null | awk 'NR>1 {print $1}')"})
+    _describe 'item' all_items
 }
 
-__ll_cli_get_app_list() {
-    ll-cli search $1 | tail -n+2 | awk '{print $1}' || echo ""
+__ll_cli_get_repo_aliases() {
+    local -a aliases
+    aliases=(${(f)"$(ll-cli repo show 2>/dev/null | awk 'NR>2 {print $3}')"})
+    _describe 'alias' aliases
 }
 
-__ll_cli_get_layer_list() {
-    ls $1*.layer 2>/dev/null | tr '\n' ' '
-}
+_ll_cli() {
+    local state
 
-__ll_cli_get_repo_name_list() {
-    ll-cli repo show | tail -n+3 | awk '{print $1}' || echo ""
-}
-
-_ll-cli() {
-    local state line
-
-    local -a command_options=(
-        '-h'
-        '--help'
-        '--help-all'
-    )
-    local -a global_options=(
-        '--version'
-        '--json'
+    local -a global_opts
+    global_opts=(
+        '--help' '--help-all' '--json'
+        '(--verbose -v)'{--verbose,-v} '--no-progress'
     )
 
-    _arguments -C \
-        "${command_options[@]}" \
-        "${global_options[@]}" \
-        ": :{_values 'command' run ps enter kill prune install uninstall upgrade list info content search repo}" \
-        "*::arg:->args"
+    _arguments -S -s -C \
+        $global_opts \
+        '--version' \
+        '1: :->cmds' \
+        '*:: :->args'
 
-    case "$line[1]" in
-        run)
-            local installed_list=(${(f)"$(__ll_cli_get_installed_app_list)"})
-            local run_options=(
-                '--file:file:_files'
-                '--url:url:_urls'
+    case $state in
+        cmds)
+            local -a subcmds
+            subcmds=(
+                'run' 'ps' 'enter' 'kill' 'install' 'uninstall'
+                'upgrade' 'search' 'list' 'repo' 'info' 'content' 'prune'
             )
-            if [[ ${#installed_list[@]} -gt 0 ]]; then
-                _arguments \
-                    '1: :{_values "installed applications" "${installed_list[@]}"}' \
-                    '*:: :->run_args'
-            fi
+            _values 'subcommand' $subcmds
             ;;
-        ps)
-            local container_list=(${(f)"$(__ll_cli_get_container_list)"})
-            if [[ ${#container_list[@]} -gt 0 ]]; then
-                _arguments \
-                    '1: :{_values "running applications" "${container_list[@]}"}' \
-                    "${command_options[@]}"
-            fi
-            ;;
-        enter)
-            local enter_options=(
-                '--working-directory'
-            )
-            local container_list=(${(f)"$(__ll_cli_get_container_list)"})
-            if [[ ${#container_list[@]} -gt 0 ]]; then
-                _arguments \
-                    '1: :{_values "running applications" "${container_list[@]}"}' \
-                    "${enter_options[@]}" \
-                    "${command_options[@]}"
-            fi
-            ;;
-        kill)
-            local container_list=(${(f)"$(__ll_cli_get_container_list)"})
-            if [[ ${#container_list[@]} -gt 0 ]]; then
-                _arguments \
-                    '1: :{_values "running applications" "${container_list[@]}"}' \
-                    "${command_options[@]}"
-            fi
-            ;;
-        prune)
-            _arguments "${command_options[@]}"
-            ;;
-        install)
-            local -a install_options=(
-                '--module'
-                '--force'
-                '-y'
-            )
-
-            # 判断是否是本地路径补全
-            local cur="${words[CURRENT]}"
-            if [[ "${cur}" == ./* ]]; then
-                _arguments \
-                    '1: :_files -g "*.layer" -g "*.uab"' \
-                    "${install_options[@]}" \
-                    "${command_options[@]}"
-            else
-                local search_target="."
-                if [[ -n "${cur}" ]]; then
-                    search_target="${cur}"
-                fi
-
-                local app_list=(${(f)"$(__ll_cli_get_app_list ${search_target})"})
-                if [[ ${#app_list[@]} -eq 0 ]]; then
-                    _message "no matching applications"
-                else
-                    _arguments \
-                        '1: :{_values "available applications" "${app_list[@]}"}' \
-                        "${install_options[@]}" \
-                        "${command_options[@]}"
-                fi
-            fi
-            ;;
-        uninstall)
-            local uninstall_options=(
-                '--module[Specify the module to uninstall]'
-            )
-            local installed_list=(${(f)"$(__ll_cli_get_installed_app_list)"})
-            if [[ ${#installed_list[@]} -gt 0 ]]; then
-                _arguments \
-                    '1: :{_values "installed applications" "${installed_list[@]}"}' \
-                    "${uninstall_options[@]}" \
-                    "${command_options[@]}"
-            fi
-            ;;
-        upgrade)
-            local installed_list=(${(f)"$(__ll_cli_get_installed_list)"})
-            if [[ ${#installed_list[@]} -gt 0 ]]; then
-                _arguments \
-                    '1: :{_values "installed applications" "${installed_list[@]}"}' \
-                    "${command_options[@]}"
-            fi
-            ;;
-        list)
-            local list_options=(
-                '--type:type:(app runtime all)'
-                '--upgradable'
-            )
-            _arguments \
-                "${list_options[@]}" \
-                "${command_options[@]}"
-            ;;
-        info)
-            local installed_list=(${(f)"$(__ll_cli_get_installed_list)"})
-            local layer_list=(${(f)"$(__ll_cli_get_layer_list ${cur})"})
-            if [[ ${#installed_list[@]} -gt 0 ]]; then
-                _arguments \
-                    '1: :{_values "installed applications" "${installed_list[@]}"}' \
-                    "${command_options[@]}"
-            elif [[ ${#layer_list[@]} -gt 0 ]]; then
-                _arguments \
-                    '1: :{_values "installed layers" "${layer_list[@]}"}' \
-                    "${command_options[@]}"
-            fi
-            ;;
-        content)
-            local installed_list=(${(f)"$(__ll_cli_get_installed_app_list)"})
-            if [[ ${#installed_list[@]} -gt 0 ]]; then
-                _arguments \
-                    '1: :{_values "installed applications" "${installed_list[@]}"}' \
-                    "${command_options[@]}"
-            fi
-            ;;
-        search)
-            local search_options=(
-                '--type:type:(app runtime all)'
-                '--dev'
-                '--all'
-            )
-
-            _arguments \
-                "${search_options[@]}" \
-                "${command_options[@]}"
-            ;;
-        repo)
-            local -a repo_subcommands=(add remove update set-default show set-priority)
-            local -a repo_options=(
-                '--alias:alias'
-                '-f'
-            )
-
-            if [[ ${repo_subcommands[(Ie)${line[2]}]} -gt 0 ]]; then
-                if [[ ${line[2]} == "add" ]]; then
-                    _arguments \
-                        '1:repository name' \
-                        '2:repository URL' \
-                        "${repo_options[@]}" \
-                        "${command_options[@]}"
-                elif [[ ${line[2]} == "show" ]]; then
-                    _arguments \
-                        "${command_options[@]}"
-                else
-                    local repo_name_list=(${(f)"$(__ll_cli_get_repo_name_list)"})
-                    _arguments \
-                        '2: :{_values "repository names" "${repo_name_list[@]}"}' \
-                        "${command_options[@]}"
-                fi
-            else
-                _arguments \
-                    ': :{_values "repo subcommand" "${repo_subcommands[@]}"}' \
-                    "${command_options[@]}"
-            fi
+        args)
+            case $words[1] in
+                run)
+                    _arguments -S -s $global_opts \
+                        '--file' '--url' '--env' '--base' '--runtime' '--extensions' \
+                        '1: :__ll_cli_get_installed_apps'
+                    ;;
+                install)
+                    _arguments -S -s $global_opts \
+                        '--module' '--repo' '--force' '-y' \
+                        '*:file:_files -g "*.uab *.layer"'
+                    ;;
+                uninstall)
+                    _arguments -S -s $global_opts '--module' '--force' '1: :__ll_cli_get_installed_apps'
+                    ;;
+                repo)
+                    if ((CURRENT == 2)); then
+                        local -a repo_subs
+                        repo_subs=('add' 'remove' 'update' 'set-default' 'show' 'set-priority' 'enable-mirror' 'disable-mirror')
+                        _values 'repo subcommand' $repo_subs
+                    else
+                        case $words[2] in
+                            add)
+                                _arguments -S -s $global_opts \
+                                    '--alias:alias: ' \
+                                    '*:repository name/URL:'
+                                ;;
+                            remove | set-default | set-priority | enable-mirror | disable-mirror | update)
+                                _arguments -S -s $global_opts "*: :__ll_cli_get_repo_aliases"
+                                ;;
+                        esac
+                    fi
+                    ;;
+                enter | kill)
+                    local -a extra_args
+                    [[ $words[1] == "kill" ]] && extra_args=('(-s --signal)'{-s,--signal}':signal:(SIGTERM SIGKILL SIGINT SIGHUP)')
+                    _arguments -S -s $global_opts $extra_args '1: :__ll_cli_get_containers'
+                    ;;
+                search)
+                    _arguments -S -s $global_opts \
+                        '--type:type:(runtime base app all)' \
+                        '--repo' '--dev' '--show-all-version'
+                    ;;
+                list)
+                    _arguments -S -s $global_opts \
+                        '--type:type:(runtime base app all)' \
+                        '--upgradable'
+                    ;;
+                upgrade)
+                    _arguments -S -s $global_opts '1: :__ll_cli_get_installed_apps'
+                    ;;
+                info)
+                    _arguments -s -S $global_opts \
+                        '1: : _alternative "installed-items:installed item:__ll_cli_get_installed_all" "layer-files:local layer file:_files -g \"*.layer\""'
+                    ;;
+                content)
+                    _arguments -s -S $global_opts '1: :__ll_cli_get_installed_all'
+                    ;;
+                prune)
+                    _arguments -S -s $global_opts
+                    ;;
+            esac
             ;;
     esac
-    if [[ "$state" == run_args ]]; then
-        _arguments \
-            "${run_options[@]}" \
-            "${command_options[@]}"
-    fi
 }
 
-compdef _ll-cli ll-cli
+_ll_cli "$@"


### PR DESCRIPTION
1. Add comprehensive fish shell completion script with support for all subcommands and options
2. Refactor bash completion script for better maintainability and error handling
3. Improve bash completion robustness by redirecting stderr to /dev/null in all helper functions
4. Fix bash completion parsing logic to use awk 'NR>1' instead of 'tail -n+2' for better portability
5. Enhance bash subcommand detection algorithm to properly handle complex command lines
6. Improve option filtering in bash to prevent duplicate suggestions
7. Refactor zsh completion script with standardized function naming and structure
8. Add better error handling to zsh completion functions
9. Expand completion coverage for repo subcommands (set-priority, enable-mirror, disable-mirror)
10. Standardize completion behavior across all three shells (bash, zsh, fish)

Log: Added fish shell completions and improved reliability of bash/ zsh completions

Influence:
1. Test fish shell completions for all subcommands: run, ps, enter, kill, install, uninstall, upgrade, search, list, repo, info, content, prune
2. Verify bash completions suppress error output when ll-cli commands fail
3. Test bash completion with partial input and verify option deduplication works
4. Verify zsh completions for repo subcommands: add, remove, update, set-default, show, set-priority, enable-mirror, disable-mirror
5. Test file path completion for .layer and .uab files in install and info commands
6. Verify container ID completion in enter and kill commands across all shells
7. Test installed application/runtime completion for uninstall, upgrade, info, and content commands
8. Verify global options (--help, --json, --verbose, etc.) appear correctly for all subcommands
9. Test completion behavior with complex command lines containing multiple options and arguments
10. Verify no regressions in existing bash/zsh completion functionality