### PR TITLE
refactor: add polkit authorization to PM

### DIFF
--- a/api/dbus/org.deepin.linglong.PackageManager1.xml
+++ b/api/dbus/org.deepin.linglong.PackageManager1.xml
@@ -43,9 +43,6 @@ SPDX-License-Identifier: LGPL-3.0-or-later
       <arg direction="out" name="result" type="a{sv}" />
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap" />
     </method>
-    <method name="Permissions">
-      <annotation name="org.freedesktop.DBus.Description" value="Used by the client to check whether it has permission to call privileged methods" />
-    </method>
     <method name="InitRunContext">
       <arg direction="in" name="runContextCfg" type="s" />
       <arg direction="in" name="containerID" type="s" />
@@ -66,12 +63,11 @@ SPDX-License-Identifier: LGPL-3.0-or-later
       <arg name="taskID" type="s" />
       <arg name="success" type="b" />
     </signal>
-    <method name="ReplyInteraction">
-      <arg name="task" type="o" />
-      <arg name="replies" type="a{sv}" />
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap" />
+    <method name="SetConfiguration">
+      <arg direction="in" name="parameters" type="a{sv}" />
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap" />
     </method>
-    <property name="Configuration" type="a{sv}" access="readwrite">
+    <property name="Configuration" type="a{sv}" access="read">
       <annotation name="org.qtproject.QtDBus.QtTypeName" value="QVariantMap" />
     </property>
     <signal name="TaskAdded">
@@ -79,12 +75,6 @@ SPDX-License-Identifier: LGPL-3.0-or-later
     </signal>
     <signal name="TaskRemoved">
       <arg name="task" type="o" />
-    </signal>
-    <signal name="RequestInteraction">
-      <arg name="task" type="o" />
-      <arg name="messageID" type="i" />
-      <arg name="additionalMessage" type="a{sv}" />
-      <annotation name="org.qtproject.QtDBus.QtTypeName.Out2" value="QVariantMap" />
     </signal>
   </interface>
 </node>

--- a/api/dbus/org.deepin.linglong.Task1.xml
+++ b/api/dbus/org.deepin.linglong.Task1.xml
@@ -1,15 +1,24 @@
 <?xml version="1.0"?>
 <!--
-SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 SPDX-License-Identifier: LGPL-3.0-or-later
 -->
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "https://specifications.freedesktop.org/dbus/introspect-latest.dtd">
 <node>
     <interface name="org.deepin.linglong.Task1">
         <method name="Cancel" />
+        <method name="ReplyInteraction">
+            <arg direction="in" name="replies" type="a{sv}" />
+            <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap" />
+        </method>
         <property name="State" type="i" access="read" />
         <property name="Percentage" type="d" access="read" />
         <property name="Message" type="s" access="read" />
         <property name="Code" type="i" access="read" />
+        <signal name="RequestInteraction">
+            <arg name="messageID" type="i" />
+            <arg name="additionalMessage" type="a{sv}" />
+            <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap" />
+        </signal>
     </interface>
 </node>

--- a/apps/ll-package-manager/src/main.cpp
+++ b/apps/ll-package-manager/src/main.cpp
@@ -125,7 +125,7 @@ auto runDaemonMode(ocppi::cli::CLI &cli, const CommandLineOptions &options) -> i
 
     auto packageManager =
       createPackageManager(std::move(repo).value(), cli, QCoreApplication::instance());
-    packageManager->initDaemonMode();
+    packageManager->initDaemonMode(options.noDBus);
     auto *packageManagerPtr = packageManager.get();
     new linglong::adaptors::package_manger::PackageManager1(packageManagerPtr);
 

--- a/libs/linglong/CMakeLists.txt
+++ b/libs/linglong/CMakeLists.txt
@@ -72,6 +72,8 @@ pfl_add_library(
   src/linglong/package_manager/package_task.h
   src/linglong/package_manager/package_update.cpp
   src/linglong/package_manager/package_update.h
+  src/linglong/package_manager/polkit_authority.cpp
+  src/linglong/package_manager/polkit_authority.h
   src/linglong/package_manager/ref_installation.cpp
   src/linglong/package_manager/ref_installation.h
   src/linglong/package_manager/task.cpp

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -293,14 +293,9 @@ void Cli::onTaskPropertiesChanged(
     handleTaskState();
 }
 
-void Cli::interaction(const QDBusObjectPath &object_path,
-                      int messageID,
-                      const QVariantMap &additionalMessage)
+void Cli::onTaskRequestInteraction(int messageID, const QVariantMap &additionalMessage)
 {
     LINGLONG_TRACE("interactive with user")
-    if (object_path.path() != taskObjectPath) {
-        return;
-    }
 
     auto messageType = static_cast<api::types::v1::InteractionMessageType>(messageID);
     auto msg = common::serialize::fromQVariantMap<
@@ -351,14 +346,13 @@ void Cli::interaction(const QDBusObjectPath &object_path,
     LogD("action: {}", action);
 
     auto reply = api::types::v1::InteractionReply{ .action = action };
-    auto pkgMan = this->getPkgMan();
-    if (!pkgMan) {
-        this->printer.printErr(pkgMan.error());
+    if (!this->task) {
+        this->printer.printErr(LINGLONG_ERRV("task object is null"));
         return;
     }
 
     QDBusPendingReply<void> dbusReply =
-      (*pkgMan)->ReplyInteraction(object_path, common::serialize::toQVariantMap(reply));
+      this->task->ReplyInteraction(common::serialize::toQVariantMap(reply));
     dbusReply.waitForFinished();
     if (dbusReply.isError()) {
         this->printer.printErr(
@@ -517,6 +511,8 @@ utils::error::Result<api::dbus::v1::PackageManager *> Cli::getPkgMan()
         this->pkgMan.reset();
         return LINGLONG_ERR("failed to initialize package manager signals", ret.error());
     }
+
+    this->pkgMan->setTimeout(INT_MAX);
 
     return this->pkgMan.get();
 }
@@ -1116,43 +1112,10 @@ void Cli::cancelCurrentTask()
 }
 
 int Cli::installFromFile(const QFileInfo &fileInfo,
-                         const api::types::v1::CommonOptions &commonOptions,
-                         const std::string &appid)
+                         const api::types::v1::CommonOptions &commonOptions)
 {
     auto filePath = fileInfo.absoluteFilePath();
     LINGLONG_TRACE(fmt::format("install from file {}", filePath.toStdString()));
-
-    auto authReply = this->authorization();
-    if (!authReply.isValid()) {
-        if (authReply.error().type() == QDBusError::AccessDenied) {
-            auto args = QCoreApplication::instance()->arguments();
-            // pkexec在0.120版本之前没有keep-cwd选项，会将目录切换到/root
-            // 所以将layer或uab文件的相对路径转为绝对路径，再传给pkexec
-            auto path = fileInfo.absoluteFilePath();
-            for (auto i = 0; i < args.length(); i++) {
-                if (args[i] == QString::fromStdString(appid)) {
-                    args[i] = path.toLocal8Bit().constData();
-                }
-            }
-
-            auto ret = this->runningAsRoot(args);
-            if (!ret) {
-                this->printer.printErr(ret.error());
-            }
-            return -1;
-        }
-
-        this->printer.printErr(LINGLONG_ERRV(
-          fmt::format("{} {}", authReply.error().message() + authReply.error().name()),
-          static_cast<int>(authReply.error().type())));
-        return -1;
-    }
-
-    auto res = this->initInteraction();
-    if (!res) {
-        this->printer.printErr(res.error());
-        return -1;
-    }
 
     LogI("install from file {}", filePath.toStdString());
     QFile file{ filePath };
@@ -1173,7 +1136,7 @@ int Cli::installFromFile(const QFileInfo &fileInfo,
     auto pendingReply = (*pkgMan)->InstallFromFile(dbusFileDescriptor,
                                                    fileInfo.suffix(),
                                                    common::serialize::toQVariantMap(commonOptions));
-    res = waitTaskCreated(pendingReply, TaskType::InstallFromFile);
+    auto res = waitTaskCreated(pendingReply, TaskType::InstallFromFile);
     if (!res) {
         this->handleCommonError(res.error());
         return -1;
@@ -1201,19 +1164,7 @@ int Cli::install(const InstallOptions &options)
 
     // 如果检测是文件，则直接安装
     if (info.exists() && info.isFile()) {
-        return installFromFile(QFileInfo{ info.absoluteFilePath() }, params.options, options.appid);
-    }
-
-    auto ret = this->ensureAuthorized();
-    if (!ret) {
-        this->printer.printErr(ret.error());
-        return -1;
-    }
-
-    ret = this->initInteraction();
-    if (!ret) {
-        this->printer.printErr(ret.error());
-        return -1;
+        return installFromFile(QFileInfo{ info.absoluteFilePath() }, params.options);
     }
 
     auto fuzzyRef = package::FuzzyReference::parse(options.appid);
@@ -1261,12 +1212,6 @@ int Cli::install(const InstallOptions &options)
 int Cli::upgrade(const UpgradeOptions &options)
 {
     LINGLONG_TRACE("command upgrade");
-
-    auto ret = this->ensureAuthorized();
-    if (!ret) {
-        this->printer.printErr(ret.error());
-        return -1;
-    }
 
     std::vector<package::Reference> toUpgrade;
     if (!options.appid.empty()) {
@@ -1463,12 +1408,6 @@ int Cli::prune()
 {
     LINGLONG_TRACE("command prune");
 
-    auto ret = this->ensureAuthorized();
-    if (!ret) {
-        this->printer.printErr(ret.error());
-        return -1;
-    }
-
     QEventLoop loop;
     QString jobIDReply = "";
     auto pkgMan = this->getPkgMan();
@@ -1517,12 +1456,6 @@ int Cli::prune()
 int Cli::uninstall(const UninstallOptions &options)
 {
     LINGLONG_TRACE("command uninstall");
-
-    auto ret = this->ensureAuthorized();
-    if (!ret) {
-        this->printer.printErr(ret.error());
-        return -1;
-    }
 
     auto fuzzyRef = package::FuzzyReference::parse(options.appid);
     if (!fuzzyRef) {
@@ -1791,21 +1724,16 @@ int Cli::setRepoConfig(const QVariantMap &config)
 {
     LINGLONG_TRACE("set repo config");
 
-    auto ret = this->ensureAuthorized();
-    if (!ret) {
-        this->printer.printErr(ret.error());
-        return -1;
-    }
-
     auto pkgMan = this->getPkgMan();
     if (!pkgMan) {
         this->printer.printErr(pkgMan.error());
         return -1;
     }
 
-    (*pkgMan)->setConfiguration(config);
-    if ((*pkgMan)->lastError().isValid()) {
-        auto err = LINGLONG_ERRV((*pkgMan)->lastError().message().toStdString());
+    auto reply = (*pkgMan)->SetConfiguration(config);
+    reply.waitForFinished();
+    if (reply.isError()) {
+        auto err = LINGLONG_ERRV(reply.error().message().toStdString());
         this->printer.printErr(err);
         return -1;
     }
@@ -2156,69 +2084,6 @@ void Cli::filterPackageInfosByVersion(
     }
 }
 
-utils::error::Result<void> Cli::ensureAuthorized()
-{
-    LINGLONG_TRACE("ensure authorized");
-
-    auto authReply = this->authorization();
-    if (!authReply.isValid()) {
-        if (authReply.error().type() == QDBusError::AccessDenied) {
-            auto ret = this->runningAsRoot();
-            std::string message = "failed to authorize";
-            if (!ret) {
-                message += ": " + ret.error().message();
-            }
-            return LINGLONG_ERR(message);
-        }
-
-        return LINGLONG_ERR(
-          fmt::format("{} {}", authReply.error().message(), authReply.error().name()),
-          static_cast<int>(authReply.error().type()));
-    }
-
-    return LINGLONG_OK;
-}
-
-utils::error::Result<void> Cli::runningAsRoot()
-{
-    return runningAsRoot(QCoreApplication::instance()->arguments());
-}
-
-utils::error::Result<void> Cli::runningAsRoot(const QList<QString> &args)
-{
-    LINGLONG_TRACE("run with pkexec");
-
-    const char *pkexecBin = "pkexec";
-    QStringList argv{ pkexecBin };
-    argv.append(args);
-    std::vector<char *> targetArgv;
-    for (const auto &arg : argv) {
-        QByteArray byteArray = arg.toUtf8();
-        targetArgv.push_back(strdup(byteArray.constData()));
-    }
-    LogD("run {}", fmt::join(targetArgv, " "));
-    targetArgv.push_back(nullptr);
-
-    auto ret = execvp(pkexecBin, const_cast<char **>(targetArgv.data()));
-    // NOTE: if reached here, exevpe is failed.
-    for (auto arg : targetArgv) {
-        free(arg);
-    }
-    return LINGLONG_ERR("execve error", ret);
-}
-
-QDBusReply<void> Cli::authorization()
-{
-    // Note: we have marked the method Permissions of PM as rejected.
-    // Use this method to determin that this client whether have permission to call PM.
-    auto pkgMan = this->getPkgMan();
-    if (!pkgMan) {
-        return QDBusReply<void>{ QDBusError(QDBusError::Failed, pkgMan.error().message().c_str()) };
-    }
-
-    return (*pkgMan)->Permissions();
-}
-
 utils::error::Result<std::filesystem::path> Cli::ensureCache(runtime::RunContext &context) noexcept
 {
     LINGLONG_TRACE("ensure cache via PM");
@@ -2383,29 +2248,6 @@ int Cli::getBundleDir(const InspectOptions &options)
     return 0;
 }
 
-utils::error::Result<void> Cli::initInteraction()
-{
-    LINGLONG_TRACE("initInteraction");
-
-    auto pkgMan = this->getPkgMan();
-    if (!pkgMan) {
-        return LINGLONG_ERR(pkgMan);
-    }
-
-    auto conn = (*pkgMan)->connection();
-    auto con = conn.connect((*pkgMan)->service(),
-                            (*pkgMan)->path(),
-                            (*pkgMan)->interface(),
-                            "RequestInteraction",
-                            this,
-                            SLOT(interaction(QDBusObjectPath, int, QVariantMap)));
-    if (!con) {
-        return LINGLONG_ERR("Failed to connect signal: RequestInteraction");
-    }
-
-    return LINGLONG_OK;
-}
-
 utils::error::Result<void> Cli::waitTaskCreated(QDBusPendingReply<QVariantMap> &reply,
                                                 TaskType taskType)
 {
@@ -2413,7 +2255,7 @@ utils::error::Result<void> Cli::waitTaskCreated(QDBusPendingReply<QVariantMap> &
 
     auto result = waitDBusReply<api::types::v1::PackageManager1PackageTaskResult>(reply);
     if (!result) {
-        return LINGLONG_ERR(result.error());
+        return LINGLONG_ERR(result);
     }
 
     auto resultCode = static_cast<utils::error::ErrorCode>(result->code);
@@ -2442,6 +2284,16 @@ utils::error::Result<void> Cli::waitTaskCreated(QDBusPendingReply<QVariantMap> &
                       SLOT(onTaskPropertiesChanged(QString, QVariantMap, QStringList)))) {
         Q_ASSERT(false);
         return LINGLONG_ERR(fmt::format("Failed to connect signal PropertiesChanged: {}",
+                                        conn.lastError().message().toStdString()));
+    }
+
+    if (!conn.connect((*pkgMan)->service(),
+                      taskObjectPath,
+                      "org.deepin.linglong.Task1",
+                      "RequestInteraction",
+                      this,
+                      SLOT(onTaskRequestInteraction(int, QVariantMap)))) {
+        return LINGLONG_ERR(fmt::format("Failed to connect signal RequestInteraction: {}",
                                         conn.lastError().message().toStdString()));
     }
 
@@ -2588,6 +2440,9 @@ bool Cli::handleCommonError(const utils::error::Error &error)
         break;
     case utils::error::ErrorCode::Canceled:
         this->printer.printMessage(_("Operation canceled"));
+        break;
+    case utils::error::ErrorCode::PermissionDenied:
+        this->printer.printMessage(_("Permission denied, authentication is required"));
         break;
     default:
         this->printer.printErr(error);

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -216,21 +216,15 @@ private:
     [[nodiscard]] utils::error::Result<std::vector<api::types::v1::CliContainer>>
     getCurrentContainers() const noexcept;
     int installFromFile(const QFileInfo &fileInfo,
-                        const api::types::v1::CommonOptions &commonOptions,
-                        const std::string &appid);
+                        const api::types::v1::CommonOptions &commonOptions);
     int setRepoConfig(const QVariantMap &config);
-    utils::error::Result<void> ensureAuthorized();
-    utils::error::Result<void> runningAsRoot();
-    utils::error::Result<void> runningAsRoot(const QList<QString> &args);
     utils::error::Result<std::vector<api::types::v1::UpgradeListResult>> listUpgradable();
     utils::error::Result<std::filesystem::path> ensureCache(runtime::RunContext &context) noexcept;
-    QDBusReply<void> authorization();
     void updateAM() noexcept;
     utils::error::Result<std::vector<std::string>> getRunningAppContainers(const std::string &id);
     bool isContainerIDMatch(const std::string &containerID, const std::string &shortID);
     int getLayerDir(const InspectOptions &options);
     int getBundleDir(const InspectOptions &options);
-    utils::error::Result<void> initInteraction();
     void detectDrivers();
     utils::error::Result<api::dbus::v1::PackageManager *> getPkgMan();
     utils::error::Result<void> initPkgManSignals();
@@ -277,9 +271,7 @@ private Q_SLOTS:
     void onTaskPropertiesChanged(const QString &interface,
                                  const QVariantMap &changed_properties,
                                  const QStringList &invalidated_properties);
-    void interaction(const QDBusObjectPath &object_path,
-                     int messageID,
-                     const QVariantMap &additionalMessage);
+    void onTaskRequestInteraction(int messageID, const QVariantMap &additionalMessage);
 
 Q_SIGNALS:
     void taskDone();

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -25,6 +25,7 @@
 #include "linglong/package/reference.h"
 #include "linglong/package_manager/package_task.h"
 #include "linglong/package_manager/package_update.h"
+#include "linglong/package_manager/polkit_authority.h"
 #include "linglong/package_manager/ref_installation.h"
 #include "linglong/package_manager/uab_installation.h"
 #include "linglong/repo/ostree_repo.h"
@@ -51,6 +52,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <functional>
 #include <unordered_map>
 #include <utility>
 
@@ -83,6 +85,29 @@ QVariantMap toDBusReply(utils::error::ErrorCode code,
                                     .type = type });
 }
 
+void checkPolkitAuthorizationAsync(const std::string &actionId,
+                                   const std::string &systemBusName,
+                                   std::function<void(utils::error::Result<void>)> callback)
+{
+    PolkitAuthority::checkAuthorizationAsync(
+      actionId,
+      systemBusName,
+      [callback = std::move(callback)](utils::error::Result<bool> authResult) {
+          LINGLONG_TRACE("check polkit authorization");
+          if (!authResult) {
+              callback(LINGLONG_ERR(authResult));
+              return;
+          }
+
+          if (!(*authResult)) {
+              callback(LINGLONG_ERR("not authorized", utils::error::ErrorCode::PermissionDenied));
+              return;
+          }
+
+          callback(LINGLONG_OK);
+      });
+}
+
 } // namespace
 
 PackageManager::PackageManager(
@@ -98,12 +123,13 @@ PackageManager::PackageManager(
 {
 }
 
-void PackageManager::initDaemonMode() noexcept
+void PackageManager::initDaemonMode(bool peerMode) noexcept
 {
     if (daemonModeInitialized) {
         return;
     }
     daemonModeInitialized = true;
+    m_peerMode = peerMode;
 
     // tasks and PackageManager are on the same thread, it's safe to getTask in slot
     QObject::connect(&tasks, &PackageTaskQueue::taskDone, this, [this](const QString &taskID) {
@@ -439,16 +465,62 @@ void PackageManager::deferredUninstall() noexcept
 
 auto PackageManager::getConfiguration() const noexcept -> QVariantMap
 {
+    if (!daemonModeInitialized) {
+        return toDBusReply(utils::error::ErrorCode::Failed, "daemon mode not initialized");
+    }
     return common::serialize::toQVariantMap(this->repo->getConfig());
 }
 
-void PackageManager::setConfiguration(const QVariantMap &parameters) noexcept
+void PackageManager::SetConfiguration(const QVariantMap &parameters) noexcept
 {
     LogI("set configuration for package manager");
+
+    if (!daemonModeInitialized) {
+        sendErrorReply(QDBusError::Failed, "daemon mode not initialized");
+        return;
+    }
+
+    if (!m_peerMode) {
+        auto msg = message();
+        auto conn = connection();
+        setDelayedReply(true);
+
+        checkPolkitAuthorizationAsync(
+          "org.deepin.linglong.PackageManager1.set-configuration",
+          msg.service().toStdString(),
+          [this, parameters, msg, conn](utils::error::Result<void> authResult) {
+              if (!authResult) {
+                  conn.send(
+                    msg.createErrorReply(QDBusError::AccessDenied,
+                                         QString::fromStdString(authResult.error().message())));
+                  return;
+              }
+
+              auto result = setConfigurationImpl(parameters);
+              if (!result) {
+                  conn.send(msg.createErrorReply(QDBusError::Failed,
+                                                 QString::fromStdString(result.error().message())));
+                  return;
+              }
+
+              conn.send(msg.createReply());
+          });
+        return;
+    }
+
+    auto result = setConfigurationImpl(parameters);
+    if (!result) {
+        sendErrorReply(QDBusError::Failed, QString::fromStdString(result.error().message()));
+    }
+}
+
+utils::error::Result<void>
+PackageManager::setConfigurationImpl(const QVariantMap &parameters) noexcept
+{
+    LINGLONG_TRACE("set configuration");
     auto cfg = common::serialize::fromQVariantMap<api::types::v1::RepoConfigV2>(parameters);
     if (!cfg) {
-        sendErrorReply(QDBusError::InvalidArgs, QString::fromStdString(cfg.error().message()));
-        return;
+        return LINGLONG_ERR(cfg);
     }
 
     const auto &cfgRef = *cfg;
@@ -458,7 +530,7 @@ void PackageManager::setConfiguration(const QVariantMap &parameters) noexcept
     LogD("cur config: {}", nlohmann::json(curCfg).dump());
     if (cfgRef == curCfg) {
         LogI("configuration not changed, ignore setting.");
-        return;
+        return LINGLONG_OK;
     }
     if (const auto &defaultRepo = cfg->defaultRepo;
         std::find_if(cfg->repos.begin(),
@@ -467,19 +539,20 @@ void PackageManager::setConfiguration(const QVariantMap &parameters) noexcept
                          return repo.alias.value_or(repo.name) == defaultRepo;
                      })
         == cfg->repos.end()) {
-        sendErrorReply(QDBusError::Failed,
-                       "default repository is missing after updating configuration.");
-        return;
+        return LINGLONG_ERR("default repository is missing after updating configuration.");
     }
 
     auto result = this->repo->setConfig(*cfg);
     if (!result) {
-        sendErrorReply(QDBusError::Failed, result.error().message().c_str());
+        return LINGLONG_ERR(result);
     }
+
+    return LINGLONG_OK;
 }
 
 QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
-                                             const api::types::v1::CommonOptions &options) noexcept
+                                             const api::types::v1::CommonOptions &options,
+                                             const CallerContext &ctx) noexcept
 {
     auto layerFileRet = package::LayerFile::New(fd.fileDescriptor());
     if (!layerFileRet) {
@@ -582,26 +655,9 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
           PackageTask &taskRef = dynamic_cast<PackageTask &>(task);
           if (msgType == api::types::v1::InteractionMessageType::Upgrade
               && !options.skipInteraction) {
-              Q_EMIT RequestInteraction(QDBusObjectPath(taskRef.taskObjectPath().c_str()),
-                                        static_cast<int>(msgType),
-                                        common::serialize::toQVariantMap(additionalMessage));
-              QEventLoop loop;
-              auto conn = connect(
-                this,
-                &PackageManager::ReplyReceived,
-                [&taskRef, &loop](const QVariantMap &reply) {
-                    // handle reply
-                    auto interactionReply =
-                      common::serialize::fromQVariantMap<api::types::v1::InteractionReply>(reply);
-                    if (interactionReply->action != "yes") {
-                        taskRef.updateState(linglong::api::types::v1::State::Canceled, "canceled");
-                    }
-
-                    loop.exit(0);
-                });
-              loop.exec();
-
-              disconnect(conn);
+              if (!taskRef.waitConfirm(msgType, additionalMessage)) {
+                  return;
+              }
           }
           if (taskRef.isTaskDone()) {
               return;
@@ -687,7 +743,7 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
           }
       };
 
-    auto taskRet = tasks.addPackageTask(std::move(installer), connection());
+    auto taskRet = tasks.addPackageTask(std::move(installer), ctx);
     if (!taskRet) {
         return toDBusReply(taskRet);
     }
@@ -703,7 +759,8 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
 }
 
 QVariantMap PackageManager::installFromUAB(const QDBusUnixFileDescriptor &fd,
-                                           const api::types::v1::CommonOptions &options) noexcept
+                                           const api::types::v1::CommonOptions &options,
+                                           const CallerContext &ctx) noexcept
 {
     std::unique_ptr<utils::InstallHookManager> installHookManager =
       std::make_unique<utils::InstallHookManager>();
@@ -725,12 +782,48 @@ QVariantMap PackageManager::installFromUAB(const QDBusUnixFileDescriptor &fd,
                            "failed to create uab installation action");
     }
 
-    return runActionOnTaskQueue(action);
+    return runActionOnTaskQueue(action, ctx);
 }
 
 auto PackageManager::InstallFromFile(const QDBusUnixFileDescriptor &fd,
                                      const QString &fileType,
                                      const QVariantMap &options) noexcept -> QVariantMap
+{
+    if (!daemonModeInitialized) {
+        return toDBusReply(utils::error::ErrorCode::Failed, "daemon mode not initialized");
+    }
+
+    if (!m_peerMode) {
+        auto msg = message();
+        auto conn = connection();
+        setDelayedReply(true);
+
+        CallerContext ctx{ conn, msg };
+
+        checkPolkitAuthorizationAsync(
+          "org.deepin.linglong.PackageManager1.install-from-file",
+          msg.service().toStdString(),
+          [this, fdDup = fd, fileType, options, ctx](utils::error::Result<void> authResult) {
+              if (!authResult) {
+                  ctx.connection.send(ctx.message.createErrorReply(
+                    QDBusError::AccessDenied,
+                    QString::fromStdString(authResult.error().message())));
+                  return;
+              }
+
+              auto result = installFromFileImpl(fdDup, fileType, options, ctx);
+              ctx.connection.send(ctx.message.createReply(result));
+          });
+        return {};
+    }
+
+    return installFromFileImpl(fd, fileType, options, CallerContext{ connection(), message() });
+}
+
+QVariantMap PackageManager::installFromFileImpl(const QDBusUnixFileDescriptor &fd,
+                                                const QString &fileType,
+                                                const QVariantMap &options,
+                                                const CallerContext &ctx) noexcept
 {
     if (!fd.isValid()) {
         return toDBusReply(utils::error::ErrorCode::Failed, "invalid file descriptor");
@@ -741,22 +834,53 @@ auto PackageManager::InstallFromFile(const QDBusUnixFileDescriptor &fd,
         return toDBusReply(opts);
     }
 
-    const static QHash<QString,
-                       QVariantMap (PackageManager::*)(
-                         const QDBusUnixFileDescriptor &,
-                         const api::types::v1::CommonOptions &) noexcept>
-      installers = { { "layer", &PackageManager::installFromLayer },
-                     { "uab", &PackageManager::installFromUAB } };
-
-    if (!installers.contains(fileType)) {
-        auto msg = fmt::format("{} is unsupported fileType", fileType.toStdString());
-        return toDBusReply(utils::error::ErrorCode::AppInstallUnsupportedFileFormat, msg);
+    if (fileType == "layer") {
+        return installFromLayer(fd, *opts, ctx);
     }
 
-    return std::invoke(installers[fileType], this, fd, *opts);
+    if (fileType == "uab") {
+        return installFromUAB(fd, *opts, ctx);
+    }
+
+    auto msg = fmt::format("{} is unsupported fileType", fileType.toStdString());
+    return toDBusReply(utils::error::ErrorCode::AppInstallUnsupportedFileFormat, msg);
 }
 
 auto PackageManager::Install(const QVariantMap &parameters) noexcept -> QVariantMap
+{
+    if (!daemonModeInitialized) {
+        return toDBusReply(utils::error::ErrorCode::Failed, "daemon mode not initialized");
+    }
+
+    if (!m_peerMode) {
+        auto msg = message();
+        auto conn = connection();
+        setDelayedReply(true);
+
+        CallerContext ctx{ conn, msg };
+
+        checkPolkitAuthorizationAsync(
+          "org.deepin.linglong.PackageManager1.install",
+          msg.service().toStdString(),
+          [this, parameters, ctx](utils::error::Result<void> authResult) {
+              if (!authResult) {
+                  ctx.connection.send(ctx.message.createErrorReply(
+                    QDBusError::AccessDenied,
+                    QString::fromStdString(authResult.error().message())));
+                  return;
+              }
+
+              auto result = installImpl(parameters, ctx);
+              ctx.connection.send(ctx.message.createReply(result));
+          });
+        return {};
+    }
+
+    return installImpl(parameters, CallerContext{ connection(), message() });
+}
+
+QVariantMap PackageManager::installImpl(const QVariantMap &parameters,
+                                        const CallerContext &ctx) noexcept
 {
     auto paras =
       common::serialize::fromQVariantMap<api::types::v1::PackageManager1InstallParameters>(
@@ -799,10 +923,44 @@ auto PackageManager::Install(const QVariantMap &parameters) noexcept -> QVariant
         return toDBusReply(utils::error::ErrorCode::AppInstallFailed, "");
     }
 
-    return runActionOnTaskQueue(action);
+    return runActionOnTaskQueue(action, ctx);
 }
 
 auto PackageManager::Uninstall(const QVariantMap &parameters) noexcept -> QVariantMap
+{
+    if (!daemonModeInitialized) {
+        return toDBusReply(utils::error::ErrorCode::Failed, "daemon mode not initialized");
+    }
+
+    if (!m_peerMode) {
+        auto msg = message();
+        auto conn = connection();
+        setDelayedReply(true);
+
+        CallerContext ctx{ conn, msg };
+
+        checkPolkitAuthorizationAsync(
+          "org.deepin.linglong.PackageManager1.uninstall",
+          msg.service().toStdString(),
+          [this, parameters, ctx](utils::error::Result<void> authResult) {
+              if (!authResult) {
+                  ctx.connection.send(ctx.message.createErrorReply(
+                    QDBusError::AccessDenied,
+                    QString::fromStdString(authResult.error().message())));
+                  return;
+              }
+
+              auto result = uninstallImpl(parameters, ctx);
+              ctx.connection.send(ctx.message.createReply(result));
+          });
+        return {};
+    }
+
+    return uninstallImpl(parameters, CallerContext{ connection(), message() });
+}
+
+QVariantMap PackageManager::uninstallImpl(const QVariantMap &parameters,
+                                          const CallerContext &ctx) noexcept
 {
     auto paras =
       common::serialize::fromQVariantMap<api::types::v1::PackageManager1UninstallParameters>(
@@ -898,7 +1056,7 @@ auto PackageManager::Uninstall(const QVariantMap &parameters) noexcept -> QVaria
               taskRef.reportError(std::move(res.error()));
           }
       },
-      connection());
+      ctx);
     if (!taskRet) {
         return toDBusReply(taskRet);
     }
@@ -964,6 +1122,40 @@ utils::error::Result<void> PackageManager::Uninstall(PackageTask &taskContext,
 
 auto PackageManager::Update(const QVariantMap &parameters) noexcept -> QVariantMap
 {
+    if (!daemonModeInitialized) {
+        return toDBusReply(utils::error::ErrorCode::Failed, "daemon mode not initialized");
+    }
+
+    if (!m_peerMode) {
+        auto msg = message();
+        auto conn = connection();
+        setDelayedReply(true);
+
+        CallerContext ctx{ conn, msg };
+
+        checkPolkitAuthorizationAsync(
+          "org.deepin.linglong.PackageManager1.update",
+          msg.service().toStdString(),
+          [this, parameters, ctx](utils::error::Result<void> authResult) {
+              if (!authResult) {
+                  ctx.connection.send(ctx.message.createErrorReply(
+                    QDBusError::AccessDenied,
+                    QString::fromStdString(authResult.error().message())));
+                  return;
+              }
+
+              auto result = updateImpl(parameters, ctx);
+              ctx.connection.send(ctx.message.createReply(result));
+          });
+        return {};
+    }
+
+    return updateImpl(parameters, CallerContext{ connection(), message() });
+}
+
+QVariantMap PackageManager::updateImpl(const QVariantMap &parameters,
+                                       const CallerContext &ctx) noexcept
+{
     auto paras =
       common::serialize::fromQVariantMap<api::types::v1::PackageManager1UpdateParameters>(
         parameters);
@@ -978,7 +1170,7 @@ auto PackageManager::Update(const QVariantMap &parameters) noexcept -> QVariantM
                            "failed to create update action");
     }
 
-    return runActionOnTaskQueue(action);
+    return runActionOnTaskQueue(action, ctx);
 }
 
 utils::error::Result<void> PackageManager::installRefModule(Task &task,
@@ -1139,6 +1331,10 @@ utils::error::Result<void> PackageManager::uninstallRefModule(const package::Ref
 
 auto PackageManager::Search(const QVariantMap &parameters) noexcept -> QVariantMap
 {
+    if (!daemonModeInitialized) {
+        return toDBusReply(utils::error::ErrorCode::Failed, "daemon mode not initialized");
+    }
+
     auto paras =
       common::serialize::fromQVariantMap<api::types::v1::PackageManager1SearchParameters>(
         parameters);
@@ -1379,6 +1575,37 @@ utils::error::Result<void> PackageManager::installDependsRef(Task &task,
 
 auto PackageManager::Prune() noexcept -> QVariantMap
 {
+    if (!daemonModeInitialized) {
+        return toDBusReply(utils::error::ErrorCode::Failed, "daemon mode not initialized");
+    }
+
+    if (!m_peerMode) {
+        auto msg = message();
+        auto conn = connection();
+        setDelayedReply(true);
+
+        checkPolkitAuthorizationAsync(
+          "org.deepin.linglong.PackageManager1.prune",
+          msg.service().toStdString(),
+          [this, msg, conn](utils::error::Result<void> authResult) {
+              if (!authResult) {
+                  conn.send(
+                    msg.createErrorReply(QDBusError::AccessDenied,
+                                         QString::fromStdString(authResult.error().message())));
+                  return;
+              }
+
+              auto result = pruneImpl();
+              conn.send(msg.createReply(result));
+          });
+        return {};
+    }
+
+    return pruneImpl();
+}
+
+QVariantMap PackageManager::pruneImpl() noexcept
+{
     auto task = tasks.addTask([this](Task &task) {
         std::vector<api::types::v1::PackageInfoV2> pkgs;
         auto ret = Prune(pkgs);
@@ -1587,6 +1814,10 @@ PackageManager::Prune(std::vector<api::types::v1::PackageInfoV2> &removed) noexc
 auto PackageManager::InitRunContext(const QString &runContextCfg,
                                     const QString &containerID) noexcept -> QVariantMap
 {
+    if (!daemonModeInitialized) {
+        return toDBusReply(utils::error::ErrorCode::Failed, "daemon mode not initialized");
+    }
+
     auto task = m_init_run_context_queue.addPackageTask(
       [this, runContextCfg = runContextCfg.toStdString(), containerID = containerID.toStdString()](
         Task &task) {
@@ -1654,12 +1885,6 @@ auto PackageManager::InitRunContext(const QString &runContextCfg,
       .code = 0,
       .message = "InitRunContext queued",
     });
-}
-
-void PackageManager::ReplyInteraction([[maybe_unused]] QDBusObjectPath object_path,
-                                      const QVariantMap &replies)
-{
-    Q_EMIT this->ReplyReceived(replies);
 }
 
 // no-op for now
@@ -1796,35 +2021,10 @@ PackageManager::executePostUninstallHooks(const package::Reference &ref) noexcep
     return LINGLONG_OK;
 }
 
-bool PackageManager::waitConfirm(
-  PackageTask &taskRef,
-  api::types::v1::InteractionMessageType msgType,
-  const api::types::v1::PackageManager1RequestInteractionAdditionalMessage
-    &additionalMessage) noexcept
+QVariantMap PackageManager::runActionOnTaskQueue(std::shared_ptr<Action> action,
+                                                 const CallerContext &ctx)
 {
-    Q_EMIT RequestInteraction(QDBusObjectPath(taskRef.taskObjectPath().c_str()),
-                              static_cast<int>(msgType),
-                              common::serialize::toQVariantMap(additionalMessage));
-    QEventLoop loop;
-    auto conn =
-      connect(this, &PackageManager::ReplyReceived, [&taskRef, &loop](const QVariantMap &reply) {
-          auto interactionReply =
-            common::serialize::fromQVariantMap<api::types::v1::InteractionReply>(reply);
-          if (interactionReply->action != "yes") {
-              taskRef.updateState(linglong::api::types::v1::State::Canceled, "canceled");
-          }
-          loop.exit(0);
-      });
-    loop.exec();
-
-    disconnect(conn);
-
-    return !taskRef.isTaskDone();
-}
-
-QVariantMap PackageManager::runActionOnTaskQueue(std::shared_ptr<Action> action)
-{
-    // prepare is run within the DBus calling context.
+    // prepare is run within the DBus calling context or the async polkit callback context.
     // doAction is run within the PM's packages task queue context.
     // state consistency cannot be assumed between prepare and doAction.
     // For now, DBus calling context runs on the application's main event loop,
@@ -1844,7 +2044,7 @@ QVariantMap PackageManager::runActionOnTaskQueue(std::shared_ptr<Action> action)
               LogI("action {} succeed: {}", action->getTaskName(), task.Task::message());
           }
       },
-      connection());
+      ctx);
     if (!taskRet) {
         return toDBusReply(taskRet);
     }

--- a/libs/linglong/src/linglong/package_manager/package_manager.h
+++ b/libs/linglong/src/linglong/package_manager/package_manager.h
@@ -8,8 +8,6 @@
 
 #include "linglong/api/types/v1/CommonOptions.hpp"
 #include "linglong/api/types/v1/ContainerProcessStateInfo.hpp"
-#include "linglong/api/types/v1/InteractionMessageType.hpp"
-#include "linglong/api/types/v1/PackageManager1RequestInteractionAdditionalMessage.hpp"
 #include "linglong/api/types/v1/Repo.hpp"
 #include "linglong/api/types/v1/UabLayer.hpp"
 #include "linglong/package/fuzzy_reference.h"
@@ -20,6 +18,7 @@
 #include "package_task.h"
 
 #include <QDBusArgument>
+#include <QDBusConnection>
 #include <QDBusContext>
 #include <QList>
 #include <QObject>
@@ -35,7 +34,7 @@ class PackageManager : public QObject, protected QDBusContext
 {
     Q_OBJECT
     Q_CLASSINFO("D-Bus Interface", "org.deepin.linglong.PackageManager1")
-    Q_PROPERTY(QVariantMap Configuration READ getConfiguration WRITE setConfiguration)
+    Q_PROPERTY(QVariantMap Configuration READ getConfiguration)
 
 public:
     PackageManager(std::unique_ptr<linglong::repo::OSTreeRepo> repo,
@@ -50,7 +49,7 @@ public:
 
 public
     Q_SLOT : [[nodiscard]] auto getConfiguration() const noexcept -> QVariantMap;
-    void setConfiguration(const QVariantMap &parameters) noexcept;
+    void SetConfiguration(const QVariantMap &parameters) noexcept;
     auto Install(const QVariantMap &parameters) noexcept -> QVariantMap;
     auto InstallFromFile(const QDBusUnixFileDescriptor &fd,
                          const QString &fileType,
@@ -59,21 +58,12 @@ public
     auto Update(const QVariantMap &parameters) noexcept -> QVariantMap;
     auto Search(const QVariantMap &parameters) noexcept -> QVariantMap;
     auto Prune() noexcept -> QVariantMap;
-    void ReplyInteraction(QDBusObjectPath object_path, const QVariantMap &replies);
 
     auto InitRunContext(const QString &runContextCfg, const QString &containerID) noexcept
       -> QVariantMap;
     utils::error::Result<void> initRunContext(const std::string &runContextCfg,
                                               const std::string &containerID) noexcept;
-    void initDaemonMode() noexcept;
-
-    // Nothing to do here, Permissions() will be rejected in org.deepin.linglong.PackageManager.conf
-    void Permissions() { }
-
-    bool waitConfirm(PackageTask &taskRef,
-                     api::types::v1::InteractionMessageType msgType,
-                     const api::types::v1::PackageManager1RequestInteractionAdditionalMessage
-                       &additionalMessage) noexcept;
+    void initDaemonMode(bool peerMode = false) noexcept;
 
     virtual utils::error::Result<void> applyApp(const package::Reference &reference) noexcept;
     virtual utils::error::Result<void> unapplyApp(const package::Reference &reference) noexcept;
@@ -117,20 +107,33 @@ public
 Q_SIGNALS:
     void TaskAdded(QDBusObjectPath object_path);
     void TaskRemoved(QDBusObjectPath object_path);
-    void RequestInteraction(QDBusObjectPath object_path,
-                            int messageID,
-                            QVariantMap additionalMessage);
     void SearchFinished(QString jobID, QVariantMap result);
     void PruneFinished(QString jobID, QVariantMap result);
     void InitRunContextFinished(QString jobID, bool success);
-    void ReplyReceived(const QVariantMap &replies);
 
 private:
     QVariantMap installFromLayer(const QDBusUnixFileDescriptor &fd,
-                                 const api::types::v1::CommonOptions &options) noexcept;
+                                 const api::types::v1::CommonOptions &options,
+                                 const CallerContext &ctx) noexcept;
 
     QVariantMap installFromUAB(const QDBusUnixFileDescriptor &fd,
-                               const api::types::v1::CommonOptions &options) noexcept;
+                               const api::types::v1::CommonOptions &options,
+                               const CallerContext &ctx) noexcept;
+
+    QVariantMap installFromFileImpl(const QDBusUnixFileDescriptor &fd,
+                                    const QString &fileType,
+                                    const QVariantMap &options,
+                                    const CallerContext &ctx) noexcept;
+
+    QVariantMap installImpl(const QVariantMap &parameters, const CallerContext &ctx) noexcept;
+
+    QVariantMap uninstallImpl(const QVariantMap &parameters, const CallerContext &ctx) noexcept;
+
+    QVariantMap updateImpl(const QVariantMap &parameters, const CallerContext &ctx) noexcept;
+
+    QVariantMap pruneImpl() noexcept;
+
+    utils::error::Result<void> setConfigurationImpl(const QVariantMap &parameters) noexcept;
 
     [[nodiscard]] utils::error::Result<void> lockRepo() noexcept;
     [[nodiscard]] utils::error::Result<void> unlockRepo() noexcept;
@@ -143,7 +146,7 @@ private:
     Prune(std::vector<api::types::v1::PackageInfoV2> &removedInfo) noexcept;
     utils::error::Result<void> removeCache(const package::Reference &ref) noexcept;
 
-    QVariantMap runActionOnTaskQueue(std::shared_ptr<Action> action);
+    QVariantMap runActionOnTaskQueue(std::shared_ptr<Action> action, const CallerContext &ctx);
 
     std::unique_ptr<linglong::repo::OSTreeRepo> repo;
     std::unique_ptr<linglong::runtime::ContainerBuilder> containerBuilder;
@@ -153,6 +156,7 @@ private:
 
     int lockFd{ -1 };
     bool daemonModeInitialized{ false };
+    bool m_peerMode{ false };
 };
 
 } // namespace linglong::service

--- a/libs/linglong/src/linglong/package_manager/package_task.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_task.cpp
@@ -6,12 +6,16 @@
 
 #include "linglong/adaptors/task/task1.h"
 #include "linglong/common/dbus/register.h"
+#include "linglong/common/serialize/json.h"
 #include "linglong/package_manager/package_manager.h"
 #include "linglong/utils/error/error.h"
 #include "linglong/utils/log/formatter.h" // IWYU pragma: keep
 
 #include <fmt/format.h>
 #include <sys/prctl.h>
+
+#include <QDBusServiceWatcher>
+#include <QTimer>
 
 #include <utility>
 
@@ -85,7 +89,109 @@ void PackageTask::Cancel() noexcept
     g_cancellable_cancel(m_cancelFlag);
 }
 
-utils::error::Result<void> PackageTask::exposeOnDBus(const QDBusConnection &connection) noexcept
+void PackageTask::ReplyInteraction(const QVariantMap &replies) noexcept
+{
+    Q_EMIT this->ReplyReceived(replies);
+}
+
+void PackageTask::onPeerDisconnected() noexcept
+{
+    LogW("peer caller disconnected");
+    Q_EMIT peerDisconnected();
+}
+
+void PackageTask::setCallerContext(const CallerContext &ctx)
+{
+    m_callerContext = ctx;
+}
+
+bool PackageTask::waitConfirm(
+  api::types::v1::InteractionMessageType msgType,
+  const api::types::v1::PackageManager1RequestInteractionAdditionalMessage &additionalMessage,
+  std::chrono::milliseconds timeout) noexcept
+{
+    Q_EMIT RequestInteraction(static_cast<int>(msgType),
+                              common::serialize::toQVariantMap(additionalMessage));
+    QEventLoop loop;
+
+    QTimer timeoutTimer;
+    timeoutTimer.setSingleShot(true);
+
+    std::unique_ptr<QDBusServiceWatcher> watcher;
+
+    auto peerDisconnectedConn =
+      QObject::connect(this, &PackageTask::peerDisconnected, &loop, [&loop, this]() {
+          updateState(linglong::api::types::v1::State::Canceled, "caller disconnected");
+          loop.exit(1);
+      });
+
+    if (m_callerContext.isPeerMode()) {
+        auto connected = m_callerContext.connection.connect("",
+                                                            "/org/freedesktop/DBus/Local",
+                                                            "org.freedesktop.DBus.Local",
+                                                            "Disconnected",
+                                                            this,
+                                                            SLOT(onPeerDisconnected()));
+        if (!connected) {
+            LogW("failed to connect to Disconnected signal for peer mode");
+        }
+    } else {
+        auto callerName = m_callerContext.callerBusName();
+        if (!callerName.isEmpty()) {
+            watcher =
+              std::make_unique<QDBusServiceWatcher>(callerName,
+                                                    m_callerContext.connection,
+                                                    QDBusServiceWatcher::WatchForUnregistration);
+            connect(
+              watcher.get(),
+              &QDBusServiceWatcher::serviceUnregistered,
+              &loop,
+              [&loop, this]() {
+                  LogW("caller {} disconnected", m_callerContext.callerBusName().toStdString());
+                  updateState(linglong::api::types::v1::State::Canceled, "caller disconnected");
+                  loop.exit(1);
+              });
+        }
+    }
+
+    auto replyConn =
+      connect(this, &PackageTask::ReplyReceived, &loop, [this, &loop](const QVariantMap &reply) {
+          auto interactionReply =
+            common::serialize::fromQVariantMap<api::types::v1::InteractionReply>(reply);
+          if (!interactionReply || interactionReply->action != "yes") {
+              updateState(linglong::api::types::v1::State::Canceled, "canceled");
+          }
+          loop.exit(0);
+      });
+
+    auto timeoutConn = connect(&timeoutTimer, &QTimer::timeout, &loop, [this, &loop]() {
+        auto msg = fmt::format("task {} confirm timeout", taskID());
+        LogW(msg);
+        updateState(linglong::api::types::v1::State::Canceled, msg);
+        loop.exit(1);
+    });
+
+    timeoutTimer.start(timeout);
+    loop.exec();
+    timeoutTimer.stop();
+
+    disconnect(replyConn);
+    disconnect(timeoutConn);
+    disconnect(peerDisconnectedConn);
+
+    if (m_callerContext.isPeerMode()) {
+        m_callerContext.connection.disconnect("",
+                                              "/org/freedesktop/DBus/Local",
+                                              "org.freedesktop.DBus.Local",
+                                              "Disconnected",
+                                              this,
+                                              SLOT(onPeerDisconnected()));
+    }
+
+    return !isTaskDone();
+}
+
+utils::error::Result<void> PackageTask::exposeOnDBus() noexcept
 {
     LINGLONG_TRACE(fmt::format("expose task {} on dbus", taskID()));
 
@@ -99,14 +205,17 @@ utils::error::Result<void> PackageTask::exposeOnDBus(const QDBusConnection &conn
     if (interfaceIndex == -1) {
         return LINGLONG_ERR("internal adaptor error");
     }
-    auto ret = common::dbus::registerDBusObject(connection, taskObjectPath().c_str(), this);
+    auto ret =
+      common::dbus::registerDBusObject(m_callerContext.connection, taskObjectPath().c_str(), this);
     if (!ret) {
         return LINGLONG_ERR(ret);
     }
 
     const auto *interface = mo->classInfo(interfaceIndex).value();
-    m_forwarder =
-      new common::dbus::PropertiesForwarder(connection, taskObjectPath().c_str(), interface, this);
+    m_forwarder = new common::dbus::PropertiesForwarder(m_callerContext.connection,
+                                                        taskObjectPath().c_str(),
+                                                        interface,
+                                                        this);
 
     QObject::connect(this, &PackageTask::changePropertiesDone, m_forwarder, [this]() {
         auto ret = m_forwarder->forward();

--- a/libs/linglong/src/linglong/package_manager/package_task.h
+++ b/libs/linglong/src/linglong/package_manager/package_task.h
@@ -1,16 +1,20 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 
+#include "linglong/api/types/v1/InteractionMessageType.hpp"
+#include "linglong/api/types/v1/PackageManager1RequestInteractionAdditionalMessage.hpp"
 #include "linglong/api/types/v1/State.hpp"
 #include "linglong/common/dbus/properties_forwarder.h"
 #include "linglong/package_manager/task.h"
 #include "linglong/utils/error/error.h"
 #include "linglong/utils/log/log.h"
 
+#include <QDBusConnection>
 #include <QDBusContext>
+#include <QDBusMessage>
 #include <QDBusObjectPath>
 #include <QEvent>
 #include <QMap>
@@ -18,6 +22,7 @@
 #include <QString>
 #include <QUuid>
 
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -26,6 +31,18 @@
 Q_DECLARE_METATYPE(linglong::api::types::v1::State)
 
 namespace linglong::service {
+
+using namespace std::chrono_literals;
+
+struct CallerContext
+{
+    QDBusConnection connection{ QDBusConnection::systemBus() };
+    QDBusMessage message;
+
+    [[nodiscard]] QString callerBusName() const { return message.service(); }
+
+    [[nodiscard]] bool isPeerMode() const { return connection.baseService().isEmpty(); }
+};
 
 class PackageTaskQueue;
 
@@ -72,10 +89,19 @@ public:
 
     virtual GCancellable *cancellable() noexcept override { return m_cancelFlag; }
 
-    utils::error::Result<void> exposeOnDBus(const QDBusConnection &connection) noexcept;
+    utils::error::Result<void> exposeOnDBus() noexcept;
+
+    void setCallerContext(const CallerContext &ctx);
+
+    bool waitConfirm(
+      api::types::v1::InteractionMessageType msgType,
+      const api::types::v1::PackageManager1RequestInteractionAdditionalMessage &additionalMessage,
+      std::chrono::milliseconds timeout = 180000ms) noexcept;
 
 public Q_SLOTS:
     void Cancel() noexcept;
+    void ReplyInteraction(const QVariantMap &replies) noexcept;
+    void onPeerDisconnected() noexcept;
 
 Q_SIGNALS:
     void StateChanged(int newState);
@@ -87,10 +113,15 @@ Q_SIGNALS:
 
     void changePropertiesDone();
 
+    void RequestInteraction(int messageID, QVariantMap additionalMessage);
+    void ReplyReceived(const QVariantMap &replies);
+    void peerDisconnected();
+
 private:
     friend class PackageTaskQueue;
     GCancellable *m_cancelFlag{ nullptr };
     common::dbus::PropertiesForwarder *m_forwarder{ nullptr };
+    CallerContext m_callerContext;
 };
 
 // PackageTaskQueue is used to manage tasks and run them in a separated thread
@@ -105,7 +136,7 @@ public:
 
     template <typename Func>
     utils::error::Result<std::reference_wrapper<PackageTask>>
-    addPackageTask(Func &&job, std::optional<QDBusConnection> conn = std::nullopt) noexcept;
+    addPackageTask(Func &&job, std::optional<CallerContext> ctx = std::nullopt) noexcept;
 
     template <typename Func>
     utils::error::Result<std::reference_wrapper<Task>> addTask(Func &&job) noexcept;
@@ -125,7 +156,7 @@ private:
 
 template <typename Func>
 utils::error::Result<std::reference_wrapper<PackageTask>>
-PackageTaskQueue::addPackageTask(Func &&job, std::optional<QDBusConnection> conn) noexcept
+PackageTaskQueue::addPackageTask(Func &&job, std::optional<CallerContext> ctx) noexcept
 {
     LINGLONG_TRACE("add package task");
     static_assert(std::is_invocable_r_v<void, Func, Task &>, "mismatch function signature");
@@ -133,8 +164,9 @@ PackageTaskQueue::addPackageTask(Func &&job, std::optional<QDBusConnection> conn
     PackageTask &task = dynamic_cast<PackageTask &>(
       enqueueTask(std::make_unique<PackageTask>(std::forward<Func>(job), this)));
 
-    if (conn) {
-        auto ret = task.exposeOnDBus(*conn);
+    if (ctx) {
+        task.setCallerContext(*ctx);
+        auto ret = task.exposeOnDBus();
         if (!ret) {
             return LINGLONG_ERR(ret);
         }

--- a/libs/linglong/src/linglong/package_manager/polkit_authority.cpp
+++ b/libs/linglong/src/linglong/package_manager/polkit_authority.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "polkit_authority.h"
+
+#include "linglong/utils/log/log.h"
+
+#include <QDBusArgument>
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QDBusMetaType>
+#include <QDBusPendingCallWatcher>
+#include <QDBusPendingReply>
+#include <QMap>
+#include <QString>
+#include <QVariant>
+
+#include <mutex>
+
+namespace {
+
+struct PolkitSubject
+{
+    QString kind;
+    QVariantMap details;
+};
+
+struct PolkitResult
+{
+    bool isAuthorized = false;
+    bool isChallenge = false;
+    QMap<QString, QString> details;
+};
+
+QDBusArgument &operator<<(QDBusArgument &arg, const PolkitSubject &subject)
+{
+    arg.beginStructure();
+    arg << subject.kind << subject.details;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &arg, PolkitSubject &subject)
+{
+    arg.beginStructure();
+    arg >> subject.kind >> subject.details;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument &operator<<(QDBusArgument &arg, const PolkitResult &result)
+{
+    arg.beginStructure();
+    arg << result.isAuthorized << result.isChallenge << result.details;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &arg, PolkitResult &result)
+{
+    arg.beginStructure();
+    arg >> result.isAuthorized >> result.isChallenge >> result.details;
+    arg.endStructure();
+    return arg;
+}
+
+void register_type()
+{
+    static std::once_flag flag;
+    std::call_once(flag, []() {
+        qDBusRegisterMetaType<PolkitSubject>();
+        qDBusRegisterMetaType<PolkitResult>();
+        qDBusRegisterMetaType<QMap<QString, QString>>();
+    });
+}
+
+constexpr const char *POLKIT_SERVICE = "org.freedesktop.PolicyKit1";
+constexpr const char *POLKIT_PATH = "/org/freedesktop/PolicyKit1/Authority";
+constexpr const char *POLKIT_INTERFACE = "org.freedesktop.PolicyKit1.Authority";
+
+} // namespace
+
+Q_DECLARE_METATYPE(PolkitSubject)
+Q_DECLARE_METATYPE(PolkitResult)
+
+namespace linglong::service {
+
+void PolkitAuthority::checkAuthorizationAsync(
+  const std::string &actionId,
+  const std::string &systemBusName,
+  std::function<void(utils::error::Result<bool>)> callback,
+  bool userInteraction)
+{
+    LINGLONG_TRACE("check polkit authorization");
+
+    register_type();
+
+    auto bus = QDBusConnection::systemBus();
+
+    auto msg = QDBusMessage::createMethodCall(QString::fromLatin1(POLKIT_SERVICE),
+                                              QString::fromLatin1(POLKIT_PATH),
+                                              QString::fromLatin1(POLKIT_INTERFACE),
+                                              QStringLiteral("CheckAuthorization"));
+
+    PolkitSubject subject;
+    subject.kind = QStringLiteral("system-bus-name");
+    subject.details.insert(QStringLiteral("name"),
+                           QVariant::fromValue(QString::fromStdString(systemBusName)));
+
+    msg << QVariant::fromValue(subject) << QString::fromStdString(actionId)
+        << QVariant::fromValue(QMap<QString, QString>())
+        << static_cast<uint>(userInteraction ? 1 : 0) << QString();
+
+    auto pendingCall = bus.asyncCall(msg);
+    auto *watcher = new QDBusPendingCallWatcher(pendingCall);
+    QObject::connect(
+      watcher,
+      &QDBusPendingCallWatcher::finished,
+      [callback = std::move(callback)](QDBusPendingCallWatcher *self) {
+          LINGLONG_TRACE("check polkit authorization");
+
+          LogD("CheckAuthorization return");
+          self->deleteLater();
+
+          QDBusPendingReply<PolkitResult> res = *self;
+          if (res.isError()) {
+              callback(LINGLONG_ERR(
+                fmt::format("polkit check failed: {}", res.error().message().toStdString())));
+              return;
+          }
+
+          callback(res.value().isAuthorized);
+      });
+}
+
+} // namespace linglong::service

--- a/libs/linglong/src/linglong/package_manager/polkit_authority.h
+++ b/libs/linglong/src/linglong/package_manager/polkit_authority.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "linglong/utils/error/error.h"
+
+#include <functional>
+#include <string>
+
+namespace linglong::service {
+
+class PolkitAuthority
+{
+public:
+    PolkitAuthority() = delete;
+
+    static void checkAuthorizationAsync(const std::string &actionId,
+                                        const std::string &systemBusName,
+                                        std::function<void(utils::error::Result<bool>)> callback,
+                                        bool userInteraction = true);
+};
+
+} // namespace linglong::service

--- a/libs/linglong/src/linglong/package_manager/ref_installation.cpp
+++ b/libs/linglong/src/linglong/package_manager/ref_installation.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -173,9 +173,8 @@ utils::error::Result<void> RefInstallationAction::preInstall(Task &task)
             .localRef = operation->oldRef->toString(),
             .remoteRef = operation->newRef->reference.toString()
         };
-        if (!pm.waitConfirm(*mainTask,
-                            api::types::v1::InteractionMessageType::Upgrade,
-                            additionalMessage)) {
+        if (!mainTask->waitConfirm(api::types::v1::InteractionMessageType::Upgrade,
+                                   additionalMessage)) {
             return LINGLONG_ERR("action canceled");
         }
     }

--- a/libs/linglong/src/linglong/package_manager/uab_installation.cpp
+++ b/libs/linglong/src/linglong/package_manager/uab_installation.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -288,9 +288,7 @@ utils::error::Result<void> UabInstallationAction::preInstall(PackageTask &task)
             .localRef = operation->oldRef->toString(),
             .remoteRef = operation->newRef->reference.toString()
         };
-        if (!pm.waitConfirm(task,
-                            api::types::v1::InteractionMessageType::Upgrade,
-                            additionalMessage)) {
+        if (!task.waitConfirm(api::types::v1::InteractionMessageType::Upgrade, additionalMessage)) {
             return LINGLONG_ERR("action canceled");
         }
     }

--- a/libs/utils/src/linglong/utils/error/error.h
+++ b/libs/utils/src/linglong/utils/error/error.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+ * SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
@@ -21,6 +21,7 @@ enum class ErrorCode : int {
     Failed = -1, // 通用失败错误码
     Success = 0, // 成功
     Canceled = 1,
+    PermissionDenied = 2, // 权限被拒绝
 
     Unknown = 1000,               // 未知错误
     AppNotFoundFromRemote = 1001, // 从远程找不到对应应用

--- a/misc/share/dbus-1/system.d/org.deepin.linglong.PackageManager1.conf
+++ b/misc/share/dbus-1/system.d/org.deepin.linglong.PackageManager1.conf
@@ -13,31 +13,9 @@ SPDX-License-Identifier: LGPL-3.0-or-later
     <allow receive_sender="org.deepin.linglong.PackageManager1"/>
   </policy>
 
+  <!-- Allow anyone to access the service. Permission control is handled by polkit. -->
   <policy context="default">
-    <deny send_destination="org.deepin.linglong.PackageManager1"/>
-
-    <!-- Completely open to anyone: org.freedesktop.DBus.* interfaces -->
-    <allow send_destination="org.deepin.linglong.PackageManager1"
-           send_interface="org.freedesktop.DBus.Peer"/>
-
-    <allow send_destination="org.deepin.linglong.PackageManager1"
-           send_interface="org.freedesktop.DBus.Properties"
-           send_member="Get"/>
-
-    <allow send_destination="org.deepin.linglong.PackageManager1"
-           send_interface="org.freedesktop.DBus.Properties"
-           send_member="GetAll"/>
-
-    <!-- Allow anyone to invoke method Search -->
-    <allow send_destination="org.deepin.linglong.PackageManager1"
-           send_interface="org.deepin.linglong.PackageManager1" send_member="Search"/>
-
-    <allow send_destination="org.deepin.linglong.PackageManager1"
-           send_interface="org.deepin.linglong.PackageManager1" send_member="InitRunContext"/>
-  </policy>
-  <!-- Allow root to invoke all methods -->
-  <policy user="root">
-  <allow send_destination="org.deepin.linglong.PackageManager1"/>
-  <allow receive_sender="org.deepin.linglong.PackageManager1"/>
+    <allow send_destination="org.deepin.linglong.PackageManager1"/>
+    <allow receive_sender="org.deepin.linglong.PackageManager1"/>
   </policy>
 </busconfig>

--- a/misc/share/polkit-1/actions/org.deepin.linglong.PackageManager1.policy
+++ b/misc/share/polkit-1/actions/org.deepin.linglong.PackageManager1.policy
@@ -2,127 +2,72 @@
 <!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
 "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
 <policyconfig>
-	<vendor />
-	<vendor_url />
-	<icon_name>stock_person</icon_name>
-	<action id="org.deepin.linglong.PackageManager1.checkAuthentication">
-		<description>Check Authentication</description>
-		<message>Authentication is required to perform this action</message>
-		<defaults>
-			<allow_any>auth_admin</allow_any>
-			<allow_inactive>auth_admin</allow_inactive>
-			<allow_active>auth_admin_keep</allow_active>
-		</defaults>
-		<annotate key="org.freedesktop.policykit.exec.path">@CMAKE_INSTALL_FULL_BINDIR@/@LINGLONG_CLI_BIN@</annotate>
-		<description xml:lang="ar">التحقق من المصادقة</description>
-		<message xml:lang="ar">المصادقة مطلوبة لتنفيذ هذا الإجراء</message>
-		<description xml:lang="ast">Comprobar l'autenticación</description>
-		<message xml:lang="ast">Ríquese l'autenticación pa realizar esta aición</message>
-		<description xml:lang="az">Doğrulamaya nəzarət et</description>
-		<message xml:lang="az">Bu əməliyyatı yerinə yetirmək üçün doğrulama tələບ olunur</message>
-		<description xml:lang="bg">Проверете удостоверяването</description>
-		<message xml:lang="bg">Удостоверяването е задължително за извършване на това действие</message>
-		<description xml:lang="bn">প্রমাণীকরণ পরীক্ষা করুন</description>
-		<message xml:lang="bn">এই কাজটি সম্পন্ন করার জন্য প্রমাণীকরণের প্রয়োজন</message>
-		<description xml:lang="bo">ར་ສྤྲོད་བསྐྱར་ཞິບབྱེད་པ།</description>
-		<message xml:lang="bo">ལས་ཀ་འདི་སྒྲུབ་པར་ར་སྤྲོད་བྱེད་དགོས།</message>
-		<description xml:lang="ca">Comprova l'autenticació</description>
-		<message xml:lang="ca">Cal autenticació per a dur a terme aquesta acció.</message>
-		<description xml:lang="cs">Ověřit autentizaci</description>
-		<message xml:lang="cs">Provedení této akce vyžaduje autentizaci</message>
-		<description xml:lang="da">Kontroller godkendelse</description>
-		<message xml:lang="da">Der kræves godkendelse for at udføre denne handling</message>
-		<description xml:lang="de">Authentifizierung prüfen</description>
-		<message xml:lang="de">Zur Durchführung dieser Aktion ist eine Authentifizierung erforderlich</message>
-		<description xml:lang="el">Έλεγχος ταυτότητας</description>
-		<message xml:lang="el">Απαιτείται πιστοποίηση για την εκτέλεση αυτής της ενέργειας</message>
-		<description xml:lang="en_AU">Check Authentication</description>
-		<message xml:lang="en_AU">Authentication is required to perform this action</message>
-		<description xml:lang="en_GB">Check Authentication</description>
-		<message xml:lang="en_GB">Authentication is required to perform this action</message>
-		<description xml:lang="en_US">Check Authentication</description>
-		<message xml:lang="en_US">Authentication is required to perform this action</message>
-		<description xml:lang="eo">Kontroli Aŭtentigon</description>
-		<message xml:lang="eo">Aŭtentigo bezonatas por plenumi ĉi tiun agon</message>
-		<description xml:lang="es">Comprobar autenticación</description>
-		<message xml:lang="es">Se requiere autenticación para realizar esta acción</message>
-		<description xml:lang="fa">بررسی احراز هویت</description>
-		<message xml:lang="fa">احراز هویت برای انجام این عمل لازم است</message>
-		<description xml:lang="fi">Tarkista todennus</description>
-		<message xml:lang="fi">Tämän toiminnon suorittaminen edellyttää todennusta</message>
-		<description xml:lang="fr">Vérifier l'authentification</description>
-		<message xml:lang="fr">L'authentification est requise pour effectuer cette action</message>
-		<description xml:lang="gl_ES">Comprobar autenticación</description>
-		<message xml:lang="gl_ES">Requírese autenticación para realizar esta acción</message>
-		<description xml:lang="hi_IN">प्रमाणीकरण की जाँच करें</description>
-		<message xml:lang="hi_IN">यह कार्य करने हेतु प्रमाणीकरण आवश्यक है</message>
-		<description xml:lang="hr">Provjera ovjere</description>
-		<message xml:lang="hr">Potrebna je ovjera za obavljanje ove radnje</message>
-		<description xml:lang="hu">Hitelesítés ellenőrzése</description>
-		<message xml:lang="hu">A művelet végrehajtásához hitelesítés szükséges</message>
-		<description xml:lang="id">Periksa Otentikasi</description>
-		<message xml:lang="id">Otentikasi diperlukan untuk melakukan tindakan ini</message>
-		<description xml:lang="it">Verifica Autenticazione</description>
-		<message xml:lang="it">Autenticazione richiesta per eseguire questa operazione</message>
-		<description xml:lang="ja">認証を確認</description>
-		<message xml:lang="ja">この操作を実行するには認証が必要です</message>
-		<description xml:lang="kab">Sesteb n usemdu</description>
-		<message xml:lang="kab">Yetwasra usesteb akken ad tbeddeleḍ tazzla-a.</message>
-		<description xml:lang="ko">인증 확인</description>
-		<message xml:lang="ko">이 작업을 수행하려면 인증이 필요합니다</message>
-		<description xml:lang="lo">ກວດສອບການກວດສອບຄວາມຖືກຕ້ອງ</description>
-		<message xml:lang="lo">ຕ້ອງການການພິສູດຢືນຢັນຕົວຕົນເພື່ອປະຕິບັດການກະທຳນີ້</message>
-		<description xml:lang="lt">Patikrinti tapatybės nustatymą</description>
-		<message xml:lang="lt">Norint atlikti šį veiksmą, reikalingas tapatybės nustatymas</message>
-		<description xml:lang="lv">Pārbaudīt autentifikāciju</description>
-		<message xml:lang="lv">Lai veiktu šo darbību, nepieciešama autentifikācija</message>
-		<description xml:lang="mn">Баталгаажуулалт шалгах</description>
-		<message xml:lang="mn">Энэ үйлдлийг хийхэд баталгаажуулалт шаардлагатай</message>
-		<description xml:lang="ms">Semak Pengesahihan</description>
-		<message xml:lang="ms">Pengesahihan diperlukan untuk melakukan tindakan ini</message>
-		<description xml:lang="ne">प्रमाणीकरण जाँच गर्नुहोस्</description>
-		<message xml:lang="ne">यो कार्य गर्न प्रमाणीकरण आवश्यक छ</message>
-		<description xml:lang="nl">Authenticatie controleren</description>
-		<message xml:lang="nl">Authenticatie vereist om deze actie uit te voeren</message>
-		<description xml:lang="pa">ਪ੍ਰਮਾਣਕਤਾ ਦੀ ਜਾਂਚ ਕਰੋ</description>
-		<message xml:lang="pa">ਇਹ ਕਾਰਵਾਈ ਕਰਨ ਲਈ ਪ੍ਰਮਾਣਕਤਾ ਦੀ ਲੋੜ ਹੈ</message>
-		<description xml:lang="pl">Sprawdź uwierzytelnienie</description>
-		<message xml:lang="pl">Wymagane jest uwierzytelnienie, aby wykonać tę czynność</message>
-		<description xml:lang="pt">Verificar autenticação</description>
-		<message xml:lang="pt">É necessária a autenticação para efetuar esta ação</message>
-		<description xml:lang="pt_BR">Verificar autenticação</description>
-		<message xml:lang="pt_BR">A autenticação é necessária para realizar esta ação</message>
-		<description xml:lang="ro">Verificare autentificare</description>
-		<message xml:lang="ro">Autentificarea este necesară pentru a efectua această acțiune</message>
-		<description xml:lang="ru">Проверить аутентификацию</description>
-		<message xml:lang="ru">Для выполнения этого действия требуется аутентификация</message>
-		<description xml:lang="si">සත්‍යාපනය පරීක්ෂා කරන්න</description>
-		<message xml:lang="si">මෙම ක්‍රියාව සිදු කිරීමට සත්‍යාපනය අවශ්‍ය වේ</message>
-		<description xml:lang="sk">Skontrolovať overenie totožnosti</description>
-		<message xml:lang="sk">Na vykonanie tejto akcie sa vyžaduje overenie totožnosti</message>
-		<description xml:lang="sl">Preverite avtentikacijo</description>
-		<message xml:lang="sl">Za izvedbo tega dejanja je potrebna avtentikacija</message>
-		<description xml:lang="sq">Kontrollo Mirëfilltësimin</description>
-		<message xml:lang="sq">Për të kryer këtë veprim, lypset mirëfilltësim</message>
-		<description xml:lang="sr">Провери идентификацију</description>
-		<message xml:lang="sr">Идентификација је неопходна за извршење ове радње</message>
-		<description xml:lang="sv">Kontrollera autentisering</description>
-		<message xml:lang="sv">Autentisering krävs för att utföra denna åtgärd</message>
-		<description xml:lang="sw">Angalia Uthibitishaji</description>
-		<message xml:lang="sw">Uthibitishaji unahitajika kutekeleza kitendo hiki</message>
-		<description xml:lang="tr">Kimlik Doğrulamayı Kontrol Et</description>
-		<message xml:lang="tr">Bu eylemi gerçekleştirmek için kimlik doğrulaması gereklidir</message>
-		<description xml:lang="ug">سالاھىيەتنى دەلىللەش</description>
-		<message xml:lang="ug">بۇ ھەرىكەتنى ئىجرا قىلىش ئۈچۈن سالاھىيەتنى دەلىللەش كېرەك</message>
-		<description xml:lang="uk">Перевірити розпізнавання</description>
-		<message xml:lang="uk">Для виконання цієї дії потрібно пройти розпізнавання</message>
-		<description xml:lang="vi">Kiểm tra Xác thực</description>
-		<message xml:lang="vi">Cần xác thực để thực hiện hành động này</message>
-		<description xml:lang="zh_CN">检查认证</description>
-		<message xml:lang="zh_CN">当前操作需要密码认证</message>
-		<description xml:lang="zh_HK">檢查認證</description>
-		<message xml:lang="zh_HK">執行此操作需要認證</message>
-		<description xml:lang="zh_TW">檢查驗證</description>
-		<message xml:lang="zh_TW">執行此操作需要驗證</message>
-	</action>
+  <vendor>UnionTech</vendor>
+  <vendor_url>https://www.uniontech.com</vendor_url>
+
+  <action id="org.deepin.linglong.PackageManager1.install">
+    <description>Install packages</description>
+    <message>Authentication is required to install packages</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.owner">unix-user:@LINGLONG_USERNAME@</annotate>
+  </action>
+
+  <action id="org.deepin.linglong.PackageManager1.update">
+    <description>Update packages</description>
+    <message>Authentication is required to update packages</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.owner">unix-user:@LINGLONG_USERNAME@</annotate>
+  </action>
+
+  <action id="org.deepin.linglong.PackageManager1.uninstall">
+    <description>Uninstall packages</description>
+    <message>Authentication is required to uninstall packages</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.owner">unix-user:@LINGLONG_USERNAME@</annotate>
+  </action>
+
+  <action id="org.deepin.linglong.PackageManager1.install-from-file">
+    <description>Install packages from local files</description>
+    <message>Authentication is required to install packages from local files</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.owner">unix-user:@LINGLONG_USERNAME@</annotate>
+  </action>
+
+  <action id="org.deepin.linglong.PackageManager1.prune">
+    <description>Prune package cache</description>
+    <message>Authentication is required to prune package cache</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.owner">unix-user:@LINGLONG_USERNAME@</annotate>
+  </action>
+
+  <action id="org.deepin.linglong.PackageManager1.set-configuration">
+    <description>Modify package manager configuration</description>
+    <message>Authentication is required to modify package manager configuration</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.owner">unix-user:@LINGLONG_USERNAME@</annotate>
+  </action>
 </policyconfig>


### PR DESCRIPTION
Add PolkitAuthority helper class to check authorization before Install, InstallFromFile, Uninstall, Update, Prune and SetConfiguration operations.

Move interaction interface from PM to Task.