### PR TITLE
feat(cli): add --no-truncated option to ll-cli ps

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -212,12 +212,13 @@ ll-cli run org.deepin.demo -- bash -x /path/to/bash/script)"));
 }
 
 // Function to add the ps subcommand
-void addPsCommand(CLI::App &commandParser, const std::string &group)
+void addPsCommand(CLI::App &commandParser, PsOptions &psOptions, const std::string &group)
 {
-    commandParser.add_subcommand("ps", _("List running applications"))
-      ->fallthrough()
-      ->group(group)
-      ->usage(_("Usage: ll-cli ps [OPTIONS]"));
+    auto *cliPs = commandParser.add_subcommand("ps", _("List running applications"))
+                    ->fallthrough()
+                    ->group(group);
+    cliPs->add_flag("--no-truncated", psOptions.noTruncate, _("Do not truncate container IDs"));
+    cliPs->usage(_("Usage: ll-cli ps [OPTIONS]"));
 }
 
 // Function to add the exec subcommand
@@ -612,6 +613,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     RunOptions runOptions{};
     EnterOptions enterOptions{};
     KillOptions killOptions{};
+    PsOptions psOptions{};
     InstallOptions installOptions{};
     UpgradeOptions upgradeOptions{};
     SearchOptions searchOptions{};
@@ -632,7 +634,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
 
     // add all subcommands using the new functions
     addRunCommand(commandParser, runOptions, CliAppManagingGroup);
-    addPsCommand(commandParser, CliAppManagingGroup);
+    addPsCommand(commandParser, psOptions, CliAppManagingGroup);
     addEnterCommand(commandParser, enterOptions, CliAppManagingGroup);
     addKillCommand(commandParser, killOptions, CliAppManagingGroup);
     addInstallCommand(commandParser, installOptions, CliBuildInGroup);
@@ -784,7 +786,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     } else if (name == "enter") {
         result = cli->enter(enterOptions);
     } else if (name == "ps") {
-        result = cli->ps();
+        result = cli->ps(psOptions);
     } else if (name == "kill") {
         result = cli->kill(killOptions);
     } else if (name == "install") {

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -1399,7 +1399,7 @@ Cli::getCurrentContainers() const noexcept
     return myContainers;
 }
 
-int Cli::ps()
+int Cli::ps(const PsOptions &options)
 {
     auto myContainers = getCurrentContainers();
     if (!myContainers) {
@@ -1407,12 +1407,13 @@ int Cli::ps()
         return -1;
     }
 
-    // TODO: add option --no-truncated
-    std::for_each(myContainers->begin(),
-                  myContainers->end(),
-                  [](api::types::v1::CliContainer &container) {
-                      container.id = container.id.substr(0, ContainerIDDisplayLength);
-                  });
+    if (!options.noTruncate) {
+        std::for_each(myContainers->begin(),
+                      myContainers->end(),
+                      [](api::types::v1::CliContainer &container) {
+                          container.id = container.id.substr(0, ContainerIDDisplayLength);
+                      });
+    }
 
     this->printer.printContainers(*myContainers);
 

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -79,6 +79,11 @@ struct KillOptions
     std::string signal{ "SIGTERM" };
 };
 
+struct PsOptions
+{
+    bool noTruncate{ false };
+};
+
 struct InstallOptions
 {
     std::string appid;
@@ -185,7 +190,7 @@ public:
     int run(const RunOptions &options);
     int runWithContext(const RunOptions &options);
     int enter(const EnterOptions &options);
-    int ps();
+    int ps(const PsOptions &options);
     int kill(const KillOptions &options);
     int install(const InstallOptions &options);
     int upgrade(const UpgradeOptions &options);


### PR DESCRIPTION
## Problem

`ll-cli ps` always truncates container IDs to 12 characters (`ContainerIDDisplayLength`), with no way to see the full ID — inconvenient when you need the exact ID for `ll-cli enter` / `kill`. This was a known gap, marked `// TODO: add option --no-truncated` at `cli.cpp:1410`.

## Change

Add a `--no-truncated` flag to `ll-cli ps` (mirrors `docker ps --no-trunc`). When set, the container ID is printed in full instead of being truncated.

- `PsOptions { bool noTruncate{ false }; }` added next to the other subcommand option structs in `cli.h`.
- `Cli::ps(const PsOptions &options)` skips the `substr` truncation when `noTruncate` is set.
- `addPsCommand` in `main.cpp` registers the flag; the dispatch passes `psOptions`.

The flag defaults to `false`, so existing behavior is unchanged.
