### PR TITLE
feat: auto-detect NVIDIA GPU via CDI

### DIFF
--- a/libs/cdi/src/linglong/cdi/cdi.cpp
+++ b/libs/cdi/src/linglong/cdi/cdi.cpp
@@ -167,12 +167,17 @@ utils::error::Result<types::ContainerEdits> getCDIDeviceEdits(const types::Cdi &
 
 } // namespace
 
-utils::error::Result<std::vector<api::types::v1::CdiDeviceEntry>>
-getCDIDevices(const std::vector<std::string> &specDirs, const std::vector<std::string> &devices)
+utils::error::Result<std::vector<api::types::v1::CdiDeviceEntry>> getCDIDevices(
+  const std::vector<std::string> &specDirs, const std::optional<std::vector<std::string>> &devices)
 {
-    LINGLONG_TRACE(fmt::format("get CDI devices {} from {}",
-                               fmt::join(devices, ", "),
-                               fmt::join(specDirs, ", ")));
+    std::string devicesStr;
+    if (devices) {
+        devicesStr = fmt::format("{}", fmt::join(*devices, ", "));
+    } else {
+        devicesStr = "(all)";
+    }
+    LINGLONG_TRACE(
+      fmt::format("get CDI devices {} from {}", devicesStr, fmt::join(specDirs, ", ")));
 
     struct ParsedSpec
     {
@@ -212,7 +217,25 @@ getCDIDevices(const std::vector<std::string> &specDirs, const std::vector<std::s
     }
 
     std::vector<api::types::v1::CdiDeviceEntry> result;
-    for (const auto &deviceStr : devices) {
+
+    if (!devices) {
+        for (const auto &spec : specs) {
+            for (const auto &dev : spec.spec.devices) {
+                result.emplace_back(api::types::v1::CdiDeviceEntry{
+                  .kind = spec.spec.kind,
+                  .name = dev.name,
+                  .spec =
+                    api::types::v1::CdiSpec{
+                      .checksum = spec.checksum,
+                      .path = spec.path.string(),
+                    },
+                });
+            }
+        }
+        return result;
+    }
+
+    for (const auto &deviceStr : *devices) {
         auto device = common::strings::split(deviceStr, '=');
         if (device.size() != 2) {
             return LINGLONG_ERR(fmt::format("invalid device format: {}", deviceStr));

--- a/libs/cdi/src/linglong/cdi/cdi.h
+++ b/libs/cdi/src/linglong/cdi/cdi.h
@@ -11,13 +11,14 @@
 #include "linglong/utils/error/error.h"
 
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
 namespace linglong::cdi {
 
-utils::error::Result<std::vector<api::types::v1::CdiDeviceEntry>>
-getCDIDevices(const std::vector<std::string> &specDirs, const std::vector<std::string> &devices);
+utils::error::Result<std::vector<api::types::v1::CdiDeviceEntry>> getCDIDevices(
+  const std::vector<std::string> &specDirs, const std::optional<std::vector<std::string>> &devices);
 
 utils::error::Result<types::ContainerEdits>
 getCDIDeviceEdits(const api::types::v1::CdiDeviceEntry &device);

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -563,7 +563,29 @@ int Cli::run(const RunOptions &options)
 {
     LINGLONG_TRACE("command run");
 
-    detectDrivers();
+    bool nvidiaCdiFound =
+      std::any_of(options.cdiDevices.begin(), options.cdiDevices.end(), [](const std::string &d) {
+          return d.find("nvidia.com/gpu") != std::string::npos;
+      });
+    std::optional<std::vector<api::types::v1::CdiDeviceEntry>> autoDetectedCdiDevices;
+
+    if (!nvidiaCdiFound && options.cdiDevices.empty()) {
+        auto allCdiDevices = cdi::getCDIDevices(options.cdiSpecDir, std::nullopt);
+        if (allCdiDevices) {
+            for (const auto &device : *allCdiDevices) {
+                LogD("{}={} detected", device.kind, device.name);
+                if (device.kind == "nvidia.com/gpu" && device.name == "all") {
+                    nvidiaCdiFound = true;
+                    autoDetectedCdiDevices = std::vector<api::types::v1::CdiDeviceEntry>{ device };
+                    break;
+                }
+            }
+        }
+    }
+
+    if (!nvidiaCdiFound) {
+        detectDrivers();
+    }
 
     auto userContainerDir = std::filesystem::path{ "/run/linglong" } / std::to_string(getuid());
     if (auto ret = utils::ensureDirectory(userContainerDir); !ret) {
@@ -630,6 +652,8 @@ int Cli::run(const RunOptions &options)
             return -1;
         }
         opts.cdiDevices = std::move(*cdiDevices);
+    } else if (autoDetectedCdiDevices) {
+        opts.cdiDevices = std::move(*autoDetectedCdiDevices);
     }
 
     // 调整日志输出，打印扩展列表（用逗号拼接）


### PR DESCRIPTION
When no CDI devices are explicitly specified, automatically detect nvidia.com/gpu=all and use it for GPU support, skipping the legacy detectDrivers() call.