### PR TITLE
feat: add layer signature extraction support

### DIFF
--- a/libs/linglong/src/linglong/package/layer_packager.cpp
+++ b/libs/linglong/src/linglong/package/layer_packager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+ * SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
@@ -8,17 +8,23 @@
 
 #include "linglong/api/types/v1/Generators.hpp"
 #include "linglong/api/types/v1/LayerInfo.hpp"
+#include "linglong/common/error.h"
 #include "linglong/utils/cmd.h"
 #include "linglong/utils/file.h"
+#include "linglong/utils/finally/finally.h"
 #include "linglong/utils/log/log.h"
+
+#include <nlohmann/json.hpp>
 
 #include <QDataStream>
 #include <QSysInfo>
 
+#include <array>
 #include <filesystem>
 #include <fstream>
 #include <string>
 
+#include <fcntl.h>
 #include <unistd.h>
 
 namespace linglong::package {
@@ -281,6 +287,111 @@ void LayerPackager::setCompressor(const QString &compressor) noexcept
 utils::error::Result<bool> LayerPackager::checkErofsFuseExists() const
 {
     return utils::Cmd("erofsfuse").exists();
+}
+
+utils::error::Result<void> LayerPackager::extractSignData(LayerFile &file,
+                                                          const std::filesystem::path &signDir)
+{
+    LINGLONG_TRACE("extract sign data from layer");
+
+    const auto &number = magicNumber();
+    file.seek(number.size());
+
+    QDataStream metaLenStream(&file);
+    metaLenStream.setByteOrder(QDataStream::LittleEndian);
+    quint32 metaLen = 0;
+    metaLenStream >> metaLen;
+
+    auto metaRawData = file.read(metaLen);
+    auto metaJson = nlohmann::json::parse(metaRawData.toStdString());
+    auto erofsSize = metaJson.value("erofs_size", 0ULL);
+    auto signSize = metaJson.value("sign_size", 0ULL);
+
+    if (signSize == 0) {
+        return LINGLONG_OK;
+    }
+
+    auto signOffset = static_cast<int64_t>(number.size() + sizeof(quint32) + metaLen + erofsSize);
+
+    std::error_code ec;
+    auto destination = signDir / "entries" / "share" / "deepin-elf-verify" / ".elfsign";
+    if (!std::filesystem::create_directories(destination, ec) && ec) {
+        return LINGLONG_ERR(ec.message().c_str());
+    }
+
+    auto tarFile = destination / "sign.tar";
+    auto tarFd = ::open(tarFile.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (tarFd == -1) {
+        return LINGLONG_ERR(
+          fmt::format("open {} failed: {}", tarFile.string(), common::error::errorString(errno)));
+    }
+
+    auto removeTar = utils::finally::finally([&tarFd, &tarFile] {
+        if (tarFd != -1) {
+            ::close(tarFd);
+        }
+
+        std::error_code ec;
+        if (!std::filesystem::remove(tarFile, ec) && ec) {
+            LogW("failed to remove {}: {}", tarFile.string(), ec.message());
+        }
+    });
+
+    file.seek(signOffset);
+    auto selfFd = file.handle();
+
+    auto totalBytes = signSize;
+    std::array<unsigned char, 4096> buf{};
+    while (totalBytes > 0) {
+        auto bytesToRead = totalBytes > buf.size() ? buf.size() : totalBytes;
+        auto readBytes = ::read(selfFd, buf.data(), bytesToRead);
+        if (readBytes == -1) {
+            if (errno == EINTR) {
+                errno = 0;
+                continue;
+            }
+            return LINGLONG_ERR(
+              fmt::format("read sign data error: {}", common::error::errorString(errno)));
+        }
+
+        while (true) {
+            auto writeBytes = ::write(tarFd, buf.data(), readBytes);
+            if (writeBytes == -1) {
+                if (errno == EINTR) {
+                    errno = 0;
+                    continue;
+                }
+                return LINGLONG_ERR(
+                  fmt::format("write sign.tar error: {}", common::error::errorString(errno)));
+            }
+
+            if (writeBytes != readBytes) {
+                return LINGLONG_ERR("write sign.tar failed: byte mismatch");
+            }
+
+            totalBytes -= writeBytes;
+            break;
+        }
+    }
+
+    if (::fsync(tarFd) == -1) {
+        return LINGLONG_ERR(
+          fmt::format("fsync sign.tar error: {}", common::error::errorString(errno)));
+    }
+
+    if (::close(tarFd) == -1) {
+        tarFd = -1;
+        return LINGLONG_ERR(
+          fmt::format("failed to close tar: {}", common::error::errorString(errno)));
+    }
+    tarFd = -1;
+
+    auto ret = utils::Cmd("tar").exec({ "-xf", tarFile.string(), "-C", destination.string() });
+    if (!ret) {
+        return LINGLONG_ERR(ret);
+    }
+
+    return LINGLONG_OK;
 }
 
 } // namespace linglong::package

--- a/libs/linglong/src/linglong/package/layer_packager.h
+++ b/libs/linglong/src/linglong/package/layer_packager.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+ * SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
@@ -37,6 +37,9 @@ public:
     utils::error::Result<LayerDir> unpack(LayerFile &file);
     void setCompressor(const QString &compressor) noexcept;
     const std::filesystem::path &getWorkDir() const;
+
+    utils::error::Result<void> extractSignData(LayerFile &file,
+                                               const std::filesystem::path &signDir);
 
 private:
     std::filesystem::path workDir;

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -689,7 +689,20 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
           }
 
           taskRef.updateProgress(60);
-          auto result = this->repo->importLayerDir(*layerDir);
+          auto signOverlayRootDir = layerPackager.getWorkDir() / "sign";
+          auto signRet = layerPackager.extractSignData(*layerFile, signOverlayRootDir);
+          if (!signRet) {
+              taskRef.reportError(std::move(signRet).error());
+              return;
+          }
+          std::vector<std::filesystem::path> overlays;
+          auto signDir =
+            signOverlayRootDir / "entries" / "share" / "deepin-elf-verify" / ".elfsign";
+          if (std::filesystem::exists(signDir)) {
+              overlays.emplace_back(signOverlayRootDir);
+          }
+
+          auto result = this->repo->importLayerDir(*layerDir, overlays);
           if (!result) {
               taskRef.reportError(std::move(result).error());
               return;
@@ -715,6 +728,14 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
               return;
           }
 
+          utils::Transaction transaction;
+          transaction.addRollBack([this, newRef = *newRef, module]() noexcept {
+              auto res = repo->remove(newRef, module);
+              if (!res) {
+                  LogW("failed to roll back importLayerDir {} {}", newRef.toString(), module);
+              }
+          });
+
           auto ret = executePostInstallHooks(*newRef);
           if (!ret) {
               taskRef.reportError(std::move(ret).error());
@@ -725,12 +746,15 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
               auto res = applyApp(*newRef);
               if (!res) {
                   taskRef.reportError(std::move(res).error());
+                  return;
               }
+              transaction.commit();
               return;
           }
 
           auto modules = this->repo->getModuleList(*localRef);
           if (std::find(modules.cbegin(), modules.cend(), module) == modules.cend()) {
+              transaction.commit();
               return;
           }
 
@@ -741,6 +765,7 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
                    packageRef.toString(),
                    ret.error().message());
           }
+          transaction.commit();
       };
 
     auto taskRet = tasks.addPackageTask(std::move(installer), ctx);
@@ -1195,10 +1220,20 @@ utils::error::Result<void> PackageManager::installRefModule(Task &task,
         return LINGLONG_ERR(res);
     }
 
+    utils::Transaction transaction;
+    transaction.addRollBack([this, &ref, module]() noexcept {
+        auto res = repo->remove(ref.reference, module);
+        if (!res) {
+            LogW("failed to roll back pull {} {}", ref.reference.toString(), module);
+        }
+    });
+
     res = executePostInstallHooks(ref.reference);
     if (!res) {
-        LogW(fmt::format("failed to execute postInstall hooks {}", ref.reference.toString()));
+        return LINGLONG_ERR("signature verification failed", res);
     }
+
+    transaction.commit();
 
     return LINGLONG_OK;
 }
@@ -1242,9 +1277,16 @@ utils::error::Result<void> PackageManager::installRef(Task &task,
             return LINGLONG_ERR(res);
         }
 
+        transaction.addRollBack([this, &ref, module]() noexcept {
+            auto res = repo->remove(ref.reference, module);
+            if (!res) {
+                LogW("failed to roll back pull {} {}", ref.reference.toString(), module);
+            }
+        });
+
         res = executePostInstallHooks(ref.reference);
         if (!res) {
-            LogW(fmt::format("failed to execute postInstall hooks {}", ref.reference.toString()));
+            return LINGLONG_ERR("signature verification failed", res);
         }
     }
 

--- a/libs/linglong/tests/ll-tests/src/linglong/package/layer_packager_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/layer_packager_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -12,12 +12,16 @@
 #include "linglong/utils/cmd.h"
 #include "linglong/utils/error/error.h"
 
+#include <nlohmann/json.hpp>
+
 #include <QDir>
+#include <QFile>
 #include <QSharedPointer>
 
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <sstream>
 #include <string>
 
 using namespace linglong;
@@ -180,6 +184,98 @@ TEST_F(LayerPackagerTest, InitWorkDir)
     ASSERT_TRUE(ret.has_value()) << "Failed to init workdir" << ret.error().message();
     ASSERT_NE(packager.getWorkDir().string(), tmpDir.path() / "not-exists")
       << "workdir should be temporary directory";
+}
+
+TEST_F(LayerPackagerTest, ExtractSignData)
+{
+    TempDir signTempDir("linglong-sign-test-");
+    ASSERT_TRUE(signTempDir.isValid());
+
+    auto signContentDir = signTempDir.path() / "sign";
+    std::filesystem::create_directories(signContentDir);
+    std::ofstream signFile(signContentDir / "sign_test_file");
+    signFile << "sign data content";
+    signFile.close();
+
+    auto signTarPath = signTempDir.path() / "sign.tar";
+    auto tarRet =
+      utils::Cmd("tar").exec({ "-cvf", signTarPath.c_str(), "-C", signContentDir.c_str(), "." });
+    ASSERT_TRUE(tarRet.has_value()) << "Failed to create sign.tar";
+
+    QFile originalLayer(layerFilePath.c_str());
+    ASSERT_TRUE(originalLayer.open(QIODevice::ReadOnly));
+
+    auto magic = originalLayer.read(40);
+    ASSERT_EQ(magic, magicNumber());
+
+    QDataStream metaLenStream(&originalLayer);
+    metaLenStream.setByteOrder(QDataStream::LittleEndian);
+    quint32 metaLen = 0;
+    metaLenStream >> metaLen;
+
+    auto metaData = originalLayer.read(metaLen);
+    auto metaJson = nlohmann::json::parse(metaData.toStdString());
+
+    auto erofsData = originalLayer.readAll();
+    auto erofsSize = static_cast<uint64_t>(erofsData.size());
+    originalLayer.close();
+
+    QFile signTarFile(signTarPath.c_str());
+    ASSERT_TRUE(signTarFile.open(QIODevice::ReadOnly));
+    auto signData = signTarFile.readAll();
+    auto signSize = static_cast<uint64_t>(signData.size());
+    signTarFile.close();
+
+    metaJson["erofs_size"] = erofsSize;
+    metaJson["sign_size"] = signSize;
+    auto newMetaData = QByteArray::fromStdString(metaJson.dump());
+    quint32 newMetaLen = static_cast<quint32>(newMetaData.size());
+
+    auto signedLayerPath = signTempDir.path() / "signed.layer";
+    QFile signedLayer(signedLayerPath.c_str());
+    ASSERT_TRUE(signedLayer.open(QIODevice::WriteOnly));
+
+    signedLayer.write(magicNumber());
+
+    QByteArray lenBytes;
+    QDataStream lenStream(&lenBytes, QIODevice::WriteOnly);
+    lenStream.setByteOrder(QDataStream::LittleEndian);
+    lenStream << newMetaLen;
+    signedLayer.write(lenBytes);
+    signedLayer.write(newMetaData);
+    signedLayer.write(erofsData);
+    signedLayer.write(signData);
+    signedLayer.close();
+
+    auto signedLayerFileRet = package::LayerFile::New(signedLayerPath.c_str());
+    ASSERT_TRUE(signedLayerFileRet.has_value())
+      << "Failed to create layer file: " << signedLayerFileRet.error().message();
+    auto signedLayerFile = *signedLayerFileRet;
+
+    package::LayerPackager packager;
+    auto extractRet = packager.extractSignData(*signedLayerFile, signTempDir.path());
+    ASSERT_TRUE(extractRet.has_value()) << "Failed to extract sign data";
+
+    auto signDataDir = signTempDir.path() / "entries" / "share" / "deepin-elf-verify" / ".elfsign";
+    ASSERT_TRUE(std::filesystem::exists(signDataDir / "sign_test_file"))
+      << "sign_test_file not found in " << signDataDir;
+
+    std::ifstream testFile(signDataDir / "sign_test_file");
+    std::stringstream buffer;
+    buffer << testFile.rdbuf();
+    ASSERT_EQ(buffer.str(), "sign data content");
+}
+
+TEST_F(LayerPackagerTest, ExtractSignDataNoSign)
+{
+    auto layerFileRet = package::LayerFile::New(layerFilePath.c_str());
+    ASSERT_TRUE(layerFileRet.has_value())
+      << "Failed to create layer file: " << layerFileRet.error().message();
+    auto layerFile = *layerFileRet;
+
+    package::LayerPackager packager;
+    auto extractRet = packager.extractSignData(*layerFile, packager.getWorkDir());
+    ASSERT_TRUE(extractRet.has_value()) << "extractSignData should succeed";
 }
 
 } // namespace linglong::package


### PR DESCRIPTION
1. Implement extractSignData in LayerPackager to extract signature data from layer files
2. Modify installFromLayer to extract sign data and pass overlays to repo->importLayerDir
3. Add transaction rollback for importLayerDir in installFromLayer and installRef
4. Fix error handling in executePostInstallHooks: return error instead of logging
5. Add unit tests for extractSignData with signed and unsigned layers

Log: Added signature extraction for layer installation, enabling signature verification and overlay application.

Influence:
1. Test installation of layers with valid signatures
2. Test installation of layers without signatures (should succeed)
3. Test installation with corrupted or missing signature metadata
4. Verify that signature overlay is correctly extracted and placed
5. Test rollback on failure during signature extraction
6. Verify error when post-install hooks fail due to signature mismatch
7. Test cleanup of temporary signature files after installation