### PR TITLE
feat: add shell completion files for ll-builder

### DIFF
--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -36,6 +36,8 @@ configure_files(
   lib/tmpfiles.d/linglong.conf
   script/linglong.sh
   share/bash-completion/completions/ll-builder
+  share/zsh/vendor-completions/_ll-builder
+  share/fish/vendor_completions.d/ll-builder.fish
   share/bash-completion/completions/ll-cli
   share/zsh/vendor-completions/_ll-cli
   share/fish/vendor_completions.d/ll-cli.fish


### PR DESCRIPTION
Added shell completion configuration files for ll-builder command across different shell environments:
- Zsh completion file: share/zsh/vendor-completions/_ll-builder
- Fish completion file: share/fish/vendor_completions.d/ll-builder.fish

This change ensures that ll-builder command now has proper shell completion support in Zsh and Fish shells, similar to what was already available for ll-cli command. The completion files will be automatically installed and configured during the build process.

Log: Added shell auto-completion support for ll-builder command in Zsh and Fish shells

Influence:
1. Test ll-builder command completion in Zsh shell
2. Verify ll-builder command completion in Fish shell
3. Ensure existing ll-cli completion still works correctly
4. Test completion behavior after fresh installation
5. Verify completion files are properly installed to correct locations