### PR TITLE
feat: support config.d drop-ins and CDI devices in runtime config

### DIFF
--- a/api/schema/v1.json
+++ b/api/schema/v1.json
@@ -1469,6 +1469,12 @@
           "additionalProperties": {
             "$ref": "#/$defs/RuntimeConfigure"
           }
+        },
+        "devices": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -1111,6 +1111,10 @@ $defs:
         type: object
         additionalProperties:
           $ref: '#/$defs/RuntimeConfigure'
+      devices:
+        type: array
+        items:
+          type: string
   RunContextConfig:
     title: RunContextConfig
     type: object

--- a/libs/api/src/linglong/api/types/v1/Generators.hpp
+++ b/libs/api/src/linglong/api/types/v1/Generators.hpp
@@ -1311,6 +1311,7 @@ j["version"] = x.version;
 
 inline void from_json(const json & j, RuntimeConfigure& x) {
 x.deviceMode = get_stack_optional<std::vector<DeviceOption>>(j, "device_mode");
+x.devices = get_stack_optional<std::vector<std::string>>(j, "devices");
 x.disableXdp = get_stack_optional<bool>(j, "disable_xdp");
 x.env = get_stack_optional<std::map<std::string, std::string>>(j, "env");
 x.extDefs = get_stack_optional<std::map<std::string, std::vector<ExtensionDefine>>>(j, "ext_defs");
@@ -1322,6 +1323,9 @@ inline void to_json(json & j, const RuntimeConfigure & x) {
 j = json::object();
 if (x.deviceMode) {
 j["device_mode"] = x.deviceMode;
+}
+if (x.devices) {
+j["devices"] = x.devices;
 }
 if (x.disableXdp) {
 j["disable_xdp"] = x.disableXdp;

--- a/libs/api/src/linglong/api/types/v1/RuntimeConfigure.hpp
+++ b/libs/api/src/linglong/api/types/v1/RuntimeConfigure.hpp
@@ -38,6 +38,7 @@ using nlohmann::json;
 
 struct RuntimeConfigure {
 std::optional<std::vector<DeviceOption>> deviceMode;
+std::optional<std::vector<std::string>> devices;
 std::optional<bool> disableXdp;
 std::optional<std::map<std::string, std::string>> env;
 /**

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -24,7 +24,6 @@
 #include "linglong/api/types/v1/PackageManager1UninstallParameters.hpp"
 #include "linglong/api/types/v1/State.hpp"
 #include "linglong/api/types/v1/UpgradeListResult.hpp"
-#include "linglong/cdi/cdi.h"
 #include "linglong/cli/printer.h"
 #include "linglong/common/dir.h"
 #include "linglong/common/error.h"
@@ -561,30 +560,6 @@ int Cli::run(const RunOptions &options)
 {
     LINGLONG_TRACE("command run");
 
-    bool nvidiaCdiFound =
-      std::any_of(options.cdiDevices.begin(), options.cdiDevices.end(), [](const std::string &d) {
-          return d.find("nvidia.com/gpu") != std::string::npos;
-      });
-    std::optional<std::vector<api::types::v1::CdiDeviceEntry>> autoDetectedCdiDevices;
-
-    if (!nvidiaCdiFound && options.cdiDevices.empty()) {
-        auto allCdiDevices = cdi::getCDIDevices(options.cdiSpecDir, std::nullopt);
-        if (allCdiDevices) {
-            for (const auto &device : *allCdiDevices) {
-                LogD("{}={} detected", device.kind, device.name);
-                if (device.kind == "nvidia.com/gpu" && device.name == "all") {
-                    nvidiaCdiFound = true;
-                    autoDetectedCdiDevices = std::vector<api::types::v1::CdiDeviceEntry>{ device };
-                    break;
-                }
-            }
-        }
-    }
-
-    if (!nvidiaCdiFound) {
-        detectDrivers();
-    }
-
     auto userContainerDir = std::filesystem::path{ "/run/linglong" } / std::to_string(getuid());
     if (auto ret = utils::ensureDirectory(userContainerDir); !ret) {
         this->printer.printErr(ret.error());
@@ -630,27 +605,23 @@ int Cli::run(const RunOptions &options)
 
     runtime::RunContext runContext(this->repository);
     linglong::runtime::ResolveOptions opts;
-    if (runtimeConfig) {
-        auto cfgRes = opts.applyRuntimeConfig(*runtimeConfig);
-        if (!cfgRes) {
-            this->printer.printErr(cfgRes.error());
-            return -1;
-        }
-    }
-    auto cliRes = opts.applyCliRunOptions(options);
-    if (!cliRes) {
-        this->printer.printErr(cliRes.error());
+    auto resolveOptionsRes = opts.applyOptions(runtimeConfig, options);
+    if (!resolveOptionsRes) {
+        this->printer.printErr(resolveOptionsRes.error());
         return -1;
     }
-    if (!options.cdiDevices.empty()) {
-        auto cdiDevices = cdi::getCDIDevices(options.cdiSpecDir, options.cdiDevices);
-        if (!cdiDevices) {
-            handleCommonError(cdiDevices.error());
-            return -1;
-        }
-        opts.cdiDevices = std::move(*cdiDevices);
-    } else if (autoDetectedCdiDevices) {
-        opts.cdiDevices = std::move(*autoDetectedCdiDevices);
+
+    bool nvidiaCdiFound = false;
+    if (opts.cdiDevices) {
+        nvidiaCdiFound = std::any_of(opts.cdiDevices->begin(),
+                                     opts.cdiDevices->end(),
+                                     [](const api::types::v1::CdiDeviceEntry &device) {
+                                         return device.kind == "nvidia.com/gpu";
+                                     });
+    }
+
+    if (!nvidiaCdiFound) {
+        detectDrivers();
     }
 
     auto res = runContext.resolve(*curAppRef, opts);

--- a/libs/linglong/src/linglong/runtime/run_context.cpp
+++ b/libs/linglong/src/linglong/runtime/run_context.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/ranges.h>
 
+#include <algorithm>
 #include <cstdlib>
 #include <utility>
 
@@ -57,6 +58,34 @@ std::optional<std::string> timezoneFromPath(const std::filesystem::path &path,
     return relative.string();
 }
 
+utils::error::Result<std::vector<api::types::v1::CdiDeviceEntry>>
+filterCDIDevices(const std::vector<api::types::v1::CdiDeviceEntry> &allDevices,
+                 const std::vector<std::string> &requestedDevices)
+{
+    LINGLONG_TRACE(fmt::format("filter CDI devices {}", fmt::join(requestedDevices, ", ")));
+
+    std::vector<api::types::v1::CdiDeviceEntry> result;
+    for (const auto &deviceStr : requestedDevices) {
+        auto device = common::strings::split(deviceStr, '=');
+        if (device.size() != 2) {
+            return LINGLONG_ERR(fmt::format("invalid device format: {}", deviceStr));
+        }
+
+        auto entry = std::find_if(allDevices.begin(),
+                                  allDevices.end(),
+                                  [&device](const api::types::v1::CdiDeviceEntry &entry) {
+                                      return entry.kind == device[0] && entry.name == device[1];
+                                  });
+        if (entry == allDevices.end()) {
+            return LINGLONG_ERR(fmt::format("device not found: {}", deviceStr));
+        }
+
+        result.emplace_back(*entry);
+    }
+
+    return result;
+}
+
 } // namespace
 
 RunContext::~RunContext() = default;
@@ -64,6 +93,8 @@ RunContext::~RunContext() = default;
 auto ResolveOptions::applyRuntimeConfig(const api::types::v1::RuntimeConfigure &runtimeConfig)
   -> utils::error::Result<void>
 {
+    LINGLONG_TRACE("apply runtime config to resolve options");
+
     if (runtimeConfig.extDefs) {
         this->externalExtensionDefs = *runtimeConfig.extDefs;
     }
@@ -76,12 +107,74 @@ auto ResolveOptions::applyRuntimeConfig(const api::types::v1::RuntimeConfigure &
 auto ResolveOptions::applyCliRunOptions(const cli::RunOptions &options)
   -> utils::error::Result<void>
 {
+    LINGLONG_TRACE("apply cli run options to resolve options");
+
     this->baseRef = options.base;
+    this->cdiSpecDirs = options.cdiSpecDir;
     this->runtimeRef = options.runtime;
     if (!options.extensions.empty()) {
         this->extensionRefs = options.extensions;
     }
     this->instance = options.instance;
+    return LINGLONG_OK;
+}
+
+auto ResolveOptions::applyOptions(
+  const std::optional<api::types::v1::RuntimeConfigure> &runtimeConfig,
+  const cli::RunOptions &options) -> utils::error::Result<void>
+{
+    LINGLONG_TRACE("apply runtime config and cli run options to resolve options");
+
+    if (runtimeConfig) {
+        auto result = this->applyRuntimeConfig(*runtimeConfig);
+        if (!result) {
+            return LINGLONG_ERR(result);
+        }
+    }
+
+    auto result = this->applyCliRunOptions(options);
+    if (!result) {
+        return LINGLONG_ERR(result);
+    }
+
+    this->cdiDevices.reset();
+    std::optional<std::vector<std::string>> requestedCDIDevices;
+    if (!options.cdiDevices.empty()) {
+        requestedCDIDevices = options.cdiDevices;
+    } else if (runtimeConfig && runtimeConfig->devices) {
+        requestedCDIDevices = runtimeConfig->devices;
+    }
+
+    if (requestedCDIDevices && requestedCDIDevices->empty()) {
+        this->cdiDevices = std::vector<api::types::v1::CdiDeviceEntry>{};
+        return LINGLONG_OK;
+    }
+
+    auto allCDIDevices = cdi::getCDIDevices(this->cdiSpecDirs, std::nullopt);
+    if (!allCDIDevices) {
+        return LINGLONG_ERR(allCDIDevices);
+    }
+
+    if (requestedCDIDevices) {
+        auto devices = filterCDIDevices(*allCDIDevices, *requestedCDIDevices);
+        if (!devices) {
+            return LINGLONG_ERR(devices);
+        }
+        this->cdiDevices = std::move(*devices);
+        return LINGLONG_OK;
+    }
+
+    auto nvidiaAllDevice =
+      std::find_if(allCDIDevices->begin(),
+                   allCDIDevices->end(),
+                   [](const api::types::v1::CdiDeviceEntry &device) {
+                       return device.kind == "nvidia.com/gpu" && device.name == "all";
+                   });
+    if (nvidiaAllDevice != allCDIDevices->end()) {
+        LogD("{}={} detected", nvidiaAllDevice->kind, nvidiaAllDevice->name);
+        this->cdiDevices = std::vector<api::types::v1::CdiDeviceEntry>{ *nvidiaAllDevice };
+    }
+
     return LINGLONG_OK;
 }
 

--- a/libs/linglong/src/linglong/runtime/run_context.h
+++ b/libs/linglong/src/linglong/runtime/run_context.h
@@ -36,6 +36,7 @@ struct ResolveOptions
     std::optional<std::vector<std::string>> appModules;
     std::optional<std::string> baseRef;
     std::optional<std::vector<api::types::v1::CdiDeviceEntry>> cdiDevices;
+    std::vector<std::string> cdiSpecDirs{ "/etc/cdi", "/var/run/cdi" };
     std::optional<std::string> runtimeRef;
     std::optional<std::vector<std::string>> extensionRefs;
     std::optional<std::string> instance;
@@ -46,6 +47,8 @@ struct ResolveOptions
     auto applyRuntimeConfig(const api::types::v1::RuntimeConfigure &runtimeConfig)
       -> utils::error::Result<void>;
     auto applyCliRunOptions(const cli::RunOptions &options) -> utils::error::Result<void>;
+    auto applyOptions(const std::optional<api::types::v1::RuntimeConfigure> &runtimeConfig,
+                      const cli::RunOptions &options) -> utils::error::Result<void>;
 };
 
 class RunContext

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_test.cpp
@@ -839,6 +839,144 @@ TEST(ResolveOptionsTest, ApplyRuntimeConfigSetsMounts)
     EXPECT_EQ(opts.mounts->at(0).source, "/host/tmp");
 }
 
+TEST(ResolveOptionsTest, ApplyOptionsSetsEmptyRuntimeConfigCdiDevices)
+{
+    TempDir tempDir;
+    const auto specPath = tempDir.path() / "nvidia.yaml";
+    std::ofstream spec(specPath);
+    spec << R"(cdiVersion: "0.6.0"
+kind: "nvidia.com/gpu"
+devices:
+  - name: "all"
+    containerEdits:
+      env:
+        - "NVIDIA_VISIBLE_DEVICES=all"
+)";
+    spec.close();
+
+    ResolveOptions opts;
+
+    api::types::v1::RuntimeConfigure runtimeConfig;
+    runtimeConfig.devices = std::vector<std::string>{};
+    cli::RunOptions runOptions;
+    runOptions.cdiSpecDir = { tempDir.path().string() };
+
+    auto result = opts.applyOptions(runtimeConfig, runOptions);
+    ASSERT_TRUE(result);
+    ASSERT_TRUE(opts.cdiDevices.has_value());
+    EXPECT_TRUE(opts.cdiDevices->empty());
+}
+
+TEST(ResolveOptionsTest, ApplyOptionsRejectsInvalidRuntimeConfigCdiDeviceFormat)
+{
+    ResolveOptions opts;
+
+    api::types::v1::RuntimeConfigure runtimeConfig;
+    runtimeConfig.devices = std::vector<std::string>{ "invalid-device" };
+    cli::RunOptions runOptions;
+
+    auto result = opts.applyOptions(runtimeConfig, runOptions);
+    ASSERT_FALSE(result);
+    EXPECT_THAT(result.error().message(), ::testing::HasSubstr("invalid device format"));
+}
+
+TEST(ResolveOptionsTest, ApplyOptionsUsesCliCdiSpecDirsForRuntimeConfigCdiDevices)
+{
+    TempDir tempDir;
+    const auto specPath = tempDir.path() / "vendor.yaml";
+    std::ofstream spec(specPath);
+    spec << R"(cdiVersion: "0.6.0"
+kind: "vendor.com/device"
+devices:
+  - name: "gpu0"
+    containerEdits:
+      env:
+        - "FOO=GPU0"
+  - name: "gpu1"
+    containerEdits:
+      env:
+        - "FOO=GPU1"
+)";
+    spec.close();
+
+    ResolveOptions opts;
+
+    api::types::v1::RuntimeConfigure runtimeConfig;
+    runtimeConfig.devices = std::vector<std::string>{ "vendor.com/device=gpu0" };
+
+    cli::RunOptions runOptions;
+    runOptions.cdiSpecDir = { tempDir.path().string() };
+
+    auto result = opts.applyOptions(runtimeConfig, runOptions);
+    ASSERT_TRUE(result);
+    ASSERT_TRUE(opts.cdiDevices.has_value());
+    ASSERT_EQ(opts.cdiDevices->size(), 1);
+    EXPECT_EQ(opts.cdiDevices->at(0).name, "gpu0");
+}
+
+TEST(ResolveOptionsTest, ApplyOptionsCliCdiDevicesOverrideRuntimeConfigCdiDevices)
+{
+    TempDir tempDir;
+    const auto specPath = tempDir.path() / "vendor.yaml";
+    std::ofstream spec(specPath);
+    spec << R"(cdiVersion: "0.6.0"
+kind: "vendor.com/device"
+devices:
+  - name: "gpu0"
+    containerEdits:
+      env:
+        - "FOO=GPU0"
+  - name: "gpu1"
+    containerEdits:
+      env:
+        - "FOO=GPU1"
+)";
+    spec.close();
+
+    ResolveOptions opts;
+
+    api::types::v1::RuntimeConfigure runtimeConfig;
+    runtimeConfig.devices = std::vector<std::string>{ "vendor.com/device=gpu0" };
+
+    cli::RunOptions runOptions;
+    runOptions.cdiSpecDir = { tempDir.path().string() };
+    runOptions.cdiDevices = { "vendor.com/device=gpu1" };
+
+    auto result = opts.applyOptions(runtimeConfig, runOptions);
+    ASSERT_TRUE(result);
+    ASSERT_TRUE(opts.cdiDevices.has_value());
+    ASSERT_EQ(opts.cdiDevices->size(), 1);
+    EXPECT_EQ(opts.cdiDevices->at(0).name, "gpu1");
+}
+
+TEST(ResolveOptionsTest, ApplyOptionsAutoDetectsNvidiaCdiDevice)
+{
+    TempDir tempDir;
+    const auto specPath = tempDir.path() / "nvidia.yaml";
+    std::ofstream spec(specPath);
+    spec << R"(cdiVersion: "0.6.0"
+kind: "nvidia.com/gpu"
+devices:
+  - name: "all"
+    containerEdits:
+      env:
+        - "NVIDIA_VISIBLE_DEVICES=all"
+)";
+    spec.close();
+
+    ResolveOptions opts;
+
+    cli::RunOptions runOptions;
+    runOptions.cdiSpecDir = { tempDir.path().string() };
+
+    auto result = opts.applyOptions(std::nullopt, runOptions);
+    ASSERT_TRUE(result);
+    ASSERT_TRUE(opts.cdiDevices.has_value());
+    ASSERT_EQ(opts.cdiDevices->size(), 1);
+    EXPECT_EQ(opts.cdiDevices->at(0).kind, "nvidia.com/gpu");
+    EXPECT_EQ(opts.cdiDevices->at(0).name, "all");
+}
+
 TEST(ResolveOptionsTest, ApplyCliRunOptionsSetsFields)
 {
     ResolveOptions opts;
@@ -848,10 +986,12 @@ TEST(ResolveOptionsTest, ApplyCliRunOptionsSetsFields)
     runOptions.runtime = "org.deepin.runtime/23.0.0";
     runOptions.extensions = { "org.deepin.extension1", "org.deepin.extension2" };
     runOptions.instance = "test-instance";
+    runOptions.cdiSpecDir = { "/tmp/cdi" };
 
     auto result = opts.applyCliRunOptions(runOptions);
     ASSERT_TRUE(result);
     EXPECT_EQ(opts.baseRef.value(), "org.deepin.base/23.0.0");
+    EXPECT_EQ(opts.cdiSpecDirs, std::vector<std::string>{ "/tmp/cdi" });
     EXPECT_EQ(opts.runtimeRef.value(), "org.deepin.runtime/23.0.0");
     ASSERT_TRUE(opts.extensionRefs.has_value());
     EXPECT_EQ(opts.extensionRefs->size(), 2);

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/runtime_config_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/runtime_config_test.cpp
@@ -84,6 +84,7 @@ TEST(RuntimeConfigTest, MergeConfigs)
     RuntimeConfigure config1;
     config1.disableXdp = false;
     config1.deviceMode = std::vector<DeviceOption>{ DeviceOption::Passthru };
+    config1.devices = std::vector<std::string>{ "vendor.com/device=gpu0" };
     config1.env =
       std::map<std::string, std::string>{ { "PATH", "/usr/bin" }, { "HOME", "/home/user1" } };
 
@@ -97,6 +98,7 @@ TEST(RuntimeConfigTest, MergeConfigs)
     RuntimeConfigure config2;
     config2.disableXdp = true;
     config2.deviceMode = std::vector<DeviceOption>{ DeviceOption::Passthru };
+    config2.devices = std::vector<std::string>{ "vendor.com/device=gpu1" };
     config2.env =
       std::map<std::string, std::string>{ { "PATH", "/usr/local/bin" }, { "USER", "testuser" } };
 
@@ -120,6 +122,11 @@ TEST(RuntimeConfigTest, MergeConfigs)
     EXPECT_EQ(merged.deviceMode->size(), 2);
     EXPECT_EQ(merged.deviceMode->at(0), DeviceOption::Passthru);
     EXPECT_EQ(merged.deviceMode->at(1), DeviceOption::Passthru);
+
+    ASSERT_TRUE(merged.devices);
+    EXPECT_EQ(merged.devices->size(), 2);
+    EXPECT_EQ(merged.devices->at(0), "vendor.com/device=gpu0");
+    EXPECT_EQ(merged.devices->at(1), "vendor.com/device=gpu1");
 
     // Check environment variables
     ASSERT_TRUE(merged.env);
@@ -358,4 +365,64 @@ TEST(RuntimeConfigTest, LoadRuntimeConfigWithInstanceMounts)
     ASSERT_TRUE(devConfig.env.has_value());
     EXPECT_EQ(devConfig.env->at("DEBUG"), "1");
     EXPECT_FALSE(devConfig.instances.has_value());
+}
+
+TEST(RuntimeConfigTest, LoadRuntimeConfigWithConfigD)
+{
+    TempDir tempDir;
+
+    RuntimeConfigure config;
+    config.env = std::map<std::string, std::string>{ { "ORDER", "base" } };
+    config.devices = std::vector<std::string>{ "vendor.com/device=base" };
+
+    RuntimeConfigure config10;
+    config10.env = std::map<std::string, std::string>{ { "ORDER", "10" } };
+    config10.devices = std::vector<std::string>{ "vendor.com/device=10" };
+
+    RuntimeConfigure config20;
+    config20.env = std::map<std::string, std::string>{ { "ORDER", "20" }, { "EXTRA", "enabled" } };
+    config20.devices = std::vector<std::string>{ "vendor.com/device=20" };
+
+    fs::path configDir = tempDir.path() / "linglong" / "apps" / "test-config-d";
+    fs::create_directories(configDir / "config.d");
+
+    {
+        std::ofstream file(configDir / "config.json");
+        nlohmann::json j;
+        linglong::api::types::v1::to_json(j, config);
+        file << j.dump();
+    }
+    {
+        std::ofstream file(configDir / "config.d" / "20-runtime.json");
+        nlohmann::json j;
+        linglong::api::types::v1::to_json(j, config20);
+        file << j.dump();
+    }
+    {
+        std::ofstream file(configDir / "config.d" / "10-runtime.json");
+        nlohmann::json j;
+        linglong::api::types::v1::to_json(j, config10);
+        file << j.dump();
+    }
+    {
+        std::ofstream file(configDir / "config.d" / "README");
+        file << "runtime config drop-ins must use the .json suffix";
+    }
+
+    EnvironmentVariableGuard xdgGuard("XDG_CONFIG_HOME", tempDir.path().string());
+
+    auto loaded = linglong::utils::loadRuntimeConfig("test-config-d", "");
+    ASSERT_TRUE(loaded.has_value());
+    ASSERT_TRUE(loaded->has_value());
+
+    auto &loadedConfig = **loaded;
+    ASSERT_TRUE(loadedConfig.env.has_value());
+    EXPECT_EQ(loadedConfig.env->at("ORDER"), "20");
+    EXPECT_EQ(loadedConfig.env->at("EXTRA"), "enabled");
+
+    ASSERT_TRUE(loadedConfig.devices.has_value());
+    ASSERT_EQ(loadedConfig.devices->size(), 3);
+    EXPECT_EQ(loadedConfig.devices->at(0), "vendor.com/device=base");
+    EXPECT_EQ(loadedConfig.devices->at(1), "vendor.com/device=10");
+    EXPECT_EQ(loadedConfig.devices->at(2), "vendor.com/device=20");
 }

--- a/libs/utils/src/linglong/utils/runtime_config.cpp
+++ b/libs/utils/src/linglong/utils/runtime_config.cpp
@@ -10,6 +10,7 @@
 #include "linglong/utils/error/error.h"
 #include "linglong/utils/serialize/json.h"
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 
@@ -17,22 +18,61 @@ using RuntimeConfigure = linglong::api::types::v1::RuntimeConfigure;
 
 namespace {
 
+bool isRuntimeConfigDropIn(const std::filesystem::path &path)
+{
+    return path.extension() == ".json";
+}
+
 linglong::utils::error::Result<std::optional<RuntimeConfigure>>
 loadRuntimeConfigFromDir(const std::filesystem::path &configDir, const std::string &appId)
 {
-    std::filesystem::path configPath;
+    LINGLONG_TRACE("load runtime config from dir " + configDir.string());
+
+    std::filesystem::path configBaseDir;
     if (appId.empty()) {
-        configPath = configDir / "config.json";
+        configBaseDir = configDir;
     } else {
-        configPath = configDir / "apps" / appId / "config.json";
+        configBaseDir = configDir / "apps" / appId;
     }
 
+    std::vector<RuntimeConfigure> configs;
+    auto configPath = configBaseDir / "config.json";
     std::error_code ec;
-    if (!std::filesystem::exists(configPath, ec)) {
+    if (std::filesystem::exists(configPath, ec)) {
+        auto config = linglong::utils::loadRuntimeConfig(configPath);
+        if (!config) {
+            return LINGLONG_ERR(config);
+        }
+        configs.emplace_back(std::move(*config));
+    }
+
+    auto configDPath = configBaseDir / "config.d";
+    if (std::filesystem::is_directory(configDPath, ec)) {
+        std::vector<std::filesystem::path> paths;
+        for (const auto &entry : std::filesystem::directory_iterator(
+               configDPath,
+               std::filesystem::directory_options::skip_permission_denied,
+               ec)) {
+            if (entry.is_regular_file(ec) && isRuntimeConfigDropIn(entry.path())) {
+                paths.emplace_back(entry.path());
+            }
+        }
+
+        std::sort(paths.begin(), paths.end());
+        for (const auto &path : paths) {
+            auto config = linglong::utils::loadRuntimeConfig(path);
+            if (!config) {
+                return LINGLONG_ERR(config);
+            }
+            configs.emplace_back(std::move(*config));
+        }
+    }
+
+    if (configs.empty()) {
         return std::nullopt;
     }
 
-    return linglong::utils::loadRuntimeConfig(configPath);
+    return linglong::utils::MergeRuntimeConfig(configs);
 }
 
 linglong::utils::error::Result<std::optional<RuntimeConfigure>>
@@ -78,6 +118,16 @@ RuntimeConfigure MergeRuntimeConfig(const std::vector<RuntimeConfigure> &configs
                 result.deviceMode->insert(result.deviceMode->end(),
                                           config.deviceMode->begin(),
                                           config.deviceMode->end());
+            }
+        }
+
+        if (config.devices) {
+            if (!result.devices) {
+                result.devices = config.devices;
+            } else {
+                result.devices->insert(result.devices->end(),
+                                       config.devices->begin(),
+                                       config.devices->end());
             }
         }
 


### PR DESCRIPTION
Add a `devices` field to RuntimeConfigure holding CDI device references (e.g. "vendor.com/device=gpu0").