### PR TITLE
fix(cli): use HOME env instead of hardcoded "/home/" path prefix check

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -1787,8 +1787,18 @@ int Cli::content(const ContentOptions &options)
         LogE("failed to check symlink {}: {}", file.c_str(), ec.message());
     }
 
-    // Don't mapping the file under /home
-    if (auto tmp = target.string(); tmp.rfind("/home/", 0) == 0) {
+    auto *homePath = ::getenv("HOME");
+    if (homePath == nullptr || homePath[0] == '\0') {
+        LogE("failed to get HOME env");
+        return target;
+    }
+
+    // Don't map files under the user's home directory
+    auto homeStr = std::string(homePath);
+    if (homeStr.back() != '/') {
+        homeStr.push_back('/');
+    }
+    if (auto tmp = target.string(); tmp.rfind(homeStr, 0) == 0) {
         return target;
     }
 


### PR DESCRIPTION
- Replace hardcoded "/home/" string prefix check with HOME environment variable to support non-standard home directories
- Add null and empty string checks for HOME env to handle edge cases
- Append trailing slash to HOME path before prefix matching to avoid false positive on paths like /home/bob-xxx
- Fix minor indentation on LogE call