### PR TITLE
feat: add PipeWire socket binding for audio support

### DIFF
--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -1281,6 +1281,16 @@ utils::error::Result<void> ContainerCfgBuilder::buildMountIPC() noexcept
                 (*containerXDGRuntimeDir / "gvfs").string(),
                 false);
 
+    auto pwSocketName = "pipewire-0";
+    auto *pwRemoteEnv = getenv("PIPEWIRE_REMOTE");
+    if (pwRemoteEnv != nullptr && pwRemoteEnv[0] != '\0') {
+        pwSocketName = pwRemoteEnv;
+    }
+    bindIfExist(*ipcMount,
+                hostXDGRuntimeDir / pwSocketName,
+                (*containerXDGRuntimeDir / pwSocketName).string(),
+                false);
+
     [this, &hostXDGRuntimeDir]() {
         auto dconfPath = std::filesystem::path(hostXDGRuntimeDir) / "dconf";
         if (!std::filesystem::exists(dconfPath)) {


### PR DESCRIPTION
Add binding for the PipeWire socket (pipewire-0) from host's XDG_RUNTIME_DIR
into the container's runtime directory. This enables audio functionality for applications running inside containers that require PipeWire access.

The change extends the existing IPC mount configuration to include the PipeWire socket alongside existing bindings like gvfs and dconf.

Influence:
1. Verify audio playback works in containerized applications
2. Test PipeWire socket presence in container's XDG_RUNTIME_DIR
3. Check applications can connect to host PipeWire daemon
4. Verify fallback behavior when host PipeWire is not running
5. Test audio recording functionality if applicable