### PR TITLE
fix: fix regression by 9937c5456e16dd1dd764b946ed382c0095048c53

### DIFF
--- a/api/dbus/org.deepin.linglong.PackageManager1.xml
+++ b/api/dbus/org.deepin.linglong.PackageManager1.xml
@@ -67,6 +67,11 @@ SPDX-License-Identifier: LGPL-3.0-or-later
       <arg direction="in" name="parameters" type="a{sv}" />
       <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap" />
     </method>
+    <method name="ReplyInteraction">
+      <arg direction="in" name="task" type="o" />
+      <arg direction="in" name="replies" type="a{sv}" />
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap" />
+    </method>
     <property name="Configuration" type="a{sv}" access="read">
       <annotation name="org.qtproject.QtDBus.QtTypeName" value="QVariantMap" />
     </property>
@@ -75,6 +80,12 @@ SPDX-License-Identifier: LGPL-3.0-or-later
     </signal>
     <signal name="TaskRemoved">
       <arg name="task" type="o" />
+    </signal>
+    <signal name="RequestInteraction">
+      <arg name="task" type="o" />
+      <arg name="messageID" type="i" />
+      <arg name="additionalMessage" type="a{sv}" />
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out2" value="QVariantMap" />
     </signal>
   </interface>
 </node>

--- a/api/dbus/org.deepin.linglong.Task1.xml
+++ b/api/dbus/org.deepin.linglong.Task1.xml
@@ -7,18 +7,9 @@ SPDX-License-Identifier: LGPL-3.0-or-later
 <node>
     <interface name="org.deepin.linglong.Task1">
         <method name="Cancel" />
-        <method name="ReplyInteraction">
-            <arg direction="in" name="replies" type="a{sv}" />
-            <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap" />
-        </method>
         <property name="State" type="i" access="read" />
         <property name="Percentage" type="d" access="read" />
         <property name="Message" type="s" access="read" />
         <property name="Code" type="i" access="read" />
-        <signal name="RequestInteraction">
-            <arg name="messageID" type="i" />
-            <arg name="additionalMessage" type="a{sv}" />
-            <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="QVariantMap" />
-        </signal>
     </interface>
 </node>

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -51,6 +51,8 @@
 #include <linux/un.h>
 #include <nlohmann/json.hpp>
 
+#include <QDBusInterface>
+#include <QDBusReply>
 #include <QEventLoop>
 #include <QFileInfo>
 #include <QProcess>
@@ -293,9 +295,14 @@ void Cli::onTaskPropertiesChanged(
     handleTaskState();
 }
 
-void Cli::onTaskRequestInteraction(int messageID, const QVariantMap &additionalMessage)
+void Cli::interaction(const QDBusObjectPath &object_path,
+                      int messageID,
+                      const QVariantMap &additionalMessage)
 {
     LINGLONG_TRACE("interactive with user")
+    if (object_path.path() != taskObjectPath) {
+        return;
+    }
 
     auto messageType = static_cast<api::types::v1::InteractionMessageType>(messageID);
     auto msg = common::serialize::fromQVariantMap<
@@ -346,13 +353,14 @@ void Cli::onTaskRequestInteraction(int messageID, const QVariantMap &additionalM
     LogD("action: {}", action);
 
     auto reply = api::types::v1::InteractionReply{ .action = action };
-    if (!this->task) {
-        this->printer.printErr(LINGLONG_ERRV("task object is null"));
+    auto pkgMan = this->getPkgMan();
+    if (!pkgMan) {
+        this->printer.printErr(pkgMan.error());
         return;
     }
 
     QDBusPendingReply<void> dbusReply =
-      this->task->ReplyInteraction(common::serialize::toQVariantMap(reply));
+      (*pkgMan)->ReplyInteraction(object_path, common::serialize::toQVariantMap(reply));
     dbusReply.waitForFinished();
     if (dbusReply.isError()) {
         this->printer.printErr(
@@ -535,7 +543,7 @@ utils::error::Result<void> Cli::initPkgManSignals()
     if (!conn.connect(pkgMan->service(),
                       pkgMan->path(),
                       pkgMan->interface(),
-                      "TaskAdd",
+                      "TaskAdded",
                       this,
                       SLOT(onTaskAdded(QDBusObjectPath)))) {
         return LINGLONG_ERR("couldn't connect to package manager signal 'TaskAdded'");
@@ -548,6 +556,16 @@ utils::error::Result<void> Cli::initPkgManSignals()
                       this,
                       SLOT(onTaskRemoved(QDBusObjectPath)))) {
         return LINGLONG_ERR("couldn't connect to package manager signal 'TaskRemoved'");
+    }
+
+    if (!conn.connect(pkgMan->service(),
+                      pkgMan->path(),
+                      pkgMan->interface(),
+                      "RequestInteraction",
+                      this,
+                      SLOT(interaction(QDBusObjectPath, int, QVariantMap)))) {
+        return LINGLONG_ERR(fmt::format("Failed to connect signal RequestInteraction: {}",
+                                        conn.lastError().message().toStdString()));
     }
 
     this->pkgManSignalsInitialized = true;
@@ -2246,6 +2264,30 @@ int Cli::getBundleDir(const InspectOptions &options)
     return 0;
 }
 
+utils::error::Result<void> Cli::syncTaskProperties()
+{
+    LINGLONG_TRACE("syncTaskProperties");
+
+    auto pkgMan = this->getPkgMan();
+    if (!pkgMan) {
+        return LINGLONG_ERR(pkgMan);
+    }
+
+    QDBusInterface properties((*pkgMan)->service(),
+                              this->taskObjectPath,
+                              "org.freedesktop.DBus.Properties",
+                              (*pkgMan)->connection());
+    QDBusReply<QVariantMap> reply =
+      properties.call("GetAll", QStringLiteral("org.deepin.linglong.Task1"));
+    if (!reply.isValid()) {
+        return LINGLONG_ERR(
+          fmt::format("failed to get task properties: {}", reply.error().message().toStdString()));
+    }
+
+    this->onTaskPropertiesChanged(QStringLiteral("org.deepin.linglong.Task1"), reply.value(), {});
+    return LINGLONG_OK;
+}
+
 utils::error::Result<void> Cli::waitTaskCreated(QDBusPendingReply<QVariantMap> &reply,
                                                 TaskType taskType)
 {
@@ -2285,21 +2327,17 @@ utils::error::Result<void> Cli::waitTaskCreated(QDBusPendingReply<QVariantMap> &
                                         conn.lastError().message().toStdString()));
     }
 
-    if (!conn.connect((*pkgMan)->service(),
-                      taskObjectPath,
-                      "org.deepin.linglong.Task1",
-                      "RequestInteraction",
-                      this,
-                      SLOT(onTaskRequestInteraction(int, QVariantMap)))) {
-        return LINGLONG_ERR(fmt::format("Failed to connect signal RequestInteraction: {}",
-                                        conn.lastError().message().toStdString()));
-    }
-
-    return LINGLONG_OK;
+    return this->syncTaskProperties();
 }
 
 void Cli::waitTaskDone()
 {
+    if (this->taskState.state == api::types::v1::State::Failed
+        || this->taskState.state == api::types::v1::State::Canceled
+        || this->taskState.state == api::types::v1::State::Succeed) {
+        return;
+    }
+
     QEventLoop loop;
     if (QObject::connect(this, &Cli::taskDone, &loop, &QEventLoop::quit) == nullptr) {
         LogE("connect taskDone failed");

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -229,6 +229,7 @@ private:
     void detectDrivers();
     utils::error::Result<api::dbus::v1::PackageManager *> getPkgMan();
     utils::error::Result<void> initPkgManSignals();
+    utils::error::Result<void> syncTaskProperties();
     int runResolvedContext(runtime::RunContext &runContext,
                            const RunOptions &options,
                            std::optional<api::types::v1::RuntimeConfigure> runtimeConfig);
@@ -272,7 +273,9 @@ private Q_SLOTS:
     void onTaskPropertiesChanged(const QString &interface,
                                  const QVariantMap &changed_properties,
                                  const QStringList &invalidated_properties);
-    void onTaskRequestInteraction(int messageID, const QVariantMap &additionalMessage);
+    void interaction(const QDBusObjectPath &object_path,
+                     int messageID,
+                     const QVariantMap &additionalMessage);
 
 Q_SIGNALS:
     void taskDone();

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -9,6 +9,7 @@
 #include "configure.h"
 #include "linglong/api/types/helper.h"
 #include "linglong/api/types/v1/Generators.hpp" // IWYU pragma: keep
+#include "linglong/api/types/v1/InteractionReply.hpp"
 #include "linglong/api/types/v1/PackageInfoV2.hpp"
 #include "linglong/api/types/v1/PackageManager1JobInfo.hpp"
 #include "linglong/api/types/v1/PackageManager1PruneResult.hpp"
@@ -45,12 +46,14 @@
 
 #include <QDBusInterface>
 #include <QDBusReply>
+#include <QDBusServiceWatcher>
 #include <QDBusUnixFileDescriptor>
 #include <QEventLoop>
 #include <QMetaObject>
 #include <QTimer>
 
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <unordered_map>
@@ -655,7 +658,7 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
           PackageTask &taskRef = dynamic_cast<PackageTask &>(task);
           if (msgType == api::types::v1::InteractionMessageType::Upgrade
               && !options.skipInteraction) {
-              if (!taskRef.waitConfirm(msgType, additionalMessage)) {
+              if (!this->waitConfirm(taskRef, msgType, additionalMessage)) {
                   return;
               }
           }
@@ -1885,6 +1888,117 @@ auto PackageManager::InitRunContext(const QString &runContextCfg,
       .code = 0,
       .message = "InitRunContext queued",
     });
+}
+
+void PackageManager::ReplyInteraction(QDBusObjectPath object_path, const QVariantMap &replies)
+{
+    Q_EMIT this->ReplyReceived(object_path, replies);
+}
+
+void PackageManager::onPeerDisconnected() noexcept
+{
+    LogW("peer caller disconnected");
+    Q_EMIT CallerDisconnected();
+}
+
+bool PackageManager::waitConfirm(
+  PackageTask &taskRef,
+  api::types::v1::InteractionMessageType msgType,
+  const api::types::v1::PackageManager1RequestInteractionAdditionalMessage
+    &additionalMessage) noexcept
+{
+    auto objectPath = QDBusObjectPath(taskRef.taskObjectPath().c_str());
+    QEventLoop loop;
+    QTimer timeoutTimer;
+    timeoutTimer.setSingleShot(true);
+
+    auto callerContext = taskRef.callerContext();
+    std::unique_ptr<QDBusServiceWatcher> watcher;
+
+    QMetaObject::Connection callerDisconnectedConn;
+
+    if (callerContext.isPeerMode()) {
+        callerDisconnectedConn =
+          connect(this, &PackageManager::CallerDisconnected, &loop, [&taskRef, &loop]() {
+              taskRef.updateState(linglong::api::types::v1::State::Canceled, "caller disconnected");
+              loop.exit(1);
+          });
+
+        auto connected = callerContext.connection.connect("",
+                                                          "/org/freedesktop/DBus/Local",
+                                                          "org.freedesktop.DBus.Local",
+                                                          "Disconnected",
+                                                          this,
+                                                          SLOT(onPeerDisconnected()));
+        if (!connected) {
+            LogW("failed to connect to Disconnected signal for peer mode");
+        }
+    } else {
+        auto callerName = callerContext.callerBusName();
+        if (!callerName.isEmpty()) {
+            watcher =
+              std::make_unique<QDBusServiceWatcher>(callerName,
+                                                    callerContext.connection,
+                                                    QDBusServiceWatcher::WatchForUnregistration);
+            connect(watcher.get(),
+                    &QDBusServiceWatcher::serviceUnregistered,
+                    &loop,
+                    [&taskRef, &loop, callerName]() {
+                        LogW("caller {} disconnected", callerName.toStdString());
+                        taskRef.updateState(linglong::api::types::v1::State::Canceled,
+                                            "caller disconnected");
+                        loop.exit(1);
+                    });
+        }
+    }
+
+    auto replyConn =
+      connect(this,
+              &PackageManager::ReplyReceived,
+              &loop,
+              [&taskRef, &loop, objectPath](const QDBusObjectPath &replyObjectPath,
+                                            const QVariantMap &reply) {
+                  if (replyObjectPath.path() != objectPath.path()) {
+                      return;
+                  }
+
+                  auto interactionReply =
+                    common::serialize::fromQVariantMap<api::types::v1::InteractionReply>(reply);
+                  if (!interactionReply || interactionReply->action != "yes") {
+                      taskRef.updateState(linglong::api::types::v1::State::Canceled, "canceled");
+                  }
+                  loop.exit(0);
+              });
+
+    auto timeoutConn = connect(&timeoutTimer, &QTimer::timeout, &loop, [&taskRef, &loop]() {
+        auto msg = fmt::format("task {} confirm timeout", taskRef.taskID());
+        LogW(msg);
+        taskRef.updateState(linglong::api::types::v1::State::Canceled, msg);
+        loop.exit(1);
+    });
+
+    Q_EMIT RequestInteraction(objectPath,
+                              static_cast<int>(msgType),
+                              common::serialize::toQVariantMap(additionalMessage));
+
+    timeoutTimer.start(std::chrono::milliseconds{ 180000 });
+    loop.exec();
+    timeoutTimer.stop();
+
+    disconnect(replyConn);
+    disconnect(timeoutConn);
+    disconnect(callerDisconnectedConn);
+
+    if (callerContext.isPeerMode()) {
+        callerContext.connection.disconnect("",
+                                            "/org/freedesktop/DBus/Local",
+                                            "org.freedesktop.DBus.Local",
+                                            "Disconnected",
+                                            this,
+                                            SLOT(onPeerDisconnected()));
+    }
+
+    return !taskRef.isTaskDone();
 }
 
 // no-op for now

--- a/libs/linglong/src/linglong/package_manager/package_manager.h
+++ b/libs/linglong/src/linglong/package_manager/package_manager.h
@@ -8,6 +8,8 @@
 
 #include "linglong/api/types/v1/CommonOptions.hpp"
 #include "linglong/api/types/v1/ContainerProcessStateInfo.hpp"
+#include "linglong/api/types/v1/InteractionMessageType.hpp"
+#include "linglong/api/types/v1/PackageManager1RequestInteractionAdditionalMessage.hpp"
 #include "linglong/api/types/v1/Repo.hpp"
 #include "linglong/api/types/v1/UabLayer.hpp"
 #include "linglong/package/fuzzy_reference.h"
@@ -20,6 +22,7 @@
 #include <QDBusArgument>
 #include <QDBusConnection>
 #include <QDBusContext>
+#include <QDBusObjectPath>
 #include <QList>
 #include <QObject>
 
@@ -58,6 +61,7 @@ public
     auto Update(const QVariantMap &parameters) noexcept -> QVariantMap;
     auto Search(const QVariantMap &parameters) noexcept -> QVariantMap;
     auto Prune() noexcept -> QVariantMap;
+    void ReplyInteraction(QDBusObjectPath object_path, const QVariantMap &replies);
 
     auto InitRunContext(const QString &runContextCfg, const QString &containerID) noexcept
       -> QVariantMap;
@@ -73,6 +77,10 @@ public
     virtual utils::error::Result<void> tryGenerateCache(const package::Reference &ref) noexcept;
     utils::error::Result<void> executePostInstallHooks(const package::Reference &ref) noexcept;
     utils::error::Result<void> executePostUninstallHooks(const package::Reference &ref) noexcept;
+    bool waitConfirm(PackageTask &taskRef,
+                     api::types::v1::InteractionMessageType msgType,
+                     const api::types::v1::PackageManager1RequestInteractionAdditionalMessage
+                       &additionalMessage) noexcept;
 
     virtual utils::error::Result<void> installAppDepends(Task &task,
                                                          const api::types::v1::PackageInfoV2 &app);
@@ -107,9 +115,17 @@ public
 Q_SIGNALS:
     void TaskAdded(QDBusObjectPath object_path);
     void TaskRemoved(QDBusObjectPath object_path);
+    void RequestInteraction(QDBusObjectPath object_path,
+                            int messageID,
+                            QVariantMap additionalMessage);
+    void CallerDisconnected();
     void SearchFinished(QString jobID, QVariantMap result);
     void PruneFinished(QString jobID, QVariantMap result);
     void InitRunContextFinished(QString jobID, bool success);
+    void ReplyReceived(QDBusObjectPath object_path, const QVariantMap &replies);
+
+private Q_SLOTS:
+    void onPeerDisconnected() noexcept;
 
 private:
     QVariantMap installFromLayer(const QDBusUnixFileDescriptor &fd,

--- a/libs/linglong/src/linglong/package_manager/package_task.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_task.cpp
@@ -6,16 +6,12 @@
 
 #include "linglong/adaptors/task/task1.h"
 #include "linglong/common/dbus/register.h"
-#include "linglong/common/serialize/json.h"
 #include "linglong/package_manager/package_manager.h"
 #include "linglong/utils/error/error.h"
 #include "linglong/utils/log/formatter.h" // IWYU pragma: keep
 
 #include <fmt/format.h>
 #include <sys/prctl.h>
-
-#include <QDBusServiceWatcher>
-#include <QTimer>
 
 #include <utility>
 
@@ -89,106 +85,9 @@ void PackageTask::Cancel() noexcept
     g_cancellable_cancel(m_cancelFlag);
 }
 
-void PackageTask::ReplyInteraction(const QVariantMap &replies) noexcept
-{
-    Q_EMIT this->ReplyReceived(replies);
-}
-
-void PackageTask::onPeerDisconnected() noexcept
-{
-    LogW("peer caller disconnected");
-    Q_EMIT peerDisconnected();
-}
-
 void PackageTask::setCallerContext(const CallerContext &ctx)
 {
     m_callerContext = ctx;
-}
-
-bool PackageTask::waitConfirm(
-  api::types::v1::InteractionMessageType msgType,
-  const api::types::v1::PackageManager1RequestInteractionAdditionalMessage &additionalMessage,
-  std::chrono::milliseconds timeout) noexcept
-{
-    Q_EMIT RequestInteraction(static_cast<int>(msgType),
-                              common::serialize::toQVariantMap(additionalMessage));
-    QEventLoop loop;
-
-    QTimer timeoutTimer;
-    timeoutTimer.setSingleShot(true);
-
-    std::unique_ptr<QDBusServiceWatcher> watcher;
-
-    auto peerDisconnectedConn =
-      QObject::connect(this, &PackageTask::peerDisconnected, &loop, [&loop, this]() {
-          updateState(linglong::api::types::v1::State::Canceled, "caller disconnected");
-          loop.exit(1);
-      });
-
-    if (m_callerContext.isPeerMode()) {
-        auto connected = m_callerContext.connection.connect("",
-                                                            "/org/freedesktop/DBus/Local",
-                                                            "org.freedesktop.DBus.Local",
-                                                            "Disconnected",
-                                                            this,
-                                                            SLOT(onPeerDisconnected()));
-        if (!connected) {
-            LogW("failed to connect to Disconnected signal for peer mode");
-        }
-    } else {
-        auto callerName = m_callerContext.callerBusName();
-        if (!callerName.isEmpty()) {
-            watcher =
-              std::make_unique<QDBusServiceWatcher>(callerName,
-                                                    m_callerContext.connection,
-                                                    QDBusServiceWatcher::WatchForUnregistration);
-            connect(
-              watcher.get(),
-              &QDBusServiceWatcher::serviceUnregistered,
-              &loop,
-              [&loop, this]() {
-                  LogW("caller {} disconnected", m_callerContext.callerBusName().toStdString());
-                  updateState(linglong::api::types::v1::State::Canceled, "caller disconnected");
-                  loop.exit(1);
-              });
-        }
-    }
-
-    auto replyConn =
-      connect(this, &PackageTask::ReplyReceived, &loop, [this, &loop](const QVariantMap &reply) {
-          auto interactionReply =
-            common::serialize::fromQVariantMap<api::types::v1::InteractionReply>(reply);
-          if (!interactionReply || interactionReply->action != "yes") {
-              updateState(linglong::api::types::v1::State::Canceled, "canceled");
-          }
-          loop.exit(0);
-      });
-
-    auto timeoutConn = connect(&timeoutTimer, &QTimer::timeout, &loop, [this, &loop]() {
-        auto msg = fmt::format("task {} confirm timeout", taskID());
-        LogW(msg);
-        updateState(linglong::api::types::v1::State::Canceled, msg);
-        loop.exit(1);
-    });
-
-    timeoutTimer.start(timeout);
-    loop.exec();
-    timeoutTimer.stop();
-
-    disconnect(replyConn);
-    disconnect(timeoutConn);
-    disconnect(peerDisconnectedConn);
-
-    if (m_callerContext.isPeerMode()) {
-        m_callerContext.connection.disconnect("",
-                                              "/org/freedesktop/DBus/Local",
-                                              "org.freedesktop.DBus.Local",
-                                              "Disconnected",
-                                              this,
-                                              SLOT(onPeerDisconnected()));
-    }
-
-    return !isTaskDone();
 }
 
 utils::error::Result<void> PackageTask::exposeOnDBus() noexcept

--- a/libs/linglong/src/linglong/package_manager/package_task.h
+++ b/libs/linglong/src/linglong/package_manager/package_task.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "linglong/api/types/v1/InteractionMessageType.hpp"
-#include "linglong/api/types/v1/PackageManager1RequestInteractionAdditionalMessage.hpp"
 #include "linglong/api/types/v1/State.hpp"
 #include "linglong/common/dbus/properties_forwarder.h"
 #include "linglong/package_manager/task.h"
@@ -22,7 +20,6 @@
 #include <QString>
 #include <QUuid>
 
-#include <chrono>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -31,8 +28,6 @@
 Q_DECLARE_METATYPE(linglong::api::types::v1::State)
 
 namespace linglong::service {
-
-using namespace std::chrono_literals;
 
 struct CallerContext
 {
@@ -93,15 +88,10 @@ public:
 
     void setCallerContext(const CallerContext &ctx);
 
-    bool waitConfirm(
-      api::types::v1::InteractionMessageType msgType,
-      const api::types::v1::PackageManager1RequestInteractionAdditionalMessage &additionalMessage,
-      std::chrono::milliseconds timeout = 180000ms) noexcept;
+    [[nodiscard]] const CallerContext &callerContext() const noexcept { return m_callerContext; }
 
 public Q_SLOTS:
     void Cancel() noexcept;
-    void ReplyInteraction(const QVariantMap &replies) noexcept;
-    void onPeerDisconnected() noexcept;
 
 Q_SIGNALS:
     void StateChanged(int newState);
@@ -112,10 +102,6 @@ Q_SIGNALS:
     void CodeChanged(int newCode);
 
     void changePropertiesDone();
-
-    void RequestInteraction(int messageID, QVariantMap additionalMessage);
-    void ReplyReceived(const QVariantMap &replies);
-    void peerDisconnected();
 
 private:
     friend class PackageTaskQueue;

--- a/libs/linglong/src/linglong/package_manager/ref_installation.cpp
+++ b/libs/linglong/src/linglong/package_manager/ref_installation.cpp
@@ -173,8 +173,9 @@ utils::error::Result<void> RefInstallationAction::preInstall(Task &task)
             .localRef = operation->oldRef->toString(),
             .remoteRef = operation->newRef->reference.toString()
         };
-        if (!mainTask->waitConfirm(api::types::v1::InteractionMessageType::Upgrade,
-                                   additionalMessage)) {
+        if (!pm.waitConfirm(*mainTask,
+                            api::types::v1::InteractionMessageType::Upgrade,
+                            additionalMessage)) {
             return LINGLONG_ERR("action canceled");
         }
     }

--- a/libs/linglong/src/linglong/package_manager/uab_installation.cpp
+++ b/libs/linglong/src/linglong/package_manager/uab_installation.cpp
@@ -288,7 +288,9 @@ utils::error::Result<void> UabInstallationAction::preInstall(PackageTask &task)
             .localRef = operation->oldRef->toString(),
             .remoteRef = operation->newRef->reference.toString()
         };
-        if (!task.waitConfirm(api::types::v1::InteractionMessageType::Upgrade, additionalMessage)) {
+        if (!pm.waitConfirm(task,
+                            api::types::v1::InteractionMessageType::Upgrade,
+                            additionalMessage)) {
             return LINGLONG_ERR("action canceled");
         }
     }


### PR DESCRIPTION
ReplyInteraction signal may lost if Task object is not ready. Move it from per-task interface to the PackageManager1 interface. Add syncTaskProperties to fetch initial task state also.