### PR TITLE
test: adapt ostree repo tests for root and non-root execution

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/repo/ostree_repo_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/ostree_repo_test.cpp
@@ -22,6 +22,8 @@
 #include <memory>
 #include <string>
 
+#include <unistd.h>
+
 namespace linglong::repo::test {
 
 namespace fs = std::filesystem;
@@ -50,6 +52,11 @@ api::types::v1::RepoConfigV2 createRepoConfig(std::string defaultRepo,
                                          .url = std::move(repoUrl) } },
         .version = 2,
     };
+}
+
+bool shouldPersistRepoCache() noexcept
+{
+    return getuid() != 0;
 }
 
 class RepoTest : public ::testing::Test
@@ -116,10 +123,14 @@ TEST_F(RepoTest, createPersistsConfigAndBootstrapsRepoArtifacts)
 
     EXPECT_TRUE(fs::exists(repoRoot / "config.yaml"));
     EXPECT_TRUE(fs::exists(repoRoot / "repo"));
-    EXPECT_TRUE(fs::exists(repoRoot / "states.json"));
+    EXPECT_EQ(fs::exists(repoRoot / "states.json"), shouldPersistRepoCache());
 
     auto loaded = OSTreeRepo::loadFromPath(repoRoot);
-    EXPECT_TRUE(loaded.has_value()) << loaded.error().message();
+    if (shouldPersistRepoCache()) {
+        EXPECT_TRUE(loaded.has_value()) << loaded.error().message();
+    } else {
+        EXPECT_FALSE(loaded.has_value());
+    }
 }
 
 TEST_F(RepoTest, createPrefersRepoLocalConfigOverFallbackConfig)
@@ -183,7 +194,7 @@ TEST_F(RepoTest, loadFromPathFailsWhenCacheIsMissingButCreateCanRepairIt)
 
     auto repaired = OSTreeRepo::create(repoRoot, config);
     ASSERT_TRUE(repaired.has_value()) << repaired.error().message();
-    EXPECT_TRUE(fs::exists(repoRoot / "states.json"));
+    EXPECT_EQ(fs::exists(repoRoot / "states.json"), shouldPersistRepoCache());
 }
 
 TEST_F(RepoTest, exportDir)
@@ -411,7 +422,7 @@ class OSTreeRepoMock : public repo::OSTreeRepo
 public:
     OSTreeRepoMock(const std::filesystem::path &path)
         : repo::OSTreeRepo(
-            path, api::types::v1::RepoConfigV2{ .defaultRepo = "", .repos = {}, .version = 2 })
+          path, api::types::v1::RepoConfigV2{ .defaultRepo = "", .repos = {}, .version = 2 })
     {
     }
 
@@ -428,7 +439,7 @@ public:
 
     OSTreeRepoAccessor()
         : repo::OSTreeRepo(
-            "", api::types::v1::RepoConfigV2{ .defaultRepo = "", .repos = {}, .version = 2 })
+          "", api::types::v1::RepoConfigV2{ .defaultRepo = "", .repos = {}, .version = 2 })
     {
     }
 };
@@ -614,7 +625,7 @@ class OSTreeRepoMock : public repo::OSTreeRepo
 public:
     OSTreeRepoMock(const std::filesystem::path &path)
         : repo::OSTreeRepo(
-            path, api::types::v1::RepoConfigV2{ .defaultRepo = "", .repos = {}, .version = 2 })
+          path, api::types::v1::RepoConfigV2{ .defaultRepo = "", .repos = {}, .version = 2 })
     {
     }
 


### PR DESCRIPTION
This change makes the OSTree repo tests conditional based on whether they run as root or non-root user. The tests previously assumed root- only behavior where repo cache persistence differs.

1. Add `shouldPersistRepoCache()` helper function that checks if running as root (uid == 0)
2. Update `createPersistsConfigAndBootstrapsRepoArtifacts` test to conditionally verify states.json existence and loadFromPath behavior based on user privileges
3. Update `loadFromPathFailsWhenCacheIsMissingButCreateCanRepairIt` test similarly
4. Minor formatting adjustments in mock class constructors for consistency

The tests now properly handle: when running as root, states.json may not be created and loadFromPath should fail; when running as non-root, states.json exists and loadFromPath succeeds.

Influence:
1. Verify tests pass when run as non-root user
2. Verify tests pass when run as root user
3. Confirm states.json is created for non-root but not for root execution
4. Verify loadFromPath behavior matches expected outcome for each privilege level
5. Test the repair mechanism works correctly in both environments
6. Ensure mock class constructors still function properly after formatting changes