### PR TITLE
feat(oci): enable xdg-desktop-portal for GTK/Qt apps by default

### DIFF
--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -1438,6 +1438,11 @@ utils::error::Result<void> ContainerCfgBuilder::buildEnv() noexcept
         environment["LINGLONG_APPID"] = appId;
     }
 
+    if (!disableGenerateContainerInfo) {
+        environment.try_emplace("GTK_USE_PORTAL", "1");
+        environment.try_emplace("QT_QPA_PLATFORMTHEME", "xdgdesktopportal");
+    }
+
     auto envShFile = bundlePath / "00env.sh";
     std::ofstream ofs(envShFile);
     if (!ofs.is_open()) {

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
@@ -325,7 +325,7 @@ private:
 
     bool isolateNetWorkEnabled = false;
     bool disableUserNamespaceEnabled = false;
-    bool disableGenerateContainerInfo{ true };
+    bool disableGenerateContainerInfo{ false };
     bool applyPatchEnabled = true;
     bool isolateTmp{ false };
 


### PR DESCRIPTION
Sets GTK_USE_PORTAL=1 and QT_QPA_PLATFORMTHEME=xdgdesktopportal to ensure file dialogs use the host portal when running sandboxed.