### PR TITLE
feat: add `ll-cli analyze size` subcommand

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -432,6 +432,40 @@ ll-cli list --upgradable
                         "application(s), base(s) or runtime(s)"));
 }
 
+// Function to add the analyze size subcommand
+void addAnalyzeSizeCommand(CLI::App &cliAnalyze, SizeOptions &sizeOptions)
+{
+    auto *cliSize =
+      cliAnalyze.add_subcommand("size", _("Show installed module sizes and repository real size"))
+        ->fallthrough();
+    cliSize->usage(_(R"(Usage: ll-cli analyze size [OPTIONS]
+
+Example:
+# show installed module sizes
+ll-cli analyze size
+)"));
+    cliSize
+      ->add_option(
+        "--sort",
+        sizeOptions.sortBy,
+        _(R"(Sort result by specify field. One of "actual", "logical", "exclusive", "shared" or "id")"))
+      ->type_name("FIELD")
+      ->capture_default_str()
+      ->check(CLI::IsMember({ "actual", "logical", "exclusive", "shared", "id" }));
+    cliSize->add_flag("--asc", sizeOptions.ascending, _("Sort in ascending order"));
+}
+
+// Function to add the analyze subcommands
+void addAnalyzeCommand(CLI::App &commandParser, SizeOptions &sizeOptions, const std::string &group)
+{
+    auto *cliAnalyze = commandParser.add_subcommand("analyze", _("Analyze installed applications"))
+                         ->group(group)
+                         ->usage(_("Usage: ll-cli analyze SUBCOMMAND [OPTIONS]"));
+    cliAnalyze->require_subcommand(1);
+
+    addAnalyzeSizeCommand(*cliAnalyze, sizeOptions);
+}
+
 // Function to add the info subcommand
 void addInfoCommand(CLI::App &commandParser, InfoOptions &infoOptions, const std::string &group)
 {
@@ -566,6 +600,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     SearchOptions searchOptions{};
     UninstallOptions uninstallOptions{};
     ListOptions listOptions{};
+    SizeOptions sizeOptions{};
     InfoOptions infoOptions{};
     ContentOptions contentOptions{};
     linglong::common::cli::RepoOptions repoOptions{};
@@ -587,6 +622,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     addUpgradeCommand(commandParser, upgradeOptions, CliBuildInGroup);
     addSearchCommand(commandParser, searchOptions, CliSearchGroup);
     addListCommand(commandParser, listOptions, CliBuildInGroup);
+    addAnalyzeCommand(commandParser, sizeOptions, CliBuildInGroup);
     linglong::common::cli::addRepoCommand(commandParser,
                                           repoOptions,
                                           CliRepoGroup,
@@ -743,6 +779,14 @@ You can report bugs to the linyaps team under this project: https://github.com/O
         result = cli->uninstall(uninstallOptions);
     } else if (name == "list") {
         result = cli->list(listOptions);
+    } else if (name == "analyze") {
+        const auto &subcommands = (*ret)->get_subcommands();
+        auto subcommand = std::find_if(subcommands.begin(), subcommands.end(), [](CLI::App *app) {
+            return app->parsed();
+        });
+        if (subcommand != subcommands.end() && (*subcommand)->get_name() == "size") {
+            result = cli->size(sizeOptions);
+        }
     } else if (name == "info") {
         result = cli->info(infoOptions);
     } else if (name == "content") {

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -30,6 +30,7 @@
 #include "linglong/common/strings.h"
 #include "linglong/package/layer_file.h"
 #include "linglong/package/reference.h"
+#include "linglong/package/version.h"
 #include "linglong/runtime/container_builder.h"
 #include "linglong/runtime/run_context.h"
 #include "linglong/utils/bash_command_helper.h"
@@ -68,12 +69,15 @@
 #include <string>
 #include <system_error>
 #include <thread>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include <fcntl.h>
 #include <pwd.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 using namespace linglong::utils::error;
@@ -281,6 +285,229 @@ bool delegateToContainerInit(const std::string &containerID,
     ret = ::recv(containerSocket, &result, sizeof(result), 0);
     LogD("delegate result: {}", result);
     return result == 0;
+}
+
+struct ModuleSize
+{
+    std::uint64_t exclusiveSize{ 0 };
+    std::uint64_t sharedSize{ 0 };
+    std::uint64_t logicalSize{ 0 };
+    std::uint64_t actualSize{ 0 };
+};
+
+struct InodeKey
+{
+    dev_t device{ 0 };
+    ino_t inode{ 0 };
+
+    bool operator==(const InodeKey &that) const noexcept
+    {
+        return this->device == that.device && this->inode == that.inode;
+    }
+};
+
+struct InodeKeyHash
+{
+    std::size_t operator()(const InodeKey &key) const noexcept
+    {
+        const auto deviceHash = std::hash<dev_t>{}(key.device);
+        const auto inodeHash = std::hash<ino_t>{}(key.inode);
+        return deviceHash ^ (inodeHash + 0x9e3779b9 + (deviceHash << 6) + (deviceHash >> 2));
+    }
+};
+
+struct InodeUsage
+{
+    std::uint64_t diskUsage{ 0 };
+    std::unordered_set<std::size_t> modules;
+};
+
+struct ModuleSizeCalculation
+{
+    std::vector<ModuleSize> moduleSizes;
+    std::uint64_t actualTotalSize{ 0 };
+};
+
+bool versionLess(const std::string &lhs, const std::string &rhs) noexcept
+{
+    auto lhsVersion = linglong::package::Version::parse(lhs);
+    auto rhsVersion = linglong::package::Version::parse(rhs);
+    if (lhsVersion && rhsVersion) {
+        if (*lhsVersion != *rhsVersion) {
+            return *lhsVersion < *rhsVersion;
+        }
+    }
+
+    return lhs < rhs;
+}
+
+bool moduleNameLess(const linglong::cli::Printer::ModuleSizeInfo &lhs,
+                    const linglong::cli::Printer::ModuleSizeInfo &rhs) noexcept
+{
+    if (lhs.id != rhs.id) {
+        return lhs.id < rhs.id;
+    }
+    if (lhs.channel != rhs.channel) {
+        return lhs.channel < rhs.channel;
+    }
+    if (lhs.module != rhs.module) {
+        return lhs.module < rhs.module;
+    }
+
+    return versionLess(lhs.version, rhs.version);
+}
+
+Result<ModuleSizeCalculation>
+calculateModuleSizes(const std::vector<std::filesystem::path> &moduleDirs) noexcept
+{
+    LINGLONG_TRACE("calculate module sizes");
+
+    ModuleSizeCalculation calculation;
+    calculation.moduleSizes.resize(moduleDirs.size());
+    std::unordered_map<InodeKey, InodeUsage, InodeKeyHash> inodeUsages;
+    std::error_code ec;
+
+    auto addEntry = [&](const std::filesystem::path &path,
+                        std::size_t moduleIndex) -> Result<void> {
+        struct stat64 st{};
+        if (::lstat64(path.c_str(), &st) == -1) {
+            const auto err = errno;
+            return LINGLONG_ERR(fmt::format("failed to stat {}: {}",
+                                            path,
+                                            linglong::common::error::errorString(err)));
+        }
+
+        const auto diskUsage = static_cast<std::uint64_t>(st.st_blocks) * 512;
+        if (st.st_nlink == 1) {
+            auto &moduleSize = calculation.moduleSizes[moduleIndex];
+            moduleSize.exclusiveSize += diskUsage;
+            moduleSize.logicalSize += diskUsage;
+            moduleSize.actualSize += diskUsage;
+            calculation.actualTotalSize += diskUsage;
+            return LINGLONG_OK;
+        }
+
+        const auto inodeKey = InodeKey{ st.st_dev, st.st_ino };
+        auto &usage = inodeUsages[inodeKey];
+        usage.diskUsage = diskUsage;
+        usage.modules.insert(moduleIndex);
+
+        return LINGLONG_OK;
+    };
+
+    for (std::size_t moduleIndex = 0; moduleIndex < moduleDirs.size(); ++moduleIndex) {
+        const auto &dir = moduleDirs[moduleIndex];
+        auto addRoot = addEntry(dir, moduleIndex);
+        if (!addRoot) {
+            return LINGLONG_ERR(addRoot);
+        }
+
+        auto iterator = std::filesystem::recursive_directory_iterator{
+            dir,
+            std::filesystem::directory_options::skip_permission_denied,
+            ec
+        };
+        if (ec) {
+            return LINGLONG_ERR(fmt::format("failed to open module directory {}", dir), ec);
+        }
+
+        const auto end = std::filesystem::recursive_directory_iterator{};
+        while (iterator != end) {
+            const auto &entry = *iterator;
+            auto addResult = addEntry(entry.path(), moduleIndex);
+            if (!addResult) {
+                return LINGLONG_ERR(addResult);
+            }
+
+            iterator.increment(ec);
+            if (ec) {
+                return LINGLONG_ERR(fmt::format("failed to iterate module directory {}", dir), ec);
+            }
+        }
+    }
+
+    for (const auto &[_, usage] : inodeUsages) {
+        const auto moduleCount = usage.modules.size();
+        if (moduleCount == 0) {
+            continue;
+        }
+
+        calculation.actualTotalSize += usage.diskUsage;
+        const auto actualSize = usage.diskUsage / moduleCount;
+        for (auto moduleIndex : usage.modules) {
+            auto &moduleSize = calculation.moduleSizes[moduleIndex];
+            moduleSize.logicalSize += usage.diskUsage;
+            if (moduleCount == 1) {
+                moduleSize.exclusiveSize += usage.diskUsage;
+                moduleSize.actualSize += usage.diskUsage;
+            } else {
+                moduleSize.sharedSize += usage.diskUsage;
+                moduleSize.actualSize += actualSize;
+            }
+        }
+    }
+
+    return calculation;
+}
+
+Result<std::uint64_t> calculateRealDiskUsage(const std::filesystem::path &dir) noexcept
+{
+    LINGLONG_TRACE("calculate real disk usage");
+
+    std::uint64_t size{ 0 };
+    std::unordered_set<InodeKey, InodeKeyHash> visitedInodes;
+
+    auto addPath = [&](const std::filesystem::path &path) -> Result<void> {
+        struct stat64 st{};
+
+        if (::lstat64(path.c_str(), &st) == -1) {
+            const auto err = errno;
+            return LINGLONG_ERR(fmt::format("failed to stat {}: {}",
+                                            path,
+                                            linglong::common::error::errorString(err)));
+        }
+
+        if (st.st_nlink > 1) {
+            const auto inodeKey = InodeKey{ st.st_dev, st.st_ino };
+            if (!visitedInodes.insert(inodeKey).second) {
+                return LINGLONG_OK;
+            }
+        }
+
+        size += static_cast<std::uint64_t>(st.st_blocks) * 512;
+        return LINGLONG_OK;
+    };
+
+    auto rootResult = addPath(dir);
+    if (!rootResult) {
+        return LINGLONG_ERR(rootResult);
+    }
+
+    std::error_code ec;
+    auto iterator = std::filesystem::recursive_directory_iterator{
+        dir,
+        std::filesystem::directory_options::skip_permission_denied,
+        ec
+    };
+    if (ec) {
+        return LINGLONG_ERR(fmt::format("failed to open repository directory {}", dir), ec);
+    }
+
+    const auto end = std::filesystem::recursive_directory_iterator{};
+    while (iterator != end) {
+        const auto &entry = *iterator;
+        auto result = addPath(entry.path());
+        if (!result) {
+            return LINGLONG_ERR(result);
+        }
+
+        iterator.increment(ec);
+        if (ec) {
+            return LINGLONG_ERR(fmt::format("failed to iterate repository directory {}", dir), ec);
+        }
+    }
+
+    return size;
 }
 
 } // namespace
@@ -1676,6 +1903,100 @@ int Cli::list(const ListOptions &options)
         return lhs.id < rhs.id;
     });
     this->printer.printPackages(list);
+    return 0;
+}
+
+int Cli::size(const SizeOptions &options)
+{
+    auto repo = this->getRepo();
+    if (!repo) {
+        this->printer.printErr(repo.error());
+        return -1;
+    }
+
+    auto items = (*repo)->listLayerItem();
+    if (!items) {
+        this->printer.printErr(items.error());
+        return -1;
+    }
+
+    std::vector<Printer::ModuleSizeInfo> moduleSizes;
+    moduleSizes.reserve(items->size());
+    std::vector<std::filesystem::path> modulePaths;
+    modulePaths.reserve(items->size());
+
+    for (const auto &item : *items) {
+        if (item.deleted.value_or(false)) {
+            continue;
+        }
+
+        auto ref = package::Reference::fromPackageInfo(item.info);
+        if (!ref) {
+            this->printer.printErr(ref.error());
+            return -1;
+        }
+
+        auto layerDir = (*repo)->getLayerDir(*ref, item.info.packageInfoV2Module);
+        if (!layerDir) {
+            this->printer.printErr(layerDir.error());
+            return -1;
+        }
+
+        moduleSizes.push_back(Printer::ModuleSizeInfo{
+          .id = item.info.id,
+          .name = item.info.name,
+          .version = item.info.version,
+          .channel = item.info.channel,
+          .module = item.info.packageInfoV2Module,
+        });
+        modulePaths.push_back(layerDir->path());
+    }
+
+    auto calculatedSizes = calculateModuleSizes(modulePaths);
+    if (!calculatedSizes) {
+        this->printer.printErr(calculatedSizes.error());
+        return -1;
+    }
+
+    for (std::size_t index = 0; index < moduleSizes.size(); ++index) {
+        moduleSizes[index].exclusiveSize = calculatedSizes->moduleSizes.at(index).exclusiveSize;
+        moduleSizes[index].sharedSize = calculatedSizes->moduleSizes.at(index).sharedSize;
+        moduleSizes[index].logicalSize = calculatedSizes->moduleSizes.at(index).logicalSize;
+        moduleSizes[index].actualSize = calculatedSizes->moduleSizes.at(index).actualSize;
+    }
+
+    std::sort(moduleSizes.begin(), moduleSizes.end(), [&options](const auto &lhs, const auto &rhs) {
+        auto compareSize = [&options, &lhs, &rhs](std::uint64_t lhsSize, std::uint64_t rhsSize) {
+            if (lhsSize == rhsSize) {
+                return moduleNameLess(lhs, rhs);
+            }
+
+            return options.ascending ? lhsSize < rhsSize : lhsSize > rhsSize;
+        };
+
+        if (options.sortBy == "id") {
+            return options.ascending ? moduleNameLess(lhs, rhs) : moduleNameLess(rhs, lhs);
+        }
+        if (options.sortBy == "logical") {
+            return compareSize(lhs.logicalSize, rhs.logicalSize);
+        }
+        if (options.sortBy == "exclusive") {
+            return compareSize(lhs.exclusiveSize, rhs.exclusiveSize);
+        }
+        if (options.sortBy == "shared") {
+            return compareSize(lhs.sharedSize, rhs.sharedSize);
+        }
+
+        return compareSize(lhs.actualSize, rhs.actualSize);
+    });
+
+    auto repoSize = calculateRealDiskUsage((*repo)->getRepoDir());
+    if (!repoSize) {
+        this->printer.printErr(repoSize.error());
+        return -1;
+    }
+
+    this->printer.printModuleSizes(moduleSizes, calculatedSizes->actualTotalSize, *repoSize);
     return 0;
 }
 

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -117,6 +117,12 @@ struct ListOptions
     bool showUpgradeList{ false };
 };
 
+struct SizeOptions
+{
+    std::string sortBy{ "actual" };
+    bool ascending{ false };
+};
+
 struct InfoOptions
 {
     std::string appid;
@@ -181,6 +187,7 @@ public:
     int search(const SearchOptions &options);
     int uninstall(const UninstallOptions &options);
     int list(const ListOptions &options);
+    int size(const SizeOptions &options);
     int repo(CLI::App *subcommand, const common::cli::RepoOptions &options);
     int info(const InfoOptions &options);
     int content(const ContentOptions &options);

--- a/libs/linglong/src/linglong/cli/cli_printer.cpp
+++ b/libs/linglong/src/linglong/cli/cli_printer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+ * SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
@@ -14,8 +14,10 @@
 
 #include <QJsonArray>
 
+#include <array>
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 
 namespace linglong::cli {
 
@@ -325,6 +327,66 @@ void CLIPrinter::printInspect(const api::types::v1::InspectResult &result)
 {
     std::cout << "appID:\t" << (result.appID.has_value() ? result.appID.value() : "none")
               << std::endl;
+}
+
+namespace {
+
+std::string formatSize(std::uint64_t size)
+{
+    constexpr std::array<const char *, 6> units{ "B", "KiB", "MiB", "GiB", "TiB", "PiB" };
+    double value = static_cast<double>(size);
+    std::size_t unitIndex = 0;
+    while (value >= 1024.0 && unitIndex + 1 < units.size()) {
+        value /= 1024.0;
+        ++unitIndex;
+    }
+
+    std::ostringstream out;
+    if (unitIndex == 0) {
+        out << size << ' ' << units[unitIndex];
+    } else {
+        out << std::fixed << std::setprecision(1) << value << ' ' << units[unitIndex];
+    }
+
+    return out.str();
+}
+
+} // namespace
+
+void CLIPrinter::printModuleSizes(const std::vector<ModuleSizeInfo> &list,
+                                  std::uint64_t actualTotalSize,
+                                  std::uint64_t repoSize)
+{
+    std::uint64_t totalExclusiveSize{ 0 };
+    std::uint64_t totalSharedSize{ 0 };
+    std::uint64_t totalLogicalSize{ 0 };
+
+    std::cout << "\033[38;5;214m" << std::left << adjustDisplayWidth(qUtf8Printable(_("ID")), 43)
+              << adjustDisplayWidth(qUtf8Printable(_("Version")), 16)
+              << adjustDisplayWidth(qUtf8Printable(_("Channel")), 16)
+              << adjustDisplayWidth(qUtf8Printable(_("Module")), 14)
+              << adjustDisplayWidth(qUtf8Printable(_("Exclusive")), 14)
+              << adjustDisplayWidth(qUtf8Printable(_("Shared")), 14)
+              << adjustDisplayWidth(qUtf8Printable(_("Logical")), 14) << qUtf8Printable(_("Actual"))
+              << "\033[0m" << std::endl;
+
+    for (const auto &info : list) {
+        totalExclusiveSize += info.exclusiveSize;
+        totalSharedSize += info.sharedSize;
+        totalLogicalSize += info.logicalSize;
+        std::cout << std::setw(43) << info.id + " " << std::setw(16) << info.version + " "
+                  << std::setw(16) << info.channel + " " << std::setw(14) << info.module + " "
+                  << std::setw(14) << formatSize(info.exclusiveSize) + " " << std::setw(14)
+                  << formatSize(info.sharedSize) + " " << std::setw(14)
+                  << formatSize(info.logicalSize) + " " << formatSize(info.actualSize) << std::endl;
+    }
+
+    std::cout << std::endl
+              << _("Calculated logical total size: ") << formatSize(totalLogicalSize) << " ("
+              << _("Exclusive: ") << formatSize(totalExclusiveSize) << ", " << _("Shared: ")
+              << formatSize(totalSharedSize) << ")" << std::endl
+              << _("Calculated actual total size: ") << formatSize(actualTotalSize) << std::endl
+              << _("Repository real size: ") << formatSize(repoSize) << std::endl;
 }
 
 void CLIPrinter::printMessage(const std::string &message)

--- a/libs/linglong/src/linglong/cli/cli_printer.h
+++ b/libs/linglong/src/linglong/cli/cli_printer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+ * SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
@@ -46,6 +46,9 @@ public:
     void printContent(const QStringList &filePaths) override;
     virtual void printUpgradeList(std::vector<api::types::v1::UpgradeListResult> &) override;
     void printInspect(const api::types::v1::InspectResult &result) override;
+    void printModuleSizes(const std::vector<ModuleSizeInfo> &list,
+                          std::uint64_t actualTotalSize,
+                          std::uint64_t repoSize) override;
     void printMessage(const std::string &message) override;
     void clearLine() override;
 };

--- a/libs/linglong/src/linglong/cli/json_printer.cpp
+++ b/libs/linglong/src/linglong/cli/json_printer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+ * SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
@@ -110,6 +110,44 @@ void JSONPrinter::printUpgradeList(std::vector<api::types::v1::UpgradeListResult
 void JSONPrinter::printInspect(const api::types::v1::InspectResult &result)
 {
     std::cout << nlohmann::json(result).dump(4) << std::endl;
+}
+
+void JSONPrinter::printModuleSizes(const std::vector<ModuleSizeInfo> &list,
+                                   std::uint64_t actualTotalSize,
+                                   std::uint64_t repoSize)
+{
+    std::uint64_t totalExclusiveSize{ 0 };
+    std::uint64_t totalSharedSize{ 0 };
+    std::uint64_t totalLogicalSize{ 0 };
+    nlohmann::json modules = nlohmann::json::array();
+
+    for (const auto &info : list) {
+        totalExclusiveSize += info.exclusiveSize;
+        totalSharedSize += info.sharedSize;
+        totalLogicalSize += info.logicalSize;
+        modules.push_back({
+          { "id", info.id },
+          { "name", info.name },
+          { "version", info.version },
+          { "channel", info.channel },
+          { "module", info.module },
+          { "exclusiveSize", info.exclusiveSize },
+          { "sharedSize", info.sharedSize },
+          { "logicalSize", info.logicalSize },
+          { "actualSize", info.actualSize },
+        });
+    }
+
+    std::cout << nlohmann::json{
+      { "modules", modules },
+      { "calculatedLogicalSize",
+        { { "exclusiveSize", totalExclusiveSize },
+          { "sharedSize", totalSharedSize },
+          { "logicalSize", totalLogicalSize } } },
+      { "calculatedActualSize", actualTotalSize },
+      { "repositoryRealSize", repoSize },
+    }.dump(4)
+              << std::endl;
 }
 
 void JSONPrinter::printMessage(const std::string &message)

--- a/libs/linglong/src/linglong/cli/json_printer.h
+++ b/libs/linglong/src/linglong/cli/json_printer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+ * SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
@@ -31,6 +31,9 @@ public:
     void printContent(const QStringList &desktopPaths) override;
     void printUpgradeList(std::vector<api::types::v1::UpgradeListResult> &) override;
     void printInspect(const api::types::v1::InspectResult &) override;
+    void printModuleSizes(const std::vector<ModuleSizeInfo> &list,
+                          std::uint64_t actualTotalSize,
+                          std::uint64_t repoSize) override;
     void printMessage(const std::string &message) override;
 };
 

--- a/libs/linglong/src/linglong/cli/printer.h
+++ b/libs/linglong/src/linglong/cli/printer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+ * SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
@@ -17,6 +17,11 @@
 #include "linglong/api/types/v1/UpgradeListResult.hpp"
 #include "linglong/cli/cli.h"
 #include "linglong/utils/error/error.h"
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
 
 namespace linglong::cli {
 
@@ -43,6 +48,19 @@ inline std::string toString(linglong::api::types::v1::State state) noexcept
 class Printer
 {
 public:
+    struct ModuleSizeInfo
+    {
+        std::string id;
+        std::string name;
+        std::string version;
+        std::string channel;
+        std::string module;
+        std::uint64_t exclusiveSize{ 0 };
+        std::uint64_t sharedSize{ 0 };
+        std::uint64_t logicalSize{ 0 };
+        std::uint64_t actualSize{ 0 };
+    };
+
     Printer() = default;
     Printer(const Printer &) = delete;
     Printer(Printer &&) = delete;
@@ -63,6 +81,9 @@ public:
     virtual void printContent(const QStringList &filePaths) = 0;
     virtual void printUpgradeList(std::vector<api::types::v1::UpgradeListResult> &) = 0;
     virtual void printInspect(const api::types::v1::InspectResult &) = 0;
+    virtual void printModuleSizes(const std::vector<ModuleSizeInfo> &list,
+                                  std::uint64_t actualTotalSize,
+                                  std::uint64_t repoSize) = 0;
     virtual void printMessage(const std::string &message) = 0;
 
     virtual void clearLine() { }

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -208,6 +208,8 @@ public:
         return linglong::repo::getDefaultRepo(cfg);
     }
 
+    [[nodiscard]] const std::filesystem::path &getRepoDir() const noexcept { return repoDir; }
+
     virtual utils::error::Result<std::vector<api::types::v1::PackageInfoV2>>
     listLocalApps() const noexcept;
     utils::error::Result<std::vector<std::pair<package::Reference, package::ReferenceWithRepo>>>


### PR DESCRIPTION
Add a new `analyze size` subcommand to ll-cli that reports on-disk usage of installed layers, breaking each module's footprint into:

- exclusive: bytes unique to that module
- shared:    bytes shared with at least one other module
- logical:   exclusive + shared (apparent size to the module)
- actual:    shared bytes divided across the sharing modules

Sizes are computed from st_blocks (real block usage, not file size), and hard-linked inodes are deduplicated by (st_dev, st_ino) so they are counted once per sharing module. A separate pass reports the total real disk usage of the repository directory for cross-reference.

Options:
  --sort {actual|logical|exclusive|shared|id}  (default: actual)
  --asc                                        (default: descending)