### PR TITLE
chore: exclude polkit translations from pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,8 @@ exclude: |
     tools/openapi-c-libcurl-client/|
     .obs/|
     misc/share/linglong/builder/templates/|
-    apps/ll-builder-utils/patch/
+    apps/ll-builder-utils/patch/|
+    misc/share/polkit-1/translations/
   )
 
 ci:


### PR DESCRIPTION
Add `misc/share/polkit-1/translations/` to the pre-commit exclusions to prevent linting or formatting checks on generated translation files under that path.

Influence:
1. Verify that pre-commit hooks no longer run on any file within `misc/ share/polkit-1/translations/`
2. Ensure that pre-commit still runs on files outside the exclusion list
3. Confirm that the YAML syntax remains valid after the change