### PR TITLE
fix(cli): use HOME env instead of hardcoded "/home/" path prefix check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.11.4)
 
 project(
   linglong
-  VERSION 1.13.3
+  VERSION 1.13.4
   DESCRIPTION "a container based application package manager for Linux desktop"
   HOMEPAGE_URL "https://github.com/OpenAtom-Linyaps/linyaps"
   LANGUAGES CXX C)

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -1787,8 +1787,18 @@ int Cli::content(const ContentOptions &options)
         LogE("failed to check symlink {}: {}", file.c_str(), ec.message());
     }
 
-    // Dont't mapping the file under /home
-    if (auto tmp = target.string(); tmp.rfind("/home/", 0) == 0) {
+    auto *homePath = ::getenv("HOME");
+    if (homePath == nullptr || homePath[0] == '\0') {
+        LogE("failed to get HOME env");
+        return target;
+    }
+
+    // Don't map files under the user's home directory
+    auto homeStr = std::string(homePath);
+    if (homeStr.back() != '/') {
+        homeStr.push_back('/');
+    }
+    if (auto tmp = target.string(); tmp.rfind(homeStr, 0) == 0) {
         return target;
     }
 


### PR DESCRIPTION
- Replace hardcoded "/home/" string prefix check with HOME environment variable to support non-standard home directories
- Add null and empty string checks for HOME env to handle edge cases
- Append trailing slash to HOME path before prefix matching to avoid false positive on paths like /home/bob-xxx
- Fix minor indentation on LogE call