### PR TITLE
feat: support system-wide runtime configuration

### DIFF
--- a/configure.h.in
+++ b/configure.h.in
@@ -22,8 +22,9 @@
 #define LINGLONG_CLIENT_NAME "@LINGLONG_CLI_BIN@"
 #define LINGLONG_CLIENT_PATH "@CMAKE_INSTALL_FULL_BINDIR@/@LINGLONG_CLI_BIN@"
 #define LINGLONG_EXPORT_PATH "@LINGLONG_EXPORT_PATH@"
+#define LINGLONG_SYSCONFDIR SYSCONFDIR "/linglong"
 // The directory where the package install hooks reside.
-#define LINGLONG_INSTALL_HOOKS_DIR "@CMAKE_INSTALL_FULL_SYSCONFDIR@/linglong/config.d"
+#define LINGLONG_INSTALL_HOOKS_DIR LINGLONG_SYSCONFDIR "/config.d"
 
 #define LINGLONG_EXPORT_VERSION "1.0.0.2"
 // The package's locale domain.

--- a/libs/common/src/linglong/common/dir.cpp
+++ b/libs/common/src/linglong/common/dir.cpp
@@ -53,4 +53,9 @@ std::filesystem::path getUserRuntimeConfigDir() noexcept
     return configDir / "linglong";
 }
 
+std::filesystem::path getSystemRuntimeConfigDir() noexcept
+{
+    return LINGLONG_SYSCONFDIR;
+}
+
 } // namespace linglong::common::dir

--- a/libs/common/src/linglong/common/dir.h
+++ b/libs/common/src/linglong/common/dir.h
@@ -29,4 +29,6 @@ std::filesystem::path getUserCacheDir() noexcept;
 
 std::filesystem::path getUserRuntimeConfigDir() noexcept;
 
+std::filesystem::path getSystemRuntimeConfigDir() noexcept;
+
 } // namespace linglong::common::dir

--- a/libs/utils/src/linglong/utils/runtime_config.cpp
+++ b/libs/utils/src/linglong/utils/runtime_config.cpp
@@ -18,16 +18,8 @@ using RuntimeConfigure = linglong::api::types::v1::RuntimeConfigure;
 namespace {
 
 linglong::utils::error::Result<std::optional<RuntimeConfigure>>
-loadUserRuntimeConfig(const std::string &appId)
+loadRuntimeConfigFromDir(const std::filesystem::path &configDir, const std::string &appId)
 {
-    LINGLONG_TRACE(
-      fmt::format("load user runtime config for {}", appId.empty() ? "global" : appId));
-
-    auto configDir = linglong::common::dir::getUserRuntimeConfigDir();
-    if (configDir.empty()) {
-        return std::nullopt;
-    }
-
     std::filesystem::path configPath;
     if (appId.empty()) {
         configPath = configDir / "config.json";
@@ -40,12 +32,30 @@ loadUserRuntimeConfig(const std::string &appId)
         return std::nullopt;
     }
 
-    auto result = linglong::utils::loadRuntimeConfig(configPath);
-    if (!result) {
-        return LINGLONG_ERR(result);
+    return linglong::utils::loadRuntimeConfig(configPath);
+}
+
+linglong::utils::error::Result<std::optional<RuntimeConfigure>>
+loadUserRuntimeConfig(const std::string &appId)
+{
+    LINGLONG_TRACE(
+      fmt::format("load user runtime config for {}", appId.empty() ? "global" : appId));
+
+    auto configDir = linglong::common::dir::getUserRuntimeConfigDir();
+    if (configDir.empty()) {
+        return std::nullopt;
     }
 
-    return std::move(result).value();
+    return loadRuntimeConfigFromDir(configDir, appId);
+}
+
+linglong::utils::error::Result<std::optional<RuntimeConfigure>>
+loadSystemRuntimeConfig(const std::string &appId)
+{
+    LINGLONG_TRACE(
+      fmt::format("load system runtime config for {}", appId.empty() ? "global" : appId));
+
+    return loadRuntimeConfigFromDir(linglong::common::dir::getSystemRuntimeConfigDir(), appId);
 }
 
 } // namespace
@@ -112,30 +122,46 @@ loadRuntimeConfig(const std::filesystem::path &path)
         return LINGLONG_ERR("failed to load runtime config", result);
     }
 
-    return std::move(result).value();
+    return result;
 }
 
 utils::error::Result<std::optional<RuntimeConfigure>> loadRuntimeConfig(const std::string &appId)
 {
     LINGLONG_TRACE("load runtime config for app: " + appId);
 
-    // Merge configs in order: user global -> user app
+    // Merge configs in order: system global -> system app -> user global -> user app
     std::vector<RuntimeConfigure> configs;
+
+    auto systemGlobal = loadSystemRuntimeConfig("");
+    if (!systemGlobal) {
+        return LINGLONG_ERR(systemGlobal);
+    }
+    if (systemGlobal->has_value()) {
+        configs.emplace_back(std::move(systemGlobal->value()));
+    }
+
+    auto systemApp = loadSystemRuntimeConfig(appId);
+    if (!systemApp) {
+        return LINGLONG_ERR(systemApp);
+    }
+    if (systemApp->has_value()) {
+        configs.emplace_back(std::move(systemApp->value()));
+    }
 
     auto userGlobal = loadUserRuntimeConfig("");
     if (!userGlobal) {
         return LINGLONG_ERR(userGlobal);
     }
-    if ((*userGlobal).has_value()) {
-        configs.emplace_back((*userGlobal).value());
+    if (userGlobal->has_value()) {
+        configs.emplace_back(std::move(userGlobal->value()));
     }
 
     auto userApp = loadUserRuntimeConfig(appId);
     if (!userApp) {
         return LINGLONG_ERR(userApp);
     }
-    if ((*userApp).has_value()) {
-        configs.emplace_back((*userApp).value());
+    if (userApp->has_value()) {
+        configs.emplace_back(std::move(userApp->value()));
     }
 
     if (configs.empty()) {


### PR DESCRIPTION
Add system configuration directory at /etc/linglong. Configs are now merged merged in order: system global, system app-specific, user global, then user global and user app-specific, allowing user configs to override system defaults.