### PR TITLE
fix: enter container error

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+ * SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
@@ -72,6 +72,8 @@
 using namespace linglong::utils::error;
 
 namespace {
+
+constexpr std::size_t ContainerIDDisplayLength = 12;
 
 std::vector<std::string> getAutoModuleList() noexcept
 {
@@ -739,19 +741,17 @@ int Cli::enter(const EnterOptions &options)
 {
     LINGLONG_TRACE("ll-cli exec");
     auto containerIDList = this->getRunningAppContainers(options.instance);
+    if (!containerIDList) {
+        this->printer.printErr(containerIDList.error());
+        return -1;
+    }
 
-    if (containerIDList.empty()) {
+    if (containerIDList->empty()) {
         this->printer.printErr(LINGLONG_ERRV("no container found"));
         return -1;
     }
 
-    if (containerIDList.size() > 1) {
-        this->printer.printErr(
-          LINGLONG_ERRV("multiple running containers found, please specify which one to enter"));
-        return -1;
-    }
-
-    auto containerID = containerIDList.front();
+    auto containerID = containerIDList->front();
     LogI("select container id: {}", containerID);
     auto commands = options.commands;
     if (commands.empty()) {
@@ -851,7 +851,7 @@ int Cli::ps()
     std::for_each(myContainers->begin(),
                   myContainers->end(),
                   [](api::types::v1::CliContainer &container) {
-                      container.id = container.id.substr(0, 12);
+                      container.id = container.id.substr(0, ContainerIDDisplayLength);
                   });
 
     this->printer.printContainers(*myContainers);
@@ -859,27 +859,55 @@ int Cli::ps()
     return 0;
 }
 
-std::vector<std::string> Cli::getRunningAppContainers(const std::string &appid)
+bool Cli::isContainerIDMatch(const std::string &containerID, const std::string &shortID)
+{
+    if (containerID == shortID) {
+        return true;
+    }
+
+    if (shortID.size() < ContainerIDDisplayLength) {
+        return false;
+    }
+
+    return common::strings::starts_with(containerID, shortID);
+}
+
+utils::error::Result<std::vector<std::string>> Cli::getRunningAppContainers(const std::string &id)
 {
     LINGLONG_TRACE("get app running containers");
 
     std::vector<std::string> containerIDList{};
     auto containers = getCurrentContainers();
     if (!containers) {
-        this->printer.printErr(containers.error());
-        return containerIDList;
+        return LINGLONG_ERR(containers);
     }
 
     for (const auto &container : *containers) {
-        auto fuzzyRef = package::FuzzyReference::parse(container.package);
-        if (!fuzzyRef) {
-            LogW("{}", fuzzyRef.error());
+        // first check if the id matches container id, then check if the id matches package appid or
+        // reference
+        if (isContainerIDMatch(container.id, id)) {
+            containerIDList.emplace_back(container.id);
             continue;
         }
 
-        if (fuzzyRef->id == appid || fuzzyRef->toString() == appid) {
+        auto ref = package::Reference::parse(container.package);
+        if (!ref) {
+            LogW("{}", ref.error());
+            continue;
+        }
+
+        if (ref->id == id || ref->toString() == id) {
             containerIDList.emplace_back(container.id);
         }
+    }
+
+    if (containerIDList.size() > 1) {
+        auto msg =
+          fmt::format("multiple running containers match the specified identifier '{}': {}. "
+                      "Please specify a more specific identifier.",
+                      id,
+                      containerIDList);
+        return LINGLONG_ERR(msg);
     }
 
     return containerIDList;
@@ -890,9 +918,18 @@ int Cli::kill(const KillOptions &options)
     LINGLONG_TRACE("command kill");
 
     auto containerIDList = this->getRunningAppContainers(options.appid);
+    if (!containerIDList) {
+        this->printer.printErr(containerIDList.error());
+        return -1;
+    }
+
+    if (containerIDList->empty()) {
+        this->printer.printErr(LINGLONG_ERRV("no container found"));
+        return -1;
+    }
 
     auto ret = 0;
-    for (const auto &containerID : containerIDList) {
+    for (const auto &containerID : *containerIDList) {
         LogI("select container id {}", containerID);
         auto result = this->ociCLI.kill(ocppi::runtime::ContainerID(containerID),
                                         ocppi::runtime::Signal(options.signal));
@@ -2191,7 +2228,7 @@ int Cli::getLayerDir(const InspectOptions &options)
         return -1;
     }
 
-    std::cout << layerDir->path() << std::endl;
+    std::cout << layerDir->path().string() << std::endl;
 
     return 0;
 }
@@ -2201,20 +2238,17 @@ int Cli::getBundleDir(const InspectOptions &options)
     LINGLONG_TRACE("Get Bundle dir");
 
     auto containerIDList = getRunningAppContainers(options.appid);
+    if (!containerIDList) {
+        this->printer.printErr(containerIDList.error());
+        return -1;
+    }
 
-    if (containerIDList.empty()) {
+    if (containerIDList->empty()) {
         this->printer.printErr(LINGLONG_ERRV("Can not find the running application."));
         return -1;
     }
 
-    if (containerIDList.size() > 1) {
-        this->printer.printErr(
-          LINGLONG_ERRV("Found multiple running containers for the application, please specify "
-                        "the container ID to inspect."));
-        return -1;
-    }
-
-    auto bundleDir = linglong::common::dir::getBundleDir(containerIDList.front());
+    auto bundleDir = linglong::common::dir::getBundleDir(containerIDList->front());
 
     std::cout << bundleDir.string() << std::endl;
 

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+ * SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
@@ -224,7 +224,8 @@ private:
       runtime::RunContext &runContext, const generator::ContainerCfgBuilder &cfgBuilder) noexcept;
     QDBusReply<void> authorization();
     void updateAM() noexcept;
-    std::vector<std::string> getRunningAppContainers(const std::string &appid);
+    utils::error::Result<std::vector<std::string>> getRunningAppContainers(const std::string &id);
+    bool isContainerIDMatch(const std::string &containerID, const std::string &shortID);
     int getLayerDir(const InspectOptions &options);
     int getBundleDir(const InspectOptions &options);
     utils::error::Result<void> initInteraction();


### PR DESCRIPTION
Refactor getRunningAppContainers to return Result type for better error handling
Add container ID prefix matching for more flexible container selection Improve error messages for multiple matching containers Update all callers to handle the new Result type properly

The changes enhance container management by:
1. Changing getRunningAppContainers to return utils::error::Result for proper error propagation
2. Adding container ID prefix matching in addition to package ID matching
3. Providing clearer error messages when multiple containers match
4. Updating enter, kill, and getBundleDir methods to handle the new error handling pattern
5. Fixing path output in getLayerDir to use string() method

This improves user experience by allowing partial container ID matching and providing more specific error messages when multiple containers are found.

Log: Improved container selection with better error messages and partial ID matching

Influence:
1. Test container enter command with partial container ID
2. Verify error messages when multiple containers match a prefix
3. Test kill command with different container identification methods
4. Verify bundle and layer directory inspection commands work correctly
5. Test edge cases with no containers found or multiple matches
6. Validate error handling for invalid container references