### PR TITLE
fix: improve detect kenrel overlay support

### DIFF
--- a/libs/linglong/src/linglong/runtime/overlayfs_driver.cpp
+++ b/libs/linglong/src/linglong/runtime/overlayfs_driver.cpp
@@ -6,12 +6,101 @@
 
 #include "linglong/runtime/overlayfs_driver.h"
 
+#include "linglong/utils/cmd.h"
 #include "linglong/utils/file.h"
 
+#include <array>
 #include <fstream>
-#include <regex>
+
+#include <sys/utsname.h>
 
 namespace linglong::runtime {
+namespace {
+
+auto filesystemHasOverlay() noexcept -> bool
+{
+    std::ifstream filesystems("/proc/filesystems");
+    if (!filesystems.is_open()) {
+        return false;
+    }
+
+    std::string line;
+    while (std::getline(filesystems, line)) {
+        if (line.find("overlay") != std::string::npos) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+auto modinfoHasOverlay() noexcept -> bool
+{
+    auto modinfo = utils::Cmd("modinfo");
+    if (!modinfo.exists()) {
+        return false;
+    }
+
+    return modinfo.exec({ "overlay" }).has_value();
+}
+
+auto overlayModuleExists() noexcept -> bool
+{
+    struct utsname uts{};
+    if (uname(&uts) != 0) {
+        return false;
+    }
+
+    const auto modulesRoot = std::filesystem::path("/lib/modules") / uts.release;
+    const auto overlayModuleDir = modulesRoot / "kernel" / "fs" / "overlayfs";
+    constexpr std::array<std::string_view, 4> overlayModules{
+        "overlay.ko",
+        "overlay.ko.gz",
+        "overlay.ko.xz",
+        "overlay.ko.zst",
+    };
+
+    std::error_code ec;
+    for (const auto module : overlayModules) {
+        if (std::filesystem::exists(overlayModuleDir / module, ec)) {
+            return true;
+        }
+    }
+
+    for (const auto &index : { "modules.dep", "modules.builtin" }) {
+        std::ifstream modulesIndex(modulesRoot / index);
+        if (!modulesIndex.is_open()) {
+            continue;
+        }
+
+        std::string line;
+        while (std::getline(modulesIndex, line)) {
+            if (line.find("kernel/fs/overlayfs/overlay.ko") != std::string::npos) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+auto kernelVersionSupportsUserNamespaceOverlay() noexcept -> bool
+{
+    struct utsname uts{};
+    if (uname(&uts) != 0) {
+        return false;
+    }
+
+    int major = 0;
+    int minor = 0;
+    if (std::sscanf(uts.release, "%d.%d", &major, &minor) == 2) {
+        return major > 5 || (major == 5 && minor >= 11);
+    }
+
+    return false;
+}
+
+} // namespace
 
 auto OverlayFSDriver::create(utils::OverlayMode mode) noexcept -> std::unique_ptr<OverlayFSDriver>
 {
@@ -34,31 +123,9 @@ auto OverlayFSDriver::detectKernelOverlaySupport() noexcept -> OverlaySupport
 {
     OverlaySupport support{ false, false, false };
 
-    std::ifstream filesystems("/proc/filesystems");
-    if (filesystems.is_open()) {
-        std::string line;
-        while (std::getline(filesystems, line)) {
-            if (line.find("overlay") != std::string::npos) {
-                support.kernelAvailable = true;
-                break;
-            }
-        }
-    }
-
-    std::ifstream version("/proc/version");
-    if (version.is_open()) {
-        std::string line;
-        std::getline(version, line);
-        std::regex versionRegex("Linux version (\\d+)\\.(\\d+)");
-        std::smatch match;
-        if (std::regex_search(line, match, versionRegex) && match.size() > 2) {
-            int major = std::stoi(match[1]);
-            int minor = std::stoi(match[2]);
-            if (major > 5 || (major == 5 && minor >= 11)) {
-                support.kernelVersionOK = true;
-            }
-        }
-    }
+    support.kernelAvailable =
+      filesystemHasOverlay() || modinfoHasOverlay() || overlayModuleExists();
+    support.kernelVersionOK = kernelVersionSupportsUserNamespaceOverlay();
 
     support.canUseInUserNS = support.kernelAvailable && support.kernelVersionOK;
     return support;
@@ -67,6 +134,40 @@ auto OverlayFSDriver::detectKernelOverlaySupport() noexcept -> OverlaySupport
 auto OverlayFSDriver::canUseKernelOverlay() noexcept -> bool
 {
     return detectKernelOverlaySupport().canUseInUserNS;
+}
+
+auto OverlayFSDriver::canUseFUSEOverlay() noexcept -> bool
+{
+    return utils::Cmd("fuse-overlayfs").exists();
+}
+
+auto OverlayFSDriver::resolveOverlayMode(utils::OverlayMode mode) noexcept
+  -> utils::error::Result<utils::OverlayMode>
+{
+    LINGLONG_TRACE("resolve overlayfs mode");
+
+    switch (mode) {
+    case utils::OverlayMode::Kernel:
+        if (canUseKernelOverlay()) {
+            return utils::OverlayMode::Kernel;
+        }
+        return LINGLONG_ERR("kernel overlayfs is unavailable");
+    case utils::OverlayMode::FUSE:
+        if (canUseFUSEOverlay()) {
+            return utils::OverlayMode::FUSE;
+        }
+        return LINGLONG_ERR("fuse-overlayfs command is unavailable");
+    case utils::OverlayMode::Auto:
+        if (canUseKernelOverlay()) {
+            return utils::OverlayMode::Kernel;
+        }
+        if (canUseFUSEOverlay()) {
+            return utils::OverlayMode::FUSE;
+        }
+        return LINGLONG_ERR("no available overlayfs implementation");
+    }
+
+    return LINGLONG_ERR("unknown overlayfs mode");
 }
 
 auto OverlayFSDriver::modeToString(utils::OverlayMode mode) noexcept -> std::string_view

--- a/libs/linglong/src/linglong/runtime/overlayfs_driver.h
+++ b/libs/linglong/src/linglong/runtime/overlayfs_driver.h
@@ -37,6 +37,9 @@ public:
     static auto create(utils::OverlayMode mode) noexcept -> std::unique_ptr<OverlayFSDriver>;
     static auto detectKernelOverlaySupport() noexcept -> OverlaySupport;
     static auto canUseKernelOverlay() noexcept -> bool;
+    static auto canUseFUSEOverlay() noexcept -> bool;
+    static auto resolveOverlayMode(utils::OverlayMode mode) noexcept
+      -> utils::error::Result<utils::OverlayMode>;
     static auto modeToString(utils::OverlayMode mode) noexcept -> std::string_view;
     static auto modeFromString(std::string_view mode) noexcept
       -> utils::error::Result<utils::OverlayMode>;

--- a/libs/linglong/src/linglong/runtime/run_context.cpp
+++ b/libs/linglong/src/linglong/runtime/run_context.cpp
@@ -636,8 +636,12 @@ utils::error::Result<void> RunContext::resolveOverlayMode(std::optional<std::str
         mode = *parsedMode;
     }
 
-    auto driver = OverlayFSDriver::create(mode);
-    contextCfg.overlayfs = std::string(OverlayFSDriver::modeToString(driver->mode()));
+    auto resolvedMode = OverlayFSDriver::resolveOverlayMode(mode);
+    if (!resolvedMode) {
+        return LINGLONG_ERR("resolve overlayfs mode", resolvedMode);
+    }
+
+    contextCfg.overlayfs = std::string(OverlayFSDriver::modeToString(*resolvedMode));
 
     return LINGLONG_OK;
 }

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -52,6 +52,7 @@ pfl_add_executable(
   src/linglong/repo/ostree_repo_test.cpp
   src/linglong/repo/repo_cache_test.cpp
   src/linglong/runtime/container_builder_test.cpp
+  src/linglong/runtime/overlayfs_driver_test.cpp
   src/linglong/runtime/run_context_test.cpp
   src/linglong/utils/bash_command_helper_test.cpp
   src/linglong/utils/cmd_test.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/overlayfs_driver_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/overlayfs_driver_test.cpp
@@ -6,6 +6,7 @@
 
 #include "common/tempdir.h"
 #include "linglong/runtime/overlayfs_driver.h"
+#include "linglong/utils/cmd.h"
 
 #include <filesystem>
 
@@ -55,6 +56,35 @@ TEST(OverlayFSDriverStatic, CanUseKernelOverlay)
       << "canUseKernelOverlay should match canUseInUserNS from KernelOverlaySupport";
 
     std::cout << "canUseKernelOverlay: " << (canUse ? "yes" : "no") << std::endl;
+}
+
+TEST(OverlayFSDriverStatic, CanUseFUSEOverlay)
+{
+    bool canUse = linglong::runtime::OverlayFSDriver::canUseFUSEOverlay();
+
+    EXPECT_EQ(canUse, linglong::utils::Cmd("fuse-overlayfs").exists())
+      << "canUseFUSEOverlay should reflect fuse-overlayfs command availability";
+
+    std::cout << "canUseFUSEOverlay: " << (canUse ? "yes" : "no") << std::endl;
+}
+
+TEST(OverlayFSDriverStatic, ResolveOverlayMode)
+{
+    auto support = linglong::runtime::OverlayFSDriver::detectKernelOverlaySupport();
+    auto fuseAvailable = linglong::runtime::OverlayFSDriver::canUseFUSEOverlay();
+
+    auto resolvedMode =
+      linglong::runtime::OverlayFSDriver::resolveOverlayMode(linglong::utils::OverlayMode::Auto);
+
+    if (support.canUseInUserNS) {
+        ASSERT_TRUE(resolvedMode);
+        EXPECT_EQ(*resolvedMode, linglong::utils::OverlayMode::Kernel);
+    } else if (fuseAvailable) {
+        ASSERT_TRUE(resolvedMode);
+        EXPECT_EQ(*resolvedMode, linglong::utils::OverlayMode::FUSE);
+    } else {
+        EXPECT_FALSE(resolvedMode);
+    }
 }
 
 TEST_F(OverlayFSDriverTest, AutoModeSelection)


### PR DESCRIPTION
Detect kenrel overlay support by /proc/filesystems, modinfo and scan module file.