### PR TITLE
feat: avoid duplicate ll-package-manager startup by checking existing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.11.4)
 
 project(
   linglong
-  VERSION 1.13.2
+  VERSION 1.13.3
   DESCRIPTION "a container based application package manager for Linux desktop"
   HOMEPAGE_URL "https://github.com/OpenAtom-Linyaps/linyaps"
   LANGUAGES CXX C)

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -23,6 +23,7 @@
 #include <CLI/CLI.hpp>
 #include <sys/file.h>
 
+#include <QDBusConnection>
 #include <QDBusMetaType>
 #include <QDBusObjectPath>
 #include <QJsonDocument>
@@ -38,6 +39,7 @@
 #include <thread>
 
 #include <fcntl.h>
+#include <signal.h>
 #include <unistd.h>
 #include <wordexp.h>
 
@@ -46,6 +48,26 @@ using namespace linglong::package;
 using namespace linglong::cli;
 
 namespace {
+
+void startProcess(const QString &program, const QStringList &args = {})
+{
+    QProcess process;
+    auto envs = process.environment();
+    envs.push_back("QT_FORCE_STDERR_LOGGING=1");
+    process.setEnvironment(envs);
+    process.setProgram(program);
+    process.setArguments(args);
+
+    qint64 pid = 0;
+    process.startDetached(&pid);
+
+    LogD("start {} {} as {}", program.toStdString(), args.join(" ").toStdString(), pid);
+
+    QObject::connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, [pid]() {
+        LogD("kill {}", pid);
+        kill(pid, SIGTERM);
+    });
+}
 
 std::vector<std::string> transformOldExec(int argc, char **argv) noexcept
 {
@@ -692,16 +714,24 @@ You can report bugs to the linyaps team under this project: https://github.com/O
             return -1;
         }
 
-        // Start ll-package-manager --no-dbus first to initialize the repository
-        QProcess::startDetached("sudo",
-                                { "--user",
-                                  LINGLONG_USERNAME,
-                                  "--preserve-env=QT_FORCE_STDERR_LOGGING",
-                                  "--preserve-env=QDBUS_DEBUG",
-                                  LINGLONG_LIBEXEC_DIR "/ll-package-manager",
-                                  "--no-dbus" });
-        using namespace std::chrono_literals;
-        std::this_thread::sleep_for(1s);
+        const auto pkgManAddress = QString("unix:path=/tmp/linglong-package-manager.socket");
+
+        // Check if ll-package-manager is already running
+        auto pkgManConn = QDBusConnection::connectToPeer(pkgManAddress, "ll-package-manager");
+        if (!pkgManConn.isConnected()) {
+            // Only start a new process if no existing one is listening
+            startProcess("sudo",
+                         { "--user",
+                           LINGLONG_USERNAME,
+                           "--preserve-env=QT_FORCE_STDERR_LOGGING",
+                           "--preserve-env=QDBUS_DEBUG",
+                           LINGLONG_LIBEXEC_DIR "/ll-package-manager",
+                           "--no-dbus" });
+            using namespace std::chrono_literals;
+            std::this_thread::sleep_for(1s);
+        } else {
+            LogD("ll-package-manager is already running, reuse existing process");
+        }
     }
     auto repo = linglong::repo::OSTreeRepo::loadFromPath(LINGLONG_ROOT);
     if (!repo.has_value()) {


### PR DESCRIPTION
connection

1. Add `startProcess` helper to launch detached processes with proper environment and cleanup on exit.
2. Replace unconditional `startDetached` and sleep with a D-Bus peer connection check to see if `ll-package-manager` is already running.
3. Only start a new process when no existing daemon is detected; otherwise log reuse of existing instance.
4. Include signal handling to terminate spawned processes when the application quits.

Log: Improved process management for ll-package-manager to prevent duplicate instances.

Influence:
1. Verify that ll-package-manager starts correctly when not already running.
2. Test that when ll-package-manager is already running, a new process is not spawned.
3. Confirm that spawned processes are terminated when the main application exits.
4. Check logging output for "reuse existing process" or "start" messages.
5. Verify D-Bus connection to the peer socket works as expected.
6. Test in scenarios where the socket file might be stale or missing.