### PR TITLE
feat: custom user/group content exposed in container

### DIFF
--- a/libs/linglong/src/linglong/runtime/container_builder.cpp
+++ b/libs/linglong/src/linglong/runtime/container_builder.cpp
@@ -328,7 +328,6 @@ auto ContainerBuilder::prepareContainer(runtime::RunContext &context,
       .setBundlePath(prepared.context->getBundleDir())
       .addUIdMapping(uid, uid, 1)
       .addGIdMapping(gid, gid, 1)
-      .bindUserGroup()
       .bindDefault()
       .bindCgroup();
 
@@ -385,6 +384,7 @@ auto ContainerBuilder::configureBuildContainer(PreparedContainer &prepared,
     LINGLONG_TRACE("configure build container");
 
     prepared.cfgBuilder.setBasePath(options.basePath, false)
+      .bindUserGroup()
       .forwardDefaultEnv()
       .appendEnv("LINYAPS_INIT_SINGLE_MODE", "1")
       .disableUserNamespace()
@@ -461,7 +461,11 @@ auto ContainerBuilder::configureInitContainer(PreparedContainer &prepared) noexc
 
     auto &runContext = *prepared.runContext;
 
-    prepared.cfgBuilder.bindXDGRuntime().bindHostRoot().bindHostStatics().forwardDefaultEnv();
+    prepared.cfgBuilder.bindUserGroup()
+      .bindXDGRuntime()
+      .bindHostRoot()
+      .bindHostStatics()
+      .forwardDefaultEnv();
 
     if (runContext.getConfig().overlayfs) {
         auto res = prepared.context->setupOverlayFS(runContext, true);
@@ -518,6 +522,7 @@ auto ContainerBuilder::configureRunContainer(PreparedContainer &prepared,
     std::filesystem::path homePath{ homeEnv };
 
     prepared.cfgBuilder.setAnnotation(generator::ANNOTATION::LAST_PID, std::to_string(::getpid()))
+      .bindUserGroup(true)
       .bindXDGRuntime()
       .bindRemovableStorageMounts()
       .bindHostRoot()

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -32,6 +32,8 @@
 #include <sstream>
 #include <vector>
 
+#include <grp.h>
+#include <pwd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -372,20 +374,68 @@ ContainerCfgBuilder &ContainerCfgBuilder::bindTmp() noexcept
     return *this;
 }
 
-ContainerCfgBuilder &ContainerCfgBuilder::bindUserGroup() noexcept
+ContainerCfgBuilder &ContainerCfgBuilder::bindUserGroup(bool minimal) noexcept
 {
-    UGMount = {
-        Mount{ .destination = "/etc/passwd",
-               .options = string_list{ "rbind", "ro" },
-               .source = "/etc/passwd",
-               .type = "bind" },
-        Mount{ .destination = "/etc/group",
-               .options = string_list{ "rbind", "ro" },
-               .source = "/etc/group",
-               .type = "bind" },
-    };
+    UGBind = minimal;
 
     return *this;
+}
+
+utils::error::Result<void> ContainerCfgBuilder::buildUserGroup() noexcept
+{
+    LINGLONG_TRACE("build user group");
+
+    if (!UGBind.has_value()) {
+        return LINGLONG_OK;
+    }
+
+    std::filesystem::path passwdSrc{ "/etc/passwd" };
+    std::filesystem::path groupSrc{ "/etc/group" };
+
+    if (UGBind.value()) {
+        auto uid = ::getuid();
+        auto gid = ::getgid();
+
+        passwdSrc = bundlePath / "passwd";
+        groupSrc = bundlePath / "group";
+
+        {
+            std::ofstream ofs(passwdSrc);
+            if (!ofs.is_open()) {
+                return LINGLONG_ERR(fmt::format("{} can't be created", passwdSrc));
+            }
+
+            if (auto *pw = ::getpwuid(uid); pw != nullptr) {
+                ofs << pw->pw_name << ":x:" << pw->pw_uid << ":" << pw->pw_gid << ":"
+                    << (pw->pw_gecos ? pw->pw_gecos : "") << ":" << (pw->pw_dir ? pw->pw_dir : "")
+                    << ":" << (pw->pw_shell ? pw->pw_shell : "") << "\n";
+            }
+            ofs << "nobody:x:65534:65534:nobody:/:/usr/sbin/nologin\n";
+        }
+
+        {
+            std::ofstream ofs(groupSrc);
+            if (!ofs.is_open()) {
+                return LINGLONG_ERR(fmt::format("{} can't be created", groupSrc));
+            }
+
+            if (auto *gr = ::getgrgid(gid); gr != nullptr) {
+                ofs << gr->gr_name << ":x:" << gr->gr_gid << ":\n";
+            }
+            ofs << "nobody:x:65534:\n";
+        }
+    }
+
+    UGMount = { Mount{ .destination = "/etc/passwd",
+                       .options = string_list{ "rbind", "ro" },
+                       .source = passwdSrc,
+                       .type = "bind" },
+                Mount{ .destination = "/etc/group",
+                       .options = string_list{ "rbind", "ro" },
+                       .source = groupSrc,
+                       .type = "bind" } };
+
+    return LINGLONG_OK;
 }
 
 ContainerCfgBuilder &ContainerCfgBuilder::bindRemovableStorageMounts() noexcept
@@ -2243,6 +2293,7 @@ utils::error::Result<void> ContainerCfgBuilder::build() noexcept
     BUILD_STEP(buildLDCache);
     BUILD_STEP(buildEnv);
     BUILD_STEP(buildHooks);
+    BUILD_STEP(buildUserGroup);
     BUILD_STEP(mergeMount);
     BUILD_STEP(finalize);
     BUILD_STEP(applyPatch);

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
@@ -106,7 +106,7 @@ public:
     ContainerCfgBuilder &bindXDGRuntime() noexcept;
     ContainerCfgBuilder &bindRun() noexcept;
     ContainerCfgBuilder &bindTmp() noexcept;
-    ContainerCfgBuilder &bindUserGroup() noexcept;
+    ContainerCfgBuilder &bindUserGroup(bool minimal = false) noexcept;
     ContainerCfgBuilder &bindRemovableStorageMounts() noexcept;
 
     ContainerCfgBuilder &forwardDefaultEnv() noexcept;
@@ -213,6 +213,7 @@ private:
     utils::error::Result<void> buildLDCache() noexcept;
     utils::error::Result<void> buildMountTimeZone() noexcept;
     utils::error::Result<void> buildMountNetworkConf() noexcept;
+    utils::error::Result<void> buildUserGroup() noexcept;
     utils::error::Result<void> buildQuirkVolatile() noexcept;
     utils::error::Result<void> buildXDGRuntime() noexcept;
     utils::error::Result<void> buildEnv() noexcept;
@@ -276,6 +277,7 @@ private:
     std::optional<std::vector<ocppi::runtime::config::types::Mount>> runMount;
     std::optional<ocppi::runtime::config::types::Mount> tmpMount;
     std::optional<std::vector<ocppi::runtime::config::types::Mount>> UGMount;
+    std::optional<bool> UGBind{ std::nullopt };
     std::optional<std::vector<ocppi::runtime::config::types::Mount>> removableStorageMounts;
     std::optional<std::vector<ocppi::runtime::config::types::Mount>> hostRootMount;
     std::optional<std::vector<ocppi::runtime::config::types::Mount>> hostStaticsMount;


### PR DESCRIPTION
Write minimal /etc/passwd and /etc/group containing only the current user and "nobody". This reduces the information visible inside the container and ensures the user always exists, even when an nss module is used on the host.