### PR TITLE
chore: improve --workdir option description

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -788,7 +788,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
       ->delimiter(',')
       ->allow_extra_args(false)
       ->type_name("modules");
-    buildRun->add_option("--workdir", runOpts.workdir, _("Working directory inside the app"))
+    buildRun->add_option("--workdir", runOpts.workdir, _("Specify the working directory where the application runs"))
       ->type_name("PATH");
     buildRun->add_option(
       "COMMAND",

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -179,7 +179,10 @@ ll-cli run org.deepin.demo -- bash -x /path/to/bash/script)"));
                    _("Specify the runtime used by the application to run"))
       ->type_name("REF")
       ->check(validatorString);
-    cliRun->add_option("--workdir", runOptions.workdir, _("Working directory inside the app"))
+    cliRun
+      ->add_option("--workdir",
+                   runOptions.workdir,
+                   _("Specify the working directory where the application runs"))
       ->type_name("PATH");
     cliRun
       ->add_option("--extensions",

--- a/po/en_US.po
+++ b/po/en_US.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-06 16:31+0800\n"
+"POT-Creation-Date: 2026-03-12 21:29+0800\n"
 "PO-Revision-Date: 2025-01-07 17:11+0800\n"
 "Last-Translator: deepiner, 2024\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,18 +22,18 @@ msgstr ""
 msgid "privileged mode requires running as root"
 msgstr "privileged mode requires running as root"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1065
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1074
 #, c++-format
 msgid "Application {} is not installed."
 msgstr "Application {} is not installed."
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1075
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1084
 #, c++-format
 msgid "{} is not an application."
 msgstr "{} is not an application."
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1167
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2390
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1177
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2401
 msgid ""
 "Network connection failed. Please:\n"
 "1. Check your internet connection\n"
@@ -43,19 +43,19 @@ msgstr ""
 "1. Check your internet connection\n"
 "2. Verify network proxy settings if used"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2275
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2286
 msgid "To install the module, one must first install the app."
 msgstr "To install the module, one must first install the app."
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2278
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2289
 msgid "Module is already installed."
 msgstr "Module is already installed."
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2281
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2292
 msgid "The module could not be found remotely."
 msgstr "The module could not be found remotely."
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2285
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2296
 #, c++-format
 msgid ""
 "Application already installed, If you want to replace it, try using 'll-cli "
@@ -64,16 +64,16 @@ msgstr ""
 "Application already installed, If you want to replace it, try using 'll-cli "
 "install {} --force'"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2291
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2302
 #, c++-format
 msgid "Application {} is not found in remote repo."
 msgstr "Application {} is not found in remote repo."
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2294
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2305
 msgid "Cannot specify a version when installing a module."
 msgstr "Cannot specify a version when installing a module."
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2298
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2309
 #, c++-format
 msgid ""
 "The latest version has been installed. If you want to replace it, try using "
@@ -82,11 +82,11 @@ msgstr ""
 "The latest version has been installed. If you want to replace it, try using "
 "'ll-cli install {} --force'"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2304
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2315
 msgid "Install failed"
 msgstr "Install failed"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2326
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2337
 msgid ""
 "The application is currently running and cannot be uninstalled. Please turn "
 "off the application and try again."
@@ -94,12 +94,12 @@ msgstr ""
 "The application is currently running and cannot be uninstalled. Please turn "
 "off the application and try again."
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2334
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2367
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2345
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2378
 msgid "Application is not installed."
 msgstr "Application is not installed."
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2338
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2349
 #, c++-format
 msgid ""
 "Multiple versions of the package are installed. Please specify a single "
@@ -110,40 +110,40 @@ msgstr ""
 "version to uninstall:\n"
 "{}"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2344
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2355
 msgid "Base or runtime cannot be uninstalled, please use 'll-cli prune'."
 msgstr "Base or runtime cannot be uninstalled, please use 'll-cli prune'."
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2348
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2359
 msgid "Uninstall failed"
 msgstr "Uninstall failed"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2371
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2382
 msgid "Upgrade failed"
 msgstr "Upgrade failed"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2395
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2406
 msgid "Package not found"
 msgstr "Package not found"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2398
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2409
 msgid "Operation canceled"
 msgstr "Operation canceled"
 
-#: ../apps/ll-cli/src/main.cpp:146 ../apps/ll-builder/src/main.cpp:44
+#: ../apps/ll-cli/src/main.cpp:124 ../apps/ll-builder/src/main.cpp:44
 msgid "Input parameter is empty, please input valid parameter instead"
 msgstr "Input parameter is empty, please input valid parameter instead"
 
-#: ../apps/ll-cli/src/main.cpp:157
+#: ../apps/ll-cli/src/main.cpp:135
 msgid "Run an application"
 msgstr "Run an application"
 
 #. add sub command run options
-#: ../apps/ll-cli/src/main.cpp:160
+#: ../apps/ll-cli/src/main.cpp:138
 msgid "Specify the application ID"
 msgstr "Specify the application ID"
 
-#: ../apps/ll-cli/src/main.cpp:163
+#: ../apps/ll-cli/src/main.cpp:141
 msgid ""
 "Usage: ll-cli run [OPTIONS] APP [COMMAND...]\n"
 "\n"
@@ -165,87 +165,91 @@ msgstr ""
 "ll-cli run org.deepin.demo -- bash\n"
 "ll-cli run org.deepin.demo -- bash -x /path/to/bash/script"
 
-#: ../apps/ll-cli/src/main.cpp:175
+#: ../apps/ll-cli/src/main.cpp:153
 msgid "Pass file to applications running in a sandbox"
 msgstr "Pass file to applications running in a sandbox"
 
-#: ../apps/ll-cli/src/main.cpp:179
+#: ../apps/ll-cli/src/main.cpp:157
 msgid "Pass url to applications running in a sandbox"
 msgstr "Pass url to applications running in a sandbox"
 
-#: ../apps/ll-cli/src/main.cpp:182
+#: ../apps/ll-cli/src/main.cpp:160
 msgid "Set environment variables for the application"
 msgstr "Set environment variables for the application"
 
-#: ../apps/ll-cli/src/main.cpp:189
+#: ../apps/ll-cli/src/main.cpp:167
 msgid "Input parameter is invalid, please input valid parameter instead"
 msgstr "Input parameter is invalid, please input valid parameter instead"
 
-#: ../apps/ll-cli/src/main.cpp:195
+#: ../apps/ll-cli/src/main.cpp:173
 msgid "Specify the base used by the application to run"
 msgstr "Specify the base used by the application to run"
 
-#: ../apps/ll-cli/src/main.cpp:201
+#: ../apps/ll-cli/src/main.cpp:179
 msgid "Specify the runtime used by the application to run"
 msgstr "Specify the runtime used by the application to run"
 
-#: ../apps/ll-cli/src/main.cpp:207
+#: ../apps/ll-cli/src/main.cpp:185 ../apps/ll-builder/src/main.cpp:791
+msgid "Specify the working directory where the application runs"
+msgstr ""
+
+#: ../apps/ll-cli/src/main.cpp:190
 msgid "Specify extension(s) used by the application to run"
 msgstr "Specify extension(s) used by the application to run"
 
-#: ../apps/ll-cli/src/main.cpp:213
+#: ../apps/ll-cli/src/main.cpp:196
 msgid "Run the application in privileged mode"
 msgstr "Run the application in privileged mode"
 
-#: ../apps/ll-cli/src/main.cpp:215
+#: ../apps/ll-cli/src/main.cpp:198
 msgid "Add capabilities to the application"
 msgstr "Add capabilities to the application"
 
-#: ../apps/ll-cli/src/main.cpp:219 ../apps/ll-cli/src/main.cpp:250
+#: ../apps/ll-cli/src/main.cpp:202 ../apps/ll-cli/src/main.cpp:233
 msgid "Run commands in a running sandbox"
 msgstr "Run commands in a running sandbox"
 
-#: ../apps/ll-cli/src/main.cpp:225
+#: ../apps/ll-cli/src/main.cpp:208
 msgid "List running applications"
 msgstr "List running applications"
 
-#: ../apps/ll-cli/src/main.cpp:228
+#: ../apps/ll-cli/src/main.cpp:211
 msgid "Usage: ll-cli ps [OPTIONS]"
 msgstr "Usage: ll-cli ps [OPTIONS]"
 
-#: ../apps/ll-cli/src/main.cpp:237
+#: ../apps/ll-cli/src/main.cpp:220
 msgid "Enter the namespace where the application is running"
 msgstr "Enter the namespace where the application is running"
 
-#: ../apps/ll-cli/src/main.cpp:243
+#: ../apps/ll-cli/src/main.cpp:226
 msgid "Specify the application running instance(you can get it by ps command)"
 msgstr "Specify the application running instance(you can get it by ps command)"
 
-#: ../apps/ll-cli/src/main.cpp:247
+#: ../apps/ll-cli/src/main.cpp:230
 msgid "Specify working directory"
 msgstr "Specify working directory"
 
-#: ../apps/ll-cli/src/main.cpp:256
+#: ../apps/ll-cli/src/main.cpp:239
 msgid "Stop running applications"
 msgstr "Stop running applications"
 
-#: ../apps/ll-cli/src/main.cpp:259
+#: ../apps/ll-cli/src/main.cpp:242
 msgid "Usage: ll-cli kill [OPTIONS] APP"
 msgstr "Usage: ll-cli kill [OPTIONS] APP"
 
-#: ../apps/ll-cli/src/main.cpp:263
+#: ../apps/ll-cli/src/main.cpp:246
 msgid "Specify the signal to send to the application"
 msgstr "Specify the signal to send to the application"
 
-#: ../apps/ll-cli/src/main.cpp:265
+#: ../apps/ll-cli/src/main.cpp:248
 msgid "Specify the running application"
 msgstr "Specify the running application"
 
-#: ../apps/ll-cli/src/main.cpp:276
+#: ../apps/ll-cli/src/main.cpp:259
 msgid "Installing an application or runtime"
 msgstr "Installing an application or runtime"
 
-#: ../apps/ll-cli/src/main.cpp:279
+#: ../apps/ll-cli/src/main.cpp:262
 msgid ""
 "Usage: ll-cli install [OPTIONS] APP\n"
 "\n"
@@ -281,64 +285,64 @@ msgstr ""
 "ll-cli install stable:org.deepin.demo/0.0.0.1/x86_64\n"
 "    "
 
-#: ../apps/ll-cli/src/main.cpp:298
+#: ../apps/ll-cli/src/main.cpp:281
 msgid "Specify the application ID, and it can also be a .uab or .layer file"
 msgstr "Specify the application ID, and it can also be a .uab or .layer file"
 
-#: ../apps/ll-cli/src/main.cpp:301
+#: ../apps/ll-cli/src/main.cpp:284
 msgid "Install a specify module"
 msgstr "Install a specify module"
 
-#: ../apps/ll-cli/src/main.cpp:304
+#: ../apps/ll-cli/src/main.cpp:287
 msgid "Install from a specific repo"
 msgstr "Install from a specific repo"
 
-#: ../apps/ll-cli/src/main.cpp:307
+#: ../apps/ll-cli/src/main.cpp:290
 msgid "Force install the application"
 msgstr "Force install the application"
 
-#: ../apps/ll-cli/src/main.cpp:310
+#: ../apps/ll-cli/src/main.cpp:293
 msgid "Automatically answer yes to all questions"
 msgstr "Automatically answer yes to all questions"
 
-#: ../apps/ll-cli/src/main.cpp:319
+#: ../apps/ll-cli/src/main.cpp:302
 msgid "Uninstall the application or runtimes"
 msgstr "Uninstall the application or runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:322
+#: ../apps/ll-cli/src/main.cpp:305
 msgid "Usage: ll-cli uninstall [OPTIONS] APP"
 msgstr "Usage: ll-cli uninstall [OPTIONS] APP"
 
-#: ../apps/ll-cli/src/main.cpp:323
+#: ../apps/ll-cli/src/main.cpp:306
 msgid "Specify the applications ID"
 msgstr "Specify the applications ID"
 
-#: ../apps/ll-cli/src/main.cpp:326
+#: ../apps/ll-cli/src/main.cpp:309
 msgid "Uninstall a specify module"
 msgstr "Uninstall a specify module"
 
-#: ../apps/ll-cli/src/main.cpp:331
+#: ../apps/ll-cli/src/main.cpp:314
 msgid "Force uninstall base or runtime"
 msgstr "Force uninstall base or runtime"
 
 #. below options are used for compatibility with old ll-cli
-#: ../apps/ll-cli/src/main.cpp:334
+#: ../apps/ll-cli/src/main.cpp:317
 msgid "Remove all unused modules"
 msgstr "Remove all unused modules"
 
-#: ../apps/ll-cli/src/main.cpp:338
+#: ../apps/ll-cli/src/main.cpp:321
 msgid "Uninstall all modules"
 msgstr "Uninstall all modules"
 
-#: ../apps/ll-cli/src/main.cpp:348
+#: ../apps/ll-cli/src/main.cpp:331
 msgid "Upgrade the application or runtimes"
 msgstr "Upgrade the application or runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:351
+#: ../apps/ll-cli/src/main.cpp:334
 msgid "Usage: ll-cli upgrade [OPTIONS] [APP]"
 msgstr "Usage: ll-cli upgrade [OPTIONS] [APP]"
 
-#: ../apps/ll-cli/src/main.cpp:355
+#: ../apps/ll-cli/src/main.cpp:338
 msgid ""
 "Specify the application ID. If it not be specified, all applications will be "
 "upgraded"
@@ -346,49 +350,53 @@ msgstr ""
 "Specify the application ID. If it not be specified, all applications will be "
 "upgraded"
 
-#: ../apps/ll-cli/src/main.cpp:360
+#: ../apps/ll-cli/src/main.cpp:343
 msgid "Only upgrade dependencies of application"
 msgstr "Only upgrade dependencies of application"
 
+#: ../apps/ll-cli/src/main.cpp:344
+msgid "Only upgrade application"
+msgstr ""
+
+#: ../apps/ll-cli/src/main.cpp:355
+msgid ""
+"Search the applications/runtimes containing the specified text from the "
+"remote repository"
+msgstr ""
+"Search the applications/runtimes containing the specified text from the "
+"remote repository"
+
+#: ../apps/ll-cli/src/main.cpp:359
+msgid ""
+"Usage: ll-cli search [OPTIONS] KEYWORDS\n"
+"\n"
+"Example:\n"
+"# find remotely application(s), base(s) or runtime(s) by keywords\n"
+"ll-cli search org.deepin.demo\n"
+"# find all of app of remote\n"
+"ll-cli search .\n"
+"# find all of base(s) of remote\n"
+"ll-cli search . --type=base\n"
+"# find all of runtime(s) of remote\n"
+"ll-cli search . --type=runtime"
+msgstr ""
+"Usage: ll-cli search [OPTIONS] KEYWORDS\n"
+"\n"
+"Example:\n"
+"# find remotely application(s), base(s) or runtime(s) by keywords\n"
+"ll-cli search org.deepin.demo\n"
+"# find all of app of remote\n"
+"ll-cli search .\n"
+"# find all of base(s) of remote\n"
+"ll-cli search . --type=base\n"
+"# find all of runtime(s) of remote\n"
+"ll-cli search . --type=runtime"
+
 #: ../apps/ll-cli/src/main.cpp:370
-msgid ""
-"Search the applications/runtimes containing the specified text from the "
-"remote repository"
-msgstr ""
-"Search the applications/runtimes containing the specified text from the "
-"remote repository"
-
-#: ../apps/ll-cli/src/main.cpp:374
-msgid ""
-"Usage: ll-cli search [OPTIONS] KEYWORDS\n"
-"\n"
-"Example:\n"
-"# find remotely application(s), base(s) or runtime(s) by keywords\n"
-"ll-cli search org.deepin.demo\n"
-"# find all of app of remote\n"
-"ll-cli search .\n"
-"# find all of base(s) of remote\n"
-"ll-cli search . --type=base\n"
-"# find all of runtime(s) of remote\n"
-"ll-cli search . --type=runtime"
-msgstr ""
-"Usage: ll-cli search [OPTIONS] KEYWORDS\n"
-"\n"
-"Example:\n"
-"# find remotely application(s), base(s) or runtime(s) by keywords\n"
-"ll-cli search org.deepin.demo\n"
-"# find all of app of remote\n"
-"ll-cli search .\n"
-"# find all of base(s) of remote\n"
-"ll-cli search . --type=base\n"
-"# find all of runtime(s) of remote\n"
-"ll-cli search . --type=runtime"
-
-#: ../apps/ll-cli/src/main.cpp:385
 msgid "Specify the Keywords"
 msgstr "Specify the Keywords"
 
-#: ../apps/ll-cli/src/main.cpp:392 ../apps/ll-cli/src/main.cpp:431
+#: ../apps/ll-cli/src/main.cpp:377 ../apps/ll-cli/src/main.cpp:416
 msgid ""
 "Filter result with specify type. One of \"runtime\", \"base\", \"app\" or "
 "\"all\""
@@ -396,23 +404,23 @@ msgstr ""
 "Filter result with specify type. One of \"runtime\", \"base\", \"app\" or "
 "\"all\""
 
-#: ../apps/ll-cli/src/main.cpp:396
+#: ../apps/ll-cli/src/main.cpp:381
 msgid "Specify the repo"
 msgstr "Specify the repo"
 
-#: ../apps/ll-cli/src/main.cpp:401
+#: ../apps/ll-cli/src/main.cpp:386
 msgid "Include develop application in result"
 msgstr "Include develop application in result"
 
-#: ../apps/ll-cli/src/main.cpp:404
+#: ../apps/ll-cli/src/main.cpp:389
 msgid "Show all versions of an application(s), base(s) or runtime(s)"
 msgstr "Show all versions of an application(s), base(s) or runtime(s)"
 
-#: ../apps/ll-cli/src/main.cpp:412
+#: ../apps/ll-cli/src/main.cpp:397
 msgid "List installed application(s), base(s) or runtime(s)"
 msgstr "List installed application(s), base(s) or runtime(s)"
 
-#: ../apps/ll-cli/src/main.cpp:415
+#: ../apps/ll-cli/src/main.cpp:400
 msgid ""
 "Usage: ll-cli list [OPTIONS]\n"
 "\n"
@@ -438,7 +446,7 @@ msgstr ""
 "# show the latest version list of the currently installed application(s)\n"
 "ll-cli list --upgradable\n"
 
-#: ../apps/ll-cli/src/main.cpp:437
+#: ../apps/ll-cli/src/main.cpp:422
 msgid ""
 "Show the list of latest version of the currently installed application(s), "
 "base(s) or runtime(s)"
@@ -446,179 +454,179 @@ msgstr ""
 "Show the list of latest version of the currently installed application(s), "
 "base(s) or runtime(s)"
 
-#: ../apps/ll-cli/src/main.cpp:447
+#: ../apps/ll-cli/src/main.cpp:432
 msgid "Display or modify information of the repository currently using"
 msgstr "Display or modify information of the repository currently using"
 
-#: ../apps/ll-cli/src/main.cpp:449
+#: ../apps/ll-cli/src/main.cpp:434
 msgid "Usage: ll-cli repo SUBCOMMAND [OPTIONS]"
 msgstr "Usage: ll-cli repo SUBCOMMAND [OPTIONS]"
 
 #. add repo sub command add
-#: ../apps/ll-cli/src/main.cpp:453 ../apps/ll-builder/src/main.cpp:907
+#: ../apps/ll-cli/src/main.cpp:438 ../apps/ll-builder/src/main.cpp:913
 msgid "Add a new repository"
 msgstr "Add a new repository"
 
-#: ../apps/ll-cli/src/main.cpp:454
+#: ../apps/ll-cli/src/main.cpp:439
 msgid "Usage: ll-cli repo add [OPTIONS] NAME URL"
 msgstr "Usage: ll-cli repo add [OPTIONS] NAME URL"
 
-#: ../apps/ll-cli/src/main.cpp:455 ../apps/ll-cli/src/main.cpp:467
-#: ../apps/ll-builder/src/main.cpp:909
+#: ../apps/ll-cli/src/main.cpp:440 ../apps/ll-cli/src/main.cpp:452
+#: ../apps/ll-builder/src/main.cpp:915
 msgid "Specify the repo name"
 msgstr "Specify the repo name"
 
-#: ../apps/ll-cli/src/main.cpp:458 ../apps/ll-cli/src/main.cpp:470
-#: ../apps/ll-cli/src/main.cpp:488 ../apps/ll-builder/src/main.cpp:912
-#: ../apps/ll-builder/src/main.cpp:935
+#: ../apps/ll-cli/src/main.cpp:443 ../apps/ll-cli/src/main.cpp:455
+#: ../apps/ll-cli/src/main.cpp:473 ../apps/ll-builder/src/main.cpp:918
+#: ../apps/ll-builder/src/main.cpp:941
 msgid "Url of the repository"
 msgstr "Url of the repository"
 
-#: ../apps/ll-cli/src/main.cpp:461 ../apps/ll-cli/src/main.cpp:477
-#: ../apps/ll-cli/src/main.cpp:485 ../apps/ll-cli/src/main.cpp:496
-#: ../apps/ll-cli/src/main.cpp:508 ../apps/ll-cli/src/main.cpp:518
-#: ../apps/ll-cli/src/main.cpp:525 ../apps/ll-builder/src/main.cpp:916
-#: ../apps/ll-builder/src/main.cpp:924 ../apps/ll-builder/src/main.cpp:932
-#: ../apps/ll-builder/src/main.cpp:944 ../apps/ll-builder/src/main.cpp:953
-#: ../apps/ll-builder/src/main.cpp:962
+#: ../apps/ll-cli/src/main.cpp:446 ../apps/ll-cli/src/main.cpp:462
+#: ../apps/ll-cli/src/main.cpp:470 ../apps/ll-cli/src/main.cpp:481
+#: ../apps/ll-cli/src/main.cpp:493 ../apps/ll-cli/src/main.cpp:503
+#: ../apps/ll-cli/src/main.cpp:510 ../apps/ll-builder/src/main.cpp:922
+#: ../apps/ll-builder/src/main.cpp:930 ../apps/ll-builder/src/main.cpp:938
+#: ../apps/ll-builder/src/main.cpp:950 ../apps/ll-builder/src/main.cpp:959
+#: ../apps/ll-builder/src/main.cpp:968
 msgid "Alias of the repo name"
 msgstr "Alias of the repo name"
 
 #. add repo sub command modify
-#: ../apps/ll-cli/src/main.cpp:466
+#: ../apps/ll-cli/src/main.cpp:451
 msgid "Modify repository URL"
 msgstr "Modify repository URL"
 
 #. add repo sub command remove
-#: ../apps/ll-cli/src/main.cpp:475 ../apps/ll-builder/src/main.cpp:921
+#: ../apps/ll-cli/src/main.cpp:460 ../apps/ll-builder/src/main.cpp:927
 msgid "Remove a repository"
 msgstr "Remove a repository"
 
-#: ../apps/ll-cli/src/main.cpp:476
+#: ../apps/ll-cli/src/main.cpp:461
 msgid "Usage: ll-cli repo remove [OPTIONS] NAME"
 msgstr "Usage: ll-cli repo remove [OPTIONS] NAME"
 
 #. add repo sub command update
 #. TODO: add --repo and --url options
 #. add repo sub command update
-#: ../apps/ll-cli/src/main.cpp:483 ../apps/ll-builder/src/main.cpp:929
+#: ../apps/ll-cli/src/main.cpp:468 ../apps/ll-builder/src/main.cpp:935
 msgid "Update the repository URL"
 msgstr "Update the repository URL"
 
-#: ../apps/ll-cli/src/main.cpp:484
+#: ../apps/ll-cli/src/main.cpp:469
 msgid "Usage: ll-cli repo update [OPTIONS] NAME URL"
 msgstr "Usage: ll-cli repo update [OPTIONS] NAME URL"
 
-#: ../apps/ll-cli/src/main.cpp:494 ../apps/ll-builder/src/main.cpp:941
+#: ../apps/ll-cli/src/main.cpp:479 ../apps/ll-builder/src/main.cpp:947
 msgid "Set a default repository name"
 msgstr "Set a default repository name"
 
-#: ../apps/ll-cli/src/main.cpp:495
+#: ../apps/ll-cli/src/main.cpp:480
 msgid "Usage: ll-cli repo set-default [OPTIONS] NAME"
 msgstr "Usage: ll-cli repo set-default [OPTIONS] NAME"
 
 #. add repo sub command show
-#: ../apps/ll-cli/src/main.cpp:501 ../apps/ll-builder/src/main.cpp:967
+#: ../apps/ll-cli/src/main.cpp:486 ../apps/ll-builder/src/main.cpp:973
 msgid "Show repository information"
 msgstr "Show repository information"
 
-#: ../apps/ll-cli/src/main.cpp:502
+#: ../apps/ll-cli/src/main.cpp:487
 msgid "Usage: ll-cli repo show [OPTIONS]"
 msgstr "Usage: ll-cli repo show [OPTIONS]"
 
-#: ../apps/ll-cli/src/main.cpp:506
+#: ../apps/ll-cli/src/main.cpp:491
 msgid "Set the priority of the repo"
 msgstr "Set the priority of the repo"
 
-#: ../apps/ll-cli/src/main.cpp:507
+#: ../apps/ll-cli/src/main.cpp:492
 msgid "Usage: ll-cli repo set-priority ALIAS PRIORITY"
 msgstr "Usage: ll-cli repo set-priority ALIAS PRIORITY"
 
-#: ../apps/ll-cli/src/main.cpp:511
+#: ../apps/ll-cli/src/main.cpp:496
 msgid "Priority of the repo"
 msgstr "Priority of the repo"
 
-#: ../apps/ll-cli/src/main.cpp:516 ../apps/ll-builder/src/main.cpp:950
+#: ../apps/ll-cli/src/main.cpp:501 ../apps/ll-builder/src/main.cpp:956
 msgid "Enable mirror for the repo"
 msgstr "Enable mirror for the repo"
 
-#: ../apps/ll-cli/src/main.cpp:517
+#: ../apps/ll-cli/src/main.cpp:502
 msgid "Usage: ll-cli repo enable-mirror [OPTIONS] ALIAS"
 msgstr "Usage: ll-cli repo enable-mirror [OPTIONS] ALIAS"
 
-#: ../apps/ll-cli/src/main.cpp:523 ../apps/ll-builder/src/main.cpp:959
+#: ../apps/ll-cli/src/main.cpp:508 ../apps/ll-builder/src/main.cpp:965
 msgid "Disable mirror for the repo"
 msgstr "Disable mirror for the repo"
 
-#: ../apps/ll-cli/src/main.cpp:524
+#: ../apps/ll-cli/src/main.cpp:509
 msgid "Usage: ll-cli repo disable-mirror [OPTIONS] ALIAS"
 msgstr "Usage: ll-cli repo disable-mirror [OPTIONS] ALIAS"
 
-#: ../apps/ll-cli/src/main.cpp:535
+#: ../apps/ll-cli/src/main.cpp:520
 msgid "Display information about installed apps or runtimes"
 msgstr "Display information about installed apps or runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:538
+#: ../apps/ll-cli/src/main.cpp:523
 msgid "Usage: ll-cli info [OPTIONS] APP"
 msgstr "Usage: ll-cli info [OPTIONS] APP"
 
-#: ../apps/ll-cli/src/main.cpp:542
+#: ../apps/ll-cli/src/main.cpp:527
 msgid "Specify the application ID, and it can also be a .layer file"
 msgstr "Specify the application ID, and it can also be a .layer file"
 
-#: ../apps/ll-cli/src/main.cpp:554
+#: ../apps/ll-cli/src/main.cpp:539
 msgid "Display the exported files of installed application"
 msgstr "Display the exported files of installed application"
 
-#: ../apps/ll-cli/src/main.cpp:557
+#: ../apps/ll-cli/src/main.cpp:542
 msgid "Usage: ll-cli content [OPTIONS] APP"
 msgstr "Usage: ll-cli content [OPTIONS] APP"
 
-#: ../apps/ll-cli/src/main.cpp:558
+#: ../apps/ll-cli/src/main.cpp:543
 msgid "Specify the installed application ID"
 msgstr "Specify the installed application ID"
 
-#: ../apps/ll-cli/src/main.cpp:566
+#: ../apps/ll-cli/src/main.cpp:551
 msgid "Remove the unused base or runtime"
 msgstr "Remove the unused base or runtime"
 
-#: ../apps/ll-cli/src/main.cpp:568
+#: ../apps/ll-cli/src/main.cpp:553
 msgid "Usage: ll-cli prune [OPTIONS]"
 msgstr "Usage: ll-cli prune [OPTIONS]"
 
-#: ../apps/ll-cli/src/main.cpp:579
+#: ../apps/ll-cli/src/main.cpp:564
 msgid "Display the inspect information of the installed application"
 msgstr "Display the inspect information of the installed application"
 
-#: ../apps/ll-cli/src/main.cpp:581
+#: ../apps/ll-cli/src/main.cpp:566
 msgid "Usage: ll-cli inspect SUBCOMMAND [OPTIONS]"
 msgstr "Usage: ll-cli inspect SUBCOMMAND [OPTIONS]"
 
-#: ../apps/ll-cli/src/main.cpp:588
+#: ../apps/ll-cli/src/main.cpp:573
 msgid ""
 "Display the data(bundle) directory of the installed(running) application"
 msgstr ""
 "Display the data(bundle) directory of the installed(running) application"
 
-#: ../apps/ll-cli/src/main.cpp:589
+#: ../apps/ll-cli/src/main.cpp:574
 msgid "Usage: ll-cli inspect dir [OPTIONS] APP"
 msgstr "Usage: ll-cli inspect dir [OPTIONS] APP"
 
-#: ../apps/ll-cli/src/main.cpp:593
+#: ../apps/ll-cli/src/main.cpp:578
 msgid "Specify the application ID, and it can also be reference"
 msgstr "Specify the application ID, and it can also be reference"
 
-#: ../apps/ll-cli/src/main.cpp:599
+#: ../apps/ll-cli/src/main.cpp:584
 msgid "Specify the directory type (layer or bundle),the default is layer"
 msgstr "Specify the directory type (layer or bundle),the default is layer"
 
-#: ../apps/ll-cli/src/main.cpp:606
+#: ../apps/ll-cli/src/main.cpp:591
 msgid ""
 "Specify the module type (binary or develop). Only works when type is layer"
 msgstr ""
 "Specify the module type (binary or develop). Only works when type is layer"
 
-#: ../apps/ll-cli/src/main.cpp:638
+#: ../apps/ll-cli/src/main.cpp:623
 msgid ""
 "linyaps CLI\n"
 "A CLI program to run application and manage application and runtime\n"
@@ -626,19 +634,19 @@ msgstr ""
 "linyaps CLI\n"
 "A CLI program to run application and manage application and runtime\n"
 
-#: ../apps/ll-cli/src/main.cpp:646 ../apps/ll-builder/src/main.cpp:695
+#: ../apps/ll-cli/src/main.cpp:631 ../apps/ll-builder/src/main.cpp:699
 msgid "Print this help message and exit"
 msgstr "Print this help message and exit"
 
-#: ../apps/ll-cli/src/main.cpp:647 ../apps/ll-builder/src/main.cpp:696
+#: ../apps/ll-cli/src/main.cpp:632 ../apps/ll-builder/src/main.cpp:700
 msgid "Expand all help"
 msgstr "Expand all help"
 
-#: ../apps/ll-cli/src/main.cpp:648
+#: ../apps/ll-cli/src/main.cpp:633
 msgid "Usage: ll-cli [OPTIONS] [SUBCOMMAND]"
 msgstr "Usage: ll-cli [OPTIONS] [SUBCOMMAND]"
 
-#: ../apps/ll-cli/src/main.cpp:649
+#: ../apps/ll-cli/src/main.cpp:634
 msgid ""
 "If you found any problems during use,\n"
 "You can report bugs to the linyaps team under this project: https://github."
@@ -649,11 +657,11 @@ msgstr ""
 "com/OpenAtom-Linyaps/linyaps/issues"
 
 #. version flag
-#: ../apps/ll-cli/src/main.cpp:656 ../apps/ll-builder/src/main.cpp:720
+#: ../apps/ll-cli/src/main.cpp:641 ../apps/ll-builder/src/main.cpp:724
 msgid "Show version"
 msgstr "Show version"
 
-#: ../apps/ll-cli/src/main.cpp:661
+#: ../apps/ll-cli/src/main.cpp:646
 msgid ""
 "Use peer to peer DBus, this is used only in case that DBus daemon is not "
 "available"
@@ -662,42 +670,42 @@ msgstr ""
 "available"
 
 #. json flag
-#: ../apps/ll-cli/src/main.cpp:666
+#: ../apps/ll-cli/src/main.cpp:651
 msgid "Use json format to output result"
 msgstr "Use json format to output result"
 
-#: ../apps/ll-cli/src/main.cpp:673
+#: ../apps/ll-cli/src/main.cpp:658
 msgid "Show debug info (verbose logs)"
 msgstr "Show debug info (verbose logs)"
 
-#: ../apps/ll-cli/src/main.cpp:676
+#: ../apps/ll-cli/src/main.cpp:661
 msgid "Don't output progress information"
 msgstr "Don't output progress information"
 
 #. groups for subcommands
-#: ../apps/ll-cli/src/main.cpp:693
+#: ../apps/ll-cli/src/main.cpp:678
 msgid "Managing installed applications and runtimes"
 msgstr "Managing installed applications and runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:694
+#: ../apps/ll-cli/src/main.cpp:679
 msgid "Managing running applications"
 msgstr "Managing running applications"
 
-#: ../apps/ll-cli/src/main.cpp:695
+#: ../apps/ll-cli/src/main.cpp:680
 msgid "Finding applications and runtimes"
 msgstr "Finding applications and runtimes"
 
-#: ../apps/ll-cli/src/main.cpp:696
+#: ../apps/ll-cli/src/main.cpp:681
 msgid "Managing remote repositories"
 msgstr "Managing remote repositories"
 
-#: ../apps/ll-cli/src/main.cpp:722
+#: ../apps/ll-cli/src/main.cpp:707
 msgid "linyaps CLI version "
 msgstr "linyaps CLI version "
 
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:71
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:134
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:310
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:314
 msgid "ID"
 msgstr "ID"
 
@@ -763,19 +771,19 @@ msgstr "Alias"
 msgid "Priority"
 msgstr "Priority"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:298
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:302
 msgid "No apps available for update."
 msgstr "No apps available for update."
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:311
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:315
 msgid "Installed"
 msgstr "Installed"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:312
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:316
 msgid "New"
 msgstr "New"
 
-#: ../apps/ll-builder/src/main.cpp:693
+#: ../apps/ll-builder/src/main.cpp:697
 msgid ""
 "linyaps builder CLI \n"
 "A CLI program to build linyaps application\n"
@@ -783,11 +791,11 @@ msgstr ""
 "linyaps builder CLI \n"
 "A CLI program to build linyaps application\n"
 
-#: ../apps/ll-builder/src/main.cpp:698
+#: ../apps/ll-builder/src/main.cpp:702
 msgid "Usage: ll-builder [OPTIONS] [SUBCOMMAND]"
 msgstr "Usage: ll-builder [OPTIONS] [SUBCOMMAND]"
 
-#: ../apps/ll-builder/src/main.cpp:700
+#: ../apps/ll-builder/src/main.cpp:704
 msgid ""
 "If you found any problems during use\n"
 "You can report bugs to the linyaps team under this project: https://github."
@@ -797,36 +805,37 @@ msgstr ""
 "You can report bugs to the linyaps team under this project: https://github."
 "com/OpenAtom-Linyaps/linyaps/issues"
 
-#: ../apps/ll-builder/src/main.cpp:724
+#: ../apps/ll-builder/src/main.cpp:728
 msgid "Create linyaps build template project"
 msgstr "Create linyaps build template project"
 
-#: ../apps/ll-builder/src/main.cpp:725
+#: ../apps/ll-builder/src/main.cpp:729
 msgid "Usage: ll-builder create [OPTIONS] NAME"
 msgstr "Usage: ll-builder create [OPTIONS] NAME"
 
-#: ../apps/ll-builder/src/main.cpp:726
+#: ../apps/ll-builder/src/main.cpp:730
 msgid "Project name"
 msgstr "Project name"
 
-#: ../apps/ll-builder/src/main.cpp:734
+#: ../apps/ll-builder/src/main.cpp:738
 msgid "Build a linyaps project"
 msgstr "Build a linyaps project"
 
-#: ../apps/ll-builder/src/main.cpp:735
+#: ../apps/ll-builder/src/main.cpp:739
 msgid "Usage: ll-builder build [OPTIONS] [COMMAND...]"
 msgstr "Usage: ll-builder build [OPTIONS] [COMMAND...]"
 
-#: ../apps/ll-builder/src/main.cpp:736 ../apps/ll-builder/src/main.cpp:777
-#: ../apps/ll-builder/src/main.cpp:816 ../apps/ll-builder/src/main.cpp:862
+#: ../apps/ll-builder/src/main.cpp:740 ../apps/ll-builder/src/main.cpp:781
+#: ../apps/ll-builder/src/main.cpp:822 ../apps/ll-builder/src/main.cpp:868
 msgid "File path of the linglong.yaml"
 msgstr "File path of the linglong.yaml"
 
-#: ../apps/ll-builder/src/main.cpp:742
+#: ../apps/ll-builder/src/main.cpp:746
 msgid "Enter the container to execute command instead of building applications"
-msgstr "Enter the container to execute command instead of building applications"
+msgstr ""
+"Enter the container to execute command instead of building applications"
 
-#: ../apps/ll-builder/src/main.cpp:745
+#: ../apps/ll-builder/src/main.cpp:749
 msgid ""
 "Only use local files. This implies --skip-fetch-source and --skip-pull-"
 "depend will be set"
@@ -834,215 +843,215 @@ msgstr ""
 "Only use local files. This implies --skip-fetch-source and --skip-pull-"
 "depend will be set"
 
-#: ../apps/ll-builder/src/main.cpp:750
+#: ../apps/ll-builder/src/main.cpp:754
 msgid "Build full develop packages, runtime requires"
 msgstr "Build full develop packages, runtime requires"
 
-#: ../apps/ll-builder/src/main.cpp:754
+#: ../apps/ll-builder/src/main.cpp:758
 msgid "Skip fetch sources"
 msgstr "Skip fetch sources"
 
-#: ../apps/ll-builder/src/main.cpp:757
+#: ../apps/ll-builder/src/main.cpp:761
 msgid "Skip pull dependency"
 msgstr "Skip pull dependency"
 
-#: ../apps/ll-builder/src/main.cpp:760
+#: ../apps/ll-builder/src/main.cpp:764
 msgid "Skip run container"
 msgstr "Skip run container"
 
-#: ../apps/ll-builder/src/main.cpp:763
+#: ../apps/ll-builder/src/main.cpp:767
 msgid "Skip commit build output"
 msgstr "Skip commit build output"
 
-#: ../apps/ll-builder/src/main.cpp:766
+#: ../apps/ll-builder/src/main.cpp:770
 msgid "Skip output check"
 msgstr "Skip output check"
 
-#: ../apps/ll-builder/src/main.cpp:769
+#: ../apps/ll-builder/src/main.cpp:773
 msgid "Skip strip debug symbols"
 msgstr "Skip strip debug symbols"
 
-#: ../apps/ll-builder/src/main.cpp:772
+#: ../apps/ll-builder/src/main.cpp:776
 msgid "Build in an isolated network environment"
 msgstr "Build in an isolated network environment"
 
 #. add builder run
-#: ../apps/ll-builder/src/main.cpp:775
+#: ../apps/ll-builder/src/main.cpp:779
 msgid "Run built linyaps app"
 msgstr "Run built linyaps app"
 
-#: ../apps/ll-builder/src/main.cpp:776
+#: ../apps/ll-builder/src/main.cpp:780
 msgid "Usage: ll-builder run [OPTIONS] [COMMAND...]"
 msgstr "Usage: ll-builder run [OPTIONS] [COMMAND...]"
 
-#: ../apps/ll-builder/src/main.cpp:783
+#: ../apps/ll-builder/src/main.cpp:787
 msgid "Run specified module. eg: --modules binary,develop"
 msgstr "Run specified module. eg: --modules binary,develop"
 
-#: ../apps/ll-builder/src/main.cpp:790
+#: ../apps/ll-builder/src/main.cpp:796
 msgid "Enter the container to execute command instead of running application"
 msgstr "Enter the container to execute command instead of running application"
 
-#: ../apps/ll-builder/src/main.cpp:793
+#: ../apps/ll-builder/src/main.cpp:799
 msgid "Run in debug mode (enable develop module)"
 msgstr "Run in debug mode (enable develop module)"
 
-#: ../apps/ll-builder/src/main.cpp:797
+#: ../apps/ll-builder/src/main.cpp:803
 msgid "Specify extension(s) used by the app to run"
 msgstr "Specify extension(s) used by the app to run"
 
-#: ../apps/ll-builder/src/main.cpp:803
+#: ../apps/ll-builder/src/main.cpp:809
 msgid "List built linyaps app"
 msgstr "List built linyaps app"
 
-#: ../apps/ll-builder/src/main.cpp:804
+#: ../apps/ll-builder/src/main.cpp:810
 msgid "Usage: ll-builder list [OPTIONS]"
 msgstr "Usage: ll-builder list [OPTIONS]"
 
-#: ../apps/ll-builder/src/main.cpp:805
+#: ../apps/ll-builder/src/main.cpp:811
 msgid "Remove built linyaps app"
 msgstr "Remove built linyaps app"
 
-#: ../apps/ll-builder/src/main.cpp:806
+#: ../apps/ll-builder/src/main.cpp:812
 msgid "Usage: ll-builder remove [OPTIONS] [APP...]"
 msgstr "Usage: ll-builder remove [OPTIONS] [APP...]"
 
-#: ../apps/ll-builder/src/main.cpp:809
+#: ../apps/ll-builder/src/main.cpp:815
 msgid "Do not clean objects files before remove apps"
 msgstr "Do not clean objects files before remove apps"
 
 #. build export
-#: ../apps/ll-builder/src/main.cpp:813
+#: ../apps/ll-builder/src/main.cpp:819
 msgid "Export to linyaps layer or uab"
 msgstr "Export to linyaps layer or uab"
 
-#: ../apps/ll-builder/src/main.cpp:814
+#: ../apps/ll-builder/src/main.cpp:820
 msgid "Usage: ll-builder export [OPTIONS]"
 msgstr "Usage: ll-builder export [OPTIONS]"
 
-#: ../apps/ll-builder/src/main.cpp:826
+#: ../apps/ll-builder/src/main.cpp:832
 msgid "Uab icon (optional)"
 msgstr "Uab icon (optional)"
 
-#: ../apps/ll-builder/src/main.cpp:831
+#: ../apps/ll-builder/src/main.cpp:837
 msgid "Export to linyaps layer file (deprecated)"
 msgstr "Export to linyaps layer file (deprecated)"
 
-#: ../apps/ll-builder/src/main.cpp:834
+#: ../apps/ll-builder/src/main.cpp:840
 msgid "Use custom loader"
 msgstr "Use custom loader"
 
-#: ../apps/ll-builder/src/main.cpp:841
+#: ../apps/ll-builder/src/main.cpp:847
 msgid "Don't export the develop module"
 msgstr "Don't export the develop module"
 
-#: ../apps/ll-builder/src/main.cpp:843
+#: ../apps/ll-builder/src/main.cpp:849
 msgid "Output file"
 msgstr "Output file"
 
-#: ../apps/ll-builder/src/main.cpp:847
+#: ../apps/ll-builder/src/main.cpp:853
 msgid "Reference of the package"
 msgstr "Reference of the package"
 
-#: ../apps/ll-builder/src/main.cpp:852
+#: ../apps/ll-builder/src/main.cpp:858
 msgid "Modules to export"
 msgstr "Modules to export"
 
-#: ../apps/ll-builder/src/main.cpp:860
+#: ../apps/ll-builder/src/main.cpp:866
 msgid "Push linyaps app to remote repo"
 msgstr "Push linyaps app to remote repo"
 
-#: ../apps/ll-builder/src/main.cpp:861
+#: ../apps/ll-builder/src/main.cpp:867
 msgid "Usage: ll-builder push [OPTIONS]"
 msgstr "Usage: ll-builder push [OPTIONS]"
 
-#: ../apps/ll-builder/src/main.cpp:865
+#: ../apps/ll-builder/src/main.cpp:871
 msgid "Remote repo url"
 msgstr "Remote repo url"
 
-#: ../apps/ll-builder/src/main.cpp:868
+#: ../apps/ll-builder/src/main.cpp:874
 msgid "Remote repo name"
 msgstr "Remote repo name"
 
-#: ../apps/ll-builder/src/main.cpp:871
+#: ../apps/ll-builder/src/main.cpp:877
 msgid "Push single module"
 msgstr "Push single module"
 
-#: ../apps/ll-builder/src/main.cpp:875
+#: ../apps/ll-builder/src/main.cpp:881
 msgid "Import linyaps layer to build repo"
 msgstr "Import linyaps layer to build repo"
 
-#: ../apps/ll-builder/src/main.cpp:876
+#: ../apps/ll-builder/src/main.cpp:882
 msgid "Usage: ll-builder import [OPTIONS] LAYER"
 msgstr "Usage: ll-builder import [OPTIONS] LAYER"
 
-#: ../apps/ll-builder/src/main.cpp:877 ../apps/ll-builder/src/main.cpp:894
+#: ../apps/ll-builder/src/main.cpp:883 ../apps/ll-builder/src/main.cpp:900
 msgid "Layer file path"
 msgstr "Layer file path"
 
-#: ../apps/ll-builder/src/main.cpp:884
+#: ../apps/ll-builder/src/main.cpp:890
 msgid "Import linyaps layer dir to build repo"
 msgstr "Import linyaps layer dir to build repo"
 
-#: ../apps/ll-builder/src/main.cpp:886
+#: ../apps/ll-builder/src/main.cpp:892
 msgid "Usage: ll-builder import-dir PATH"
 msgstr "Usage: ll-builder import-dir PATH"
 
-#: ../apps/ll-builder/src/main.cpp:887
+#: ../apps/ll-builder/src/main.cpp:893
 msgid "Layer dir path"
 msgstr "Layer dir path"
 
 #. add build extract
-#: ../apps/ll-builder/src/main.cpp:892
+#: ../apps/ll-builder/src/main.cpp:898
 msgid "Extract linyaps layer to dir"
 msgstr "Extract linyaps layer to dir"
 
-#: ../apps/ll-builder/src/main.cpp:893
+#: ../apps/ll-builder/src/main.cpp:899
 msgid "Usage: ll-builder extract [OPTIONS] LAYER DIR"
 msgstr "Usage: ll-builder extract [OPTIONS] LAYER DIR"
 
-#: ../apps/ll-builder/src/main.cpp:897
+#: ../apps/ll-builder/src/main.cpp:903
 msgid "Destination directory"
 msgstr "Destination directory"
 
 #. add build repo
-#: ../apps/ll-builder/src/main.cpp:902
+#: ../apps/ll-builder/src/main.cpp:908
 msgid "Display and manage repositories"
 msgstr "Display and manage repositories"
 
-#: ../apps/ll-builder/src/main.cpp:903
+#: ../apps/ll-builder/src/main.cpp:909
 msgid "Usage: ll-builder repo [OPTIONS] SUBCOMMAND"
 msgstr "Usage: ll-builder repo [OPTIONS] SUBCOMMAND"
 
-#: ../apps/ll-builder/src/main.cpp:908
+#: ../apps/ll-builder/src/main.cpp:914
 msgid "Usage: ll-builder repo add [OPTIONS] NAME URL"
 msgstr "Usage: ll-builder repo add [OPTIONS] NAME URL"
 
-#: ../apps/ll-builder/src/main.cpp:922
+#: ../apps/ll-builder/src/main.cpp:928
 msgid "Usage: ll-builder repo remove [OPTIONS] NAME"
 msgstr "Usage: ll-builder repo remove [OPTIONS] NAME"
 
-#: ../apps/ll-builder/src/main.cpp:930
+#: ../apps/ll-builder/src/main.cpp:936
 msgid "Usage: ll-builder repo update [OPTIONS] NAME URL"
 msgstr "Usage: ll-builder repo update [OPTIONS] NAME URL"
 
-#: ../apps/ll-builder/src/main.cpp:942
+#: ../apps/ll-builder/src/main.cpp:948
 msgid "Usage: ll-builder repo set-default [OPTIONS] NAME"
 msgstr "Usage: ll-builder repo set-default [OPTIONS] NAME"
 
-#: ../apps/ll-builder/src/main.cpp:951
+#: ../apps/ll-builder/src/main.cpp:957
 msgid "Usage: ll-builder repo enable-mirror [OPTIONS] ALIAS"
 msgstr "Usage: ll-builder repo enable-mirror [OPTIONS] ALIAS"
 
-#: ../apps/ll-builder/src/main.cpp:960
+#: ../apps/ll-builder/src/main.cpp:966
 msgid "Usage: ll-builder repo disable-mirror [OPTIONS] ALIAS"
 msgstr "Usage: ll-builder repo disable-mirror [OPTIONS] ALIAS"
 
-#: ../apps/ll-builder/src/main.cpp:968
+#: ../apps/ll-builder/src/main.cpp:974
 msgid "Usage: ll-builder repo show [OPTIONS]"
 msgstr "Usage: ll-builder repo show [OPTIONS]"
 
-#: ../apps/ll-builder/src/main.cpp:973
+#: ../apps/ll-builder/src/main.cpp:979
 msgid "linyaps build tool version "
 msgstr "linyaps build tool version "
 

--- a/po/linyaps.pot
+++ b/po/linyaps.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-06 16:31+0800\n"
+"POT-Creation-Date: 2026-03-12 21:29+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,75 +21,75 @@ msgstr ""
 msgid "privileged mode requires running as root"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1065
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1074
 #, c++-format
 msgid "Application {} is not installed."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1075
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1084
 #, c++-format
 msgid "{} is not an application."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1167
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2390
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1177
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2401
 msgid ""
 "Network connection failed. Please:\n"
 "1. Check your internet connection\n"
 "2. Verify network proxy settings if used"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2275
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2286
 msgid "To install the module, one must first install the app."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2278
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2289
 msgid "Module is already installed."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2281
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2292
 msgid "The module could not be found remotely."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2285
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2296
 #, c++-format
 msgid ""
 "Application already installed, If you want to replace it, try using 'll-cli "
 "install {} --force'"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2291
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2302
 #, c++-format
 msgid "Application {} is not found in remote repo."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2294
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2305
 msgid "Cannot specify a version when installing a module."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2298
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2309
 #, c++-format
 msgid ""
 "The latest version has been installed. If you want to replace it, try using "
 "'ll-cli install {} --force'"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2304
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2315
 msgid "Install failed"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2326
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2337
 msgid ""
 "The application is currently running and cannot be uninstalled. Please turn "
 "off the application and try again."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2334
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2367
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2345
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2378
 msgid "Application is not installed."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2338
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2349
 #, c++-format
 msgid ""
 "Multiple versions of the package are installed. Please specify a single "
@@ -97,40 +97,40 @@ msgid ""
 "{}"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2344
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2355
 msgid "Base or runtime cannot be uninstalled, please use 'll-cli prune'."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2348
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2359
 msgid "Uninstall failed"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2371
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2382
 msgid "Upgrade failed"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2395
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2406
 msgid "Package not found"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2398
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2409
 msgid "Operation canceled"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:146 ../apps/ll-builder/src/main.cpp:44
+#: ../apps/ll-cli/src/main.cpp:124 ../apps/ll-builder/src/main.cpp:44
 msgid "Input parameter is empty, please input valid parameter instead"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:157
+#: ../apps/ll-cli/src/main.cpp:135
 msgid "Run an application"
 msgstr ""
 
 #. add sub command run options
-#: ../apps/ll-cli/src/main.cpp:160
+#: ../apps/ll-cli/src/main.cpp:138
 msgid "Specify the application ID"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:163
+#: ../apps/ll-cli/src/main.cpp:141
 msgid ""
 "Usage: ll-cli run [OPTIONS] APP [COMMAND...]\n"
 "\n"
@@ -143,87 +143,91 @@ msgid ""
 "ll-cli run org.deepin.demo -- bash -x /path/to/bash/script"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:175
+#: ../apps/ll-cli/src/main.cpp:153
 msgid "Pass file to applications running in a sandbox"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:179
+#: ../apps/ll-cli/src/main.cpp:157
 msgid "Pass url to applications running in a sandbox"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:182
+#: ../apps/ll-cli/src/main.cpp:160
 msgid "Set environment variables for the application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:189
+#: ../apps/ll-cli/src/main.cpp:167
 msgid "Input parameter is invalid, please input valid parameter instead"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:195
+#: ../apps/ll-cli/src/main.cpp:173
 msgid "Specify the base used by the application to run"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:201
+#: ../apps/ll-cli/src/main.cpp:179
 msgid "Specify the runtime used by the application to run"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:207
+#: ../apps/ll-cli/src/main.cpp:185 ../apps/ll-builder/src/main.cpp:791
+msgid "Specify the working directory where the application runs"
+msgstr ""
+
+#: ../apps/ll-cli/src/main.cpp:190
 msgid "Specify extension(s) used by the application to run"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:213
+#: ../apps/ll-cli/src/main.cpp:196
 msgid "Run the application in privileged mode"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:215
+#: ../apps/ll-cli/src/main.cpp:198
 msgid "Add capabilities to the application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:219 ../apps/ll-cli/src/main.cpp:250
+#: ../apps/ll-cli/src/main.cpp:202 ../apps/ll-cli/src/main.cpp:233
 msgid "Run commands in a running sandbox"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:225
+#: ../apps/ll-cli/src/main.cpp:208
 msgid "List running applications"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:228
+#: ../apps/ll-cli/src/main.cpp:211
 msgid "Usage: ll-cli ps [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:237
+#: ../apps/ll-cli/src/main.cpp:220
 msgid "Enter the namespace where the application is running"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:243
+#: ../apps/ll-cli/src/main.cpp:226
 msgid "Specify the application running instance(you can get it by ps command)"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:247
+#: ../apps/ll-cli/src/main.cpp:230
 msgid "Specify working directory"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:256
+#: ../apps/ll-cli/src/main.cpp:239
 msgid "Stop running applications"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:259
+#: ../apps/ll-cli/src/main.cpp:242
 msgid "Usage: ll-cli kill [OPTIONS] APP"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:263
+#: ../apps/ll-cli/src/main.cpp:246
 msgid "Specify the signal to send to the application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:265
+#: ../apps/ll-cli/src/main.cpp:248
 msgid "Specify the running application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:276
+#: ../apps/ll-cli/src/main.cpp:259
 msgid "Installing an application or runtime"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:279
+#: ../apps/ll-cli/src/main.cpp:262
 msgid ""
 "Usage: ll-cli install [OPTIONS] APP\n"
 "\n"
@@ -243,80 +247,84 @@ msgid ""
 "    "
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:298
+#: ../apps/ll-cli/src/main.cpp:281
 msgid "Specify the application ID, and it can also be a .uab or .layer file"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:301
+#: ../apps/ll-cli/src/main.cpp:284
 msgid "Install a specify module"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:304
+#: ../apps/ll-cli/src/main.cpp:287
 msgid "Install from a specific repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:307
+#: ../apps/ll-cli/src/main.cpp:290
 msgid "Force install the application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:310
+#: ../apps/ll-cli/src/main.cpp:293
 msgid "Automatically answer yes to all questions"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:319
+#: ../apps/ll-cli/src/main.cpp:302
 msgid "Uninstall the application or runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:322
+#: ../apps/ll-cli/src/main.cpp:305
 msgid "Usage: ll-cli uninstall [OPTIONS] APP"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:323
+#: ../apps/ll-cli/src/main.cpp:306
 msgid "Specify the applications ID"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:326
+#: ../apps/ll-cli/src/main.cpp:309
 msgid "Uninstall a specify module"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:331
+#: ../apps/ll-cli/src/main.cpp:314
 msgid "Force uninstall base or runtime"
 msgstr ""
 
 #. below options are used for compatibility with old ll-cli
-#: ../apps/ll-cli/src/main.cpp:334
+#: ../apps/ll-cli/src/main.cpp:317
 msgid "Remove all unused modules"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:338
+#: ../apps/ll-cli/src/main.cpp:321
 msgid "Uninstall all modules"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:348
+#: ../apps/ll-cli/src/main.cpp:331
 msgid "Upgrade the application or runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:351
+#: ../apps/ll-cli/src/main.cpp:334
 msgid "Usage: ll-cli upgrade [OPTIONS] [APP]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:355
+#: ../apps/ll-cli/src/main.cpp:338
 msgid ""
 "Specify the application ID. If it not be specified, all applications will be "
 "upgraded"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:360
+#: ../apps/ll-cli/src/main.cpp:343
 msgid "Only upgrade dependencies of application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:370
+#: ../apps/ll-cli/src/main.cpp:344
+msgid "Only upgrade application"
+msgstr ""
+
+#: ../apps/ll-cli/src/main.cpp:355
 msgid ""
 "Search the applications/runtimes containing the specified text from the "
 "remote repository"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:374
+#: ../apps/ll-cli/src/main.cpp:359
 msgid ""
 "Usage: ll-cli search [OPTIONS] KEYWORDS\n"
 "\n"
@@ -331,33 +339,33 @@ msgid ""
 "ll-cli search . --type=runtime"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:385
+#: ../apps/ll-cli/src/main.cpp:370
 msgid "Specify the Keywords"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:392 ../apps/ll-cli/src/main.cpp:431
+#: ../apps/ll-cli/src/main.cpp:377 ../apps/ll-cli/src/main.cpp:416
 msgid ""
 "Filter result with specify type. One of \"runtime\", \"base\", \"app\" or "
 "\"all\""
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:396
+#: ../apps/ll-cli/src/main.cpp:381
 msgid "Specify the repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:401
+#: ../apps/ll-cli/src/main.cpp:386
 msgid "Include develop application in result"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:404
+#: ../apps/ll-cli/src/main.cpp:389
 msgid "Show all versions of an application(s), base(s) or runtime(s)"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:412
+#: ../apps/ll-cli/src/main.cpp:397
 msgid "List installed application(s), base(s) or runtime(s)"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:415
+#: ../apps/ll-cli/src/main.cpp:400
 msgid ""
 "Usage: ll-cli list [OPTIONS]\n"
 "\n"
@@ -372,201 +380,201 @@ msgid ""
 "ll-cli list --upgradable\n"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:437
+#: ../apps/ll-cli/src/main.cpp:422
 msgid ""
 "Show the list of latest version of the currently installed application(s), "
 "base(s) or runtime(s)"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:447
+#: ../apps/ll-cli/src/main.cpp:432
 msgid "Display or modify information of the repository currently using"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:449
+#: ../apps/ll-cli/src/main.cpp:434
 msgid "Usage: ll-cli repo SUBCOMMAND [OPTIONS]"
 msgstr ""
 
 #. add repo sub command add
-#: ../apps/ll-cli/src/main.cpp:453 ../apps/ll-builder/src/main.cpp:907
+#: ../apps/ll-cli/src/main.cpp:438 ../apps/ll-builder/src/main.cpp:913
 msgid "Add a new repository"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:454
+#: ../apps/ll-cli/src/main.cpp:439
 msgid "Usage: ll-cli repo add [OPTIONS] NAME URL"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:455 ../apps/ll-cli/src/main.cpp:467
-#: ../apps/ll-builder/src/main.cpp:909
+#: ../apps/ll-cli/src/main.cpp:440 ../apps/ll-cli/src/main.cpp:452
+#: ../apps/ll-builder/src/main.cpp:915
 msgid "Specify the repo name"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:458 ../apps/ll-cli/src/main.cpp:470
-#: ../apps/ll-cli/src/main.cpp:488 ../apps/ll-builder/src/main.cpp:912
-#: ../apps/ll-builder/src/main.cpp:935
+#: ../apps/ll-cli/src/main.cpp:443 ../apps/ll-cli/src/main.cpp:455
+#: ../apps/ll-cli/src/main.cpp:473 ../apps/ll-builder/src/main.cpp:918
+#: ../apps/ll-builder/src/main.cpp:941
 msgid "Url of the repository"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:461 ../apps/ll-cli/src/main.cpp:477
-#: ../apps/ll-cli/src/main.cpp:485 ../apps/ll-cli/src/main.cpp:496
-#: ../apps/ll-cli/src/main.cpp:508 ../apps/ll-cli/src/main.cpp:518
-#: ../apps/ll-cli/src/main.cpp:525 ../apps/ll-builder/src/main.cpp:916
-#: ../apps/ll-builder/src/main.cpp:924 ../apps/ll-builder/src/main.cpp:932
-#: ../apps/ll-builder/src/main.cpp:944 ../apps/ll-builder/src/main.cpp:953
-#: ../apps/ll-builder/src/main.cpp:962
+#: ../apps/ll-cli/src/main.cpp:446 ../apps/ll-cli/src/main.cpp:462
+#: ../apps/ll-cli/src/main.cpp:470 ../apps/ll-cli/src/main.cpp:481
+#: ../apps/ll-cli/src/main.cpp:493 ../apps/ll-cli/src/main.cpp:503
+#: ../apps/ll-cli/src/main.cpp:510 ../apps/ll-builder/src/main.cpp:922
+#: ../apps/ll-builder/src/main.cpp:930 ../apps/ll-builder/src/main.cpp:938
+#: ../apps/ll-builder/src/main.cpp:950 ../apps/ll-builder/src/main.cpp:959
+#: ../apps/ll-builder/src/main.cpp:968
 msgid "Alias of the repo name"
 msgstr ""
 
 #. add repo sub command modify
-#: ../apps/ll-cli/src/main.cpp:466
+#: ../apps/ll-cli/src/main.cpp:451
 msgid "Modify repository URL"
 msgstr ""
 
 #. add repo sub command remove
-#: ../apps/ll-cli/src/main.cpp:475 ../apps/ll-builder/src/main.cpp:921
+#: ../apps/ll-cli/src/main.cpp:460 ../apps/ll-builder/src/main.cpp:927
 msgid "Remove a repository"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:476
+#: ../apps/ll-cli/src/main.cpp:461
 msgid "Usage: ll-cli repo remove [OPTIONS] NAME"
 msgstr ""
 
 #. add repo sub command update
 #. TODO: add --repo and --url options
 #. add repo sub command update
-#: ../apps/ll-cli/src/main.cpp:483 ../apps/ll-builder/src/main.cpp:929
+#: ../apps/ll-cli/src/main.cpp:468 ../apps/ll-builder/src/main.cpp:935
 msgid "Update the repository URL"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:484
+#: ../apps/ll-cli/src/main.cpp:469
 msgid "Usage: ll-cli repo update [OPTIONS] NAME URL"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:494 ../apps/ll-builder/src/main.cpp:941
+#: ../apps/ll-cli/src/main.cpp:479 ../apps/ll-builder/src/main.cpp:947
 msgid "Set a default repository name"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:495
+#: ../apps/ll-cli/src/main.cpp:480
 msgid "Usage: ll-cli repo set-default [OPTIONS] NAME"
 msgstr ""
 
 #. add repo sub command show
-#: ../apps/ll-cli/src/main.cpp:501 ../apps/ll-builder/src/main.cpp:967
+#: ../apps/ll-cli/src/main.cpp:486 ../apps/ll-builder/src/main.cpp:973
 msgid "Show repository information"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:502
+#: ../apps/ll-cli/src/main.cpp:487
 msgid "Usage: ll-cli repo show [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:506
+#: ../apps/ll-cli/src/main.cpp:491
 msgid "Set the priority of the repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:507
+#: ../apps/ll-cli/src/main.cpp:492
 msgid "Usage: ll-cli repo set-priority ALIAS PRIORITY"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:511
+#: ../apps/ll-cli/src/main.cpp:496
 msgid "Priority of the repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:516 ../apps/ll-builder/src/main.cpp:950
+#: ../apps/ll-cli/src/main.cpp:501 ../apps/ll-builder/src/main.cpp:956
 msgid "Enable mirror for the repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:517
+#: ../apps/ll-cli/src/main.cpp:502
 msgid "Usage: ll-cli repo enable-mirror [OPTIONS] ALIAS"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:523 ../apps/ll-builder/src/main.cpp:959
+#: ../apps/ll-cli/src/main.cpp:508 ../apps/ll-builder/src/main.cpp:965
 msgid "Disable mirror for the repo"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:524
+#: ../apps/ll-cli/src/main.cpp:509
 msgid "Usage: ll-cli repo disable-mirror [OPTIONS] ALIAS"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:535
+#: ../apps/ll-cli/src/main.cpp:520
 msgid "Display information about installed apps or runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:538
+#: ../apps/ll-cli/src/main.cpp:523
 msgid "Usage: ll-cli info [OPTIONS] APP"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:542
+#: ../apps/ll-cli/src/main.cpp:527
 msgid "Specify the application ID, and it can also be a .layer file"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:554
+#: ../apps/ll-cli/src/main.cpp:539
 msgid "Display the exported files of installed application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:557
+#: ../apps/ll-cli/src/main.cpp:542
 msgid "Usage: ll-cli content [OPTIONS] APP"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:558
+#: ../apps/ll-cli/src/main.cpp:543
 msgid "Specify the installed application ID"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:566
+#: ../apps/ll-cli/src/main.cpp:551
 msgid "Remove the unused base or runtime"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:568
+#: ../apps/ll-cli/src/main.cpp:553
 msgid "Usage: ll-cli prune [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:579
+#: ../apps/ll-cli/src/main.cpp:564
 msgid "Display the inspect information of the installed application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:581
+#: ../apps/ll-cli/src/main.cpp:566
 msgid "Usage: ll-cli inspect SUBCOMMAND [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:588
+#: ../apps/ll-cli/src/main.cpp:573
 msgid ""
 "Display the data(bundle) directory of the installed(running) application"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:589
+#: ../apps/ll-cli/src/main.cpp:574
 msgid "Usage: ll-cli inspect dir [OPTIONS] APP"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:593
+#: ../apps/ll-cli/src/main.cpp:578
 msgid "Specify the application ID, and it can also be reference"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:599
+#: ../apps/ll-cli/src/main.cpp:584
 msgid "Specify the directory type (layer or bundle),the default is layer"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:606
+#: ../apps/ll-cli/src/main.cpp:591
 msgid ""
 "Specify the module type (binary or develop). Only works when type is layer"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:638
+#: ../apps/ll-cli/src/main.cpp:623
 msgid ""
 "linyaps CLI\n"
 "A CLI program to run application and manage application and runtime\n"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:646 ../apps/ll-builder/src/main.cpp:695
+#: ../apps/ll-cli/src/main.cpp:631 ../apps/ll-builder/src/main.cpp:699
 msgid "Print this help message and exit"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:647 ../apps/ll-builder/src/main.cpp:696
+#: ../apps/ll-cli/src/main.cpp:632 ../apps/ll-builder/src/main.cpp:700
 msgid "Expand all help"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:648
+#: ../apps/ll-cli/src/main.cpp:633
 msgid "Usage: ll-cli [OPTIONS] [SUBCOMMAND]"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:649
+#: ../apps/ll-cli/src/main.cpp:634
 msgid ""
 "If you found any problems during use,\n"
 "You can report bugs to the linyaps team under this project: https://github."
@@ -574,53 +582,53 @@ msgid ""
 msgstr ""
 
 #. version flag
-#: ../apps/ll-cli/src/main.cpp:656 ../apps/ll-builder/src/main.cpp:720
+#: ../apps/ll-cli/src/main.cpp:641 ../apps/ll-builder/src/main.cpp:724
 msgid "Show version"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:661
+#: ../apps/ll-cli/src/main.cpp:646
 msgid ""
 "Use peer to peer DBus, this is used only in case that DBus daemon is not "
 "available"
 msgstr ""
 
 #. json flag
-#: ../apps/ll-cli/src/main.cpp:666
+#: ../apps/ll-cli/src/main.cpp:651
 msgid "Use json format to output result"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:673
+#: ../apps/ll-cli/src/main.cpp:658
 msgid "Show debug info (verbose logs)"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:676
+#: ../apps/ll-cli/src/main.cpp:661
 msgid "Don't output progress information"
 msgstr ""
 
 #. groups for subcommands
-#: ../apps/ll-cli/src/main.cpp:693
+#: ../apps/ll-cli/src/main.cpp:678
 msgid "Managing installed applications and runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:694
+#: ../apps/ll-cli/src/main.cpp:679
 msgid "Managing running applications"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:695
+#: ../apps/ll-cli/src/main.cpp:680
 msgid "Finding applications and runtimes"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:696
+#: ../apps/ll-cli/src/main.cpp:681
 msgid "Managing remote repositories"
 msgstr ""
 
-#: ../apps/ll-cli/src/main.cpp:722
+#: ../apps/ll-cli/src/main.cpp:707
 msgid "linyaps CLI version "
 msgstr ""
 
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:71
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:134
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:310
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:314
 msgid "ID"
 msgstr ""
 
@@ -686,279 +694,279 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:298
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:302
 msgid "No apps available for update."
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:311
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:315
 msgid "Installed"
 msgstr ""
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:312
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:316
 msgid "New"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:693
+#: ../apps/ll-builder/src/main.cpp:697
 msgid ""
 "linyaps builder CLI \n"
 "A CLI program to build linyaps application\n"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:698
+#: ../apps/ll-builder/src/main.cpp:702
 msgid "Usage: ll-builder [OPTIONS] [SUBCOMMAND]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:700
+#: ../apps/ll-builder/src/main.cpp:704
 msgid ""
 "If you found any problems during use\n"
 "You can report bugs to the linyaps team under this project: https://github."
 "com/OpenAtom-Linyaps/linyaps/issues"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:724
+#: ../apps/ll-builder/src/main.cpp:728
 msgid "Create linyaps build template project"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:725
+#: ../apps/ll-builder/src/main.cpp:729
 msgid "Usage: ll-builder create [OPTIONS] NAME"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:726
+#: ../apps/ll-builder/src/main.cpp:730
 msgid "Project name"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:734
+#: ../apps/ll-builder/src/main.cpp:738
 msgid "Build a linyaps project"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:735
+#: ../apps/ll-builder/src/main.cpp:739
 msgid "Usage: ll-builder build [OPTIONS] [COMMAND...]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:736 ../apps/ll-builder/src/main.cpp:777
-#: ../apps/ll-builder/src/main.cpp:816 ../apps/ll-builder/src/main.cpp:862
+#: ../apps/ll-builder/src/main.cpp:740 ../apps/ll-builder/src/main.cpp:781
+#: ../apps/ll-builder/src/main.cpp:822 ../apps/ll-builder/src/main.cpp:868
 msgid "File path of the linglong.yaml"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:742
+#: ../apps/ll-builder/src/main.cpp:746
 msgid "Enter the container to execute command instead of building applications"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:745
+#: ../apps/ll-builder/src/main.cpp:749
 msgid ""
 "Only use local files. This implies --skip-fetch-source and --skip-pull-"
 "depend will be set"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:750
+#: ../apps/ll-builder/src/main.cpp:754
 msgid "Build full develop packages, runtime requires"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:754
+#: ../apps/ll-builder/src/main.cpp:758
 msgid "Skip fetch sources"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:757
+#: ../apps/ll-builder/src/main.cpp:761
 msgid "Skip pull dependency"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:760
+#: ../apps/ll-builder/src/main.cpp:764
 msgid "Skip run container"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:763
+#: ../apps/ll-builder/src/main.cpp:767
 msgid "Skip commit build output"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:766
+#: ../apps/ll-builder/src/main.cpp:770
 msgid "Skip output check"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:769
+#: ../apps/ll-builder/src/main.cpp:773
 msgid "Skip strip debug symbols"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:772
+#: ../apps/ll-builder/src/main.cpp:776
 msgid "Build in an isolated network environment"
 msgstr ""
 
 #. add builder run
-#: ../apps/ll-builder/src/main.cpp:775
+#: ../apps/ll-builder/src/main.cpp:779
 msgid "Run built linyaps app"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:776
+#: ../apps/ll-builder/src/main.cpp:780
 msgid "Usage: ll-builder run [OPTIONS] [COMMAND...]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:783
+#: ../apps/ll-builder/src/main.cpp:787
 msgid "Run specified module. eg: --modules binary,develop"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:790
+#: ../apps/ll-builder/src/main.cpp:796
 msgid "Enter the container to execute command instead of running application"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:793
+#: ../apps/ll-builder/src/main.cpp:799
 msgid "Run in debug mode (enable develop module)"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:797
+#: ../apps/ll-builder/src/main.cpp:803
 msgid "Specify extension(s) used by the app to run"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:803
+#: ../apps/ll-builder/src/main.cpp:809
 msgid "List built linyaps app"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:804
+#: ../apps/ll-builder/src/main.cpp:810
 msgid "Usage: ll-builder list [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:805
+#: ../apps/ll-builder/src/main.cpp:811
 msgid "Remove built linyaps app"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:806
+#: ../apps/ll-builder/src/main.cpp:812
 msgid "Usage: ll-builder remove [OPTIONS] [APP...]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:809
+#: ../apps/ll-builder/src/main.cpp:815
 msgid "Do not clean objects files before remove apps"
 msgstr ""
 
 #. build export
-#: ../apps/ll-builder/src/main.cpp:813
+#: ../apps/ll-builder/src/main.cpp:819
 msgid "Export to linyaps layer or uab"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:814
+#: ../apps/ll-builder/src/main.cpp:820
 msgid "Usage: ll-builder export [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:826
+#: ../apps/ll-builder/src/main.cpp:832
 msgid "Uab icon (optional)"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:831
+#: ../apps/ll-builder/src/main.cpp:837
 msgid "Export to linyaps layer file (deprecated)"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:834
+#: ../apps/ll-builder/src/main.cpp:840
 msgid "Use custom loader"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:841
+#: ../apps/ll-builder/src/main.cpp:847
 msgid "Don't export the develop module"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:843
+#: ../apps/ll-builder/src/main.cpp:849
 msgid "Output file"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:847
+#: ../apps/ll-builder/src/main.cpp:853
 msgid "Reference of the package"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:852
+#: ../apps/ll-builder/src/main.cpp:858
 msgid "Modules to export"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:860
+#: ../apps/ll-builder/src/main.cpp:866
 msgid "Push linyaps app to remote repo"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:861
+#: ../apps/ll-builder/src/main.cpp:867
 msgid "Usage: ll-builder push [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:865
+#: ../apps/ll-builder/src/main.cpp:871
 msgid "Remote repo url"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:868
+#: ../apps/ll-builder/src/main.cpp:874
 msgid "Remote repo name"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:871
+#: ../apps/ll-builder/src/main.cpp:877
 msgid "Push single module"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:875
+#: ../apps/ll-builder/src/main.cpp:881
 msgid "Import linyaps layer to build repo"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:876
+#: ../apps/ll-builder/src/main.cpp:882
 msgid "Usage: ll-builder import [OPTIONS] LAYER"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:877 ../apps/ll-builder/src/main.cpp:894
+#: ../apps/ll-builder/src/main.cpp:883 ../apps/ll-builder/src/main.cpp:900
 msgid "Layer file path"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:884
+#: ../apps/ll-builder/src/main.cpp:890
 msgid "Import linyaps layer dir to build repo"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:886
+#: ../apps/ll-builder/src/main.cpp:892
 msgid "Usage: ll-builder import-dir PATH"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:887
+#: ../apps/ll-builder/src/main.cpp:893
 msgid "Layer dir path"
 msgstr ""
 
 #. add build extract
-#: ../apps/ll-builder/src/main.cpp:892
+#: ../apps/ll-builder/src/main.cpp:898
 msgid "Extract linyaps layer to dir"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:893
+#: ../apps/ll-builder/src/main.cpp:899
 msgid "Usage: ll-builder extract [OPTIONS] LAYER DIR"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:897
+#: ../apps/ll-builder/src/main.cpp:903
 msgid "Destination directory"
 msgstr ""
 
 #. add build repo
-#: ../apps/ll-builder/src/main.cpp:902
+#: ../apps/ll-builder/src/main.cpp:908
 msgid "Display and manage repositories"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:903
+#: ../apps/ll-builder/src/main.cpp:909
 msgid "Usage: ll-builder repo [OPTIONS] SUBCOMMAND"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:908
+#: ../apps/ll-builder/src/main.cpp:914
 msgid "Usage: ll-builder repo add [OPTIONS] NAME URL"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:922
+#: ../apps/ll-builder/src/main.cpp:928
 msgid "Usage: ll-builder repo remove [OPTIONS] NAME"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:930
+#: ../apps/ll-builder/src/main.cpp:936
 msgid "Usage: ll-builder repo update [OPTIONS] NAME URL"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:942
+#: ../apps/ll-builder/src/main.cpp:948
 msgid "Usage: ll-builder repo set-default [OPTIONS] NAME"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:951
+#: ../apps/ll-builder/src/main.cpp:957
 msgid "Usage: ll-builder repo enable-mirror [OPTIONS] ALIAS"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:960
+#: ../apps/ll-builder/src/main.cpp:966
 msgid "Usage: ll-builder repo disable-mirror [OPTIONS] ALIAS"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:968
+#: ../apps/ll-builder/src/main.cpp:974
 msgid "Usage: ll-builder repo show [OPTIONS]"
 msgstr ""
 
-#: ../apps/ll-builder/src/main.cpp:973
+#: ../apps/ll-builder/src/main.cpp:979
 msgid "linyaps build tool version "
 msgstr ""
 


### PR DESCRIPTION
Updated the help text for the --workdir command line option in both ll-builder and ll-cli applications. Changed from "Working directory inside the app" to "Specify the working directory where the application runs" to provide clearer and more accurate description of the option's functionality.

The previous description was somewhat ambiguous and didn't clearly indicate that this option specifies the directory where the application will execute. The new description better communicates the purpose of the --workdir option to users.

Influence:
1. Verify --workdir option help text displays correctly in both applications
2. Test that the option functionality remains unchanged
3. Confirm help text consistency across different command help sections
4. Check that option validation and parsing behavior is unaffected