### PR TITLE
fix: improve hook command execution and parsing

### DIFF
--- a/libs/utils/src/linglong/utils/hooks.cpp
+++ b/libs/utils/src/linglong/utils/hooks.cpp
@@ -9,6 +9,7 @@
 #include "cmd.h"
 #include "configure.h"
 #include "linglong/common/error.h"
+#include "linglong/common/strings.h"
 #include "linglong/utils/error/error.h"
 #include "linglong/utils/log/log.h"
 
@@ -46,7 +47,8 @@ utils::error::Result<void> executeHookCommands(
             cmd.setEnv(name, value);
         }
 
-        auto result = cmd.exec({ "-c", command });
+        cmd.toStdin(command);
+        auto result = cmd.exec({});
         if (!result.has_value()) {
             return LINGLONG_ERR(
               fmt::format("Hook command '{}' failed: {}.", command, result.error()));
@@ -58,6 +60,17 @@ utils::error::Result<void> executeHookCommands(
 utils::error::Result<void> InstallHookManager::parseInstallHooks()
 {
     LINGLONG_TRACE("Parsing install hooks");
+
+    auto extractValue = [](const std::string &line, std::size_t prefixLen) -> std::string {
+        auto trimmed = linglong::common::strings::trim(std::string_view(line).substr(prefixLen));
+        if (trimmed.size() >= 2
+            && ((trimmed.front() == '"' && trimmed.back() == '"')
+                || (trimmed.front() == '\'' && trimmed.back() == '\''))) {
+            trimmed.remove_prefix(1);
+            trimmed.remove_suffix(1);
+        }
+        return std::string(trimmed);
+    };
 
     std::error_code ec;
     for (const auto &entry : std::filesystem::directory_iterator(LINGLONG_INSTALL_HOOKS_DIR, ec)) {
@@ -84,21 +97,21 @@ utils::error::Result<void> InstallHookManager::parseInstallHooks()
             std::size_t pos = line.find(PRE_INSTALL_ACTION_PREFIX);
             if (pos != std::string::npos) {
                 preInstallCommands.emplace_back(
-                  line.substr(pos + PRE_INSTALL_ACTION_PREFIX.length()));
+                  extractValue(line, pos + PRE_INSTALL_ACTION_PREFIX.length()));
                 break;
             }
 
             pos = line.find(POST_INSTALL_ACTION_PREFIX);
             if (pos != std::string::npos) {
                 postInstallCommands.emplace_back(
-                  line.substr(pos + POST_INSTALL_ACTION_PREFIX.length()));
+                  extractValue(line, pos + POST_INSTALL_ACTION_PREFIX.length()));
                 break;
             }
 
             pos = line.find(POST_UNINSTALL_ACTION_PREFIX);
             if (pos != std::string::npos) {
                 postUninstallCommands.emplace_back(
-                  line.substr(pos + POST_UNINSTALL_ACTION_PREFIX.length()));
+                  extractValue(line, pos + POST_UNINSTALL_ACTION_PREFIX.length()));
                 break;
             }
         }


### PR DESCRIPTION
1. Change hook command execution from shell `-c` argument to stdin pipe to avoid shell quoting and injection issues
2. Add `extractValue` lambda that trims whitespace and strips surrounding quotes (single or double) from extracted hook command values
3. Apply the new extraction logic to pre-install, post-install, and post-uninstall hook command parsing
4. Include `linglong/common/strings.h` for the `trim` utility function

Influence:
1. Test pre-install hooks with double-quoted command values
2. Test post-install hooks with single-quoted command values
3. Test post-uninstall hooks with whitespace-padded command values
4. Verify hook commands with special characters execute correctly via stdin
5. Test hook execution with unquoted command values to ensure backward compatibility
6. Verify that commands containing quotes or shell metacharacters are handled safely