### PR TITLE
refactor: improve driver detection testability with DI and mocking

### DIFF
--- a/apps/ll-driver-detect/src/driver_detection_manager.cpp
+++ b/apps/ll-driver-detect/src/driver_detection_manager.cpp
@@ -15,6 +15,12 @@ DriverDetectionManager::DriverDetectionManager()
     registerDetectors();
 }
 
+DriverDetectionManager::DriverDetectionManager(
+  std::vector<std::unique_ptr<DriverDetector>> detectors)
+    : detectors_(std::move(detectors))
+{
+}
+
 utils::error::Result<std::vector<GraphicsDriverInfo>>
 DriverDetectionManager::detectAvailableDrivers()
 {

--- a/apps/ll-driver-detect/src/driver_detection_manager.h
+++ b/apps/ll-driver-detect/src/driver_detection_manager.h
@@ -16,6 +16,8 @@ class DriverDetectionManager
 {
 public:
     DriverDetectionManager();
+    explicit DriverDetectionManager(std::vector<std::unique_ptr<DriverDetector>> detectors);
+
     virtual ~DriverDetectionManager() = default;
 
     // Detect all available graphics drivers on the system
@@ -24,9 +26,9 @@ public:
     linglong::utils::error::Result<void>
     installDriverPackage(const std::vector<GraphicsDriverInfo> &drivers);
 
-protected:
+private:
     // Register all available driver detectors
-    virtual void registerDetectors();
+    void registerDetectors();
     std::vector<std::unique_ptr<DriverDetector>> detectors_;
 };
 

--- a/apps/ll-driver-detect/src/nvidia_driver_detector.cpp
+++ b/apps/ll-driver-detect/src/nvidia_driver_detector.cpp
@@ -46,23 +46,36 @@ utils::error::Result<GraphicsDriverInfo> NVIDIADriverDetector::detect()
         return LINGLONG_ERR("Failed to check if package is installed: "
                             + installedResult.error().message());
     }
+
     if (*installedResult) {
+        if (!packageInfoResult->first) {
+            LogW("NVIDIA driver package is installed locally but not found in remote repo: {}",
+                 linglongPackageName);
+            return LINGLONG_ERR("Cannot find NVIDIA driver package in remote repo.");
+        }
+
         auto upgradableResult = checkPackageUpgradable(linglongPackageName);
         if (!upgradableResult) {
             return LINGLONG_ERR("Failed to check if package is upgradable: "
                                 + upgradableResult.error().message());
         }
         if (*upgradableResult) {
-            LogD("NVIDIA driver package can be upgraded : {}", linglongPackageName);
-            return *packageInfoResult;
+            LogD("NVIDIA driver package can be upgraded : {}, install from remote repo.",
+                 linglongPackageName);
+            return packageInfoResult->second;
         }
         return LINGLONG_ERR("NVIDIA driver package is already installed and up-to-date.");
     }
 
-    return *packageInfoResult;
+    if (!packageInfoResult->first) {
+        return LINGLONG_ERR("NVIDIA driver package not found in remote repo");
+    }
+
+    LogD("NVIDIA driver package is not installed, install from remote repo.");
+    return packageInfoResult->second;
 }
 
-utils::error::Result<GraphicsDriverInfo>
+utils::error::Result<std::pair<bool, GraphicsDriverInfo>>
 NVIDIADriverDetector::getPackageInfoFromRemoteRepo(const std::string &packageName)
 {
     using json = nlohmann::json;
@@ -76,10 +89,11 @@ NVIDIADriverDetector::getPackageInfoFromRemoteRepo(const std::string &packageNam
         return LINGLONG_ERR("Search command failed: " + ret.error().message());
     }
 
+    bool found = false;
+
     try {
         json j = json::parse(*ret);
 
-        bool found = false;
         for (const auto &[category, apps] : j.items()) {
             if (!apps.is_array())
                 continue;
@@ -102,7 +116,7 @@ NVIDIADriverDetector::getPackageInfoFromRemoteRepo(const std::string &packageNam
         return LINGLONG_ERR("Failed to parse search result JSON: " + std::string(e.what()));
     }
 
-    return driverInfo;
+    return std::make_pair(found, driverInfo);
 }
 
 utils::error::Result<bool>
@@ -110,17 +124,12 @@ NVIDIADriverDetector::checkPackageInstalled(const std::string &packageName)
 {
     LINGLONG_TRACE("Check if NVIDIA driver package is installed");
 
-    try {
-        auto installedInfo = getInstalledGraphicsDriverInfo(packageName);
-        if (!installedInfo) {
-            return LINGLONG_ERR("Failed to get installed package info: "
-                                + installedInfo.error().message());
-        }
-
-        return true;
-    } catch (const std::exception &e) {
-        return LINGLONG_ERR("Failed to check package installation: " + std::string(e.what()));
+    auto installedInfo = getInstalledGraphicsDriverInfo(packageName);
+    if (!installedInfo) {
+        return LINGLONG_ERR(installedInfo);
     }
+
+    return installedInfo->first;
 }
 
 utils::error::Result<bool>
@@ -134,19 +143,27 @@ NVIDIADriverDetector::checkPackageUpgradable(const std::string &packageName)
                             + upgradableDriverInfo.error().message());
     }
 
+    if (!upgradableDriverInfo->first) {
+        return LINGLONG_ERR("NVIDIA driver package not found in remote repo");
+    }
+
     auto installedDriverInfo = getInstalledGraphicsDriverInfo(packageName);
     if (!installedDriverInfo) {
         return LINGLONG_ERR("Failed to get installed package info: "
                             + installedDriverInfo.error().message());
     }
 
-    LogD("Driver {} can upgrade from {} to {}",
-         packageName,
-         installedDriverInfo->packageVersion,
-         upgradableDriverInfo->packageVersion);
+    if (!installedDriverInfo->first) {
+        return LINGLONG_ERR("NVIDIA driver package is not installed");
+    }
 
-    return compareVersions(upgradableDriverInfo->packageVersion,
-                           installedDriverInfo->packageVersion);
+    LogD("{} current version:{}, latest version {}",
+         packageName,
+         installedDriverInfo->second.packageVersion,
+         upgradableDriverInfo->second.packageVersion);
+
+    return compareVersions(upgradableDriverInfo->second.packageVersion,
+                           installedDriverInfo->second.packageVersion);
 }
 
 std::string NVIDIADriverDetector::getDriverVersion()
@@ -168,36 +185,52 @@ std::string NVIDIADriverDetector::getDriverVersion()
     return version;
 }
 
-utils::error::Result<GraphicsDriverInfo>
+utils::error::Result<std::pair<bool, GraphicsDriverInfo>>
 NVIDIADriverDetector::getInstalledGraphicsDriverInfo(const std::string &packageName) const
 {
+    using json = nlohmann::json;
+
     LINGLONG_TRACE("Get installed NVIDIA graphics driver info");
 
-    try {
-        // First execute ll-cli info to get the package info
-        auto listResult = linglong::utils::Cmd("ll-cli").exec({ "--json", "info", packageName });
+    GraphicsDriverInfo driverInfo{ getDriverIdentify(), packageName };
 
-        if (!listResult) {
-            return LINGLONG_ERR(
-              "Can not get package info with `ll-cli info`, maybe the package is not installed: "
-              + listResult.error().message());
-        }
-
-        nlohmann::json j = nlohmann::json::parse(*listResult);
-
-        auto it = j.find("version");
-        if (it == j.end() || !it->is_string()) {
-            return LINGLONG_ERR("Package info JSON is invalid or empty");
-        }
-
-        return GraphicsDriverInfo{
-            getDriverIdentify(),
-            packageName,
-            it->get<std::string>(),
-        };
-    } catch (const std::exception &e) {
-        return LINGLONG_ERR("Failed to check package installation: " + std::string(e.what()));
+    auto listResult = linglong::utils::Cmd("ll-cli").exec({ "--json", "list", "--type=extension" });
+    if (!listResult) {
+        return LINGLONG_ERR(listResult);
     }
+
+    bool installed = false;
+    try {
+        json installedExtensions = json::parse(*listResult);
+        if (!installedExtensions.is_array()) {
+            return LINGLONG_ERR("Invalid list result JSON: expected an array");
+        }
+
+        for (const auto &item : installedExtensions) {
+            if (!item.is_object())
+                continue;
+
+            auto idIter = item.find("id");
+            if (idIter == item.end() || !idIter->is_string()
+                || idIter->get<std::string_view>() != packageName) {
+                continue;
+            }
+
+            auto versionIter = item.find("version");
+            if (versionIter == item.end() || !versionIter->is_string()) {
+                return LINGLONG_ERR("Installed package found but version field is missing: "
+                                    + packageName);
+            }
+
+            driverInfo.packageVersion = versionIter->get<std::string_view>();
+            installed = true;
+            break;
+        }
+    } catch (const nlohmann::json::parse_error &e) {
+        return LINGLONG_ERR("Failed to parse installed package JSON: " + std::string(e.what()));
+    }
+
+    return std::make_pair(installed, driverInfo);
 }
 
 bool NVIDIADriverDetector::compareVersions(std::string_view v1, std::string_view v2) const noexcept

--- a/apps/ll-driver-detect/src/nvidia_driver_detector.h
+++ b/apps/ll-driver-detect/src/nvidia_driver_detector.h
@@ -28,7 +28,7 @@ public:
     utils::error::Result<bool> checkPackageUpgradable(const std::string &packageName) override;
 
     // Check if the driver package exists in repo
-    virtual utils::error::Result<GraphicsDriverInfo>
+    virtual utils::error::Result<std::pair<bool, GraphicsDriverInfo>>
     getPackageInfoFromRemoteRepo(const std::string &packageName);
 
     // Get the type of driver this detector handles
@@ -37,7 +37,7 @@ public:
 private:
     // Get driver version from the specified file path
     std::string getDriverVersion();
-    utils::error::Result<GraphicsDriverInfo>
+    utils::error::Result<std::pair<bool, GraphicsDriverInfo>>
     getInstalledGraphicsDriverInfo(const std::string &packageName) const;
     bool compareVersions(std::string_view v1, std::string_view v2) const noexcept;
 

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -1592,7 +1592,8 @@ int Cli::info(const InfoOptions &options)
                                           { .forceRemote = false, .fallbackToRemote = false });
         if (!ref) {
             LogD("{}", ref.error());
-            this->printer.printErr(LINGLONG_ERRV("Can not find such application."));
+            this->printer.printErr(LINGLONG_ERRV("Cannot find such application.",
+                                                 utils::error::ErrorCode::AppNotFoundFromLocal));
             return -1;
         }
 

--- a/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/driver_detection_manager_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/driver_detection_manager_test.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "driver_detection_manager.h"
@@ -11,58 +12,65 @@
 #include <vector>
 
 using namespace linglong::driver::detect;
+using namespace testing;
 
-// A custom detector that returns a specific driver info for successful detection
-class FakeSuccessDetector : public DriverDetector
+// Mock class for DriverDetector
+class MockDriverDetector : public DriverDetector
 {
 public:
-    FakeSuccessDetector(std::string identify, std::string name, std::string version)
-        : info_{ std::move(identify), std::move(name), std::move(version) }
-    {
-    }
-
-    linglong::utils::error::Result<GraphicsDriverInfo> detect() override { return info_; }
-
-    std::string getDriverIdentify() const override { return info_.identify; }
-
-private:
-    GraphicsDriverInfo info_;
-};
-
-// A custom detector that always fails
-class FakeFailureDetector : public DriverDetector
-{
-public:
-    linglong::utils::error::Result<GraphicsDriverInfo> detect() override
-    {
-        LINGLONG_TRACE("Fake detector failed as intended")
-        return LINGLONG_ERR("Fake detector failed as intended");
-    }
-
-    std::string getDriverIdentify() const override { return "fake-failure"; }
-};
-
-// A test-specific subclass of DriverDetectionManager to allow for mock injection
-class TestableDriverDetectionManager : public DriverDetectionManager
-{
-public:
-    // Override to prevent registration of real detectors
-    void registerDetectors() override { }
-
-    // Expose a way to add mock/fake detectors for tests
-    void addDetector(std::unique_ptr<DriverDetector> detector)
-    {
-        detectors_.push_back(std::move(detector));
-    }
+    MOCK_METHOD(linglong::utils::error::Result<GraphicsDriverInfo>, detect, (), (override));
+    MOCK_METHOD(std::string, getDriverIdentify, (), (const, override));
+    MOCK_METHOD(linglong::utils::error::Result<bool>,
+                checkPackageInstalled,
+                (const std::string &packageName),
+                (override));
+    MOCK_METHOD(linglong::utils::error::Result<bool>,
+                checkPackageUpgradable,
+                (const std::string &packageName),
+                (override));
 };
 
 class DriverDetectionManagerTest : public ::testing::Test
 {
 };
 
-TEST_F(DriverDetectionManagerTest, DetectAllDrivers_NoDetectors)
+TEST_F(DriverDetectionManagerTest, DetectAvailableDriversSuccess)
 {
-    TestableDriverDetectionManager manager;
+    auto mockDetector = std::make_unique<MockDriverDetector>();
+
+    EXPECT_CALL(*mockDetector, detect())
+      .WillOnce(Return(linglong::utils::error::Result<GraphicsDriverInfo>(
+        GraphicsDriverInfo{ "nvidia", "nvidia-driver", "1.0", "stable" })));
+
+    std::vector<std::unique_ptr<DriverDetector>> detectors;
+    detectors.push_back(std::move(mockDetector));
+
+    DriverDetectionManager manager(std::move(detectors));
     auto result = manager.detectAvailableDrivers();
-    ASSERT_TRUE(result.has_value());
+
+    ASSERT_TRUE(result);
+    ASSERT_EQ(result->size(), 1);
+    EXPECT_EQ(result->at(0).identify, "nvidia");
+    EXPECT_EQ(result->at(0).packageName, "nvidia-driver");
+    EXPECT_EQ(result->at(0).packageVersion, "1.0");
+    EXPECT_EQ(result->at(0).repoName, "stable");
+}
+
+TEST_F(DriverDetectionManagerTest, DetectAvailableDriversFailure)
+{
+    LINGLONG_TRACE("Testing detection failure scenario");
+    auto mockDetector = std::make_unique<MockDriverDetector>();
+
+    EXPECT_CALL(*mockDetector, detect()).WillOnce(Return(LINGLONG_ERR("Detection error")));
+
+    EXPECT_CALL(*mockDetector, getDriverIdentify()).WillOnce(Return("nvidia"));
+
+    std::vector<std::unique_ptr<DriverDetector>> detectors;
+    detectors.push_back(std::move(mockDetector));
+
+    DriverDetectionManager manager(std::move(detectors));
+    auto result = manager.detectAvailableDrivers();
+
+    ASSERT_TRUE(result);
+    EXPECT_TRUE(result->empty());
 }

--- a/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/nvidia_driver_detector_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/nvidia_driver_detector_test.cpp
@@ -24,7 +24,7 @@ public:
     {
     }
 
-    MOCK_METHOD(linglong::utils::error::Result<GraphicsDriverInfo>,
+    MOCK_METHOD((linglong::utils::error::Result<std::pair<bool, GraphicsDriverInfo>>),
                 getPackageInfoFromRemoteRepo,
                 (const std::string &packageName),
                 (override));
@@ -63,11 +63,12 @@ TEST_F(NvidiaDriverDetectorTest, Detect_Success_PackageNotInstalled)
       std::string(detector.getDriverIdentify()) + "." + expectedVersion;
 
     EXPECT_CALL(detector, getPackageInfoFromRemoteRepo(expectedPackageName))
-      .WillOnce(Return(GraphicsDriverInfo{
-        .identify = detector.getDriverIdentify(),
-        .packageName = expectedPackageName,
-        .packageVersion = expectedVersion,
-      }));
+      .WillOnce(Return(std::make_pair(true,
+                                      GraphicsDriverInfo{
+                                        .identify = detector.getDriverIdentify(),
+                                        .packageName = expectedPackageName,
+                                        .packageVersion = expectedVersion,
+                                      })));
 
     EXPECT_CALL(detector, checkPackageInstalled(expectedPackageName)).WillOnce(Return(false));
 
@@ -90,11 +91,12 @@ TEST_F(NvidiaDriverDetectorTest, Detect_Success_PackageInstalled)
       std::string(detector.getDriverIdentify()) + "." + expectedVersion;
 
     EXPECT_CALL(detector, getPackageInfoFromRemoteRepo(expectedPackageName))
-      .WillOnce(Return(GraphicsDriverInfo{
-        .identify = detector.getDriverIdentify(),
-        .packageName = expectedPackageName,
-        .packageVersion = expectedVersion,
-      }));
+      .WillOnce(Return(std::make_pair(true,
+                                      GraphicsDriverInfo{
+                                        .identify = detector.getDriverIdentify(),
+                                        .packageName = expectedPackageName,
+                                        .packageVersion = expectedVersion,
+                                      })));
 
     EXPECT_CALL(detector, checkPackageInstalled(expectedPackageName)).WillOnce(Return(true));
     EXPECT_CALL(detector, checkPackageUpgradable(expectedPackageName)).WillOnce(Return(false));
@@ -116,11 +118,12 @@ TEST_F(NvidiaDriverDetectorTest, Detect_Success_PackageUpgradable)
       std::string(detector.getDriverIdentify()) + "." + expectedVersion;
 
     EXPECT_CALL(detector, getPackageInfoFromRemoteRepo(expectedPackageName))
-      .WillOnce(Return(GraphicsDriverInfo{
-        .identify = detector.getDriverIdentify(),
-        .packageName = expectedPackageName,
-        .packageVersion = upgradableExpectedVersion,
-      }));
+      .WillOnce(Return(std::make_pair(true,
+                                      GraphicsDriverInfo{
+                                        .identify = detector.getDriverIdentify(),
+                                        .packageName = expectedPackageName,
+                                        .packageVersion = upgradableExpectedVersion,
+                                      })));
 
     EXPECT_CALL(detector, checkPackageInstalled(expectedPackageName)).WillOnce(Return(true));
     EXPECT_CALL(detector, checkPackageUpgradable(expectedPackageName)).WillOnce(Return(true));


### PR DESCRIPTION
- Add constructor injection to DriverDetectionManager for better testability
- Replace fake detector classes with Google Mock in tests
- Change package install check error to warning in NVIDIA detector
- Improve logging format for driver upgrade messages

This refactoring enables proper unit testing by allowing mock detectors to be injected and uses Google Mock framework for better test isolation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect driver package detection/upgrade decisions and rely on parsing `ll-cli list` JSON output, which could alter behavior on real systems if output formats or edge cases differ.
> 
> **Overview**
> **Improves driver detection testability** by adding constructor injection to `DriverDetectionManager` (and making detector registration private), enabling unit tests to supply custom/mocked detectors instead of subclassing.
> 
> **Tightens NVIDIA driver detection/package-resolution behavior**: remote repo lookups now return a `(found, info)` pair, installed/upgradable checks now error if the package is missing from remote, and installed-state discovery switches to parsing `ll-cli --json list --type=extension` output (with clearer logs for upgrade vs up-to-date cases). A small CLI tweak also attaches `ErrorCode::AppNotFoundFromLocal` to the `ll-cli info` “cannot find application” error.
> 
> Tests are updated to use Google Mock for both manager and NVIDIA detector scenarios, aligning with the new return types and DI path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 576fa576c246f1d511c987f0aed67e280f84b31b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->