### PR TITLE
refactor: unify fallback logic for binary module pulls

### DIFF
--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -1162,36 +1162,49 @@ OSTreeRepo::fetchRefMetaData(const package::ReferenceWithRepo &refRepo,
                              const std::string &module,
                              bool fetchPackageInfo) noexcept
 {
-    auto refString = ostreeSpecFromReferenceV2(refRepo.reference, std::nullopt, module);
     auto repoName = refRepo.repo.alias.value_or(refRepo.repo.name);
-    LINGLONG_TRACE(fmt::format("fetch info.json from {}:{}", repoName, refString));
 
     g_autoptr(GError) gErr = nullptr;
+    auto refCandidates = buildPullRefCandidates(refRepo.reference, module);
+    auto refString = refCandidates.front();
+    LINGLONG_TRACE(fmt::format("fetch info.json from {}:{}", repoName, refString));
 
-    GVariantBuilder builder = this->initOStreePullOptions(refString);
-    if (fetchPackageInfo) {
-        std::vector<const char *> subdirs{ "/info.json", nullptr };
-        g_variant_builder_add(&builder,
-                              "{s@v}",
-                              "subdirs",
-                              g_variant_new_variant(g_variant_new_strv(subdirs.data(), -1)));
-    } else {
-        g_variant_builder_add(
-          &builder,
-          "{s@v}",
-          "flags",
-          g_variant_new_variant(g_variant_new_int32(OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY)));
-    }
+    for (size_t idx = 0; idx < refCandidates.size(); ++idx) {
+        refString = refCandidates[idx];
 
-    g_autoptr(GVariant) pull_options = g_variant_ref_sink(g_variant_builder_end(&builder));
-    auto status = ostree_repo_pull_with_options(this->ostreeRepo.get(),
-                                                repoName.c_str(),
-                                                pull_options,
-                                                nullptr,
-                                                nullptr,
-                                                &gErr);
-    if (status == FALSE) {
-        return LINGLONG_ERR(fmt::format("ostree_repo_pull_with_options {}", ptr_view(gErr)));
+        GVariantBuilder builder = this->initOStreePullOptions(refString);
+        if (fetchPackageInfo) {
+            std::vector<const char *> subdirs{ "/info.json", nullptr };
+            g_variant_builder_add(&builder,
+                                  "{s@v}",
+                                  "subdirs",
+                                  g_variant_new_variant(g_variant_new_strv(subdirs.data(), -1)));
+        } else {
+            g_variant_builder_add(
+              &builder,
+              "{s@v}",
+              "flags",
+              g_variant_new_variant(g_variant_new_int32(OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY)));
+        }
+
+        g_autoptr(GVariant) pull_options = g_variant_ref_sink(g_variant_builder_end(&builder));
+        auto status = ostree_repo_pull_with_options(this->ostreeRepo.get(),
+                                                    repoName.c_str(),
+                                                    pull_options,
+                                                    nullptr,
+                                                    nullptr,
+                                                    &gErr);
+        if (status != FALSE) {
+            break;
+        }
+
+        if (idx + 1 == refCandidates.size() || !shouldFallbackToRuntimeBranch(module, gErr)) {
+            return LINGLONG_ERR(fmt::format("ostree_repo_pull_with_options {}", ptr_view(gErr)));
+        }
+
+        LogW("ostree_repo_pull_with_options failed with [{}]: {}", gErr->code, gErr->message);
+        LogW("fallback to module runtime, fetch {}", refCandidates[idx + 1]);
+        g_clear_error(&gErr);
     }
     g_clear_error(&gErr);
 
@@ -1327,12 +1340,31 @@ GVariantBuilder OSTreeRepo::initOStreePullOptions(const std::string &ref) noexce
     return builder;
 }
 
+std::vector<std::string> OSTreeRepo::buildPullRefCandidates(const package::Reference &ref,
+                                                            const std::string &module) noexcept
+{
+    std::vector<std::string> candidates;
+    candidates.emplace_back(ostreeSpecFromReferenceV2(ref, std::nullopt, module));
+    if (module == "binary") {
+        candidates.emplace_back(ostreeSpecFromReference(ref, std::nullopt, module));
+    }
+    return candidates;
+}
+
+bool OSTreeRepo::shouldFallbackToRuntimeBranch(const std::string &module,
+                                               const GError *gErr) noexcept
+{
+    return module == "binary" && gErr != nullptr && gErr->message != nullptr
+      && strstr(gErr->message, "No such branch") != nullptr;
+}
+
 utils::error::Result<void> OSTreeRepo::pull(service::Task &taskContext,
                                             const package::ReferenceWithRepo &refRepo,
                                             const std::string &module) noexcept
 {
-    auto refString = ostreeSpecFromReferenceV2(refRepo.reference, std::nullopt, module);
     auto repoName = refRepo.repo.alias.value_or(refRepo.repo.name);
+    auto refCandidates = buildPullRefCandidates(refRepo.reference, module);
+    auto refString = refCandidates.front();
     LINGLONG_TRACE(fmt::format("pull {} from {}", refString, repoName));
 
     auto *cancellable = taskContext.cancellable();
@@ -1346,51 +1378,35 @@ utils::error::Result<void> OSTreeRepo::pull(service::Task &taskContext,
 
     g_autoptr(GError) gErr = nullptr;
 
-    auto builder = this->initOStreePullOptions(refString);
-    g_autoptr(GVariant) pull_options = g_variant_ref_sink(g_variant_builder_end(&builder));
-    // 这里不能使用g_main_context_push_thread_default，因为会阻塞Qt的事件循环
+    for (size_t idx = 0; idx < refCandidates.size(); ++idx) {
+        refString = refCandidates[idx];
 
-    auto status = ostree_repo_pull_with_options(this->ostreeRepo.get(),
-                                                repoName.c_str(),
-                                                pull_options,
-                                                progress,
-                                                cancellable,
-                                                &gErr);
-    ostree_async_progress_finish(progress);
-    auto shouldFallback = false;
-    if (status == FALSE) {
-        // gErr->code is 0, so we compare string here.
-        if (!strstr(gErr->message, "No such branch")) {
+        auto builder = this->initOStreePullOptions(refString);
+        g_autoptr(GVariant) pull_options = g_variant_ref_sink(g_variant_builder_end(&builder));
+        // 这里不能使用g_main_context_push_thread_default，因为会阻塞Qt的事件循环
+
+        auto status = ostree_repo_pull_with_options(this->ostreeRepo.get(),
+                                                    repoName.c_str(),
+                                                    pull_options,
+                                                    progress,
+                                                    cancellable,
+                                                    &gErr);
+        ostree_async_progress_finish(progress);
+        if (status != FALSE) {
+            break;
+        }
+
+        if (idx + 1 == refCandidates.size() || !shouldFallbackToRuntimeBranch(module, gErr)) {
             return LINGLONG_ERR(fmt::format("ostree_repo_pull_with_options {}", ptr_view(gErr)));
         }
-        LogW("ostree_repo_pull_with_options failed with [{}]: {}", gErr->code, gErr->message);
-        shouldFallback = true;
-    }
-    // Note: this fallback is only for binary to runtime
-    if (shouldFallback && (module == "binary" || module == "runtime")) {
-        g_autoptr(OstreeAsyncProgress) progress =
-          ostree_async_progress_new_and_connect(progress_changed, (void *)&data);
-        Q_ASSERT(progress != nullptr);
-        // fallback to old ref
-        refString = ostreeSpecFromReference(refRepo.reference, std::nullopt, module);
-        LogW("fallback to module runtime, pull {}", refString);
 
+        LogW("ostree_repo_pull_with_options failed with [{}]: {}", gErr->code, gErr->message);
+        LogW("fallback to module runtime, pull {}", refCandidates[idx + 1]);
         g_clear_error(&gErr);
 
-        GVariantBuilder builder = this->initOStreePullOptions(refString);
-
-        g_autoptr(GVariant) pull_options = g_variant_ref_sink(g_variant_builder_end(&builder));
-
-        status = ostree_repo_pull_with_options(this->ostreeRepo.get(),
-                                               repoName.c_str(),
-                                               pull_options,
-                                               progress,
-                                               cancellable,
-                                               &gErr);
-        ostree_async_progress_finish(progress);
-        if (status == FALSE) {
-            return LINGLONG_ERR(fmt::format("ostree_repo_pull_with_options {}", ptr_view(gErr)));
-        }
+        g_clear_object(&progress);
+        progress = ostree_async_progress_new_and_connect(progress_changed, (void *)&data);
+        Q_ASSERT(progress != nullptr);
     }
 
     g_autofree char *commit = nullptr;

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -263,6 +263,10 @@ private:
 
 protected:
     OSTreeRepo(std::filesystem::path path, api::types::v1::RepoConfigV2 cfg) noexcept;
+    static std::vector<std::string> buildPullRefCandidates(const package::Reference &ref,
+                                                           const std::string &module) noexcept;
+    static bool shouldFallbackToRuntimeBranch(const std::string &module,
+                                              const GError *gErr) noexcept;
 
     utils::error::Result<void> init(bool create) noexcept;
     utils::error::Result<void> initCache(bool create) noexcept;

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/ostree_repo_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/ostree_repo_test.cpp
@@ -421,6 +421,18 @@ public:
                 (override, const));
 };
 
+class OSTreeRepoAccessor : public repo::OSTreeRepo
+{
+public:
+    using repo::OSTreeRepo::buildPullRefCandidates;
+
+    OSTreeRepoAccessor()
+        : repo::OSTreeRepo(
+            "", api::types::v1::RepoConfigV2{ .defaultRepo = "", .repos = {}, .version = 2 })
+    {
+    }
+};
+
 class MockClientAPIWrapper : public ClientAPIWrapper
 {
 public:
@@ -464,6 +476,18 @@ TEST(OSTreeRepoTest, searchRemote_Search)
     EXPECT_EQ(result->size(), 1);
     EXPECT_EQ((*result)[0].id, "com.example.cpp");
     EXPECT_EQ((*result)[0].version, "1.0.0");
+}
+
+TEST(OSTreeRepoTest, BuildPullRefCandidatesFallbackToRuntimeForBinary)
+{
+    auto ref = package::Reference::parse("stable:org.deepin.demo/1.0.0/x86_64");
+    ASSERT_TRUE(ref.has_value()) << ref.error().message();
+
+    auto candidates = OSTreeRepoAccessor::buildPullRefCandidates(*ref, "binary");
+
+    ASSERT_EQ(candidates.size(), 2);
+    EXPECT_EQ(candidates[0], "stable/org.deepin.demo/1.0.0/x86_64/binary");
+    EXPECT_EQ(candidates[1], "stable/org.deepin.demo/1.0.0/x86_64/runtime");
 }
 
 TEST(OSTreeRepoTest, searchRemote_MatchVersion)


### PR DESCRIPTION
Extract the fallback mechanism for pulling binary modules info reusable helper functions.  When pulling a binary module fails with "No such branch", the code now falls back to the runtime ref.