### PR TITLE
fix: start package manager before repo loading in peer mode

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -27,6 +27,7 @@
 #include <QDBusObjectPath>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QProcess>
 #include <QtGlobal>
 
 #include <algorithm>
@@ -685,6 +686,23 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     }
 
     const bool peerMode = noDBusFlag->count() > 0;
+    if (peerMode) {
+        if (getuid() != 0) {
+            LogE("--no-dbus should only be used by root user.");
+            return -1;
+        }
+
+        // Start ll-package-manager --no-dbus first to initialize the repository
+        QProcess::startDetached("sudo",
+                                { "--user",
+                                  LINGLONG_USERNAME,
+                                  "--preserve-env=QT_FORCE_STDERR_LOGGING",
+                                  "--preserve-env=QDBUS_DEBUG",
+                                  LINGLONG_LIBEXEC_DIR "/ll-package-manager",
+                                  "--no-dbus" });
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for(1s);
+    }
     auto repo = linglong::repo::OSTreeRepo::loadFromPath(LINGLONG_ROOT);
     if (!repo.has_value()) {
         LogE("failed to load repo: {}", repo.error());

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -464,21 +464,8 @@ utils::error::Result<api::dbus::v1::PackageManager *> Cli::getPkgMan()
     }
 
     if (this->peerMode) {
-        if (getuid() != 0) {
-            return LINGLONG_ERR("--no-dbus should only be used by root user.");
-        }
-
         LogW("some subcommands will failed in --no-dbus mode.");
         const auto pkgManAddress = QString("unix:path=/tmp/linglong-package-manager.socket");
-        QProcess::startDetached("sudo",
-                                { "--user",
-                                  LINGLONG_USERNAME,
-                                  "--preserve-env=QT_FORCE_STDERR_LOGGING",
-                                  "--preserve-env=QDBUS_DEBUG",
-                                  LINGLONG_LIBEXEC_DIR "/ll-package-manager",
-                                  "--no-dbus" });
-        using namespace std::chrono_literals;
-        std::this_thread::sleep_for(1s);
 
         const auto &pkgManConn =
           QDBusConnection::connectToPeer(pkgManAddress, "ll-package-manager");


### PR DESCRIPTION
1. Move the ll-package-manager --no-dbus startup logic from Cli::getPkgMan() to main.cpp
2. Start the package manager immediately after detecting peer mode (--no-dbus flag)
3. Ensure the package manager is initialized before OSTreeRepo::loadFromPath() is called
4. The previous location in getPkgMan() was too late in the execution flow, as the repo was already loaded before the package manager had a chance to initialize

Influence:
1. Test ll-cli with --no-dbus flag to verify package manager starts correctly
2. Verify that repository loading succeeds in peer mode
3. Test that subcommands work properly after the package manager initializes
4. Verify the 1-second sleep is sufficient for package manager startup
5. Test running ll-cli commands in --no-dbus mode multiple times to ensure no duplicate processes
6. Verify sudo permissions and environment variable preservation work correctly