### PR TITLE
fix(package): fall back to copy when hard link fails during UAB export

### DIFF
--- a/libs/linglong/src/linglong/package/uab_packager.cpp
+++ b/libs/linglong/src/linglong/package/uab_packager.cpp
@@ -31,7 +31,7 @@
 
 #include <fcntl.h>
 #include <sys/mman.h>
-#include <sys/statvfs.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 namespace linglong::package {
@@ -354,20 +354,20 @@ UABPackager::prepareExecutableBundle(const std::filesystem::path &bundleDir) noe
         }
 
         if (!files.empty()) {
-            struct statvfs moduleFilesDirStat{};
-            struct statvfs filesStat{};
+            struct stat moduleFilesDirStat{};
+            struct stat filesStat{};
 
-            if (statvfs(moduleFilesDir.c_str(), &moduleFilesDirStat) == -1) {
+            if (stat(moduleFilesDir.c_str(), &moduleFilesDirStat) == -1) {
                 return LINGLONG_ERR("couldn't stat module files directory: "
                                     + moduleFilesDir.string());
             }
 
-            if (statvfs((*files.begin()).c_str(), &filesStat) == -1) {
+            if (stat((*files.begin()).c_str(), &filesStat) == -1) {
                 return LINGLONG_ERR("couldn't stat files directory: "
                                     + layer.filesDirPath().string());
             }
 
-            const bool shouldCopy = moduleFilesDirStat.f_fsid != filesStat.f_fsid;
+            const bool shouldCopy = moduleFilesDirStat.st_dev != filesStat.st_dev;
             for (const std::filesystem::path source : files) {
                 auto sourceFile = source.lexically_relative(basePath);
                 auto ret = prepareSymlink(basePath, moduleFilesDir, sourceFile, symlinkCount);
@@ -640,8 +640,8 @@ UABPackager::prepareDistributedBundle(const std::filesystem::path &bundleDir) no
     }
 
     // check if we can use hard links for optimization (only need to check once)
-    struct statvfs layersDirStat{};
-    if (statvfs(layersDir.c_str(), &layersDirStat) == -1) {
+    struct stat layersDirStat{};
+    if (stat(layersDir.c_str(), &layersDirStat) == -1) {
         return LINGLONG_ERR("couldn't stat layers directory: " + layersDir.string());
     }
 
@@ -660,12 +660,12 @@ UABPackager::prepareDistributedBundle(const std::filesystem::path &bundleDir) no
         }
 
         // check if layer and target are on the same filesystem
-        struct statvfs layerStat{};
-        if (statvfs(layerPath.c_str(), &layerStat) == -1) {
+        struct stat layerStat{};
+        if (stat(layerPath.c_str(), &layerStat) == -1) {
             return LINGLONG_ERR("couldn't stat layer directory: " + layerPath.string());
         }
 
-        const bool shouldCopy = layerStat.f_fsid != layersDirStat.f_fsid;
+        const bool shouldCopy = layerStat.st_dev != layersDirStat.st_dev;
 
         if (shouldCopy) {
             // different filesystem, need to copy files

--- a/libs/linglong/src/linglong/package/uab_packager.cpp
+++ b/libs/linglong/src/linglong/package/uab_packager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -431,10 +431,15 @@ UABPackager::prepareExecutableBundle(const std::filesystem::path &bundleDir) noe
 
                 std::filesystem::create_hard_link(realSource, realDestination, ec);
                 if (ec) {
-                    return LINGLONG_ERR(fmt::format("couldn't link from {} to {} {}",
-                                                    source,
-                                                    realDestination,
-                                                    ec.message()));
+                    // fallback to copy if hard link fails, e.g. source and
+                    // destination are on different filesystems (EXDEV).
+                    std::filesystem::copy(realSource, realDestination, ec);
+                    if (ec) {
+                        return LINGLONG_ERR(fmt::format("couldn't link or copy from {} to {} {}",
+                                                        source,
+                                                        realDestination,
+                                                        ec.message()));
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Problem

`ll-builder export` aborts with a cross-device link error (EXDEV) when the builder cache directory (`~/.cache/linglong-builder`) and the project directory are on different filesystems, even though the build itself succeeds. Reported in #1605.

```
couldn't link from .../files/share/doc/copyright
to .../.uabBuild/bundle/layers/.../files/share/doc/copyright
无效的跨设备链接
```

## Root cause

In `UABPackager::prepareExecutableBundle`, copy-vs-hardlink is chosen with a filesystem-id heuristic:

```cpp
const bool shouldCopy = moduleFilesDirStat.f_fsid != filesStat.f_fsid;
```

When `shouldCopy` is `false` (the heuristic says "same filesystem"), each file is created with `std::filesystem::create_hard_link`, and any error is returned directly, aborting the whole export.

`statvfs(2).f_fsid` is not a reliable predictor of whether a hard link will succeed — its value is not guaranteed to be comparable across calls, and bind mounts / overlay setups can report the same `f_fsid` while hard links still fail with `EXDEV`. When the heuristic is wrong, the export crashes.

Notably, the **second** hard-link site in this same file already defends against this with a hard-link -> copy fallback (`// regular file - try to create hard link, fallback to copy if failed`). The first site was missing that fallback.

## Fix

Mirror the existing fallback: on `create_hard_link` failure, fall back to `std::filesystem::copy` before returning an error. The `shouldCopy` `f_fsid` check is kept as an optimization (bulk copy when the filesystems are clearly different); the new fallback handles the cases the heuristic gets wrong.

Closes #1605.
