### PR TITLE
fix: ll-package-manager process start abnormal

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -714,24 +714,15 @@ You can report bugs to the linyaps team under this project: https://github.com/O
             return -1;
         }
 
-        const auto pkgManAddress = QString("unix:path=/tmp/linglong-package-manager.socket");
-
-        // Check if ll-package-manager is already running
-        auto pkgManConn = QDBusConnection::connectToPeer(pkgManAddress, "ll-package-manager");
-        if (!pkgManConn.isConnected()) {
-            // Only start a new process if no existing one is listening
-            startProcess("sudo",
-                         { "--user",
-                           LINGLONG_USERNAME,
-                           "--preserve-env=QT_FORCE_STDERR_LOGGING",
-                           "--preserve-env=QDBUS_DEBUG",
-                           LINGLONG_LIBEXEC_DIR "/ll-package-manager",
-                           "--no-dbus" });
-            using namespace std::chrono_literals;
-            std::this_thread::sleep_for(1s);
-        } else {
-            LogD("ll-package-manager is already running, reuse existing process");
-        }
+        startProcess("sudo",
+                     { "--user",
+                       LINGLONG_USERNAME,
+                       "--preserve-env=QT_FORCE_STDERR_LOGGING",
+                       "--preserve-env=QDBUS_DEBUG",
+                       LINGLONG_LIBEXEC_DIR "/ll-package-manager",
+                       "--no-dbus" });
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for(1s);
     }
     auto repo = linglong::repo::OSTreeRepo::loadFromPath(LINGLONG_ROOT);
     if (!repo.has_value()) {


### PR DESCRIPTION
Remove the DBus connection check for ll-package-manager and always start a new process. The previous logic attempted to reuse an existing instance but the connection check was unreliable and introduced complexity. Simplify by always spawning a new process via sudo and sleeping to ensure readiness.

Log: ll-cli now always starts a new package-manager process instead of reusing existing one

Influence:
1. Test normal command execution after the change
2. Verify that only one package-manager process runs when invoked multiple times (if needed)
3. Ensure that existing operations (install, remove, etc.) still work correctly
4. Check for any race conditions or startup failures due to concurrent launches
5. Validate that the sleeping interval (1s) is sufficient for the package-manager to initialize