### PR TITLE
fix: correct spelling errors in comments and string literals

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -72,7 +72,7 @@
         {
             "name": "debug",
             "displayName": "Debug test",
-            "description": "Test linglong for developing and debuging.",
+            "description": "Test linglong for developing and debugging.",
             "configurePreset": "debug",
             "execution": {
                 "stopOnFailure": true
@@ -105,7 +105,7 @@
         {
             "name": "debug",
             "displayName": "Workflow for developers",
-            "description": "Configure, build then test for developing and debuging linglong.",
+            "description": "Configure, build then test for developing and debugging linglong.",
             "steps": [
                 {
                     "type": "configure",

--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -74,7 +74,7 @@ parseProjectConfig(const std::filesystem::path &filename)
     }
     if (project->package.kind == "app" && !project->command.has_value()) {
         return LINGLONG_ERR(
-          "'command' field is missing, app should hava command as the default startup command");
+          "'command' field is missing, app should have command as the default startup command");
     }
 
     // 校验bese和runtime版本是否合法

--- a/docs/pages/guide/extra/app-conf.md
+++ b/docs/pages/guide/extra/app-conf.md
@@ -2,7 +2,7 @@
 
 Application run conf is the file how linglong runtime module load the app,
 
-and the conf is machine related, the user can set mount path, permisson control file to the app.
+and the conf is machine related, the user can set mount path, permission control file to the app.
 
 ## File Format
 

--- a/docs/pages/guide/publishing/mirrors.md
+++ b/docs/pages/guide/publishing/mirrors.md
@@ -62,7 +62,7 @@ ostree会从url获取summary文件，如果获取不到summary文件，或者sum
 
 ### delta-indexes文件获取
 
-ostree会在每个可用的mirror中获取delta-indexes，如果mirror服务器返回4xx或5xx，则在下一个mirror中获取delta-indexes，如果最后的mirror返回5xx，则pull失败，如果最后的mirror返回4xx，则跳过dalta步骤直接拉取files。
+ostree会在每个可用的mirror中获取delta-indexes，如果mirror服务器返回4xx或5xx，则在下一个mirror中获取delta-indexes，如果最后的mirror返回5xx，则pull失败，如果最后的mirror返回4xx，则跳过delta步骤直接拉取files。
 
 ### files文件获取
 

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -1356,7 +1356,7 @@ utils::error::Result<void> Builder::build(const QStringList &args) noexcept
     }
 
     if (!(res = buildStageFetchSource())) {
-        return LINGLONG_ERR("stage fetch srouce error", res);
+        return LINGLONG_ERR("stage fetch source error", res);
     }
 
     if (!(res = buildStagePullDependency())) {

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -121,7 +121,7 @@ void progress_changed(OstreeAsyncProgress *progress, gpointer user_data)
     data->taskContext->reportDataArrived(bytes_transferred - data->last_bytes_transferred);
     data->last_bytes_transferred = bytes_transferred;
 
-    // report actual fetched and requestd data
+    // report actual fetched and requested data
     data->taskContext->reportDataHandled(fetched, requested);
 }
 

--- a/libs/ocppi/CMakePresets.json
+++ b/libs/ocppi/CMakePresets.json
@@ -66,7 +66,7 @@
                 {
                         "name": "debug",
                         "displayName": "Workflow for developers",
-                        "description": "Configure, build then test for developing and debuging ocppi.",
+                        "description": "Configure, build then test for developing and debugging ocppi.",
                         "steps": [
                                 {
                                         "type": "configure",

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -174,7 +174,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/applications/linyaps.desktop
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/icons/linyaps.svg
         DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps)
 
-# set linglong XDG_DATA_DIRS environtment
+# set linglong XDG_DATA_DIRS environment
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/script/linglong.sh
         DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/profile.d)
 

--- a/misc/lib/linglong/container/README.md
+++ b/misc/lib/linglong/container/README.md
@@ -9,7 +9,7 @@ Files in [config.d] that is executable for linglong runtime program
 are treated as OCI configuration generators for linglong.
 
 They will be executed by linglong runtime program
-with the constructing OCI configuration writed into their stdin.
+with the constructed OCI configuration written to their stdin.
 They should print **FULL** content of
 that modified OCI configuration to their **stdout**,
 and print error message or warning to their **stderr**.

--- a/misc/libexec/linglong/app-conf-generator
+++ b/misc/libexec/linglong/app-conf-generator
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 

--- a/misc/libexec/linglong/app-conf-generator
+++ b/misc/libexec/linglong/app-conf-generator
@@ -27,7 +27,7 @@ ExecReplace() {
 }
 
 IconsReplace() {
-        #Not impelement yet
+        #Not implemented yet
         echo "replace Icons"
 }
 

--- a/misc/libexec/linglong/builder/helper/ldd-check.sh
+++ b/misc/libexec/linglong/builder/helper/ldd-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 

--- a/misc/libexec/linglong/builder/helper/ldd-check.sh
+++ b/misc/libexec/linglong/builder/helper/ldd-check.sh
@@ -66,7 +66,7 @@ processExecBin() {
                                 if [[ ${rawStr} == "statically linked" ]]; then
                                         continue
                                 fi
-                                logWarn "unexpected conditions, unkonwn line: ${line}"
+                                logWarn "unexpected conditions, unknown line: ${line}"
                         fi
                 elif [[ ${elementSize} -eq 4 ]]; then
                         rawStr="${elements[2]} ${elements[3]}"
@@ -77,7 +77,7 @@ processExecBin() {
                          # clean path
                         dependLibs+=("${elements[2]}")
                 else
-                        logWarn "unexpected conditions, unkonwn line: ${line}"
+                        logWarn "unexpected conditions, unknown line: ${line}"
                 fi
         done
 }

--- a/misc/libexec/linglong/fetch-archive-source
+++ b/misc/libexec/linglong/fetch-archive-source
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 set -e

--- a/misc/libexec/linglong/fetch-archive-source
+++ b/misc/libexec/linglong/fetch-archive-source
@@ -17,7 +17,7 @@ then
     exit 1;
 fi
 
-# Clean up old directorie and create parent directory
+# Clean up old directory and create parent directory
 mkdir -p "$outputdir"
 rm -r "$outputdir"
 # Check cache

--- a/misc/libexec/linglong/fetch-dsc-source
+++ b/misc/libexec/linglong/fetch-dsc-source
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 set -e

--- a/misc/libexec/linglong/fetch-dsc-source
+++ b/misc/libexec/linglong/fetch-dsc-source
@@ -17,7 +17,7 @@ then
     exit 1;
 fi
 
-# Clean up old directorie and create parent directory
+# Clean up old directory and create parent directory
 mkdir -p "$outputdir"
 rm -r "$outputdir"
 # Check cache

--- a/tools/layer-icon-checker.sh
+++ b/tools/layer-icon-checker.sh
@@ -127,7 +127,7 @@ main() {
 		return 255
 	fi
 
-	# check desktop file, quit normaly if no Icon set
+	# check desktop file, quit normally if no Icon set
 	icons=$(getDesktopIcons ${dest})
 	if [ "${icons}" == "" ]; then
 		echo "No icon set in desktop file, nothing need to check ..."


### PR DESCRIPTION
Fix typos found in comments, error messages, log strings and documentation:
- debuging -> debugging
- hava -> have
- permisson -> permission
- dalta -> delta
- srouce -> source
- requestd -> requested
- environtment -> environment
- writed -> wrote
- impelement -> implement
- unkonwn -> unknown
- directorie -> directory
- normaly -> normally