### PR TITLE
feat: add RISC-V 64 architecture support

### DIFF
--- a/libs/linglong/src/linglong/package/architecture.cpp
+++ b/libs/linglong/src/linglong/package/architecture.cpp
@@ -38,6 +38,8 @@ std::string Architecture::toString() const noexcept
         return "sw64";
     case MIPS64:
         return "mips64";
+    case RISCV64:
+        return "riscv64";
     case UNKNOW:
         [[fallthrough]];
     default:
@@ -62,6 +64,8 @@ std::string Architecture::getTriplet() const noexcept
         return "loongarch64-linux-gnu";
     case MIPS64:
         return "mips64el-linux-gnuabi64";
+    case RISCV64:
+        return "riscv64-linux-gnu";
     }
     return "unknown";
 }
@@ -99,6 +103,10 @@ Architecture::Architecture(const std::string &raw)
 
         if (raw == "mips64") {
             return MIPS64;
+        }
+
+        if (raw == "riscv64") {
+            return RISCV64;
         }
 
         throw std::runtime_error("unknow architecture");

--- a/libs/linglong/src/linglong/package/architecture.h
+++ b/libs/linglong/src/linglong/package/architecture.h
@@ -24,6 +24,7 @@ public:
         LOONGARCH64,
         LOONG64,
         SW64,
+        RISCV64,
         MIPS64,
     };
 

--- a/libs/linglong/tests/ll-tests/src/linglong/package/architecture_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/architecture_test.cpp
@@ -27,6 +27,7 @@ constexpr ArchitectureTestData ARCHITECTURE_TEST_DATA[] = {
     { Architecture::LOONG64, "loong64", "loongarch64-linux-gnu" },
     { Architecture::SW64, "sw64", "sw_64-linux-gnu" },
     { Architecture::MIPS64, "mips64", "mips64el-linux-gnuabi64" },
+    { Architecture::RISCV64, "riscv64", "riscv64-linux-gnu" },
 };
 
 // 无效架构字符串测试数据


### PR DESCRIPTION
Added RISC-V 64 architecture support to the package architecture system. This includes:
1. Added RISCV64 enum value to Architecture class
2. Implemented toString() method returning "riscv64"
3. Implemented getTriplet() method returning "riscv64-linux-gnu"
4. Added parsing support for "riscv64" string input
5. Updated test cases to include RISC-V 64 architecture

This change enables the package system to properly handle RISC-V 64 architecture, which is necessary for supporting applications built for RISC-V 64 platforms. The architecture follows the same pattern as other supported architectures with proper string conversion and triplet generation.

Influence:
1. Verify Architecture::toString() returns "riscv64" for RISCV64 enum
2. Test Architecture::getTriplet() returns "riscv64-linux-gnu" for RISCV64
3. Validate Architecture constructor parses "riscv64" string correctly
4. Confirm existing architecture tests still pass with new RISCV64 addition
5. Test error handling for unknown architecture strings remains functional