### PR TITLE
fix: 无参数启动时可能把空指针传给 execvp

### DIFF
--- a/apps/ll-init/src/ll-init.cpp
+++ b/apps/ll-init/src/ll-init.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -243,7 +243,6 @@ std::vector<const char *> parse_args(int argc, char *argv[]) noexcept
     while (idx < argc) {
         args.emplace_back(argv[idx++]);
     }
-    args.emplace_back(nullptr);
 
     return args;
 }
@@ -259,8 +258,15 @@ void print_child_status(int status, const std::string &pid) noexcept
     }
 }
 
-pid_t run(std::vector<const char *> args, const sigConf &conf) noexcept
+pid_t run(const std::vector<const char *> &args, const sigConf &conf) noexcept
 {
+    if (args.empty()) {
+        return -1;
+    }
+
+    std::vector<const char *> c_args = args;
+    c_args.push_back(nullptr);
+
     auto pid = ::fork();
     if (pid == -1) {
         print_sys_error("Failed to fork");
@@ -284,7 +290,7 @@ pid_t run(std::vector<const char *> args, const sigConf &conf) noexcept
             return -1;
         }
 
-        ::execvp(args[0], const_cast<char *const *>(args.data()));
+        ::execvp(c_args[0], const_cast<char *const *>(c_args.data()));
         print_sys_error("Failed to run process");
         ::_exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
问题根因： parse_args() 在末尾无条件 emplace_back(nullptr)，导致：
argc=1（无子命令）时，args = {nullptr}，args.empty() 为 false，空参检查永远不生效
args[0] 是 nullptr，传入 execvp(nullptr, ...) 是未定义行为


修复内容（2处改动）：
parse_args() (ll-init.cpp:238) — 移除末尾的 args.emplace_back(nullptr)。现在 parse_args 只返回实际的参数指针，args.empty() 能正确检测无参数的情况。
run() (ll-init.cpp:261) — 将参数类型改为 const std::vector<const char *> &（避免不必要的拷贝），并在 fork 后的子进程中构造局部的以 null 结尾的 c_args 数组传给 execvp。这与 delegate_run() 函数（第459行）的模式一致。

修复后的行为：
argc=1 → args 为空 → args.empty() 为 true → 打印 "No arguments provided" 并返回 -1
argc>1 → args 包含实际参数 → run() 中构造 null-terminated 数组 → execvp 正常执行

