### PR TITLE
refactor: unify repo command handling in cli and builder

### DIFF
--- a/apps/ll-builder/src/command_options.h
+++ b/apps/ll-builder/src/command_options.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "linglong/builder/linglong_builder.h"
-#include "linglong/cli/cli.h"
+#include "linglong/common/cli/repo.h"
 
 #include <string>
 #include <vector>
@@ -54,7 +54,7 @@ struct ExportCommandOptions
 struct PushCommandOptions
 {
     std::vector<std::string> pushModules;
-    linglong::cli::RepoOptions repoOptions;
+    linglong::common::cli::RepoOptions repoOptions;
 };
 
 struct ImportCommandOptions
@@ -75,5 +75,5 @@ struct ExtractCommandOptions
 
 struct RepoSubcommandOptions
 {
-    linglong::cli::RepoOptions repoOptions;
+    linglong::common::cli::RepoOptions repoOptions;
 };

--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -9,6 +9,7 @@
 #include "linglong/builder/config.h"
 #include "linglong/builder/linglong_builder.h"
 #include "linglong/cli/cli.h"
+#include "linglong/cli/cli_printer.h"
 #include "linglong/common/global/initialize.h"
 #include "linglong/package/architecture.h"
 #include "linglong/package/version.h"
@@ -378,258 +379,6 @@ int handleExtract(const ExtractCommandOptions &options)
     return 0;
 }
 
-int handleRepoShow(linglong::repo::OSTreeRepo &repo)
-{
-    const auto &cfg = repo.getConfig();
-    // Note: keep the same format as ll-cli repo
-    size_t maxUrlLength = 0;
-    for (const auto &r : cfg.repos) {
-        maxUrlLength = std::max(maxUrlLength, r.url.size());
-    }
-    std::cout << "Default: " << cfg.defaultRepo << std::endl;
-    std::cout << std::left << std::setw(11) << "Name";
-    std::cout << std::setw(maxUrlLength + 2) << "Url" << std::setw(11) << "Alias" << std::endl;
-    for (const auto &r : cfg.repos) {
-        std::cout << std::left << std::setw(11) << r.name << std::setw(maxUrlLength + 2) << r.url
-                  << std::setw(11) << r.alias.value_or(r.name) << std::endl;
-    }
-    return 0;
-}
-
-int handleRepoAdd(linglong::repo::OSTreeRepo &repo, linglong::cli::RepoOptions &options)
-{
-    auto newCfg = repo.getConfig();
-
-    std::string alias = options.repoAlias.value_or(options.repoName);
-
-    if (options.repoUrl.empty()) {
-        std::cerr << "url is empty." << std::endl;
-        return EINVAL;
-    }
-
-    bool isExist = std::any_of(newCfg.repos.begin(), newCfg.repos.end(), [&alias](const auto &r) {
-        return r.alias.value_or(r.name) == alias;
-    });
-    if (isExist) {
-        LogE("repo {} already exist.", alias);
-        return -1;
-    }
-
-    newCfg.repos.push_back(linglong::api::types::v1::Repo{
-      .alias = options.repoAlias,
-      .name = options.repoName,
-      .url = options.repoUrl,
-    });
-
-    auto ret = repo.setConfig(newCfg);
-    if (!ret) {
-        std::cerr << ret.error().message() << std::endl;
-        return -1;
-    }
-
-    return 0;
-}
-
-int handleRepoRemove(linglong::repo::OSTreeRepo &repo, linglong::cli::RepoOptions &options)
-{
-    auto newCfg = repo.getConfig();
-    const std::string &alias = options.repoAlias.value_or(options.repoName);
-
-    auto existingRepo =
-      std::find_if(newCfg.repos.begin(), newCfg.repos.end(), [&alias](const auto &r) {
-          return r.alias.value_or(r.name) == alias;
-      });
-
-    if (existingRepo == newCfg.repos.cend()) {
-        std::cerr << "the operated repo " + alias + " doesn't exist." << std::endl;
-        return -1;
-    }
-
-    if (newCfg.defaultRepo == alias) {
-        std::cerr << "repo " + alias
-            + " is default repo, please change default repo before removing it."
-                  << std::endl;
-        return -1;
-    }
-
-    newCfg.repos.erase(existingRepo);
-    auto ret = repo.setConfig(newCfg);
-    if (!ret) {
-        std::cerr << ret.error().message() << std::endl;
-        return -1;
-    }
-
-    LogI("Repository {} removed successfully.", alias);
-    return 0;
-}
-
-int handleRepoUpdate(linglong::repo::OSTreeRepo &repo, linglong::cli::RepoOptions &options)
-{
-    auto newCfg = repo.getConfig();
-    const std::string &alias = options.repoAlias.value_or(options.repoName);
-
-    if (options.repoUrl.empty()) {
-        std::cerr << "url is empty." << std::endl;
-        return EINVAL;
-    }
-
-    auto existingRepo =
-      std::find_if(newCfg.repos.begin(), newCfg.repos.end(), [&alias](const auto &r) {
-          return r.alias.value_or(r.name) == alias;
-      });
-
-    if (existingRepo == newCfg.repos.cend()) {
-        std::cerr << "the operated repo " + alias + " doesn't exist." << std::endl;
-        return -1;
-    }
-
-    existingRepo->url = options.repoUrl;
-
-    auto ret = repo.setConfig(newCfg);
-    if (!ret) {
-        std::cerr << ret.error().message() << std::endl;
-        return -1;
-    }
-
-    LogI("Repository {} updated successfully.", alias);
-    return 0;
-}
-
-int handleRepoSetDefault(linglong::repo::OSTreeRepo &repo, linglong::cli::RepoOptions &options)
-{
-    auto newCfg = repo.getConfig();
-    const std::string &alias = options.repoAlias.value_or(options.repoName);
-
-    auto existingRepo =
-      std::find_if(newCfg.repos.begin(), newCfg.repos.end(), [&alias](const auto &r) {
-          return r.alias.value_or(r.name) == alias;
-      });
-
-    if (existingRepo == newCfg.repos.cend()) {
-        std::cerr << "the operated repo " + alias + " doesn't exist." << std::endl;
-        return -1;
-    }
-
-    if (newCfg.defaultRepo != alias) {
-        newCfg.defaultRepo = alias;
-        auto ret = repo.setConfig(newCfg);
-        if (!ret) {
-            std::cerr << ret.error().message() << std::endl;
-            return -1;
-        }
-        LogI("Default repository set to {} successfully.", alias);
-    } else {
-        LogI("{} is already the default repository.", alias);
-    }
-
-    return 0;
-}
-
-int handleRepoEnableMirror(linglong::repo::OSTreeRepo &repo, linglong::cli::RepoOptions &options)
-{
-    auto newCfg = repo.getConfig();
-    const std::string &alias = options.repoAlias.value_or(options.repoName);
-
-    auto existingRepo =
-      std::find_if(newCfg.repos.begin(), newCfg.repos.end(), [&alias](const auto &r) {
-          return r.alias.value_or(r.name) == alias;
-      });
-
-    if (existingRepo == newCfg.repos.cend()) {
-        std::cerr << "the operated repo " + alias + " doesn't exist." << std::endl;
-        return -1;
-    }
-
-    existingRepo->mirrorEnabled = true;
-    auto ret = repo.setConfig(newCfg);
-    if (!ret) {
-        std::cerr << ret.error().message() << std::endl;
-        return -1;
-    }
-
-    std::cerr << "Repository " << alias << " mirror enabled successfully.";
-    return 0;
-}
-
-int handleRepoDisableMirror(linglong::repo::OSTreeRepo &repo, linglong::cli::RepoOptions &options)
-{
-    auto newCfg = repo.getConfig();
-    const std::string &alias = options.repoAlias.value_or(options.repoName);
-
-    auto existingRepo =
-      std::find_if(newCfg.repos.begin(), newCfg.repos.end(), [&alias](const auto &r) {
-          return r.alias.value_or(r.name) == alias;
-      });
-
-    if (existingRepo == newCfg.repos.cend()) {
-        std::cerr << "the operated repo " + alias + " doesn't exist." << std::endl;
-        return -1;
-    }
-
-    existingRepo->mirrorEnabled = false;
-    auto ret = repo.setConfig(newCfg);
-    if (!ret) {
-        std::cerr << ret.error().message() << std::endl;
-        return -1;
-    }
-    std::cerr << "Repository " << alias << " mirror disabled successfully.";
-    return 0;
-}
-
-int handleRepo(linglong::repo::OSTreeRepo &repo,
-               const RepoSubcommandOptions &options,
-               CLI::App *buildRepoShow,
-               CLI::App *buildRepoAdd,
-               CLI::App *buildRepoRemove,
-               CLI::App *buildRepoUpdate,
-               CLI::App *buildRepoSetDefault,
-               CLI::App *buildRepoEnableMirror,
-               CLI::App *buildRepoDisableMirror)
-{
-    if (buildRepoShow->parsed()) {
-        return handleRepoShow(repo);
-    }
-
-    linglong::cli::RepoOptions repoOptions = options.repoOptions;
-    if (!repoOptions.repoUrl.empty()) {
-        if (repoOptions.repoUrl.rfind("http", 0) != 0) {
-            std::cerr << "url is invalid." << std::endl;
-            return EINVAL;
-        }
-
-        if (repoOptions.repoUrl.back() == '/') {
-            repoOptions.repoUrl.pop_back();
-        }
-    }
-
-    if (buildRepoAdd->parsed()) {
-        return handleRepoAdd(repo, repoOptions);
-    }
-
-    if (buildRepoRemove->parsed()) {
-        return handleRepoRemove(repo, repoOptions);
-    }
-
-    if (buildRepoUpdate->parsed()) {
-        return handleRepoUpdate(repo, repoOptions);
-    }
-
-    if (buildRepoSetDefault->parsed()) {
-        return handleRepoSetDefault(repo, repoOptions);
-    }
-
-    if (buildRepoEnableMirror->parsed()) {
-        return handleRepoEnableMirror(repo, repoOptions);
-    }
-
-    if (buildRepoDisableMirror->parsed()) {
-        return handleRepoDisableMirror(repo, repoOptions);
-    }
-
-    std::cerr << "unknown repo operation, please see help information." << std::endl;
-    return EINVAL;
-}
-
 std::vector<std::string> getProjectModule(const linglong::api::types::v1::BuilderProject &project)
 {
     std::list<std::string> modules = { "binary", "develop" }; // Start with base modules
@@ -908,74 +657,11 @@ You can report bugs to the linyaps team under this project: https://github.com/O
       ->type_name("DIR")
       ->required();
 
-    // add build repo
-    auto buildRepo = commandParser.add_subcommand("repo", _("Display and manage repositories"));
-    buildRepo->usage(_("Usage: ll-builder repo [OPTIONS] SUBCOMMAND"));
-    buildRepo->require_subcommand(1);
-
-    // add repo sub command add
-    auto buildRepoAdd = buildRepo->add_subcommand("add", _("Add a new repository"));
-    buildRepoAdd->usage(_("Usage: ll-builder repo add [OPTIONS] NAME URL"));
-    buildRepoAdd->add_option("NAME", repoCmdOpts.repoOptions.repoName, _("Specify the repo name"))
-      ->required()
-      ->check(validatorString);
-    buildRepoAdd->add_option("URL", repoCmdOpts.repoOptions.repoUrl, _("Url of the repository"))
-      ->required()
-      ->check(validatorString);
-    buildRepoAdd
-      ->add_option("--alias", repoCmdOpts.repoOptions.repoAlias, _("Alias of the repo name"))
-      ->type_name("ALIAS")
-      ->check(validatorString);
-
-    // add repo sub command remove
-    auto buildRepoRemove = buildRepo->add_subcommand("remove", _("Remove a repository"));
-    buildRepoRemove->usage(_("Usage: ll-builder repo remove [OPTIONS] NAME"));
-    buildRepoRemove
-      ->add_option("Alias", repoCmdOpts.repoOptions.repoAlias, _("Alias of the repo name"))
-      ->required()
-      ->check(validatorString);
-
-    // add repo sub command update
-    auto buildRepoUpdate = buildRepo->add_subcommand("update", _("Update the repository URL"));
-    buildRepoUpdate->usage(_("Usage: ll-builder repo update [OPTIONS] NAME URL"));
-    buildRepoUpdate
-      ->add_option("Alias", repoCmdOpts.repoOptions.repoAlias, _("Alias of the repo name"))
-      ->required()
-      ->check(validatorString);
-    buildRepoUpdate->add_option("URL", repoCmdOpts.repoOptions.repoUrl, _("Url of the repository"))
-      ->required()
-      ->check(validatorString);
-
-    // add repo sub command update
-    auto buildRepoSetDefault =
-      buildRepo->add_subcommand("set-default", _("Set a default repository name"));
-    buildRepoSetDefault->usage(_("Usage: ll-builder repo set-default [OPTIONS] NAME"));
-    buildRepoSetDefault
-      ->add_option("Alias", repoCmdOpts.repoOptions.repoAlias, _("Alias of the repo name"))
-      ->required()
-      ->check(validatorString);
-
-    // add repo sub command enable mirror
-    auto buildRepoEnableMirror =
-      buildRepo->add_subcommand("enable-mirror", _("Enable mirror for the repo"));
-    buildRepoEnableMirror->usage(_("Usage: ll-builder repo enable-mirror [OPTIONS] ALIAS"));
-    buildRepoEnableMirror
-      ->add_option("ALIAS", repoCmdOpts.repoOptions.repoAlias, _("Alias of the repo name"))
-      ->required()
-      ->check(validatorString);
-
-    // add repo sub command disable mirror
-    auto buildRepoDisableMirror =
-      buildRepo->add_subcommand("disable-mirror", _("Disable mirror for the repo"));
-    buildRepoDisableMirror->usage(_("Usage: ll-builder repo disable-mirror [OPTIONS] ALIAS"));
-    buildRepoDisableMirror
-      ->add_option("ALIAS", repoCmdOpts.repoOptions.repoAlias, _("Alias of the repo name"))
-      ->required()
-      ->check(validatorString);
-
-    // add repo sub command show
-    auto buildRepoShow = buildRepo->add_subcommand("show", _("Show repository information"));
-    buildRepoShow->usage(_("Usage: ll-builder repo show [OPTIONS]"));
+    auto *buildRepo = linglong::common::cli::addRepoCommand(commandParser,
+                                                            repoCmdOpts.repoOptions,
+                                                            _("Managing remote repositories"),
+                                                            validatorString,
+                                                            "ll-builder");
 
     CLI11_PARSE(commandParser, argc, argv);
 
@@ -1053,15 +739,38 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     }
 
     if (buildRepo->parsed()) {
-        return handleRepo(**repo,
-                          repoCmdOpts,
-                          buildRepoShow,
-                          buildRepoAdd,
-                          buildRepoRemove,
-                          buildRepoUpdate,
-                          buildRepoSetDefault,
-                          buildRepoEnableMirror,
-                          buildRepoDisableMirror);
+        linglong::cli::CLIPrinter printer;
+        linglong::common::cli::RepoConfigBackend backend{
+            .getConfig =
+              [&repo]() -> linglong::utils::error::Result<linglong::api::types::v1::RepoConfigV2> {
+                LINGLONG_TRACE("get builder repo config");
+
+                return (*repo)->getConfig();
+            },
+            .setConfig = [&repo](const linglong::api::types::v1::RepoConfigV2 &cfg)
+              -> linglong::utils::error::Result<void> {
+                LINGLONG_TRACE("set builder repo config");
+
+                auto ret = (*repo)->setConfig(cfg);
+                if (!ret) {
+                    return LINGLONG_ERR(ret);
+                }
+                return LINGLONG_OK;
+            },
+        };
+        auto ret =
+          linglong::common::cli::handleRepoCommand(buildRepo,
+                                                   repoCmdOpts.repoOptions,
+                                                   backend,
+                                                   { .showConfig = [&printer](const auto &cfg) {
+                                                       printer.printRepoConfig(cfg);
+                                                   } });
+        if (!ret) {
+            printer.printErr(ret.error());
+            return -1;
+        }
+
+        return 0;
     }
 
     if (buildImport->parsed()) {

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -431,95 +431,6 @@ ll-cli list --upgradable
                         "application(s), base(s) or runtime(s)"));
 }
 
-// Function to add the repo subcommand
-void addRepoCommand(CLI::App &commandParser, RepoOptions &repoOptions, const std::string &group)
-{
-    auto *cliRepo =
-      commandParser
-        .add_subcommand("repo",
-                        _("Display or modify information of the repository currently using"))
-        ->group(group);
-    cliRepo->usage(_("Usage: ll-cli repo SUBCOMMAND [OPTIONS]"));
-    cliRepo->require_subcommand(1);
-
-    // add repo sub command add
-    auto *repoAdd = cliRepo->add_subcommand("add", _("Add a new repository"));
-    repoAdd->usage(_("Usage: ll-cli repo add [OPTIONS] NAME URL"));
-    repoAdd->add_option("NAME", repoOptions.repoName, _("Specify the repo name"))
-      ->required()
-      ->check(validatorString);
-    repoAdd->add_option("URL", repoOptions.repoUrl, _("Url of the repository"))
-      ->required()
-      ->check(validatorString);
-    repoAdd->add_option("--alias", repoOptions.repoAlias, _("Alias of the repo name"))
-      ->type_name("ALIAS")
-      ->check(validatorString);
-
-    // add repo sub command modify
-    auto *repoModify = cliRepo->add_subcommand("modify", _("Modify repository URL"))->group("");
-    repoModify->add_option("--name", repoOptions.repoName, _("Specify the repo name"))
-      ->type_name("REPO")
-      ->check(validatorString);
-    repoModify->add_option("URL", repoOptions.repoUrl, _("Url of the repository"))
-      ->required()
-      ->check(validatorString);
-
-    // add repo sub command remove
-    auto *repoRemove = cliRepo->add_subcommand("remove", _("Remove a repository"));
-    repoRemove->usage(_("Usage: ll-cli repo remove [OPTIONS] NAME"));
-    repoRemove->add_option("ALIAS", repoOptions.repoAlias, _("Alias of the repo name"))
-      ->required()
-      ->check(validatorString);
-
-    // add repo sub command update
-    // TODO: add --repo and --url options
-    auto *repoUpdate = cliRepo->add_subcommand("update", _("Update the repository URL"));
-    repoUpdate->usage(_("Usage: ll-cli repo update [OPTIONS] NAME URL"));
-    repoUpdate->add_option("ALIAS", repoOptions.repoAlias, _("Alias of the repo name"))
-      ->required()
-      ->check(validatorString);
-    repoUpdate->add_option("URL", repoOptions.repoUrl, _("Url of the repository"))
-      ->required()
-      ->check(validatorString);
-
-    // add repo sub command set-default
-    auto *repoSetDefault =
-      cliRepo->add_subcommand("set-default", _("Set a default repository name"));
-    repoSetDefault->usage(_("Usage: ll-cli repo set-default [OPTIONS] NAME"));
-    repoSetDefault->add_option("Alias", repoOptions.repoAlias, _("Alias of the repo name"))
-      ->required()
-      ->check(validatorString);
-
-    // add repo sub command show
-    cliRepo->add_subcommand("show", _("Show repository information"))
-      ->usage(_("Usage: ll-cli repo show [OPTIONS]"));
-
-    // add repo sub command set-priority
-    auto *repoSetPriority =
-      cliRepo->add_subcommand("set-priority", _("Set the priority of the repo"));
-    repoSetPriority->usage(_("Usage: ll-cli repo set-priority ALIAS PRIORITY"));
-    repoSetPriority->add_option("ALIAS", repoOptions.repoAlias, _("Alias of the repo name"))
-      ->required()
-      ->check(validatorString);
-    repoSetPriority->add_option("PRIORITY", repoOptions.repoPriority, _("Priority of the repo"))
-      ->required()
-      ->check(validatorString);
-    // add repo sub command enable mirror
-    auto *repoEnableMirror =
-      cliRepo->add_subcommand("enable-mirror", _("Enable mirror for the repo"));
-    repoEnableMirror->usage(_("Usage: ll-cli repo enable-mirror [OPTIONS] ALIAS"));
-    repoEnableMirror->add_option("ALIAS", repoOptions.repoAlias, _("Alias of the repo name"))
-      ->required()
-      ->check(validatorString);
-    // add repo sub command disable mirror
-    auto *repoDisableMirror =
-      cliRepo->add_subcommand("disable-mirror", _("Disable mirror for the repo"));
-    repoDisableMirror->usage(_("Usage: ll-cli repo disable-mirror [OPTIONS] ALIAS"));
-    repoDisableMirror->add_option("ALIAS", repoOptions.repoAlias, _("Alias of the repo name"))
-      ->required()
-      ->check(validatorString);
-}
-
 // Function to add the info subcommand
 void addInfoCommand(CLI::App &commandParser, InfoOptions &infoOptions, const std::string &group)
 {
@@ -656,7 +567,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     ListOptions listOptions{};
     InfoOptions infoOptions{};
     ContentOptions contentOptions{};
-    RepoOptions repoOptions{};
+    linglong::common::cli::RepoOptions repoOptions{};
     InspectOptions inspectOptions{};
 
     // groups for subcommands
@@ -675,7 +586,11 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     addUpgradeCommand(commandParser, upgradeOptions, CliBuildInGroup);
     addSearchCommand(commandParser, searchOptions, CliSearchGroup);
     addListCommand(commandParser, listOptions, CliBuildInGroup);
-    addRepoCommand(commandParser, repoOptions, CliRepoGroup);
+    linglong::common::cli::addRepoCommand(commandParser,
+                                          repoOptions,
+                                          CliRepoGroup,
+                                          validatorString,
+                                          "ll-cli");
     addInfoCommand(commandParser, infoOptions, CliBuildInGroup);
     addContentCommand(commandParser, contentOptions, CliBuildInGroup);
     addPruneCommand(commandParser, CliAppManagingGroup);

--- a/libs/linglong/CMakeLists.txt
+++ b/libs/linglong/CMakeLists.txt
@@ -39,6 +39,8 @@ pfl_add_library(
   src/linglong/common/dbus/properties_forwarder.h
   src/linglong/common/dbus/register.cpp
   src/linglong/common/dbus/register.h
+  src/linglong/common/cli/repo.cpp
+  src/linglong/common/cli/repo.h
   src/linglong/common/formatter.cpp
   src/linglong/common/formatter.h
   src/linglong/common/gkeyfile_wrapper.h

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -31,7 +31,6 @@
 #include "linglong/common/strings.h"
 #include "linglong/package/layer_file.h"
 #include "linglong/package/reference.h"
-#include "linglong/repo/config.h"
 #include "linglong/runtime/container_builder.h"
 #include "linglong/runtime/run_context.h"
 #include "linglong/utils/bash_command_helper.h"
@@ -1574,166 +1573,52 @@ utils::error::Result<std::vector<api::types::v1::UpgradeListResult>> Cli::listUp
     return upgradeList;
 }
 
-int Cli::repo(CLI::App *app, const RepoOptions &options)
+int Cli::repo(CLI::App *app, const common::cli::RepoOptions &options)
 {
-    LINGLONG_TRACE("command repo");
+    common::cli::RepoConfigBackend backend{
+        .getConfig = [this]() -> utils::error::Result<api::types::v1::RepoConfigV2> {
+            LINGLONG_TRACE("get repo config from package manager");
 
-    auto pkgMan = this->getPkgMan();
-    if (!pkgMan) {
-        this->printer.printErr(pkgMan.error());
-        return -1;
-    }
+            auto pkgMan = this->getPkgMan();
+            if (!pkgMan) {
+                return LINGLONG_ERR(pkgMan);
+            }
 
-    auto propCfg = (*pkgMan)->configuration();
-    if ((*pkgMan)->lastError().isValid()) {
-        auto err = LINGLONG_ERRV((*pkgMan)->lastError().message().toStdString());
-        this->printer.printErr(err);
-        return -1;
-    }
+            auto propCfg = (*pkgMan)->configuration();
+            if ((*pkgMan)->lastError().isValid()) {
+                return LINGLONG_ERR((*pkgMan)->lastError().message().toStdString());
+            }
 
-    auto cfg = common::serialize::fromQVariantMap<api::types::v1::RepoConfigV2>(propCfg);
-    if (!cfg) {
-        LogE("fatal error: {}", cfg.error());
-        std::abort();
-    }
+            auto cfg = common::serialize::fromQVariantMap<api::types::v1::RepoConfigV2>(propCfg);
+            if (!cfg) {
+                return LINGLONG_ERR("failed to parse repo config", cfg.error());
+            }
 
-    auto argsParsed = [&app](const std::string &name) -> bool {
-        return app->get_subcommand(name)->parsed();
+            return *cfg;
+        },
+        .setConfig = [this](const api::types::v1::RepoConfigV2 &cfg) -> utils::error::Result<void> {
+            LINGLONG_TRACE("set repo config to package manager");
+
+            auto ret = this->setRepoConfig(common::serialize::toQVariantMap(cfg));
+            if (ret != 0) {
+                return LINGLONG_ERR("failed to set repo config");
+            }
+            return LINGLONG_OK;
+        },
     };
 
-    if (argsParsed("show")) {
-        this->printer.printRepoConfig(*cfg);
-        return 0;
-    }
-
-    if (argsParsed("modify")) {
-        this->printer.printErr(
-          LINGLONG_ERRV("sub-command 'modify' already has been deprecated, please use sub-command "
-                        "'add' to add a remote repository and use it as default."));
-        return EINVAL;
-    }
-
-    std::string url = options.repoUrl;
-
-    if (argsParsed("add") || argsParsed("update")) {
-        if (url.rfind("http", 0) != 0) {
-            this->printer.printErr(LINGLONG_ERRV(fmt::format("url is invalid: {}", url)));
-            return EINVAL;
-        }
-
-        // remove last slash
-        if (url.back() == '/') {
-            url.pop_back();
-        }
-    }
-
-    std::string name = options.repoName;
-    // if alias is not set, use name as alias
-    std::string alias = options.repoAlias.value_or(name);
-    auto &cfgRef = *cfg;
-
-    if (argsParsed("add")) {
-        if (url.empty()) {
-            this->printer.printErr(LINGLONG_ERRV("url is empty."));
-            return EINVAL;
-        }
-
-        bool isExist =
-          std::any_of(cfgRef.repos.begin(), cfgRef.repos.end(), [&alias](const auto &repo) {
-              return repo.alias.value_or(repo.name) == alias;
-          });
-        if (isExist) {
-            this->printer.printErr(LINGLONG_ERRV(fmt::format("repo {} already exist", alias)));
-            return -1;
-        }
-        cfgRef.repos.push_back(api::types::v1::Repo{
-          .alias = options.repoAlias,
-          .name = name,
-          .priority = 0,
-          .url = url,
-        });
-        return this->setRepoConfig(common::serialize::toQVariantMap(cfgRef));
-    }
-
-    auto existingRepo =
-      std::find_if(cfgRef.repos.begin(), cfgRef.repos.end(), [&alias](const auto &repo) {
-          return repo.alias.value_or(repo.name) == alias;
-      });
-
-    if (existingRepo == cfgRef.repos.end()) {
-        this->printer.printErr(
-          LINGLONG_ERRV(fmt::format("the operated repo {} doesn't exist", name)));
+    auto ret = common::cli::handleRepoCommand(app,
+                                              options,
+                                              backend,
+                                              { .showConfig = [this](const auto &cfg) {
+                                                  this->printer.printRepoConfig(cfg);
+                                              } });
+    if (!ret) {
+        this->printer.printErr(ret.error());
         return -1;
     }
 
-    if (argsParsed("remove")) {
-        if (cfgRef.repos.size() == 1) {
-            this->printer.printErr(
-              LINGLONG_ERRV(fmt::format("repo {} is the only repo, please add another repo before "
-                                        "removing it or update it directly.",
-                                        alias)));
-            return -1;
-        }
-        cfgRef.repos.erase(existingRepo);
-
-        if (cfgRef.defaultRepo == alias) {
-            // choose the max priority repo as default repo
-            auto maxPriority = linglong::repo::getRepoMaxPriority(cfgRef);
-            for (auto &repo : cfgRef.repos) {
-                if (repo.priority == maxPriority) {
-                    cfgRef.defaultRepo = repo.alias.value_or(repo.name);
-                    break;
-                }
-            }
-        }
-
-        return this->setRepoConfig(common::serialize::toQVariantMap(cfgRef));
-    }
-
-    if (argsParsed("update")) {
-        if (url.empty()) {
-            this->printer.printErr(LINGLONG_ERRV("url is empty."));
-            return -1;
-        }
-
-        existingRepo->url = url;
-        return this->setRepoConfig(common::serialize::toQVariantMap(cfgRef));
-    }
-
-    if (argsParsed("enable-mirror")) {
-        existingRepo->mirrorEnabled = true;
-        return this->setRepoConfig(common::serialize::toQVariantMap(cfgRef));
-    }
-
-    if (argsParsed("disable-mirror")) {
-        existingRepo->mirrorEnabled = false;
-        return this->setRepoConfig(common::serialize::toQVariantMap(cfgRef));
-    }
-
-    if (argsParsed("set-default")) {
-        if (cfgRef.defaultRepo != alias) {
-            cfgRef.defaultRepo = alias;
-            // set-default is equal to set-priority to the current max priority + 100
-            auto maxPriority = linglong::repo::getRepoMaxPriority(cfgRef);
-            for (auto &repo : cfgRef.repos) {
-                if (repo.alias.value_or(repo.name) == alias) {
-                    repo.priority = maxPriority + 100;
-                    break;
-                }
-            }
-            return this->setRepoConfig(common::serialize::toQVariantMap(cfgRef));
-        }
-
-        return 0;
-    }
-
-    if (argsParsed("set-priority")) {
-        existingRepo->priority = options.repoPriority;
-        return this->setRepoConfig(common::serialize::toQVariantMap(cfgRef));
-    }
-
-    this->printer.printErr(LINGLONG_ERRV("unknown operation"));
-    return -1;
+    return 0;
 }
 
 int Cli::setRepoConfig(const QVariantMap &config)

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -12,6 +12,7 @@
 #include "linglong/api/types/v1/PackageInfoDisplay.hpp"
 #include "linglong/cli/interactive_notifier.h"
 #include "linglong/cli/printer.h"
+#include "linglong/common/cli/repo.h"
 #include "linglong/common/serialize/json.h"
 #include "linglong/repo/ostree_repo.h"
 #include "linglong/runtime/container_builder.h"
@@ -126,14 +127,6 @@ struct ContentOptions
     std::string appid;
 };
 
-struct RepoOptions
-{
-    std::string repoName;
-    std::string repoUrl;
-    std::optional<std::string> repoAlias;
-    std::int64_t repoPriority{ 0 };
-};
-
 struct InspectOptions
 {
     std::string appid;
@@ -189,7 +182,7 @@ public:
     int search(const SearchOptions &options);
     int uninstall(const UninstallOptions &options);
     int list(const ListOptions &options);
-    int repo(CLI::App *subcommand, const RepoOptions &options);
+    int repo(CLI::App *subcommand, const common::cli::RepoOptions &options);
     int info(const InfoOptions &options);
     int content(const ContentOptions &options);
     int prune();

--- a/libs/linglong/src/linglong/common/cli/repo.cpp
+++ b/libs/linglong/src/linglong/common/cli/repo.cpp
@@ -1,0 +1,302 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include "linglong/common/cli/repo.h"
+
+#include "linglong/api/types/v1/Repo.hpp"
+#include "linglong/utils/gettext.h"
+#include "linglong/utils/log/log.h"
+
+#include <algorithm>
+#include <cerrno>
+
+namespace linglong::common::cli {
+
+namespace {
+
+std::int64_t getRepoMaxPriority(const api::types::v1::RepoConfigV2 &cfg) noexcept
+{
+    if (cfg.repos.empty()) {
+        return 0;
+    }
+
+    auto repo =
+      std::max_element(cfg.repos.cbegin(), cfg.repos.cend(), [](const auto &lhs, const auto &rhs) {
+          return lhs.priority < rhs.priority;
+      });
+
+    return repo->priority;
+}
+
+std::string usage(const std::string &programName, const std::string &suffix)
+{
+    return _("Usage: ") + programName + suffix;
+}
+
+} // namespace
+
+CLI::App *addRepoCommand(CLI::App &commandParser,
+                         RepoOptions &repoOptions,
+                         const std::string &group,
+                         const CLI::Validator &validatorString,
+                         const std::string &programName)
+{
+    auto *cliRepo =
+      commandParser
+        .add_subcommand("repo",
+                        _("Display or modify information of the repository currently using"))
+        ->group(group);
+    cliRepo->usage(usage(programName, " repo SUBCOMMAND [OPTIONS]"));
+    cliRepo->require_subcommand(1);
+
+    auto *repoAdd = cliRepo->add_subcommand("add", _("Add a new repository"));
+    repoAdd->usage(usage(programName, " repo add [OPTIONS] NAME URL"));
+    repoAdd->add_option("NAME", repoOptions.repoName, _("Specify the repo name"))
+      ->required()
+      ->check(validatorString);
+    repoAdd->add_option("URL", repoOptions.repoUrl, _("Url of the repository"))
+      ->required()
+      ->check(validatorString);
+    repoAdd->add_option("--alias", repoOptions.repoAlias, _("Alias of the repo name"))
+      ->type_name("ALIAS")
+      ->check(validatorString);
+
+    auto *repoModify = cliRepo->add_subcommand("modify", _("Modify repository URL"))->group("");
+    repoModify->add_option("--name", repoOptions.repoName, _("Specify the repo name"))
+      ->type_name("REPO")
+      ->check(validatorString);
+    repoModify->add_option("URL", repoOptions.repoUrl, _("Url of the repository"))
+      ->required()
+      ->check(validatorString);
+
+    auto *repoRemove = cliRepo->add_subcommand("remove", _("Remove a repository"));
+    repoRemove->usage(usage(programName, " repo remove [OPTIONS] NAME"));
+    repoRemove->add_option("ALIAS", repoOptions.repoAlias, _("Alias of the repo name"))
+      ->required()
+      ->check(validatorString);
+
+    auto *repoUpdate = cliRepo->add_subcommand("update", _("Update the repository URL"));
+    repoUpdate->usage(usage(programName, " repo update [OPTIONS] NAME URL"));
+    repoUpdate->add_option("ALIAS", repoOptions.repoAlias, _("Alias of the repo name"))
+      ->required()
+      ->check(validatorString);
+    repoUpdate->add_option("URL", repoOptions.repoUrl, _("Url of the repository"))
+      ->required()
+      ->check(validatorString);
+
+    auto *repoSetDefault =
+      cliRepo->add_subcommand("set-default", _("Set a default repository name"));
+    repoSetDefault->usage(usage(programName, " repo set-default [OPTIONS] NAME"));
+    repoSetDefault->add_option("ALIAS", repoOptions.repoAlias, _("Alias of the repo name"))
+      ->required()
+      ->check(validatorString);
+
+    cliRepo->add_subcommand("show", _("Show repository information"))
+      ->usage(usage(programName, " repo show [OPTIONS]"));
+
+    auto *repoSetPriority =
+      cliRepo->add_subcommand("set-priority", _("Set the priority of the repo"));
+    repoSetPriority->usage(usage(programName, " repo set-priority ALIAS PRIORITY"));
+    repoSetPriority->add_option("ALIAS", repoOptions.repoAlias, _("Alias of the repo name"))
+      ->required()
+      ->check(validatorString);
+    repoSetPriority->add_option("PRIORITY", repoOptions.repoPriority, _("Priority of the repo"))
+      ->required()
+      ->check(validatorString);
+
+    auto *repoEnableMirror =
+      cliRepo->add_subcommand("enable-mirror", _("Enable mirror for the repo"));
+    repoEnableMirror->usage(usage(programName, " repo enable-mirror [OPTIONS] ALIAS"));
+    repoEnableMirror->add_option("ALIAS", repoOptions.repoAlias, _("Alias of the repo name"))
+      ->required()
+      ->check(validatorString);
+
+    auto *repoDisableMirror =
+      cliRepo->add_subcommand("disable-mirror", _("Disable mirror for the repo"));
+    repoDisableMirror->usage(usage(programName, " repo disable-mirror [OPTIONS] ALIAS"));
+    repoDisableMirror->add_option("ALIAS", repoOptions.repoAlias, _("Alias of the repo name"))
+      ->required()
+      ->check(validatorString);
+
+    return cliRepo;
+}
+
+utils::error::Result<void> handleRepoCommand(CLI::App *app,
+                                             const RepoOptions &options,
+                                             const RepoConfigBackend &backend,
+                                             const RepoCommandCallbacks &callbacks)
+{
+    LINGLONG_TRACE("command repo");
+
+    auto cfg = backend.getConfig();
+    if (!cfg) {
+        return LINGLONG_ERR(cfg);
+    }
+
+    auto argsParsed = [&app](const std::string &name) -> bool {
+        return app->get_subcommand(name)->parsed();
+    };
+
+    if (argsParsed("show")) {
+        if (!callbacks.showConfig) {
+            return LINGLONG_ERR("missing repo show callback");
+        }
+
+        callbacks.showConfig(*cfg);
+        return LINGLONG_OK;
+    }
+
+    if (argsParsed("modify")) {
+        return LINGLONG_ERR("sub-command 'modify' already has been deprecated, please use "
+                            "sub-command 'add' to add a remote repository and use it as default.",
+                            EINVAL);
+    }
+
+    std::string url = options.repoUrl;
+
+    if (argsParsed("add") || argsParsed("update")) {
+        if (url.empty()) {
+            return LINGLONG_ERR("url is empty.", EINVAL);
+        }
+
+        if (url.rfind("http", 0) != 0) {
+            return LINGLONG_ERR("url is invalid: " + url, EINVAL);
+        }
+
+        if (url.back() == '/') {
+            url.pop_back();
+        }
+    }
+
+    std::string name = options.repoName;
+    std::string alias = options.repoAlias.value_or(name);
+    auto &cfgRef = *cfg;
+
+    if (argsParsed("add")) {
+        bool isExist =
+          std::any_of(cfgRef.repos.begin(), cfgRef.repos.end(), [&alias](const auto &repo) {
+              return repo.alias.value_or(repo.name) == alias;
+          });
+        if (isExist) {
+            return LINGLONG_ERR("repo " + alias + " already exist");
+        }
+        cfgRef.repos.push_back(api::types::v1::Repo{
+          .alias = options.repoAlias,
+          .name = name,
+          .priority = 0,
+          .url = url,
+        });
+
+        auto ret = backend.setConfig(cfgRef);
+        if (!ret) {
+            return LINGLONG_ERR(ret);
+        }
+
+        return LINGLONG_OK;
+    }
+
+    auto existingRepo =
+      std::find_if(cfgRef.repos.begin(), cfgRef.repos.end(), [&alias](const auto &repo) {
+          return repo.alias.value_or(repo.name) == alias;
+      });
+
+    if (existingRepo == cfgRef.repos.end()) {
+        return LINGLONG_ERR("the operated repo " + name + " doesn't exist");
+    }
+
+    if (argsParsed("remove")) {
+        if (cfgRef.repos.size() == 1) {
+            return LINGLONG_ERR("repo " + alias
+                                + " is the only repo, please add another repo "
+                                  "before removing it or update it directly.");
+        }
+        cfgRef.repos.erase(existingRepo);
+
+        if (cfgRef.defaultRepo == alias) {
+            auto maxPriority = getRepoMaxPriority(cfgRef);
+            for (auto &repo : cfgRef.repos) {
+                if (repo.priority == maxPriority) {
+                    cfgRef.defaultRepo = repo.alias.value_or(repo.name);
+                    LogI("default repo {} removed, use {} as default repo",
+                         alias,
+                         cfgRef.defaultRepo);
+                    break;
+                }
+            }
+        }
+
+        auto ret = backend.setConfig(cfgRef);
+        if (!ret) {
+            return LINGLONG_ERR(ret);
+        }
+
+        return LINGLONG_OK;
+    }
+
+    if (argsParsed("update")) {
+        existingRepo->url = url;
+        auto ret = backend.setConfig(cfgRef);
+        if (!ret) {
+            return LINGLONG_ERR(ret);
+        }
+
+        return LINGLONG_OK;
+    }
+
+    if (argsParsed("enable-mirror")) {
+        existingRepo->mirrorEnabled = true;
+        auto ret = backend.setConfig(cfgRef);
+        if (!ret) {
+            return LINGLONG_ERR(ret);
+        }
+
+        return LINGLONG_OK;
+    }
+
+    if (argsParsed("disable-mirror")) {
+        existingRepo->mirrorEnabled = false;
+        auto ret = backend.setConfig(cfgRef);
+        if (!ret) {
+            return LINGLONG_ERR(ret);
+        }
+
+        return LINGLONG_OK;
+    }
+
+    if (argsParsed("set-default")) {
+        if (cfgRef.defaultRepo != alias) {
+            cfgRef.defaultRepo = alias;
+            auto maxPriority = getRepoMaxPriority(cfgRef);
+            for (auto &repo : cfgRef.repos) {
+                if (repo.alias.value_or(repo.name) == alias) {
+                    repo.priority = maxPriority + 100;
+                    break;
+                }
+            }
+
+            auto ret = backend.setConfig(cfgRef);
+            if (!ret) {
+                return LINGLONG_ERR(ret);
+            }
+        }
+
+        return LINGLONG_OK;
+    }
+
+    if (argsParsed("set-priority")) {
+        existingRepo->priority = options.repoPriority;
+        auto ret = backend.setConfig(cfgRef);
+        if (!ret) {
+            return LINGLONG_ERR(ret);
+        }
+
+        return LINGLONG_OK;
+    }
+
+    return LINGLONG_ERR("unknown operation");
+}
+
+} // namespace linglong::common::cli

--- a/libs/linglong/src/linglong/common/cli/repo.h
+++ b/libs/linglong/src/linglong/common/cli/repo.h
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "linglong/api/types/v1/RepoConfigV2.hpp"
+#include "linglong/utils/error/error.h"
+
+#include <CLI/CLI.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+
+namespace linglong::common::cli {
+
+struct RepoOptions
+{
+    std::string repoName;
+    std::string repoUrl;
+    std::optional<std::string> repoAlias;
+    std::int64_t repoPriority{ 0 };
+};
+
+struct RepoConfigBackend
+{
+    std::function<utils::error::Result<api::types::v1::RepoConfigV2>()> getConfig;
+    std::function<utils::error::Result<void>(const api::types::v1::RepoConfigV2 &)> setConfig;
+};
+
+struct RepoCommandCallbacks
+{
+    std::function<void(const api::types::v1::RepoConfigV2 &)> showConfig;
+};
+
+CLI::App *addRepoCommand(CLI::App &commandParser,
+                         RepoOptions &repoOptions,
+                         const std::string &group,
+                         const CLI::Validator &validatorString,
+                         const std::string &programName);
+
+utils::error::Result<void> handleRepoCommand(CLI::App *app,
+                                             const RepoOptions &options,
+                                             const RepoConfigBackend &backend,
+                                             const RepoCommandCallbacks &callbacks);
+
+} // namespace linglong::common::cli

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -19,6 +19,7 @@ pfl_add_executable(
   src/linglong/builder/source_fetcher_test.cpp
   src/linglong/cli/cli_test.cpp
   src/linglong/common/gkeyfile_wrapper_test.cpp
+  src/linglong/common/cli/repo_test.cpp
   src/linglong/common/strings_test.cpp
   src/linglong/common/display_test.cpp
   src/linglong/common/socket_test.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/common/cli/repo_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/common/cli/repo_test.cpp
@@ -1,0 +1,194 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gtest/gtest.h>
+
+#include "linglong/common/cli/repo.h"
+
+namespace linglong::common::cli {
+namespace {
+
+using linglong::api::types::v1::Repo;
+using linglong::api::types::v1::RepoConfigV2;
+
+CLI::Validator validatorString{ [](const std::string &parameter) {
+                                   if (parameter.empty()) {
+                                       return std::string{ "empty" };
+                                   }
+                                   return std::string{};
+                               },
+                                "" };
+
+class RepoCommandTest : public ::testing::Test
+{
+protected:
+    RepoCommandTest()
+        : repoApp(addRepoCommand(app, options, "repo", validatorString, "test-app"))
+    {
+    }
+
+    void parse(const std::string &command) { app.parse(command); }
+
+    utils::error::Result<void> handle()
+    {
+        return handleRepoCommand(
+          repoApp,
+          options,
+          { .getConfig = [this]() -> utils::error::Result<RepoConfigV2> {
+               return config;
+           },
+            .setConfig = [this](const RepoConfigV2 &cfg) -> utils::error::Result<void> {
+                config = cfg;
+                ++setConfigCalls;
+                return LINGLONG_OK;
+            } },
+          { .showConfig = [this](const RepoConfigV2 &cfg) {
+              shownConfig = cfg;
+              ++showConfigCalls;
+          } });
+    }
+
+    CLI::App app{ "test" };
+    RepoOptions options;
+    CLI::App *repoApp{ nullptr };
+    RepoConfigV2 config{
+        .defaultRepo = "stable",
+        .repos = { Repo{ .alias = "stable",
+                         .mirrorEnabled = false,
+                         .name = "stable",
+                         .priority = 10,
+                         .url = "https://stable.example" },
+                   Repo{ .alias = "beta",
+                         .mirrorEnabled = true,
+                         .name = "beta",
+                         .priority = 20,
+                         .url = "https://beta.example" } },
+        .version = 2,
+    };
+    std::optional<RepoConfigV2> shownConfig;
+    int setConfigCalls{ 0 };
+    int showConfigCalls{ 0 };
+};
+
+TEST_F(RepoCommandTest, AddRepoTrimsTrailingSlash)
+{
+    parse("repo add community https://community.example/ --alias comm");
+
+    auto ret = handle();
+
+    ASSERT_TRUE(ret.has_value()) << ret.error().message();
+    ASSERT_EQ(setConfigCalls, 1);
+    ASSERT_EQ(config.repos.size(), 3);
+    EXPECT_EQ(config.repos.back().name, "community");
+    ASSERT_TRUE(config.repos.back().alias.has_value());
+    EXPECT_EQ(*config.repos.back().alias, "comm");
+    EXPECT_EQ(config.repos.back().url, "https://community.example");
+    EXPECT_EQ(config.repos.back().priority, 0);
+}
+
+TEST_F(RepoCommandTest, RejectDuplicateAlias)
+{
+    parse("repo add stable2 https://stable2.example --alias stable");
+
+    auto ret = handle();
+
+    EXPECT_FALSE(ret.has_value());
+    EXPECT_EQ(setConfigCalls, 0);
+    EXPECT_EQ(config.repos.size(), 2);
+}
+
+TEST_F(RepoCommandTest, UpdateRepoUrl)
+{
+    parse("repo update beta https://new-beta.example/");
+
+    auto ret = handle();
+
+    ASSERT_TRUE(ret.has_value()) << ret.error().message();
+    ASSERT_EQ(setConfigCalls, 1);
+    EXPECT_EQ(config.repos[1].url, "https://new-beta.example");
+}
+
+TEST_F(RepoCommandTest, RemoveDefaultRepoSelectsHighestPriorityRemainingRepo)
+{
+    parse("repo remove stable");
+
+    auto ret = handle();
+
+    ASSERT_TRUE(ret.has_value()) << ret.error().message();
+    ASSERT_EQ(setConfigCalls, 1);
+    ASSERT_EQ(config.repos.size(), 1);
+    EXPECT_EQ(config.repos[0].alias.value_or(config.repos[0].name), "beta");
+    EXPECT_EQ(config.defaultRepo, "beta");
+}
+
+TEST_F(RepoCommandTest, SetDefaultRaisesPriority)
+{
+    parse("repo set-default beta");
+
+    auto ret = handle();
+
+    ASSERT_TRUE(ret.has_value()) << ret.error().message();
+    ASSERT_EQ(setConfigCalls, 1);
+    EXPECT_EQ(config.defaultRepo, "beta");
+    EXPECT_EQ(config.repos[1].priority, 120);
+}
+
+TEST_F(RepoCommandTest, SetPriority)
+{
+    parse("repo set-priority stable 42");
+
+    auto ret = handle();
+
+    ASSERT_TRUE(ret.has_value()) << ret.error().message();
+    ASSERT_EQ(setConfigCalls, 1);
+    EXPECT_EQ(config.repos[0].priority, 42);
+}
+
+TEST_F(RepoCommandTest, EnableMirror)
+{
+    parse("repo enable-mirror stable");
+    auto ret = handle();
+
+    ASSERT_TRUE(ret.has_value()) << ret.error().message();
+    ASSERT_TRUE(config.repos[0].mirrorEnabled.has_value());
+    EXPECT_TRUE(*config.repos[0].mirrorEnabled);
+}
+
+TEST_F(RepoCommandTest, DisableMirror)
+{
+    parse("repo disable-mirror beta");
+    auto ret = handle();
+
+    ASSERT_TRUE(ret.has_value()) << ret.error().message();
+    ASSERT_TRUE(config.repos[1].mirrorEnabled.has_value());
+    EXPECT_FALSE(*config.repos[1].mirrorEnabled);
+}
+
+TEST_F(RepoCommandTest, ShowUsesCallbackWithoutSaving)
+{
+    parse("repo show");
+
+    auto ret = handle();
+
+    ASSERT_TRUE(ret.has_value()) << ret.error().message();
+    EXPECT_EQ(showConfigCalls, 1);
+    EXPECT_EQ(setConfigCalls, 0);
+    ASSERT_TRUE(shownConfig.has_value());
+    EXPECT_EQ(shownConfig->defaultRepo, "stable");
+}
+
+TEST_F(RepoCommandTest, ModifyReturnsError)
+{
+    parse("repo modify https://example.com");
+
+    auto ret = handle();
+
+    EXPECT_FALSE(ret.has_value());
+    EXPECT_EQ(setConfigCalls, 0);
+}
+
+} // namespace
+} // namespace linglong::common::cli


### PR DESCRIPTION
Consolidate duplicate repo subcommand logic from ll-cli and ll-builder into linglong::common::cli (with addRepoCommand, handleRepoCommand) using a RepoConfigBackend abstraction for config access and add unit tests.