### PR TITLE
fix: change the propagation type of the root mount to shared

### DIFF
--- a/libs/utils/src/linglong/utils/namespace.cpp
+++ b/libs/utils/src/linglong/utils/namespace.cpp
@@ -10,6 +10,7 @@
 #include "linglong/utils/log/log.h"
 
 #include <sys/capability.h>
+#include <sys/mount.h>
 #include <sys/prctl.h>
 
 #include <fstream>
@@ -310,6 +311,11 @@ int runInNamespaceEntry(void *args)
             LogE("setgid failed: {}", common::error::errorString(errno));
             return -1;
         }
+    }
+
+    if (mount("", "/", "", MS_SHARED | MS_REC, NULL) == -1) {
+        LogW("failed to change propagation type of / to shared: {}",
+             common::error::errorString(errno));
     }
 
     LogD("run command {}", runInNamespaceArgs->argv[0]);


### PR DESCRIPTION
The mount propagation type will be private,slave if a new mount namespace is creted by clone() and CLONE_NEWUSER is also used. Change it to shared,slave.