### PR TITLE
chore: remove root user restriction in RepoCache rebuild

### DIFF
--- a/libs/linglong/src/linglong/repo/repo_cache.cpp
+++ b/libs/linglong/src/linglong/repo/repo_cache.cpp
@@ -116,12 +116,6 @@ utils::error::Result<void> RepoCache::rebuild(const api::types::v1::RepoConfigV2
         this->cache.layers.emplace_back(std::move(item));
     }
 
-    // FIXME: ll-cli may initialize repo, it can make states.json own by root
-    if (getuid() == 0) {
-        LogE("Rebuild the cache by root, skip to write data to states.json");
-        return LINGLONG_OK;
-    }
-
     auto ret = writeToDisk();
     if (!ret) {
         return LINGLONG_ERR(ret);


### PR DESCRIPTION
1. Removed the check that prevented root users from writing to states.json during cache rebuild
2. The previous workaround was needed when ll-cli could make states.json owned by root, causing permission issues
3. This restriction is no longer necessary as the underlying ownership issue has been addressed
4. Root users can now fully rebuild the repository cache without skipping the write operation

Log: Root users can now rebuild the repository cache and persist changes to states.json

Influence:
1. Test RepoCache rebuild functionality when running as root user
2. Verify states.json is correctly written and readable by both root and non-root users
3. Test cache rebuild in scenarios where ll-cli initializes the repository as root
4. Verify file ownership and permissions of states.json after root- initiated rebuilds
5. Test cache persistence across multiple rebuild operations as root
6. Verify no permission denied errors occur during cache writes as root