### PR TITLE
fix: follow symlinks when iterating entries directory

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -1715,7 +1715,7 @@ int Cli::content(const ContentOptions &options)
 
     QDirIterator it(entriesDir.absolutePath(),
                     QDir::AllEntries | QDir::NoDot | QDir::NoDotDot | QDir::System,
-                    QDirIterator::Subdirectories);
+                    QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
     while (it.hasNext()) {
         it.next();
         const auto entryPath = it.fileInfo().absoluteFilePath();

--- a/libs/linglong/tests/ll-tests/src/linglong/cli/cli_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/cli/cli_test.cpp
@@ -291,6 +291,90 @@ TEST_F(CliTest, contentPreferDesktopFromDefaultSharedDir)
     EXPECT_EQ(cli->content(cli::ContentOptions{ .appid = "org.example.app" }), 0);
 }
 
+TEST_F(CliTest, contentResolvesDesktopFromSymlinkedEntriesShareDir)
+{
+    auto ref = package::Reference::parse("main:org.example.app/1.0.0/x86_64");
+    ASSERT_TRUE(ref.has_value());
+
+    const std::string commit = "test-commit-symlinked-share";
+    const auto layerFilesDir =
+      tempDir->path() / "layers" / commit / "files" / "share" / "applications";
+    const auto layerEntriesShareLink = tempDir->path() / "layers" / commit / "entries" / "share";
+    const auto defaultDesktopPath =
+      repo->defaultSharedDir() / "applications" / "org.example.app.desktop";
+
+    std::filesystem::create_directories(layerFilesDir);
+    std::filesystem::create_directories(layerEntriesShareLink.parent_path());
+    std::filesystem::create_directories(defaultDesktopPath.parent_path());
+    std::ofstream(layerFilesDir / "org.example.app.desktop") << "Test desktop content";
+    std::ofstream(defaultDesktopPath) << "Test desktop content in default";
+
+    std::error_code ec;
+    std::filesystem::create_directory_symlink("../files/share", layerEntriesShareLink, ec);
+    if (ec) {
+        GTEST_SKIP() << "directory symlink support is required: " << ec.message();
+    }
+
+    api::types::v1::RepositoryCacheLayersItem layerItem;
+    layerItem.commit = commit;
+    layerItem.info.kind = "app";
+
+    EXPECT_CALL(*repo, clearReference(_, _, _, _)).WillOnce(Return(*ref));
+    EXPECT_CALL(*repo, getLayerItem(_, _, _))
+      .WillRepeatedly(
+        [layerItem](const package::Reference &, std::string, const std::optional<std::string> &)
+          -> utils::error::Result<api::types::v1::RepositoryCacheLayersItem> {
+            return layerItem;
+        });
+    EXPECT_CALL(*printer,
+                printContent(ElementsAre(QString::fromStdString(defaultDesktopPath.string()))))
+      .WillOnce(Return());
+
+    EXPECT_EQ(cli->content(cli::ContentOptions{ .appid = "org.example.app" }), 0);
+}
+
+TEST_F(CliTest, contentResolvesOverlayDesktopFromSymlinkedEntriesShareDir)
+{
+    auto ref = package::Reference::parse("main:org.example.app/1.0.0/x86_64");
+    ASSERT_TRUE(ref.has_value());
+
+    const std::string commit = "test-commit-symlinked-share-overlay";
+    const auto layerFilesDir =
+      tempDir->path() / "layers" / commit / "files" / "share" / "applications";
+    const auto layerEntriesShareLink = tempDir->path() / "layers" / commit / "entries" / "share";
+    const auto overlayDesktopPath =
+      repo->overlaySharedDir() / "applications" / "org.example.app.desktop";
+
+    std::filesystem::create_directories(layerFilesDir);
+    std::filesystem::create_directories(layerEntriesShareLink.parent_path());
+    std::filesystem::create_directories(overlayDesktopPath.parent_path());
+    std::ofstream(layerFilesDir / "org.example.app.desktop") << "Test desktop content";
+    std::ofstream(overlayDesktopPath) << "Test desktop content in overlay";
+
+    std::error_code ec;
+    std::filesystem::create_directory_symlink("../files/share", layerEntriesShareLink, ec);
+    if (ec) {
+        GTEST_SKIP() << "directory symlink support is required: " << ec.message();
+    }
+
+    api::types::v1::RepositoryCacheLayersItem layerItem;
+    layerItem.commit = commit;
+    layerItem.info.kind = "app";
+
+    EXPECT_CALL(*repo, clearReference(_, _, _, _)).WillOnce(Return(*ref));
+    EXPECT_CALL(*repo, getLayerItem(_, _, _))
+      .WillRepeatedly(
+        [layerItem](const package::Reference &, std::string, const std::optional<std::string> &)
+          -> utils::error::Result<api::types::v1::RepositoryCacheLayersItem> {
+            return layerItem;
+        });
+    EXPECT_CALL(*printer,
+                printContent(ElementsAre(QString::fromStdString(overlayDesktopPath.string()))))
+      .WillOnce(Return());
+
+    EXPECT_EQ(cli->content(cli::ContentOptions{ .appid = "org.example.app" }), 0);
+}
+
 TEST_F(CliTest, contentFallbackDesktopToOverlaySharedDir)
 {
     auto ref = package::Reference::parse("main:org.example.app/1.0.0/x86_64");


### PR DESCRIPTION
1. Add QDirIterator::FollowSymlinks flag to directory iterator in Cli::content method
2. This enables proper resolution of desktop files from symlinked entries/share directories
3. Previously, symlinks in the entries directory were not being followed, causing desktop files pointed to by symbolic links to be missed
4. Add two test cases to verify symlink resolution works correctly:
   - contentResolvesDesktopFromSymlinkedEntriesShareDir: tests resolving desktop from symlinked entries
   - contentResolvesOverlayDesktopFromSymlinkedEntriesShareDir: tests overlay desktop resolution with symlinks

Influence:
1. Test content command with applications that have symlinked entries/ share directories
2. Verify desktop file discovery works correctly when entries/share is a symlink to files/share
3. Test both default directory fallback and overlay directory scenarios with symlinked paths
4. Verify no regression in normal (non-symlinked) directory traversal
5. Test that symlinked directories pointing outside expected paths are handled safely