### PR TITLE
refactor: remove monolithic clearReference

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -110,10 +110,11 @@ fetchSources(const std::vector<api::types::v1::BuilderProjectSource> &sources,
 
 namespace detail {
 
-utils::error::Result<void> pullResolvedRef(const package::Reference &ref,
+utils::error::Result<void> pullResolvedRef(const package::ReferenceWithRepo &refRepo,
                                            repo::OSTreeRepo &repo,
                                            const std::string &module) noexcept
 {
+    const auto &ref = refRepo.reference;
     LINGLONG_TRACE("pull " + ref.toString());
 
     if (repo.getLayerDir(ref, module)) {
@@ -142,10 +143,7 @@ utils::error::Result<void> pullResolvedRef(const package::Reference &ref,
                      [&tmpTask]() {
                          tmpTask.Cancel();
                      });
-    auto res =
-      repo.pull(tmpTask,
-                package::ReferenceWithRepo{ .repo = repo.getDefaultRepo(), .reference = ref },
-                module);
+    auto res = repo.pull(tmpTask, refRepo, module);
     if (!res) {
         return LINGLONG_ERR(res);
     }
@@ -153,12 +151,13 @@ utils::error::Result<void> pullResolvedRef(const package::Reference &ref,
     return LINGLONG_OK;
 }
 
-utils::error::Result<package::Reference> pullDependency(const std::string &fuzzyRefStr,
-                                                        repo::OSTreeRepo &repo,
-                                                        const std::string &module,
-                                                        bool useRemote) noexcept
+utils::error::Result<DependencyReference>
+clearDependency(const std::string &fuzzyRefStr,
+                repo::OSTreeRepo &repo,
+                bool useRemote,
+                std::optional<std::string> module) noexcept
 {
-    LINGLONG_TRACE("pull dependency " + fuzzyRefStr);
+    LINGLONG_TRACE("clear dependency " + fuzzyRefStr);
 
     auto fuzzyRef = package::FuzzyReference::parse(fuzzyRefStr);
     if (!fuzzyRef) {
@@ -166,54 +165,77 @@ utils::error::Result<package::Reference> pullDependency(const std::string &fuzzy
     }
 
     std::optional<package::Reference> localRef;
-    auto localResult = repo.clearReference(
-      *fuzzyRef,
-      { .forceRemote = false, .fallbackToRemote = false, .semanticMatching = true });
+    auto localResult = repo.clearReferenceLocal(*fuzzyRef, true);
     if (localResult) {
         localRef = std::move(localResult).value();
+    }
+    if (localRef && module && !repo.getLayerDir(*localRef, *module)) {
+        localRef.reset();
+    }
+
+    if (localRef && fuzzyRef->version && *fuzzyRef->version == localRef->version.toString()) {
+        return DependencyReference{ std::nullopt, std::move(localRef) };
     }
 
     if (!useRemote) {
         if (localRef) {
-            return std::move(*localRef);
+            return DependencyReference{ std::nullopt, std::move(localRef) };
         }
         return LINGLONG_ERR(fmt::format("failed to get local ref {}", fuzzyRef->toString()),
                             localResult);
     }
 
-    std::optional<package::Reference> remoteRef;
-    auto remoteResult = repo.clearReference(
-      *fuzzyRef,
-      { .forceRemote = true, .fallbackToRemote = true, .semanticMatching = true });
+    std::optional<package::ReferenceWithRepo> remoteRef;
+    auto remoteResult = repo.latestRemoteReference(*fuzzyRef);
     if (remoteResult) {
         remoteRef = std::move(remoteResult).value();
     }
 
-    bool preferRemote = remoteRef && (!localRef || remoteRef->version > localRef->version);
-    auto &bestRef = preferRemote ? remoteRef : localRef;
-
-    if (!bestRef) {
+    bool preferRemote =
+      remoteRef && (!localRef || remoteRef->reference.version > localRef->version);
+    if (!preferRemote && !localRef) {
         return LINGLONG_ERR(fmt::format("ref doesn't exist {}", fuzzyRef->toString()));
     }
 
-    auto pullRes = pullResolvedRef(*bestRef, repo, module);
-    if (pullRes) {
-        return std::move(*bestRef);
+    if (!preferRemote) {
+        remoteRef.reset();
     }
 
-    if (preferRemote && localRef) {
-        LogW("failed to pull remote version {}, falling back to local: {}",
-             bestRef->toString(),
-             pullRes.error().message());
-        auto fallbackRes = pullResolvedRef(*localRef, repo, module);
-        if (fallbackRes) {
+    return DependencyReference{ std::move(remoteRef), std::move(localRef) };
+}
+
+utils::error::Result<package::Reference> pullDependency(const std::string &fuzzyRefStr,
+                                                        repo::OSTreeRepo &repo,
+                                                        const std::string &module) noexcept
+{
+    LINGLONG_TRACE("pull dependency " + fuzzyRefStr);
+
+    auto ref = clearDependency(fuzzyRefStr,
+                               repo,
+                               true,
+                               module == "binary" ? std::nullopt : std::optional{ module });
+    if (!ref) {
+        return LINGLONG_ERR(ref);
+    }
+
+    auto [refRepo, localRef] = std::move(*ref);
+    if (!refRepo) {
+        return std::move(*localRef);
+    }
+
+    auto pullRes = pullResolvedRef(*refRepo, repo, module);
+    if (!pullRes) {
+        if (localRef) {
+            LogW("failed to pull version {}, use local version {}: {}",
+                 refRepo->reference.toString(),
+                 localRef->toString(),
+                 pullRes.error().message());
             return std::move(*localRef);
         }
-        return LINGLONG_ERR("failed to pull local fallback version " + localRef->toString(),
-                            fallbackRes);
+        return LINGLONG_ERR("failed to pull version " + refRepo->reference.toString(), pullRes);
     }
 
-    return LINGLONG_ERR("failed to pull version " + bestRef->toString(), pullRes);
+    return std::move(refRepo->reference);
 }
 
 void mergeOutput(const std::vector<std::filesystem::path> &src,
@@ -495,7 +517,7 @@ Builder::ensureUtils(const std::string &id, const package::Architecture &arch) n
         return LINGLONG_ERR(fuzzyRef);
     }
 
-    auto ref = detail::pullDependency(fuzzyRef->toString(), this->repo, "binary", true);
+    auto ref = detail::pullDependency(fuzzyRef->toString(), this->repo, "binary");
     if (!ref) {
         return LINGLONG_ERR("failed to get utils " + id, ref);
     }
@@ -509,13 +531,13 @@ Builder::ensureUtils(const std::string &id, const package::Architecture &arch) n
     // assumes these dependencies are available for the current architecture,
     // this requires the same version of `build-utils` to be built for both
     // the target and the current architectures.
-    auto baseRef = detail::pullDependency(info.base, this->repo, "binary", true);
+    auto baseRef = detail::pullDependency(info.base, this->repo, "binary");
     if (!baseRef) {
         return LINGLONG_ERR("base not exist: " + info.base, baseRef);
     }
 
     if (info.runtime) {
-        auto runtimeRef = detail::pullDependency(info.runtime.value(), this->repo, "binary", true);
+        auto runtimeRef = detail::pullDependency(info.runtime.value(), this->repo, "binary");
         if (!runtimeRef) {
             return LINGLONG_ERR("runtime not exist: " + info.runtime.value(), runtimeRef);
         }
@@ -537,61 +559,93 @@ utils::error::Result<void> Builder::buildStagePullDependency() noexcept
                    .toStdString(),
                  2);
 
-    auto baseRef = detail::pullDependency(this->project->base,
-                                          this->repo,
-                                          "binary",
-                                          !this->buildOptions.skipPullDepend);
-    if (!baseRef) {
-        return LINGLONG_ERR("base dependency error", baseRef);
-    }
+    auto handleDependency = [this](const std::string &refStr) -> utils::error::Result<void> {
+        LINGLONG_TRACE("handle dependency " + refStr);
 
-    std::optional<package::Reference> runtimeRef;
-    if (this->project->runtime) {
-        auto ref = detail::pullDependency(*this->project->runtime,
-                                          this->repo,
-                                          "binary",
-                                          !this->buildOptions.skipPullDepend);
+        auto printStatus = [](const package::Reference &ref,
+                              std::string_view module,
+                              std::string_view status) {
+            printReplacedText(
+              fmt::format("{:<35}{:<15}{:<15}{}\n", ref.id, ref.version.toString(), module, status),
+              2);
+        };
+
+        auto ref = detail::clearDependency(refStr, this->repo, !this->buildOptions.skipPullDepend);
         if (!ref) {
-            return LINGLONG_ERR("runtime dependency error", ref);
+            return LINGLONG_ERR(ref);
         }
-        runtimeRef = std::move(ref).value();
+
+        const package::Reference *resolvedRef = nullptr;
+        auto &[refRepo, localRef] = *ref;
+        if (!refRepo) {
+            const auto &local = *localRef;
+            resolvedRef = &local;
+            // binary module is install
+            printStatus(local, "binary", "complete");
+
+            // try pull develop module if skipPullDepend is not set
+            if (!this->buildOptions.skipPullDepend) {
+                auto res = detail::pullDependency(localRef->toString(), this->repo, "develop");
+                if (!res) {
+                    LogW("failed to pull develop module of {}: {}", refStr, res.error().message());
+                }
+            }
+        } else {
+            // use remote reference
+            resolvedRef = &refRepo->reference;
+            auto res = detail::pullResolvedRef(*refRepo, this->repo, "binary");
+            if (!res) {
+                if (!localRef) {
+                    return LINGLONG_ERR(res);
+                }
+
+                LogW("failed to pull binary module of {}, use local version {}: {}",
+                     refRepo->reference.toString(),
+                     localRef->toString(),
+                     res.error());
+                printStatus(*localRef, "binary", "complete");
+
+                auto layerDir = this->repo.getLayerDir(*localRef, "develop");
+                if (!layerDir) {
+                    auto developRes =
+                      detail::pullDependency(localRef->toString(), this->repo, "develop");
+                    if (!developRes) {
+                        LogW("failed to pull develop module of {}: {}",
+                             refStr,
+                             developRes.error().message());
+                    }
+                    layerDir = this->repo.getLayerDir(*localRef, "develop");
+                }
+
+                printStatus(*localRef, "develop", layerDir ? "complete" : "missing");
+
+                return LINGLONG_OK;
+            }
+            printStatus(refRepo->reference, "binary", "complete");
+
+            res = detail::pullResolvedRef(*refRepo, this->repo, "develop");
+            if (!res) {
+                LogW("failed to pull develop module of {}: {}",
+                     refRepo->reference.toString(),
+                     res.error().message());
+            }
+        }
+
+        auto layerDir = this->repo.getLayerDir(*resolvedRef, "develop");
+        printStatus(*resolvedRef, "develop", layerDir ? "complete" : "missing");
+
+        return LINGLONG_OK;
+    };
+
+    auto res = handleDependency(this->project->base);
+    if (!res) {
+        return LINGLONG_ERR(res);
     }
 
-    if (!this->buildOptions.skipPullDepend) {
-        printReplacedText(fmt::format("{:<35}{:<15}{:<15}complete\n",
-                                      baseRef->id,
-                                      baseRef->version.toString(),
-                                      "binary"),
-                          2);
-
-        auto res = detail::pullResolvedRef(*baseRef, this->repo, "develop");
+    if (this->project->runtime) {
+        res = handleDependency(*this->project->runtime);
         if (!res) {
-            return LINGLONG_ERR("failed to pull base develop " + baseRef->toString(), res);
-        }
-
-        printReplacedText(fmt::format("{:<35}{:<15}{:<15}complete\n",
-                                      baseRef->id,
-                                      baseRef->version.toString(),
-                                      "develop"),
-                          2);
-
-        if (runtimeRef) {
-            printReplacedText(fmt::format("{:<35}{:<15}{:<15}complete\n",
-                                          runtimeRef->id,
-                                          runtimeRef->version.toString(),
-                                          "binary"),
-                              2);
-            res = detail::pullResolvedRef(*runtimeRef, this->repo, "develop");
-            if (!res) {
-                return LINGLONG_ERR("failed to pull runtime develop " + runtimeRef->toString(),
-                                    res);
-            }
-
-            printReplacedText(fmt::format("{:<35}{:<15}{:<15}complete\n",
-                                          runtimeRef->id,
-                                          runtimeRef->version.toString(),
-                                          "develop"),
-                              2);
+            return LINGLONG_ERR(res);
         }
     }
 
@@ -1391,7 +1445,7 @@ utils::error::Result<void> Builder::exportUAB(const ExportOption &option,
                 return LINGLONG_ERR("fuzzy ref", fuzzyRef);
             }
 
-            auto targetRef = this->repo.clearReference(*fuzzyRef, { .fallbackToRemote = false });
+            auto targetRef = this->repo.clearReferenceLocal(*fuzzyRef);
             if (!targetRef) {
                 return LINGLONG_ERR("clear ref", targetRef);
             }
@@ -1572,12 +1626,13 @@ utils::error::Result<void> Builder::exportUAB(const ExportOption &option,
         }
     }
 
-    auto baseRef = detail::pullDependency(this->project->base, this->repo, "binary", false);
+    auto baseRef = detail::clearDependency(this->project->base, this->repo, false);
     if (!baseRef) {
         return LINGLONG_ERR(baseRef);
     }
+    auto baseReference = std::move(*baseRef).second.value();
 
-    auto baseDir = this->repo.getLayerDir(*baseRef);
+    auto baseDir = this->repo.getLayerDir(baseReference);
     if (!baseDir) {
         return LINGLONG_ERR(baseDir);
     }
@@ -1593,12 +1648,13 @@ utils::error::Result<void> Builder::exportUAB(const ExportOption &option,
 
     if (this->project->runtime) {
         auto runtimeRef =
-          detail::pullDependency(this->project->runtime.value(), this->repo, "binary", false);
+          detail::clearDependency(this->project->runtime.value(), this->repo, false);
         if (!runtimeRef) {
             return LINGLONG_ERR(runtimeRef);
         }
+        auto runtimeReference = std::move(*runtimeRef).second.value();
 
-        auto runtimeDir = this->repo.getLayerDir(*runtimeRef);
+        auto runtimeDir = this->repo.getLayerDir(runtimeReference);
         if (!runtimeDir) {
             return LINGLONG_ERR(runtimeDir);
         }

--- a/libs/linglong/src/linglong/builder/linglong_builder.h
+++ b/libs/linglong/src/linglong/builder/linglong_builder.h
@@ -15,8 +15,10 @@
 #include "linglong/utils/overlayfs.h"
 
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace linglong::builder {
@@ -59,13 +61,19 @@ void mergeOutput(const std::vector<std::filesystem::path> &src,
                  const std::filesystem::path &dest,
                  const std::vector<std::string> &targets,
                  const std::vector<std::string> &excludes);
-utils::error::Result<void> pullResolvedRef(const package::Reference &ref,
+utils::error::Result<void> pullResolvedRef(const package::ReferenceWithRepo &refRepo,
                                            repo::OSTreeRepo &repo,
                                            const std::string &module) noexcept;
+using DependencyReference =
+  std::pair<std::optional<package::ReferenceWithRepo>, std::optional<package::Reference>>;
+utils::error::Result<DependencyReference>
+clearDependency(const std::string &fuzzyRefStr,
+                repo::OSTreeRepo &repo,
+                bool useRemote,
+                std::optional<std::string> module = std::nullopt) noexcept;
 utils::error::Result<package::Reference> pullDependency(const std::string &fuzzyRefStr,
                                                         repo::OSTreeRepo &repo,
-                                                        const std::string &module,
-                                                        bool useRemote) noexcept;
+                                                        const std::string &module) noexcept;
 } // namespace detail
 
 class Builder

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -629,11 +629,7 @@ int Cli::run(const RunOptions &options)
         return -1;
     }
 
-    auto curAppRef = this->repository.clearReference(*fuzzyRef,
-                                                     {
-                                                       .forceRemote = false,
-                                                       .fallbackToRemote = false,
-                                                     });
+    auto curAppRef = this->repository.clearReferenceLocal(*fuzzyRef);
     if (!curAppRef) {
         this->printer.printErr(curAppRef.error());
         return -1;
@@ -1236,11 +1232,7 @@ int Cli::upgrade(const UpgradeOptions &options)
             return -1;
         }
 
-        auto localRef = this->repository.clearReference(*fuzzyRef,
-                                                        {
-                                                          .forceRemote = false,
-                                                          .fallbackToRemote = false,
-                                                        });
+        auto localRef = this->repository.clearReferenceLocal(*fuzzyRef);
         if (!localRef) {
             this->printer.printMessage(
               fmt::format(_("Application {} is not installed."), options.appid));
@@ -1664,9 +1656,7 @@ int Cli::info(const InfoOptions &options)
             return -1;
         }
 
-        auto ref =
-          this->repository.clearReference(*fuzzyRef,
-                                          { .forceRemote = false, .fallbackToRemote = false });
+        auto ref = this->repository.clearReferenceLocal(*fuzzyRef);
         if (!ref) {
             LogD("{}", ref.error());
             this->printer.printErr(LINGLONG_ERRV("Cannot find such application.",
@@ -1720,8 +1710,7 @@ int Cli::content(const ContentOptions &options)
         return -1;
     }
 
-    auto ref = this->repository.clearReference(*fuzzyRef,
-                                               { .forceRemote = false, .fallbackToRemote = false });
+    auto ref = this->repository.clearReferenceLocal(*fuzzyRef);
     if (!ref) {
         LogD("{}", ref.error());
         this->printer.printErr(LINGLONG_ERRV("Can not find such application."));
@@ -2103,8 +2092,7 @@ int Cli::getLayerDir(const InspectOptions &options)
         return -1;
     }
 
-    auto ref = this->repository.clearReference(*fuzzyRef,
-                                               { .forceRemote = false, .fallbackToRemote = false });
+    auto ref = this->repository.clearReferenceLocal(*fuzzyRef);
     if (!ref) {
         LogD("{}", ref.error());
         this->printer.printErr(LINGLONG_ERRV("Can not find such application."));

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -613,10 +613,7 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
         return toDBusReply(fuzzyRef);
     }
 
-    auto localRef = this->repo->clearReference(*fuzzyRef,
-                                               {
-                                                 .fallbackToRemote = false // NOLINT
-                                               });
+    auto localRef = this->repo->clearReferenceLocal(*fuzzyRef);
     if (localRef) {
         auto layerDir = this->repo->getLayerDir(*localRef, packageInfo.packageInfoV2Module);
         if (layerDir && layerDir->valid()) {
@@ -1431,12 +1428,7 @@ PackageManager::needToInstall(const std::string &refStr, std::optional<std::stri
         fuzzyRef->channel = *channel;
     }
 
-    auto local = this->repo->clearReference(*fuzzyRef,
-                                            {
-                                              .forceRemote = false,
-                                              .fallbackToRemote = false,
-                                              .semanticMatching = true,
-                                            });
+    auto local = this->repo->clearReferenceLocal(*fuzzyRef, true);
     // if the ref is already installed, do nothing
     if (local) {
         return std::nullopt;
@@ -1458,12 +1450,7 @@ PackageManager::needToUpgrade(const package::FuzzyReference &fuzzyRef,
     LINGLONG_TRACE(fmt::format("need to upgrade ref {}", fuzzyRef.toString()));
 
     if (!local) {
-        auto res = this->repo->clearReference(fuzzyRef,
-                                              {
-                                                .forceRemote = false,
-                                                .fallbackToRemote = false,
-                                                .semanticMatching = true,
-                                              });
+        auto res = this->repo->clearReferenceLocal(fuzzyRef, true);
         if (res) {
             local = std::move(res).value();
         }
@@ -1552,12 +1539,7 @@ utils::error::Result<void> PackageManager::installDependsRef(Task &task,
         fuzzyRef->version = version;
     }
 
-    auto local = this->repo->clearReference(*fuzzyRef,
-                                            {
-                                              .forceRemote = false,
-                                              .fallbackToRemote = false,
-                                              .semanticMatching = true,
-                                            });
+    auto local = this->repo->clearReferenceLocal(*fuzzyRef, true);
     // if the ref is already installed, do nothing
     if (local) {
         return LINGLONG_OK;
@@ -1686,9 +1668,7 @@ PackageManager::Prune(std::vector<api::types::v1::PackageInfoV2> &removed) noexc
                                                                 name,
                                                                 extension.version,
                                                                 std::nullopt);
-                auto ref = repo->clearReference(
-                  *fuzzyRef,
-                  { .forceRemote = false, .fallbackToRemote = false, .semanticMatching = true });
+                auto ref = repo->clearReferenceLocal(*fuzzyRef, true);
                 if (ref) {
                     touchTarget(*ref, true);
                 }
@@ -1731,12 +1711,7 @@ PackageManager::Prune(std::vector<api::types::v1::PackageInfoV2> &removed) noexc
                 continue;
             }
 
-            auto runtimeRef = this->repo->clearReference(*runtimeFuzzyRef,
-                                                         {
-                                                           .forceRemote = false,
-                                                           .fallbackToRemote = false,
-                                                           .semanticMatching = true,
-                                                         });
+            auto runtimeRef = this->repo->clearReferenceLocal(*runtimeFuzzyRef, true);
             if (!runtimeRef) {
                 LogW("{}", runtimeRef.error());
                 continue;
@@ -1751,12 +1726,7 @@ PackageManager::Prune(std::vector<api::types::v1::PackageInfoV2> &removed) noexc
             continue;
         }
 
-        auto baseRef = this->repo->clearReference(*baseFuzzyRef,
-                                                  {
-                                                    .forceRemote = false,
-                                                    .fallbackToRemote = false,
-                                                    .semanticMatching = true,
-                                                  });
+        auto baseRef = this->repo->clearReferenceLocal(*baseFuzzyRef, true);
         if (!baseRef) {
             LogW("{}", baseRef.error());
             continue;

--- a/libs/linglong/src/linglong/package_manager/uab_installation.cpp
+++ b/libs/linglong/src/linglong/package_manager/uab_installation.cpp
@@ -146,12 +146,7 @@ utils::error::Result<void> UabInstallationAction::checkUABLayersConstrain(
             return LINGLONG_ERR(fuzzyRef);
         }
 
-        auto localRef = repo.clearReference(*fuzzyRef,
-                                            {
-                                              .forceRemote = false,
-                                              .fallbackToRemote = false,
-                                              .semanticMatching = false,
-                                            });
+        auto localRef = repo.clearReferenceLocal(*fuzzyRef);
 
         auto version = package::Version::parse(front.version);
         if (!version) {

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -357,9 +357,40 @@ createOstreeRepo(const std::filesystem::path &location,
     return static_cast<OstreeRepo *>(g_steal_pointer(&ostreeRepo));
 }
 
-utils::error::Result<package::Reference> clearReferenceLocal(const RepoCache &cache,
-                                                             package::FuzzyReference fuzzy,
-                                                             bool semanticMatching = false) noexcept
+utils::error::Result<bool> semanticMatch(const package::FuzzyReference &fuzzy,
+                                         const api::types::v1::PackageInfoV2 &record) noexcept
+{
+    LINGLONG_TRACE("semanticMatch");
+
+    if (fuzzy.id != record.id) {
+        return false;
+    }
+
+    if (fuzzy.channel && fuzzy.channel != record.channel) {
+        return false;
+    }
+
+    if (fuzzy.arch && fuzzy.arch->toString() != record.arch[0]) {
+        return false;
+    }
+
+    if (fuzzy.version) {
+        auto version = package::Version::parse(record.version);
+        if (!version) {
+            return LINGLONG_ERR(version);
+        }
+        if (!version->semanticMatch(*fuzzy.version)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+} // namespace
+
+utils::error::Result<package::Reference> OSTreeRepo::clearReferenceLocal(
+  const package::FuzzyReference &fuzzy, bool semanticMatching) const noexcept
 {
     LINGLONG_TRACE("clear fuzzy reference locally");
 
@@ -370,7 +401,7 @@ utils::error::Result<package::Reference> clearReferenceLocal(const RepoCache &ca
     if (fuzzy.arch) {
         query.architecture = fuzzy.arch->toString();
     }
-    const auto availablePackage = cache.queryLayerItem(query);
+    const auto availablePackage = this->cache->queryLayerItem(query);
     if (availablePackage.empty()) {
         return LINGLONG_ERR("package not found:" + fuzzy.toString(),
                             utils::error::ErrorCode::AppNotFoundFromLocal);
@@ -427,81 +458,6 @@ utils::error::Result<package::Reference> clearReferenceLocal(const RepoCache &ca
     LogD("clear fuzzy ref {} to {}", fuzzy.toString(), ref->toString());
     return ref;
 }
-
-utils::error::Result<bool> semanticMatch(const package::FuzzyReference &fuzzy,
-                                         const api::types::v1::PackageInfoV2 &record) noexcept
-{
-    LINGLONG_TRACE("semanticMatch");
-
-    if (fuzzy.id != record.id) {
-        return false;
-    }
-
-    if (fuzzy.channel && fuzzy.channel != record.channel) {
-        return false;
-    }
-
-    if (fuzzy.arch && fuzzy.arch->toString() != record.arch[0]) {
-        return false;
-    }
-
-    if (fuzzy.version) {
-        auto version = package::Version::parse(record.version);
-        if (!version) {
-            return LINGLONG_ERR(version);
-        }
-        if (!version->semanticMatch(*fuzzy.version)) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-std::optional<package::Reference> matchReference(const api::types::v1::PackageInfoV2 &record,
-                                                 const package::FuzzyReference &fuzzy,
-                                                 const std::string &module) noexcept
-{
-    auto recordStr = nlohmann::json(record).dump();
-    if (fuzzy.channel && fuzzy.channel != record.channel) {
-        return std::nullopt;
-    }
-    if (fuzzy.id != record.id) {
-        return std::nullopt;
-    }
-    auto version = package::Version::parse(record.version);
-    if (!version) {
-        LogW("Ignore invalid package record {}: {}", recordStr, version.error());
-        return std::nullopt;
-    }
-    if (record.arch.empty()) {
-        LogW("Ignore empty arch package record {}", recordStr);
-        return std::nullopt;
-    }
-    if (module == "binary") {
-        if (record.packageInfoV2Module != "binary" && record.packageInfoV2Module != "runtime") {
-            return std::nullopt;
-        }
-    } else {
-        if (record.packageInfoV2Module != module) {
-            return std::nullopt;
-        }
-    }
-    auto arch = package::Architecture::parse(record.arch[0]);
-    if (!arch) {
-        LogW("Ignore invalid package record {}: {}", recordStr, arch.error());
-        return std::nullopt;
-    }
-
-    auto currentRef = package::Reference::create(record.channel, fuzzy.id, *version, *arch);
-    if (!currentRef) {
-        LogW("Ignore invalid package record {}: {}", recordStr, currentRef.error());
-        return std::nullopt;
-    }
-    return *currentRef;
-}
-
-} // namespace
 
 utils::error::Result<api::types::v1::PackageInfoV2> RefMetaData::getPackageInfo() const noexcept
 {
@@ -1527,97 +1483,6 @@ utils::error::Result<void> OSTreeRepo::pull(service::Task &taskContext,
     }
 
     return LINGLONG_OK;
-}
-
-utils::error::Result<package::Reference>
-OSTreeRepo::clearReference(const package::FuzzyReference &fuzzy,
-                           const clearReferenceOption &opts,
-                           const std::string &module,
-                           const std::optional<std::string> &repo) const noexcept
-{
-    LINGLONG_TRACE(fmt::format("clear fuzzy reference {}", fuzzy.toString()));
-
-    utils::error::Result<package::Reference> reference = LINGLONG_ERR("reference not exists");
-
-    if (!opts.forceRemote) {
-        reference = clearReferenceLocal(*cache, fuzzy, opts.semanticMatching);
-        if (reference) {
-            return reference;
-        }
-
-        if (!opts.fallbackToRemote) {
-            return LINGLONG_ERR(reference);
-        }
-
-        LogD("fallback to remote: {}", reference.error());
-    }
-
-    // TODO
-    // repo should not optional
-    api::types::v1::Repo remoteRepo = getDefaultRepo();
-
-    if (repo) {
-        auto repoRet = this->getRepoByAlias(*repo);
-        if (!repoRet) {
-            return LINGLONG_ERR(repoRet);
-        }
-        remoteRepo = *repoRet;
-    }
-
-    auto listRet = this->searchRemote(fuzzy, remoteRepo);
-    if (!listRet.has_value()) {
-        return LINGLONG_ERR("get ref list from remote " + listRet.error().message(),
-                            listRet.error().code());
-    }
-
-    std::optional<package::Version> fuzzyVersion;
-    auto list = std::move(listRet).value();
-    if (fuzzy.version) {
-        list = package::Version::filterByFuzzyVersion(list, *fuzzy.version);
-
-        auto fuzzyVerRet = linglong::package::Version::parse(*fuzzy.version);
-        if (!fuzzyVerRet) {
-            return LINGLONG_ERR(fuzzyVerRet);
-        }
-        fuzzyVersion = std::move(fuzzyVerRet).value();
-    }
-
-    for (const auto &record : list) {
-        auto currentRefRet = matchReference(record, fuzzy, module);
-        if (!currentRefRet) {
-            continue;
-        }
-
-        if (fuzzyVersion) {
-            // 语义化匹配最新的版本
-            if (opts.semanticMatching) {
-                if (!reference || currentRefRet->version > reference->version) {
-                    reference = *currentRefRet;
-                }
-                continue;
-            }
-
-            // 精确匹配版本
-            if (currentRefRet->version == *fuzzyVersion) {
-                reference = *currentRefRet;
-                break;
-            }
-            continue;
-        }
-
-        // 匹配最新版本
-        if (!reference || currentRefRet->version > reference->version) {
-            reference = *currentRefRet;
-        }
-    }
-
-    if (!reference) {
-        auto msg =
-          fmt::format("not found ref:{} module:{} from remote repo", fuzzy.toString(), module);
-        return LINGLONG_ERR(msg, utils::error::ErrorCode::AppNotFoundFromRemote);
-    }
-
-    return reference;
 }
 
 utils::error::Result<std::vector<api::types::v1::PackageInfoV2>>
@@ -3165,7 +3030,7 @@ OSTreeRepo::latestLocalReference(const package::FuzzyReference &fuzzyRef) const 
 {
     LINGLONG_TRACE("get latest local reference");
 
-    auto ref = clearReferenceLocal(*cache, fuzzyRef, true);
+    auto ref = this->clearReferenceLocal(fuzzyRef, true);
     if (!ref) {
         return LINGLONG_ERR(ref);
     }

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -31,13 +31,6 @@
 
 namespace linglong::repo {
 
-struct clearReferenceOption
-{
-    bool forceRemote = false;      // force clear remote reference
-    bool fallbackToRemote = true;  // fallback to remote if local not found
-    bool semanticMatching = false; // semantic matching compatible version
-};
-
 class RefMetaData
 {
 public:
@@ -123,11 +116,8 @@ public:
                                                           const package::ReferenceWithRepo &refRepo,
                                                           const std::string &module) noexcept;
 
-    [[nodiscard]] virtual utils::error::Result<package::Reference>
-    clearReference(const package::FuzzyReference &fuzzy,
-                   const clearReferenceOption &opts,
-                   const std::string &module = "binary",
-                   const std::optional<std::string> &repo = std::nullopt) const noexcept;
+    [[nodiscard]] virtual utils::error::Result<package::Reference> clearReferenceLocal(
+      const package::FuzzyReference &fuzzyRef, bool semanticMatching = false) const noexcept;
 
     virtual utils::error::Result<std::vector<api::types::v1::PackageInfoV2>>
     listLocal() const noexcept;

--- a/libs/linglong/src/linglong/runtime/run_context.cpp
+++ b/libs/linglong/src/linglong/runtime/run_context.cpp
@@ -108,12 +108,7 @@ utils::error::Result<void> RunContext::resolve(const linglong::package::Referenc
                 return LINGLONG_ERR(runtimeFuzzyRef);
             }
 
-            auto ref = repo.clearReference(*runtimeFuzzyRef,
-                                           {
-                                             .forceRemote = false,
-                                             .fallbackToRemote = false,
-                                             .semanticMatching = true,
-                                           });
+            auto ref = repo.clearReferenceLocal(*runtimeFuzzyRef, true);
             if (!ref) {
                 return LINGLONG_ERR("ref doesn't exist " + runtimeFuzzyRef->toString());
             }
@@ -137,12 +132,7 @@ utils::error::Result<void> RunContext::resolve(const linglong::package::Referenc
             return LINGLONG_ERR(baseFuzzyRef);
         }
 
-        auto ref = repo.clearReference(*baseFuzzyRef,
-                                       {
-                                         .forceRemote = false,
-                                         .fallbackToRemote = false,
-                                         .semanticMatching = true,
-                                       });
+        auto ref = repo.clearReferenceLocal(*baseFuzzyRef, true);
         if (!ref) {
             return LINGLONG_ERR(ref);
         }
@@ -253,12 +243,7 @@ utils::error::Result<void> RunContext::resolve(const api::types::v1::BuilderProj
         return LINGLONG_ERR(baseFuzzyRef);
     }
 
-    auto ref = repo.clearReference(*baseFuzzyRef,
-                                   {
-                                     .forceRemote = false,
-                                     .fallbackToRemote = false,
-                                     .semanticMatching = true,
-                                   });
+    auto ref = repo.clearReferenceLocal(*baseFuzzyRef, true);
     if (!ref) {
         return LINGLONG_ERR(ref);
     }
@@ -274,12 +259,7 @@ utils::error::Result<void> RunContext::resolve(const api::types::v1::BuilderProj
             return LINGLONG_ERR(runtimeFuzzyRef);
         }
 
-        ref = repo.clearReference(*runtimeFuzzyRef,
-                                  {
-                                    .forceRemote = false,
-                                    .fallbackToRemote = false,
-                                    .semanticMatching = true,
-                                  });
+        ref = repo.clearReferenceLocal(*runtimeFuzzyRef, true);
         if (!ref) {
             return LINGLONG_ERR("ref doesn't exist " + runtimeFuzzyRef->toString());
         }
@@ -294,12 +274,7 @@ utils::error::Result<void> RunContext::resolve(const api::types::v1::BuilderProj
         if (!fuzzyRef) {
             return LINGLONG_ERR(fuzzyRef);
         }
-        auto ref = repo.clearReference(*fuzzyRef,
-                                       {
-                                         .forceRemote = false,
-                                         .fallbackToRemote = false,
-                                         .semanticMatching = true,
-                                       });
+        auto ref = repo.clearReferenceLocal(*fuzzyRef, true);
         if (!ref || *ref != baseLayer->getReference()) {
             auto msg = fmt::format("Base is not compatible with runtime. \n - Current base: {}\n - "
                                    "Current runtime: {}\n - Base required by runtime: {}",
@@ -768,8 +743,7 @@ RunContext::resolveExtension(RuntimeLayer &targetLayer,
             version = extDef.version;
         }
         auto fuzzyRef = package::FuzzyReference::create(channel, name, version, std::nullopt);
-        auto ref =
-          repo.clearReference(*fuzzyRef, { .fallbackToRemote = false, .semanticMatching = true });
+        auto ref = repo.clearReferenceLocal(*fuzzyRef, true);
         if (!ref) {
             LogD("extension is not installed: {}", fuzzyRef->toString());
             if (skipOnNotFound) {

--- a/libs/linglong/tests/ll-tests/src/linglong/builder/pull_dependency_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/builder/pull_dependency_test.cpp
@@ -6,38 +6,27 @@
 #include <gtest/gtest.h>
 
 #include "common/tempdir.h"
+#define private public
 #include "linglong/builder/linglong_builder.h"
+#undef private
 #include "linglong/package/fuzzy_reference.h"
 #include "linglong/package/reference.h"
 #include "linglong/package_manager/package_task.h"
 #include "linglong/repo/ostree_repo.h"
 #include "linglong/utils/error/error.h"
+#include "ocppi/cli/crun/Crun.hpp"
 
 #include <filesystem>
 #include <memory>
 #include <string>
+#include <utility>
 
 using namespace linglong;
 using ::testing::_;
-using ::testing::AllOf;
-using ::testing::Field;
+using ::testing::InSequence;
 using ::testing::Return;
 
 namespace {
-
-auto isLocalOption()
-{
-    return AllOf(Field(&repo::clearReferenceOption::forceRemote, false),
-                 Field(&repo::clearReferenceOption::fallbackToRemote, false),
-                 Field(&repo::clearReferenceOption::semanticMatching, true));
-}
-
-auto isRemoteOption()
-{
-    return AllOf(Field(&repo::clearReferenceOption::forceRemote, true),
-                 Field(&repo::clearReferenceOption::fallbackToRemote, true),
-                 Field(&repo::clearReferenceOption::semanticMatching, true));
-}
 
 class MockRepo : public repo::OSTreeRepo
 {
@@ -55,11 +44,12 @@ public:
                 (override, const, noexcept));
 
     MOCK_METHOD(utils::error::Result<package::Reference>,
-                clearReference,
-                (const package::FuzzyReference &fuzzy,
-                 const repo::clearReferenceOption &opts,
-                 const std::string &module,
-                 const std::optional<std::string> &repo),
+                clearReferenceLocal,
+                (const package::FuzzyReference &fuzzy, bool semanticMatching),
+                (override, const, noexcept));
+    MOCK_METHOD(utils::error::Result<package::ReferenceWithRepo>,
+                latestRemoteReference,
+                (const package::FuzzyReference &fuzzyRef),
                 (override, const, noexcept));
 
     MOCK_METHOD(utils::error::Result<void>,
@@ -68,6 +58,8 @@ public:
                  const package::ReferenceWithRepo &refRepo,
                  const std::string &module),
                 (override, noexcept));
+
+    MOCK_METHOD(utils::error::Result<void>, mergeModules, (), (override, const, noexcept));
 
 private:
     static api::types::v1::RepoConfigV2 makeConfig()
@@ -84,14 +76,53 @@ private:
     }
 };
 
-auto notFound()
-{
-    return tl::make_unexpected(utils::error::Error::Err(__FILE__, __LINE__, "", "not found"));
-}
-
 auto layerCached()
 {
     return package::LayerDir("/fake/layer/dir");
+}
+
+auto refWithRepo(package::Reference ref, std::string repoName = "stable")
+{
+    api::types::v1::Repo remoteRepo;
+    remoteRepo.name = std::move(repoName);
+    remoteRepo.priority = 0;
+    remoteRepo.url = "https://example.com/repo";
+
+    return package::ReferenceWithRepo{
+        .repo = std::move(remoteRepo),
+        .reference = std::move(ref),
+    };
+}
+
+auto builderProject(std::optional<std::string> runtime = std::nullopt)
+{
+    api::types::v1::BuilderProject project;
+    project.base = "org.deepin.base/23.0.0.0/x86_64";
+    project.build = "";
+    project.command = std::vector<std::string>{ "true" };
+    project.package = api::types::v1::BuilderProjectPackage{
+        .architecture = std::string{ "x86_64" },
+        .description = "test app",
+        .id = "org.example.app",
+        .kind = "app",
+        .name = "test app",
+        .version = "1.0.0.0",
+    };
+    project.runtime = std::move(runtime);
+    project.version = "1";
+    return project;
+}
+
+auto builderConfig()
+{
+    return api::types::v1::BuilderConfig{ .repo = "", .version = 1 };
+}
+
+runtime::ContainerBuilder &containerBuilder()
+{
+    static auto cli = ocppi::cli::crun::Crun::New(std::filesystem::current_path());
+    static runtime::ContainerBuilder builder(**cli);
+    return builder;
 }
 
 class PullDependencyTest : public ::testing::Test
@@ -105,29 +136,87 @@ protected:
     std::unique_ptr<MockRepo> m_repo;
 };
 
-TEST_F(PullDependencyTest, useRemoteFalse_returns_local_ref)
+TEST_F(PullDependencyTest, clearDependency_useRemoteFalse_returns_local_ref)
 {
     auto ref = package::Reference::parse("main:org.example.test/1.0.0.0/x86_64");
     ASSERT_TRUE(ref.has_value()) << ref.error().message();
 
-    EXPECT_CALL(*m_repo, clearReference(_, isLocalOption(), _, _))
-      .WillOnce(Return(utils::error::Result<package::Reference>{ std::move(*ref) }));
+    EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(std::move(*ref)));
 
     auto result =
-      builder::detail::pullDependency("org.example.test/1.0.0.0/x86_64", *m_repo, "binary", false);
+      builder::detail::clearDependency("org.example.test/1.0.0.0/x86_64", *m_repo, false);
     ASSERT_TRUE(result.has_value()) << result.error().message();
-    EXPECT_EQ(result->toString(), "main:org.example.test/1.0.0.0/x86_64");
+    EXPECT_FALSE(result->first);
+    ASSERT_TRUE(result->second);
+    EXPECT_EQ(result->second->toString(), "main:org.example.test/1.0.0.0/x86_64");
 }
 
-TEST_F(PullDependencyTest, useRemoteFalse_not_found_returns_error)
+TEST_F(PullDependencyTest, clearDependency_useRemoteFalse_not_found_returns_error)
 {
-    EXPECT_CALL(*m_repo, clearReference(_, isLocalOption(), _, _)).WillOnce(Return(notFound()));
+    LINGLONG_TRACE("clearDependency_useRemoteFalse_not_found_returns_error");
 
-    auto result = builder::detail::pullDependency("org.example.missing/1.0.0.0/x86_64",
-                                                  *m_repo,
-                                                  "binary",
-                                                  false);
+    EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(LINGLONG_ERR("not found")));
+
+    auto result =
+      builder::detail::clearDependency("org.example.missing/1.0.0.0/x86_64", *m_repo, false);
     EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(PullDependencyTest, clearDependency_returns_local_variant)
+{
+    auto localRef = package::Reference::parse("main:org.example.test/3.0.0.0/x86_64");
+    auto remoteRef = package::Reference::parse("main:org.example.test/2.0.0.0/x86_64");
+    ASSERT_TRUE(localRef.has_value());
+    ASSERT_TRUE(remoteRef.has_value());
+
+    EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(std::move(*localRef)));
+    EXPECT_CALL(*m_repo, latestRemoteReference(_))
+      .WillOnce(Return(refWithRepo(std::move(*remoteRef))));
+
+    auto result =
+      builder::detail::clearDependency("org.example.test/2.0.0.0/x86_64", *m_repo, true);
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_FALSE(result->first);
+    ASSERT_TRUE(result->second);
+    EXPECT_EQ(result->second->version.toString(), "3.0.0.0");
+}
+
+TEST_F(PullDependencyTest, clearDependency_exact_version_returns_local_variant)
+{
+    auto localRef = package::Reference::parse("main:org.example.test/1.0.0.0/x86_64");
+    ASSERT_TRUE(localRef.has_value());
+
+    EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(std::move(*localRef)));
+    EXPECT_CALL(*m_repo, latestRemoteReference(_)).Times(0);
+
+    auto result =
+      builder::detail::clearDependency("org.example.test/1.0.0.0/x86_64", *m_repo, true);
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(result->second);
+    EXPECT_FALSE(result->first);
+    EXPECT_EQ(result->second->version.toString(), "1.0.0.0");
+}
+
+TEST_F(PullDependencyTest, clearDependency_module_missing_returns_remote_variant)
+{
+    LINGLONG_TRACE("clearDependency_module_missing_returns_remote_variant");
+
+    auto localRef = package::Reference::parse("main:org.example.test/3.0.0.0/x86_64");
+    auto remoteRef = package::Reference::parse("main:org.example.test/2.0.0.0/x86_64");
+    ASSERT_TRUE(localRef.has_value());
+    ASSERT_TRUE(remoteRef.has_value());
+
+    EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(std::move(*localRef)));
+    EXPECT_CALL(*m_repo, getLayerDir(_, "develop", _)).WillOnce(Return(LINGLONG_ERR("not found")));
+    EXPECT_CALL(*m_repo, latestRemoteReference(_))
+      .WillOnce(Return(refWithRepo(std::move(*remoteRef), "custom")));
+
+    auto result =
+      builder::detail::clearDependency("org.example.test/1.0.0.0/x86_64", *m_repo, true, "develop");
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(result->first);
+    EXPECT_FALSE(result->second);
+    EXPECT_EQ(result->first->repo.name, "custom");
 }
 
 TEST_F(PullDependencyTest, useRemoteTrue_prefers_remote_when_newer)
@@ -137,15 +226,13 @@ TEST_F(PullDependencyTest, useRemoteTrue_prefers_remote_when_newer)
     ASSERT_TRUE(localRef.has_value());
     ASSERT_TRUE(remoteRef.has_value());
 
-    EXPECT_CALL(*m_repo, clearReference(_, isLocalOption(), _, _))
-      .WillOnce(Return(utils::error::Result<package::Reference>{ std::move(*localRef) }));
-    EXPECT_CALL(*m_repo, clearReference(_, isRemoteOption(), _, _))
-      .WillOnce(Return(utils::error::Result<package::Reference>{ std::move(*remoteRef) }));
+    EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(std::move(*localRef)));
+    EXPECT_CALL(*m_repo, latestRemoteReference(_))
+      .WillOnce(Return(refWithRepo(std::move(*remoteRef))));
 
-    EXPECT_CALL(*m_repo, getLayerDir(_, _, _)).WillOnce(Return(layerCached()));
+    EXPECT_CALL(*m_repo, getLayerDir(_, "binary", _)).WillOnce(Return(layerCached()));
 
-    auto result =
-      builder::detail::pullDependency("org.example.test/1.0.0.0/x86_64", *m_repo, "binary", true);
+    auto result = builder::detail::pullDependency("org.example.test", *m_repo, "binary");
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->version.toString(), "2.0.0.0");
 }
@@ -157,17 +244,37 @@ TEST_F(PullDependencyTest, useRemoteTrue_prefers_local_when_newer)
     ASSERT_TRUE(localRef.has_value());
     ASSERT_TRUE(remoteRef.has_value());
 
-    EXPECT_CALL(*m_repo, clearReference(_, isLocalOption(), _, _))
-      .WillOnce(Return(utils::error::Result<package::Reference>{ std::move(*localRef) }));
-    EXPECT_CALL(*m_repo, clearReference(_, isRemoteOption(), _, _))
-      .WillOnce(Return(utils::error::Result<package::Reference>{ std::move(*remoteRef) }));
+    EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(std::move(*localRef)));
+    EXPECT_CALL(*m_repo, latestRemoteReference(_))
+      .WillOnce(Return(refWithRepo(std::move(*remoteRef))));
 
-    EXPECT_CALL(*m_repo, getLayerDir(_, _, _)).WillOnce(Return(layerCached()));
+    EXPECT_CALL(*m_repo, getLayerDir(_, _, _)).Times(0);
 
     auto result =
-      builder::detail::pullDependency("org.example.test/2.0.0.0/x86_64", *m_repo, "binary", true);
+      builder::detail::pullDependency("org.example.test/2.0.0.0/x86_64", *m_repo, "binary");
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->version.toString(), "3.0.0.0");
+}
+
+TEST_F(PullDependencyTest, useRemoteTrue_falls_back_to_local_when_remote_pull_fails)
+{
+    LINGLONG_TRACE("useRemoteTrue_falls_back_to_local_when_remote_pull_fails");
+
+    auto localRef = package::Reference::parse("main:org.example.test/1.0.0.0/x86_64");
+    auto remoteRef = package::Reference::parse("main:org.example.test/2.0.0.0/x86_64");
+    ASSERT_TRUE(localRef.has_value());
+    ASSERT_TRUE(remoteRef.has_value());
+
+    EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(std::move(*localRef)));
+    EXPECT_CALL(*m_repo, latestRemoteReference(_))
+      .WillOnce(Return(refWithRepo(std::move(*remoteRef))));
+
+    EXPECT_CALL(*m_repo, getLayerDir(_, "binary", _)).WillOnce(Return(LINGLONG_ERR("not found")));
+    EXPECT_CALL(*m_repo, pull(_, _, "binary")).WillOnce(Return(LINGLONG_ERR("not found")));
+
+    auto result = builder::detail::pullDependency("org.example.test", *m_repo, "binary");
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(result->version.toString(), "1.0.0.0");
 }
 
 TEST_F(PullDependencyTest, useRemoteTrue_equal_version_prefers_local)
@@ -177,66 +284,82 @@ TEST_F(PullDependencyTest, useRemoteTrue_equal_version_prefers_local)
     ASSERT_TRUE(localRef.has_value());
     ASSERT_TRUE(remoteRef.has_value());
 
-    EXPECT_CALL(*m_repo, clearReference(_, isLocalOption(), _, _))
-      .WillOnce(Return(utils::error::Result<package::Reference>{ std::move(*localRef) }));
-    EXPECT_CALL(*m_repo, clearReference(_, isRemoteOption(), _, _))
-      .WillOnce(Return(utils::error::Result<package::Reference>{ std::move(*remoteRef) }));
+    EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(std::move(*localRef)));
+    EXPECT_CALL(*m_repo, latestRemoteReference(_))
+      .WillOnce(Return(refWithRepo(std::move(*remoteRef))));
 
-    EXPECT_CALL(*m_repo, getLayerDir(_, _, _)).WillOnce(Return(layerCached()));
+    EXPECT_CALL(*m_repo, getLayerDir(_, _, _)).Times(0);
 
-    auto result =
-      builder::detail::pullDependency("org.example.test/2.0.0.0/x86_64", *m_repo, "binary", true);
+    auto result = builder::detail::pullDependency("org.example.test", *m_repo, "binary");
     ASSERT_TRUE(result.has_value()) << result.error().message();
 }
 
-TEST_F(PullDependencyTest, useRemoteTrue_only_local_exists)
+TEST_F(PullDependencyTest, exact_version_local_match_skips_remote_lookup)
 {
     auto localRef = package::Reference::parse("main:org.example.test/1.0.0.0/x86_64");
     ASSERT_TRUE(localRef.has_value());
 
-    EXPECT_CALL(*m_repo, clearReference(_, isLocalOption(), _, _))
-      .WillOnce(Return(utils::error::Result<package::Reference>{ std::move(*localRef) }));
-    EXPECT_CALL(*m_repo, clearReference(_, isRemoteOption(), _, _)).WillOnce(Return(notFound()));
-
-    EXPECT_CALL(*m_repo, getLayerDir(_, _, _)).WillOnce(Return(layerCached()));
+    EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(std::move(*localRef)));
+    EXPECT_CALL(*m_repo, latestRemoteReference(_)).Times(0);
 
     auto result =
-      builder::detail::pullDependency("org.example.test/1.0.0.0/x86_64", *m_repo, "binary", true);
+      builder::detail::clearDependency("org.example.test/1.0.0.0/x86_64", *m_repo, true);
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_FALSE(result->first);
+    ASSERT_TRUE(result->second);
+    EXPECT_EQ(result->second->toString(), "main:org.example.test/1.0.0.0/x86_64");
+}
+
+TEST_F(PullDependencyTest, useRemoteTrue_only_local_exists)
+{
+    LINGLONG_TRACE("useRemoteTrue_only_local_exists");
+
+    auto localRef = package::Reference::parse("main:org.example.test/1.0.0.0/x86_64");
+    ASSERT_TRUE(localRef.has_value());
+
+    EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(std::move(*localRef)));
+    EXPECT_CALL(*m_repo, latestRemoteReference(_)).WillOnce(Return(LINGLONG_ERR("not found")));
+
+    EXPECT_CALL(*m_repo, getLayerDir(_, _, _)).Times(0);
+
+    auto result = builder::detail::pullDependency("org.example.test", *m_repo, "binary");
     ASSERT_TRUE(result.has_value()) << result.error().message();
     EXPECT_EQ(result->toString(), "main:org.example.test/1.0.0.0/x86_64");
 }
 
 TEST_F(PullDependencyTest, useRemoteTrue_only_remote_exists)
 {
+    LINGLONG_TRACE("useRemoteTrue_only_remote_exists");
+
     auto remoteRef = package::Reference::parse("main:org.example.test/1.0.0.0/x86_64");
     ASSERT_TRUE(remoteRef.has_value());
 
-    EXPECT_CALL(*m_repo, clearReference(_, isLocalOption(), _, _)).WillOnce(Return(notFound()));
-    EXPECT_CALL(*m_repo, clearReference(_, isRemoteOption(), _, _))
-      .WillOnce(Return(utils::error::Result<package::Reference>{ std::move(*remoteRef) }));
+    EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(LINGLONG_ERR("not found")));
+    EXPECT_CALL(*m_repo, latestRemoteReference(_))
+      .WillOnce(Return(refWithRepo(std::move(*remoteRef))));
 
     EXPECT_CALL(*m_repo, getLayerDir(_, _, _)).WillOnce(Return(layerCached()));
 
     auto result =
-      builder::detail::pullDependency("org.example.test/1.0.0.0/x86_64", *m_repo, "binary", true);
+      builder::detail::pullDependency("org.example.test/1.0.0.0/x86_64", *m_repo, "binary");
     ASSERT_TRUE(result.has_value()) << result.error().message();
 }
 
 TEST_F(PullDependencyTest, useRemoteTrue_neither_exists_returns_error)
 {
-    EXPECT_CALL(*m_repo, clearReference(_, isLocalOption(), _, _)).WillOnce(Return(notFound()));
-    EXPECT_CALL(*m_repo, clearReference(_, isRemoteOption(), _, _)).WillOnce(Return(notFound()));
+    LINGLONG_TRACE("useRemoteTrue_neither_exists_returns_error");
 
-    auto result = builder::detail::pullDependency("org.example.missing/1.0.0.0/x86_64",
-                                                  *m_repo,
-                                                  "binary",
-                                                  true);
+    EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(LINGLONG_ERR("not found")));
+    EXPECT_CALL(*m_repo, latestRemoteReference(_)).WillOnce(Return(LINGLONG_ERR("not found")));
+
+    auto result =
+      builder::detail::pullDependency("org.example.missing/1.0.0.0/x86_64", *m_repo, "binary");
     EXPECT_FALSE(result.has_value());
 }
 
 TEST_F(PullDependencyTest, invalid_fuzzy_ref_returns_error)
 {
-    auto result = builder::detail::pullDependency("::invalid///ref", *m_repo, "binary", true);
+    auto result = builder::detail::pullDependency("::invalid///ref", *m_repo, "binary");
     EXPECT_FALSE(result.has_value());
 }
 
@@ -247,19 +370,56 @@ TEST_F(PullDependencyTest, pullResolvedRef_cached_module_returns_ok)
 
     EXPECT_CALL(*m_repo, getLayerDir(_, _, _)).WillOnce(Return(layerCached()));
 
-    auto result = builder::detail::pullResolvedRef(*ref, *m_repo, "binary");
+    auto result = builder::detail::pullResolvedRef(refWithRepo(std::move(*ref)), *m_repo, "binary");
     EXPECT_TRUE(result.has_value()) << result.error().message();
 }
 
 TEST_F(PullDependencyTest, pullResolvedRef_not_cached_triggers_pull)
 {
+    LINGLONG_TRACE("pullResolvedRef_not_cached_triggers_pull");
+
     auto ref = package::Reference::parse("main:org.example.test/1.0.0.0/x86_64");
     ASSERT_TRUE(ref.has_value()) << ref.error().message();
 
-    EXPECT_CALL(*m_repo, getLayerDir(_, _, _)).WillOnce(Return(notFound()));
-    EXPECT_CALL(*m_repo, pull(_, _, _)).WillOnce(Return(utils::error::Result<void>{}));
+    EXPECT_CALL(*m_repo, getLayerDir(_, _, _)).WillOnce(Return(LINGLONG_ERR("not found")));
+    EXPECT_CALL(*m_repo, pull(_, _, _))
+      .WillOnce([](service::Task &,
+                   const package::ReferenceWithRepo &refRepo,
+                   const std::string &) -> utils::error::Result<void> {
+          EXPECT_EQ(refRepo.repo.name, "custom");
+          return {};
+      });
 
-    auto result = builder::detail::pullResolvedRef(*ref, *m_repo, "binary");
+    auto result =
+      builder::detail::pullResolvedRef(refWithRepo(std::move(*ref), "custom"), *m_repo, "binary");
+    EXPECT_TRUE(result.has_value()) << result.error().message();
+}
+
+TEST_F(PullDependencyTest, buildStagePullDependency_continues_when_local_develop_pull_fails)
+{
+    LINGLONG_TRACE("buildStagePullDependency_continues_when_local_develop_pull_fails");
+
+    auto baseRef = package::Reference::parse("main:org.deepin.base/23.0.0.0/x86_64");
+    ASSERT_TRUE(baseRef.has_value());
+
+    builder::Builder builder(builderProject(),
+                             m_tmpDir.path(),
+                             *m_repo,
+                             containerBuilder(),
+                             builderConfig());
+
+    {
+        InSequence seq;
+        EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(*baseRef));
+        EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(*baseRef));
+    }
+    EXPECT_CALL(*m_repo, latestRemoteReference(_)).WillOnce(Return(LINGLONG_ERR("not found")));
+    EXPECT_CALL(*m_repo, getLayerDir(_, "develop", _))
+      .WillOnce(Return(LINGLONG_ERR("not found")))
+      .WillOnce(Return(LINGLONG_ERR("not found")));
+    EXPECT_CALL(*m_repo, mergeModules()).WillOnce(Return(utils::error::Result<void>{}));
+
+    auto result = builder.buildStagePullDependency();
     EXPECT_TRUE(result.has_value()) << result.error().message();
 }
 

--- a/libs/linglong/tests/ll-tests/src/linglong/cli/cli_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/cli/cli_test.cpp
@@ -43,11 +43,8 @@ public:
                 (),
                 (override, const, noexcept));
     MOCK_METHOD(utils::error::Result<package::Reference>,
-                clearReference,
-                (const package::FuzzyReference &fuzzyRef,
-                 const repo::clearReferenceOption &opts,
-                 const std::string &module,
-                 const std::optional<std::string> &repo),
+                clearReferenceLocal,
+                (const package::FuzzyReference &fuzzyRef, bool semanticMatching),
                 (override, const, noexcept));
     MOCK_METHOD(utils::error::Result<api::types::v1::RepositoryCacheLayersItem>,
                 getLayerItem,
@@ -270,7 +267,7 @@ TEST_F(CliTest, contentPreferDesktopFromDefaultSharedDir)
     layerItem.commit = commit;
     layerItem.info.kind = "app";
 
-    EXPECT_CALL(*repo, clearReference(_, _, _, _)).WillOnce(Return(*ref));
+    EXPECT_CALL(*repo, clearReferenceLocal(_, _)).WillOnce(Return(*ref));
     EXPECT_CALL(*repo, getLayerItem(_, _, _))
       .WillRepeatedly(
         [layerItem](const package::Reference &, std::string, const std::optional<std::string> &)
@@ -312,7 +309,7 @@ TEST_F(CliTest, contentResolvesDesktopFromSymlinkedEntriesShareDir)
     layerItem.commit = commit;
     layerItem.info.kind = "app";
 
-    EXPECT_CALL(*repo, clearReference(_, _, _, _)).WillOnce(Return(*ref));
+    EXPECT_CALL(*repo, clearReferenceLocal(_, _)).WillOnce(Return(*ref));
     EXPECT_CALL(*repo, getLayerItem(_, _, _))
       .WillRepeatedly(
         [layerItem](const package::Reference &, std::string, const std::optional<std::string> &)
@@ -354,7 +351,7 @@ TEST_F(CliTest, contentResolvesOverlayDesktopFromSymlinkedEntriesShareDir)
     layerItem.commit = commit;
     layerItem.info.kind = "app";
 
-    EXPECT_CALL(*repo, clearReference(_, _, _, _)).WillOnce(Return(*ref));
+    EXPECT_CALL(*repo, clearReferenceLocal(_, _)).WillOnce(Return(*ref));
     EXPECT_CALL(*repo, getLayerItem(_, _, _))
       .WillRepeatedly(
         [layerItem](const package::Reference &, std::string, const std::optional<std::string> &)
@@ -388,7 +385,7 @@ TEST_F(CliTest, contentFallbackDesktopToOverlaySharedDir)
     layerItem.commit = commit;
     layerItem.info.kind = "app";
 
-    EXPECT_CALL(*repo, clearReference(_, _, _, _)).WillOnce(Return(*ref));
+    EXPECT_CALL(*repo, clearReferenceLocal(_, _)).WillOnce(Return(*ref));
     EXPECT_CALL(*repo, getLayerItem(_, _, _))
       .WillRepeatedly(
         [layerItem](const package::Reference &, std::string, const std::optional<std::string> &)
@@ -423,7 +420,7 @@ TEST_F(CliTest, contentMapsLegacySystemdUserPathToExportedLibPath)
     layerItem.commit = commit;
     layerItem.info.kind = "app";
 
-    EXPECT_CALL(*repo, clearReference(_, _, _, _)).WillOnce(Return(*ref));
+    EXPECT_CALL(*repo, clearReferenceLocal(_, _)).WillOnce(Return(*ref));
     EXPECT_CALL(*repo, getLayerItem(_, _, _))
       .WillRepeatedly(
         [layerItem](const package::Reference &, std::string, const std::optional<std::string> &)
@@ -460,7 +457,7 @@ TEST_F(CliTest, contentPrefersLibSystemdUserOverLegacySharePath)
     layerItem.commit = commit;
     layerItem.info.kind = "app";
 
-    EXPECT_CALL(*repo, clearReference(_, _, _, _)).WillOnce(Return(*ref));
+    EXPECT_CALL(*repo, clearReferenceLocal(_, _)).WillOnce(Return(*ref));
     EXPECT_CALL(*repo, getLayerItem(_, _, _))
       .WillRepeatedly(
         [layerItem](const package::Reference &, std::string, const std::optional<std::string> &)

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/uab_installation_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/uab_installation_test.cpp
@@ -31,11 +31,8 @@ public:
     }
 
     MOCK_METHOD(utils::error::Result<package::Reference>,
-                clearReference,
-                (const package::FuzzyReference &fuzzyRef,
-                 const repo::clearReferenceOption &option,
-                 const std::string &module,
-                 const std::optional<std::string> &repo),
+                clearReferenceLocal,
+                (const package::FuzzyReference &fuzzyRef, bool semanticMatching),
                 (override, const, noexcept));
 
     MOCK_METHOD(utils::error::Result<package::Reference>,
@@ -67,7 +64,7 @@ TEST(CheckUABLayersConstrain, EmptyLayers)
     TempDir tempDir;
     MockOSTreeRepo mockRepo(tempDir.path());
     repo::OSTreeRepo &repo = mockRepo;
-    EXPECT_CALL(mockRepo, clearReference(_, _, _, _)).Times(0);
+    EXPECT_CALL(mockRepo, clearReferenceLocal(_, _)).Times(0);
     std::vector<api::types::v1::UabLayer> layers;
     auto result = UabInstallationAction::checkUABLayersConstrain(repo, layers);
     EXPECT_TRUE(result.has_value());
@@ -158,7 +155,7 @@ TEST(CheckUABLayersConstrain, ExtraModuleNoBinaryAndNotInstalled)
     layer1.info.packageInfoV2Module = "extra";
     layers.push_back(layer1);
 
-    EXPECT_CALL(mockRepo, clearReference(_, _, _, _)).WillOnce(Return(LINGLONG_ERR("")));
+    EXPECT_CALL(mockRepo, clearReferenceLocal(_, _)).WillOnce(Return(LINGLONG_ERR("")));
 
     auto result = UabInstallationAction::checkUABLayersConstrain(repo, layers);
     EXPECT_FALSE(result.has_value());
@@ -184,7 +181,7 @@ TEST(CheckUABLayersConstrain, ExtraModuleNoBinaryAndWrongVersionInstalled)
     auto localRef = package::Reference::parse("main:id1/2.0.0/" + currentArch);
     EXPECT_TRUE(localRef.has_value());
 
-    EXPECT_CALL(mockRepo, clearReference(_, _, _, _)).WillOnce(Return(*localRef));
+    EXPECT_CALL(mockRepo, clearReferenceLocal(_, _)).WillOnce(Return(*localRef));
 
     auto result = UabInstallationAction::checkUABLayersConstrain(repo, layers);
     EXPECT_FALSE(result.has_value());
@@ -210,7 +207,7 @@ TEST(CheckUABLayersConstrain, ExtraModuleNoBinaryButInstalled)
     auto localRef = package::Reference::parse("main:id1/1.0.0/" + currentArch);
     EXPECT_TRUE(localRef.has_value());
 
-    EXPECT_CALL(mockRepo, clearReference(_, _, _, _)).WillOnce(Return(*localRef));
+    EXPECT_CALL(mockRepo, clearReferenceLocal(_, _)).WillOnce(Return(*localRef));
 
     auto result = UabInstallationAction::checkUABLayersConstrain(repo, layers);
     EXPECT_TRUE(result.has_value());

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_test.cpp
@@ -69,11 +69,8 @@ public:
                 (const package::Reference &ref, const std::vector<std::string> &modules),
                 (override, const, noexcept));
     MOCK_METHOD(utils::error::Result<package::Reference>,
-                clearReference,
-                (const package::FuzzyReference &fuzzy,
-                 const repo::clearReferenceOption &opts,
-                 const std::string &module,
-                 const std::optional<std::string> &repo),
+                clearReferenceLocal,
+                (const package::FuzzyReference &fuzzy, bool semanticMatching),
                 (override, const, noexcept));
 };
 
@@ -290,7 +287,7 @@ TEST_F(RunContextTest, resolveRunnableWithApp)
 
     EXPECT_CALL(*repo, getLayerItem(*runnableRef, testing::_, testing::_))
       .WillOnce(Return(appItem));
-    EXPECT_CALL(*repo, clearReference(testing::_, testing::_, testing::_, testing::_))
+    EXPECT_CALL(*repo, clearReferenceLocal(testing::_, testing::_))
       .WillOnce(Return(*runtimeRef))
       .WillOnce(Return(*baseRef));
 
@@ -346,8 +343,7 @@ TEST_F(RunContextTest, resolveRunnableWithRuntime)
 
     EXPECT_CALL(*repo, getLayerItem(*runnableRef, testing::_, testing::_))
       .WillOnce(Return(runtimeItem));
-    EXPECT_CALL(*repo, clearReference(testing::_, testing::_, testing::_, testing::_))
-      .WillOnce(Return(*baseRef));
+    EXPECT_CALL(*repo, clearReferenceLocal(testing::_, testing::_)).WillOnce(Return(*baseRef));
 
     EXPECT_CALL(*repo, getLayerItem(*baseRef, testing::_, testing::_)).WillOnce(Return(baseItem));
 
@@ -475,7 +471,7 @@ TEST_F(RunContextTest, toConfig)
 
     EXPECT_CALL(*repo, getLayerItem(*runnableRef, testing::_, testing::_))
       .WillOnce(Return(appItem));
-    EXPECT_CALL(*repo, clearReference(testing::_, testing::_, testing::_, testing::_))
+    EXPECT_CALL(*repo, clearReferenceLocal(testing::_, testing::_))
       .Times(AtLeast(2))
       .WillOnce(Return(*runtimeRef))
       .WillOnce(Return(*baseRef))


### PR DESCRIPTION
The old clearReference implementation always uses the default remote repo and ignores repo priority, which is not expected when the builder also supports repository priorities. We use clearReferenceLocal for local-only resolution and lookup remote reference via latestRemoteReference.