### PR TITLE
fix: make tests pass without /etc/localtime

### DIFF
--- a/libs/linglong/src/linglong/runtime/run_context.cpp
+++ b/libs/linglong/src/linglong/runtime/run_context.cpp
@@ -655,6 +655,10 @@ utils::error::Result<void> RunContext::resolveTimeZone()
     std::error_code ec;
     auto localtimeStatus = std::filesystem::symlink_status(localtimePath, ec);
     if (ec) {
+        if (ec == std::errc::no_such_file_or_directory) {
+            contextCfg.timezone = "UTC";
+            return LINGLONG_OK;
+        }
         return LINGLONG_ERR(fmt::format("failed to get status of {}", localtimePath), ec);
     }
 


### PR DESCRIPTION
Handle ENOENT from std::filesystem::symlink_status() when resolving /etc/localtime, so the existing UTC fallback is reachable in clean Arch build chroots where /etc/localtime is absent.