### PR TITLE
refactor: redesign prune logic

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -51,6 +51,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <unordered_map>
 #include <utility>
 
 #include <fcntl.h>
@@ -953,6 +954,11 @@ utils::error::Result<void> PackageManager::Uninstall(PackageTask &taskContext,
         LogE("merge modules failed: {}", mergeRet.error());
     }
 
+    auto pruneRet = this->repo->prune();
+    if (!pruneRet) {
+        return LINGLONG_ERR(pruneRet);
+    }
+
     return LINGLONG_OK;
 }
 
@@ -1409,14 +1415,35 @@ utils::error::Result<void>
 PackageManager::Prune(std::vector<api::types::v1::PackageInfoV2> &removed) noexcept
 {
     LINGLONG_TRACE("prune");
-    auto pkgsInfo = this->repo->listLocal();
-    if (!pkgsInfo) {
-        return LINGLONG_ERR(pkgsInfo);
+    auto layerItems = this->repo->listLocalBy({});
+    if (!layerItems) {
+        return LINGLONG_ERR(layerItems);
     }
 
-    std::unordered_map<package::Reference, int> target;
+    struct PruneTarget
+    {
+        int references{ 0 };
+        std::optional<api::types::v1::RepositoryCacheLayersItem> layerItem;
+    };
 
-    auto scanExtensionsByInfo = [&target, this](const api::types::v1::PackageInfoV2 &info) {
+    std::unordered_map<package::Reference, PruneTarget> target;
+
+    auto touchTarget = [&target](const package::Reference &ref,
+                                 bool increaseReferences = false,
+                                 std::optional<api::types::v1::RepositoryCacheLayersItem> item =
+                                   std::nullopt) {
+        auto [it, inserted] = target.try_emplace(ref);
+        if (item) {
+            it->second.layerItem = std::move(item);
+        }
+        if (increaseReferences) {
+            it->second.references += 1;
+        }
+
+        return it;
+    };
+
+    auto scanExtensionsByInfo = [&touchTarget, this](const api::types::v1::PackageInfoV2 &info) {
         if (info.extensions) {
             for (const auto &extension : *info.extensions) {
                 std::string name = extension.name;
@@ -1433,7 +1460,7 @@ PackageManager::Prune(std::vector<api::types::v1::PackageInfoV2> &removed) noexc
                   *fuzzyRef,
                   { .forceRemote = false, .fallbackToRemote = false, .semanticMatching = true });
                 if (ref) {
-                    target[*ref] += 1;
+                    touchTarget(*ref, true);
                 }
             }
         }
@@ -1447,19 +1474,23 @@ PackageManager::Prune(std::vector<api::types::v1::PackageInfoV2> &removed) noexc
         scanExtensionsByInfo(item->info);
     };
 
-    for (const auto &info : *pkgsInfo) {
+    for (const auto &layerItem : *layerItems) {
+        const auto &info = layerItem.info;
         if (info.packageInfoV2Module != "binary" && info.packageInfoV2Module != "runtime") {
             continue;
         }
 
-        if (info.kind != "app") {
-            auto ref = package::Reference::fromPackageInfo(info);
-            if (!ref) {
-                LogW("{}", ref.error());
-                continue;
-            }
-            // Note: if the ref already exists, it's ok, somebody depends it.
-            target.try_emplace(std::move(*ref), 0);
+        auto ref = package::Reference::fromPackageInfo(info);
+        if (!ref) {
+            LogW("{}", ref.error());
+            continue;
+        }
+
+        // app always needs to be reserved
+        if (info.kind == "app") {
+            touchTarget(*ref, true, layerItem);
+        } else {
+            touchTarget(*ref, false, layerItem);
             continue;
         }
 
@@ -1480,7 +1511,7 @@ PackageManager::Prune(std::vector<api::types::v1::PackageInfoV2> &removed) noexc
                 LogW("{}", runtimeRef.error());
                 continue;
             }
-            target[*runtimeRef] += 1;
+            touchTarget(*runtimeRef, true);
             scanExtensionsByRef(*runtimeRef);
         }
 
@@ -1500,36 +1531,41 @@ PackageManager::Prune(std::vector<api::types::v1::PackageInfoV2> &removed) noexc
             LogW("{}", baseRef.error());
             continue;
         }
-        target[*baseRef] += 1;
+        touchTarget(*baseRef, true);
         scanExtensionsByRef(*baseRef);
         scanExtensionsByInfo(info);
     }
 
-    for (const auto &it : target) {
-        if (it.second != 0) {
-            continue;
+    std::vector<api::types::v1::RepositoryCacheLayersItem> reserved;
+    for (const auto &[ref, pruneTarget] : target) {
+        std::optional<api::types::v1::RepositoryCacheLayersItem> item;
+        if (pruneTarget.layerItem) {
+            item = pruneTarget.layerItem;
+        } else {
+            auto layerItem = this->repo->getLayerItem(ref);
+            if (!layerItem) {
+                LogW("{}", layerItem.error());
+                continue;
+            }
+            item = std::move(layerItem).value();
         }
 
-        // NOTE: if the binary module is removed, other modules should be removed too.
-        for (const auto &module : this->repo->getModuleList(it.first)) {
-            auto layer = this->repo->getLayerDir(it.first, module);
-            if (!layer) {
-                LogW("{}", layer.error());
+        if (pruneTarget.references == 0) {
+            auto res = uninstallRef(ref);
+            if (!res) {
+                LogW("{}", res.error());
                 continue;
             }
-
-            auto info = layer->info();
-
-            if (!info) {
-                LogW("{}", info.error());
-                continue;
-            }
-
-            removed.emplace_back(std::move(*info));
-
-            auto result = this->repo->remove(it.first, module);
-            if (!result) {
-                return LINGLONG_ERR(result);
+            removed.emplace_back(item->info);
+        } else {
+            // all modules should be handled
+            for (const auto &module : this->repo->getModuleList(ref)) {
+                auto layerItem = this->repo->getLayerItem(ref, module);
+                if (!layerItem) {
+                    LogW("{}", layerItem.error());
+                    continue;
+                }
+                reserved.emplace_back(std::move(*layerItem));
             }
         }
     }
@@ -1540,7 +1576,8 @@ PackageManager::Prune(std::vector<api::types::v1::PackageInfoV2> &removed) noexc
             LogE("merge modules failed: {}", mergeRet.error());
         }
     }
-    auto pruneRet = this->repo->prune();
+
+    auto pruneRet = this->repo->clean(reserved);
     if (!pruneRet) {
         return LINGLONG_ERR(pruneRet);
     }

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -59,6 +59,7 @@
 #include <string>
 #include <system_error>
 #include <thread>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -76,6 +77,12 @@ struct ostreeUserData
     service::Task *taskContext{ nullptr };
 
     ~ostreeUserData() { g_clear_pointer(&ostree_status, g_free); }
+};
+
+struct OstreeRefEntry
+{
+    std::string refspec;
+    std::string commit;
 };
 
 void progress_changed(OstreeAsyncProgress *progress, gpointer user_data)
@@ -507,13 +514,13 @@ utils::error::Result<api::types::v1::PackageInfoV2> RefMetaData::getPackageInfo(
     return utils::serialize::parsePackageInfo(packageInfoContent);
 }
 
-utils::error::Result<void>
-OSTreeRepo::removeOstreeRef(const api::types::v1::RepositoryCacheLayersItem &layer) noexcept
+utils::error::Result<void> OSTreeRepo::removeOstreeRef(const std::string &remote,
+                                                       const std::string &ref,
+                                                       const std::string &commit) noexcept
 {
     LINGLONG_TRACE("remove ostree refspec from repository");
 
-    std::string refspec = ostreeRefSpecFromLayerItem(layer);
-    std::string ref = ostreeRefFromLayerItem(layer);
+    auto refspec = remote.empty() ? ref : remote + ":" + ref;
 
     g_autoptr(GError) gErr = nullptr;
     g_autofree char *rev{ nullptr };
@@ -524,13 +531,13 @@ OSTreeRepo::removeOstreeRef(const api::types::v1::RepositoryCacheLayersItem &lay
                                     OstreeRepoResolveRevExtFlags::OSTREE_REPO_RESOLVE_REV_EXT_NONE,
                                     &rev,
                                     &gErr)) {
-        if (layer.commit != rev) {
+        if (commit != rev) {
             LogD("skip unset ref on mismatched commit");
             return LINGLONG_OK;
         }
 
         if (ostree_repo_set_ref_immediate(this->ostreeRepo.get(),
-                                          layer.repo.c_str(),
+                                          remote.c_str(),
                                           ref.c_str(),
                                           nullptr,
                                           nullptr,
@@ -541,6 +548,12 @@ OSTreeRepo::removeOstreeRef(const api::types::v1::RepositoryCacheLayersItem &lay
     }
 
     return LINGLONG_OK;
+}
+
+utils::error::Result<void>
+OSTreeRepo::removeOstreeRef(const api::types::v1::RepositoryCacheLayersItem &layer) noexcept
+{
+    return this->removeOstreeRef(layer.repo, ostreeRefFromLayerItem(layer), layer.commit);
 }
 
 utils::error::Result<void> OSTreeRepo::handleRepositoryUpdate(
@@ -1095,13 +1108,11 @@ OSTreeRepo::remove(const api::types::v1::RepositoryCacheLayersItem &item) noexce
     return LINGLONG_OK;
 }
 
-utils::error::Result<void>
-OSTreeRepo::undeployedLayer(const api::types::v1::RepositoryCacheLayersItem &layer) noexcept
+utils::error::Result<void> OSTreeRepo::undeployedLayer(const std::string &commit) noexcept
 {
-    LINGLONG_TRACE(fmt::format("undeployed layer {}", layer.commit));
+    LINGLONG_TRACE(fmt::format("undeployed layer {}", commit));
 
-    // It is crucial to remove the layer directory by commit
-    auto layerDir = getLayerDir(layer);
+    auto layerDir = getLayerDir(commit);
     if (!layerDir) {
         LogW("layer dir not found, skip remove: {}", layerDir.error());
         return LINGLONG_OK;
@@ -1138,6 +1149,67 @@ OSTreeRepo::undeployedLayer(const api::types::v1::RepositoryCacheLayersItem &lay
 
     QFile::remove(layerDir->path().c_str());
     return LINGLONG_OK;
+}
+
+utils::error::Result<void>
+OSTreeRepo::undeployedLayer(const api::types::v1::RepositoryCacheLayersItem &layer) noexcept
+{
+    return this->undeployedLayer(layer.commit);
+}
+
+// clean all checkout files and refs/objects from ostree repo but reserved items
+utils::error::Result<void>
+OSTreeRepo::clean(const std::vector<api::types::v1::RepositoryCacheLayersItem> &reserved) noexcept
+{
+    LINGLONG_TRACE(fmt::format("clean refs: {}", reserved.size()));
+
+    std::unordered_set<std::string> keepCommits;
+    keepCommits.reserve(reserved.size());
+    for (const auto &item : reserved) {
+        keepCommits.insert(item.commit);
+    }
+
+    g_autoptr(GHashTable) refsTable = nullptr;
+    g_autoptr(GError) gErr = nullptr;
+    std::vector<OstreeRefEntry> existingRefs;
+    if (ostree_repo_list_refs(this->ostreeRepo.get(), nullptr, &refsTable, nullptr, &gErr)
+        == FALSE) {
+        return LINGLONG_ERR(fmt::format("ostree_repo_list_refs {}", ptr_view(gErr)));
+    }
+
+    g_hash_table_foreach(
+      refsTable,
+      [](gpointer key, gpointer value, gpointer data) {
+          auto *entries = static_cast<std::vector<OstreeRefEntry> *>(data);
+          entries->push_back(
+            OstreeRefEntry{ static_cast<const char *>(key), static_cast<const char *>(value) });
+      },
+      &existingRefs);
+
+    for (const auto &entry : existingRefs) {
+        if (keepCommits.find(entry.commit) != keepCommits.end()) {
+            continue;
+        }
+
+        auto removedLayer = this->undeployedLayer(entry.commit);
+        if (!removedLayer) {
+            LogW("failed to remove layer dir for {}: {}", entry.commit, removedLayer.error());
+        }
+
+        g_autoptr(GError) parseErr = nullptr;
+        g_autofree char *remote = nullptr;
+        g_autofree char *ref = nullptr;
+        if (ostree_parse_refspec(entry.refspec.c_str(), &remote, &ref, &parseErr) == FALSE) {
+            return LINGLONG_ERR(fmt::format("ostree_parse_refspec {}", ptr_view(parseErr)));
+        }
+
+        auto removedRef = this->removeOstreeRef(remote ? remote : "", ref ? ref : "", entry.commit);
+        if (!removedRef) {
+            return LINGLONG_ERR(removedRef);
+        }
+    }
+
+    return this->prune();
 }
 
 utils::error::Result<void> OSTreeRepo::prune()
@@ -2392,18 +2464,30 @@ OSTreeRepo::getLayerItem(const package::Reference &ref,
     return *item;
 }
 
-auto OSTreeRepo::getLayerDir(const api::types::v1::RepositoryCacheLayersItem &layer) const noexcept
+std::filesystem::path OSTreeRepo::layerPath(const std::string &commit) const noexcept
+{
+    return this->repoDir / "layers" / commit;
+}
+
+auto OSTreeRepo::getLayerDir(const std::string &commit) const noexcept
   -> utils::error::Result<package::LayerDir>
 {
-    LINGLONG_TRACE(fmt::format("get dir from layer {}", layer.commit));
+    LINGLONG_TRACE(fmt::format("get dir from commit {}", commit));
 
-    auto dir = this->repoDir / "layers" / layer.commit;
+    auto dir = this->layerPath(commit);
     std::error_code ec;
     if (!std::filesystem::exists(dir, ec)) {
         return LINGLONG_ERR(fmt::format("{} doesn't exist", dir));
     }
 
     return dir;
+}
+
+auto OSTreeRepo::getLayerDir(const api::types::v1::RepositoryCacheLayersItem &layer) const noexcept
+  -> utils::error::Result<package::LayerDir>
+{
+    LINGLONG_TRACE(fmt::format("get dir from layer {}", layer.commit));
+    return getLayerDir(layer.commit);
 }
 
 auto OSTreeRepo::getLayerDir(const package::Reference &ref,

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -154,6 +154,8 @@ public:
            const std::optional<std::string> &subRef = std::nullopt) noexcept;
     utils::error::Result<void>
     remove(const api::types::v1::RepositoryCacheLayersItem &item) noexcept;
+    utils::error::Result<void>
+    clean(const std::vector<api::types::v1::RepositoryCacheLayersItem> &reserved) noexcept;
 
     utils::error::Result<void> prune();
 
@@ -241,10 +243,17 @@ private:
     ensureEmptyLayerDir(const std::string &commit) const noexcept;
     utils::error::Result<void> handleRepositoryUpdate(
       QDir layerDir, const api::types::v1::RepositoryCacheLayersItem &layer) noexcept;
+    utils::error::Result<void> removeOstreeRef(const std::string &remote,
+                                               const std::string &ref,
+                                               const std::string &commit) noexcept;
     utils::error::Result<void>
     removeOstreeRef(const api::types::v1::RepositoryCacheLayersItem &layer) noexcept;
+    utils::error::Result<void> undeployedLayer(const std::string &commit) noexcept;
     utils::error::Result<void>
     undeployedLayer(const api::types::v1::RepositoryCacheLayersItem &layer) noexcept;
+    [[nodiscard]] std::filesystem::path layerPath(const std::string &commit) const noexcept;
+    [[nodiscard]] utils::error::Result<package::LayerDir>
+    getLayerDir(const std::string &commit) const noexcept;
     [[nodiscard]] utils::error::Result<package::LayerDir>
     getLayerDir(const api::types::v1::RepositoryCacheLayersItem &layer) const noexcept;
 

--- a/libs/linglong/src/linglong/repo/repo_cache.cpp
+++ b/libs/linglong/src/linglong/repo/repo_cache.cpp
@@ -104,7 +104,8 @@ utils::error::Result<void> RepoCache::rebuild(const api::types::v1::RepoConfigV2
         g_clear_error(&gErr);
         g_autofree gchar *content = nullptr;
         if (!g_file_load_contents(infoFile, nullptr, &content, nullptr, nullptr, &gErr)) {
-            return LINGLONG_ERR(fmt::format("g_file_load_contents: {}", ptr_view(gErr)));
+            LogE("skip broken ref {}, failed to load info.json: {}", ref, ptr_view(gErr));
+            continue;
         }
         auto info = utils::serialize::parsePackageInfo(content);
         if (!info) {


### PR DESCRIPTION
1. Prune when uninstalling an app.
2. Remove all refs/objects in ostree if they are not referenced by any app.