### PR TITLE
feat: add --debug mode with gdbserver integration

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -208,6 +208,30 @@ ll-cli run org.deepin.demo -- bash -x /path/to/bash/script)"));
                    _("Specify the container instance name for reuse or identification"))
       ->type_name("NAME")
       ->check(validatorString);
+    auto *debugOpt =
+      cliRun->add_flag("--debug", runOptions.debug, _("Run the application under gdbserver"));
+    cliRun
+      ->add_option("--debug-listen",
+                   runOptions.debugListen,
+                   _("Specify the gdbserver listen address"))
+      ->type_name("ADDR")
+      ->check(validatorString)
+      ->capture_default_str()
+      ->needs(debugOpt);
+    cliRun
+      ->add_option("--debug-debuginfod",
+                   runOptions.debugDebuginfod,
+                   _("Specify debuginfod urls for debugging"))
+      ->type_name("URLS")
+      ->check(validatorString)
+      ->needs(debugOpt);
+    cliRun
+      ->add_option("--debug-symbol-dir",
+                   runOptions.debugSymbolDir,
+                   _("Specify the directory used by gdb to load debug symbols"))
+      ->type_name("DIR")
+      ->check(validatorString)
+      ->needs(debugOpt);
     cliRun->add_option("COMMAND", runOptions.commands, _("Run commands in a running sandbox"));
 }
 

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -1838,7 +1838,7 @@ utils::error::Result<void> Builder::run(std::vector<std::string> modules,
 
     runtime::RunContext runContext(this->repo);
     linglong::runtime::ResolveOptions opts;
-    opts.depsBinaryOnly = !debug;
+    opts.depsExcludeDev = !debug;
     opts.appModules = std::move(modules);
     if (!extensions.empty()) {
         opts.extensionRefs = extensions;

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -28,6 +28,7 @@
 #include "linglong/common/dir.h"
 #include "linglong/common/error.h"
 #include "linglong/common/strings.h"
+#include "linglong/oci-cfg-generators/container_cfg_builder.h"
 #include "linglong/package/layer_file.h"
 #include "linglong/package/reference.h"
 #include "linglong/package/version.h"
@@ -49,6 +50,7 @@
 #include <fmt/ranges.h>
 #include <linux/un.h>
 #include <nlohmann/json.hpp>
+#include <uuid.h>
 
 #include <QDBusInterface>
 #include <QDBusReply>
@@ -59,13 +61,17 @@
 #include <QProcess>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <chrono>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <system_error>
 #include <thread>
@@ -85,6 +91,203 @@ using namespace linglong::utils::error;
 namespace {
 
 constexpr std::size_t ContainerIDDisplayLength = 12;
+constexpr const char *DebugDevelopModule = "develop";
+const std::filesystem::path BaseDebugFileDirectory{ "/usr/lib/debug" };
+
+std::string makeDebugInstanceID()
+{
+    uuid_t uuid;
+    uuid_generate_random(uuid);
+
+    std::array<char, 37> uuidString{};
+    uuid_unparse_lower(uuid, uuidString.data());
+    return "debug-" + std::string{ uuidString.data() };
+}
+
+std::string gdbRemoteTarget(const std::string &listen) noexcept
+{
+    if (!listen.empty() && listen.front() == ':') {
+        return "localhost" + listen;
+    }
+
+    return listen;
+}
+
+std::string shellQuote(const std::string &value)
+{
+    std::string quoted{ "'" };
+    for (auto ch : value) {
+        if (ch == '\'') {
+            quoted += "'\\''";
+            continue;
+        }
+        quoted += ch;
+    }
+    quoted += "'";
+
+    return quoted;
+}
+
+std::vector<std::string> makeDebugCommand(const linglong::cli::RunOptions &options,
+                                          std::vector<std::string> commands)
+{
+    commands.insert(commands.begin(), options.debugListen);
+    commands.insert(commands.begin(), "--once");
+    commands.insert(commands.begin(), "gdbserver");
+    return commands;
+}
+
+std::string makeDebugSymbolDir(const linglong::runtime::RunContext &runContext)
+{
+    std::vector<std::filesystem::path> dirs{
+        BaseDebugFileDirectory,
+    };
+
+    if (runContext.getRuntimeLayer()) {
+        dirs.emplace_back(linglong::generator::ContainerCfgBuilder::runtimeMountPoint
+                          / "lib/debug");
+    }
+
+    if (runContext.getAppLayer()) {
+        dirs.emplace_back(
+          linglong::generator::ContainerCfgBuilder::appMountPoint(runContext.getTargetID())
+          / "lib/debug");
+    }
+
+    for (const auto &extension : runContext.getExtensionLayers()) {
+        dirs.emplace_back(
+          linglong::generator::ContainerCfgBuilder::extensionMountPoint(extension.getReference().id)
+          / "lib/debug");
+    }
+
+    std::ostringstream stream;
+    for (const auto &dir : dirs) {
+        if (stream.tellp() > 0) {
+            stream << ':';
+        }
+        stream << dir.string();
+    }
+
+    return stream.str();
+}
+
+std::string mergeDebugSymbolDir(const std::optional<std::string> &debugSymbolDir,
+                                const std::string &defaultDebugSymbolDir)
+{
+    if (!debugSymbolDir || debugSymbolDir->empty()) {
+        return defaultDebugSymbolDir;
+    }
+
+    if (defaultDebugSymbolDir.empty()) {
+        return *debugSymbolDir;
+    }
+
+    return *debugSymbolDir + ":" + defaultDebugSymbolDir;
+}
+
+std::string makeDebugAttachScriptContent(const linglong::cli::RunOptions &options)
+{
+    std::ostringstream script;
+    script << "#!/bin/sh\n";
+
+    script << "set -- -ex " << shellQuote("target remote " + gdbRemoteTarget(options.debugListen))
+           << " \"$@\"\n";
+    if (options.debugSymbolDir && !options.debugSymbolDir->empty()) {
+        script << "set -- -ex " << shellQuote("set debug-file-directory " + *options.debugSymbolDir)
+               << " \"$@\"\n";
+    }
+    if (options.debugDebuginfod && !options.debugDebuginfod->empty()) {
+        script << "DEBUGINFOD_URLS=" << shellQuote(*options.debugDebuginfod) << "\n";
+        script << "export DEBUGINFOD_URLS\n";
+        script << "if gdb -nx -batch -ex " << shellQuote("show debuginfod enabled")
+               << " 2>&1 | grep -q " << shellQuote("^Debuginfod ") << "; then\n";
+        script << "    set -- -ex " << shellQuote("set debuginfod urls " + *options.debugDebuginfod)
+               << " \"$@\"\n";
+        script << "    set -- -ex " << shellQuote("set debuginfod enabled on") << " \"$@\"\n";
+        script << "fi\n";
+    }
+    script << "exec gdb \"$@\"\n";
+
+    return script.str();
+}
+
+Result<std::filesystem::path> createDebugAttachScript(const linglong::cli::RunOptions &options)
+{
+    LINGLONG_TRACE("create debug attach script");
+
+    std::error_code ec;
+    auto tempDir = std::filesystem::temp_directory_path(ec);
+    if (ec) {
+        return LINGLONG_ERR("failed to get temporary directory", ec);
+    }
+
+    uuid_t uuid;
+    uuid_generate_random(uuid);
+    std::array<char, 37> uuidString{};
+    uuid_unparse_lower(uuid, uuidString.data());
+
+    auto scriptPath = tempDir / ("linglong-gdb-" + std::string{ uuidString.data() } + ".sh");
+    std::ofstream script{ scriptPath };
+    if (!script) {
+        return LINGLONG_ERR(fmt::format("failed to create {}", scriptPath.string()));
+    }
+
+    script << makeDebugAttachScriptContent(options);
+    script.close();
+    if (!script) {
+        return LINGLONG_ERR(fmt::format("failed to write {}", scriptPath.string()));
+    }
+
+    std::filesystem::permissions(scriptPath,
+                                 std::filesystem::perms::owner_read
+                                   | std::filesystem::perms::owner_write
+                                   | std::filesystem::perms::owner_exec,
+                                 std::filesystem::perm_options::replace,
+                                 ec);
+    if (ec) {
+        return LINGLONG_ERR(fmt::format("failed to set {} executable", scriptPath.string()), ec);
+    }
+
+    return scriptPath;
+}
+
+void printDebugAttachHint(const linglong::cli::RunOptions &options)
+{
+    if (::isatty(::fileno(stdout)) == 0) {
+        return;
+    }
+
+    auto script = createDebugAttachScript(options);
+    if (!script) {
+        std::cout << _("Debug mode is enabled. Attach from another terminal with gdb:")
+                  << std::endl;
+        if (options.debugDebuginfod && !options.debugDebuginfod->empty()) {
+            std::cout << "  (shell) export DEBUGINFOD_URLS=" << shellQuote(*options.debugDebuginfod)
+                      << std::endl;
+            std::cout << "  (shell) gdb" << std::endl;
+            std::cout << "  (gdb) # For newer gdb, you may also enable debuginfod explicitly."
+                      << std::endl;
+        }
+        if (options.debugSymbolDir && !options.debugSymbolDir->empty()) {
+            std::cout << "  (gdb) set debug-file-directory " << *options.debugSymbolDir
+                      << std::endl;
+        }
+        std::cout << "  (gdb) target remote " << gdbRemoteTarget(options.debugListen) << std::endl;
+        LogW("failed to create gdb attach script: {}", script.error().message());
+        return;
+    }
+
+    auto scriptContent = makeDebugAttachScriptContent(options);
+    std::cout << "============================================================" << std::endl;
+    std::cout << _("Debug mode is enabled. Attach from another terminal with:") << std::endl;
+    std::cout << "  " << script->string() << std::endl;
+    std::cout << std::endl;
+    std::cout << _("Generated gdb attach script:") << std::endl;
+    std::cout << "------------------------------------------------------------" << std::endl;
+    std::cout << scriptContent;
+    std::cout << "------------------------------------------------------------" << std::endl;
+    std::cout << "============================================================" << std::endl;
+}
 
 Result<std::filesystem::path> preparePeerSocketDir() noexcept
 {
@@ -787,11 +990,11 @@ Cli::Cli(Printer &printer,
 {
 }
 
-utils::error::Result<repo::OSTreeRepo *> Cli::getRepo() noexcept
+utils::error::Result<repo::OSTreeRepo *> Cli::getRepo(bool forceReload) noexcept
 {
     LINGLONG_TRACE("get local repo");
 
-    if (this->repository) {
+    if (this->repository && !forceReload) {
         return this->repository.get();
     }
 
@@ -1029,12 +1232,14 @@ int Cli::run(const RunOptions &options)
     }
     auto runtimeConfig = std::move(loaded).value();
 
-    runtime::RunContext runContext(**repo);
     linglong::runtime::ResolveOptions opts;
     auto resolveOptionsRes = opts.applyOptions(runtimeConfig, options);
     if (!resolveOptionsRes) {
         this->printer.printErr(resolveOptionsRes.error());
         return -1;
+    }
+    if (options.debug) {
+        opts.instance = makeDebugInstanceID();
     }
 
     bool nvidiaCdiFound = false;
@@ -1050,19 +1255,41 @@ int Cli::run(const RunOptions &options)
         detectDrivers();
     }
 
-    auto res = runContext.resolve(*curAppRef, opts);
+    auto runContext = std::make_unique<runtime::RunContext>(**repo);
+    auto res = runContext->resolve(*curAppRef, opts);
     if (!res) {
         handleCommonError(res.error());
         return -1;
     }
 
-    auto runContextCfg = runContext.getConfig();
+    if (options.debug) {
+        auto installRes = ensureBaseDevelopModule(*runContext);
+        if (!installRes) {
+            this->printer.printErr(installRes.error());
+            return -1;
+        }
+
+        repo = this->getRepo(true);
+        if (!repo) {
+            this->printer.printErr(repo.error());
+            return -1;
+        }
+
+        runContext = std::make_unique<runtime::RunContext>(**repo);
+        res = runContext->resolve(*curAppRef, opts);
+        if (!res) {
+            handleCommonError(res.error());
+            return -1;
+        }
+    }
+
+    auto runContextCfg = runContext->getConfig();
     LogD("RunContext Config:\n{}", nlohmann::json(runContextCfg).dump());
 
-    auto containerID = runContext.getContainerId();
+    auto containerID = runContext->getContainerId();
     LogD("run {} with container id: {}", curAppRef->toString(), containerID);
 
-    auto targetItem = runContext.getCachedTargetItem();
+    auto targetItem = runContext->getCachedTargetItem();
     if (!targetItem) {
         this->printer.printErr(LINGLONG_ERRV("failed to get cached target item", targetItem));
         return -1;
@@ -1096,7 +1323,7 @@ int Cli::run(const RunOptions &options)
               LINGLONG_ERRV(fmt::format("failed to open {}", pidFile.c_str())));
             return false;
         }
-        stream << nlohmann::json(runContext.stateInfo());
+        stream << nlohmann::json(runContext->stateInfo());
         stream.close();
 
         return true;
@@ -1121,7 +1348,7 @@ int Cli::run(const RunOptions &options)
         break;
     }
 
-    auto cacheRes = this->ensureCache(runContext);
+    auto cacheRes = this->ensureCache(*runContext);
     if (!cacheRes) {
         this->printer.printErr(LINGLONG_ERRV(cacheRes));
         return -1;
@@ -1158,7 +1385,7 @@ int Cli::run(const RunOptions &options)
             return -1;
         }
 
-        auto contextJson = nlohmann::json(runContext.getConfig()).dump();
+        auto contextJson = nlohmann::json(runContext->getConfig()).dump();
         args.insert(insertPos + 1, { "--run-context", contextJson });
 
         std::vector<char *> argPointers;
@@ -1180,7 +1407,7 @@ int Cli::run(const RunOptions &options)
         return *runRes;
     }
 
-    return this->runResolvedContext(runContext, options, std::move(runtimeConfig));
+    return this->runResolvedContext(*runContext, options, std::move(runtimeConfig));
 }
 
 int Cli::runWithContext(const RunOptions &options)
@@ -1223,6 +1450,37 @@ int Cli::runWithContext(const RunOptions &options)
     return this->runResolvedContext(runContext, options, std::move(runtimeConfig));
 }
 
+utils::error::Result<void> Cli::ensureBaseDevelopModule(runtime::RunContext &runContext)
+{
+    LINGLONG_TRACE("ensure base develop module");
+
+    const auto &baseLayer = runContext.getBaseLayer();
+    if (!baseLayer) {
+        return LINGLONG_ERR("run context has no base layer");
+    }
+
+    const auto &baseRef = baseLayer->getReference();
+    auto modules = runContext.getRepo().getModuleList(baseRef);
+    if (std::find(modules.begin(), modules.end(), DebugDevelopModule) != modules.end()) {
+        return LINGLONG_OK;
+    }
+
+    this->printer.printMessage(
+      fmt::format(_("Base {} has no develop module installed, installing it now."),
+                  baseRef.toString()));
+
+    auto installResult = this->install(InstallOptions{
+      .appid = baseRef.toString(),
+      .module = DebugDevelopModule,
+    });
+    if (installResult != 0) {
+        return LINGLONG_ERR(
+          fmt::format("failed to install develop module for base {}", baseRef.toString()));
+    }
+
+    return LINGLONG_OK;
+}
+
 int Cli::runResolvedContext(runtime::RunContext &runContext,
                             const RunOptions &options,
                             std::optional<api::types::v1::RuntimeConfigure> runtimeConfig)
@@ -1235,11 +1493,20 @@ int Cli::runResolvedContext(runtime::RunContext &runContext,
         return -1;
     }
 
-    auto commands = options.commands;
+    auto debugOptions = options;
+    if (debugOptions.debug) {
+        debugOptions.debugSymbolDir =
+          mergeDebugSymbolDir(debugOptions.debugSymbolDir, makeDebugSymbolDir(runContext));
+    }
+
+    auto commands = debugOptions.commands;
     if (options.commands.empty()) {
         commands = targetItem->info.command.value_or(std::vector<std::string>{ "bash" });
     }
-    commands = filePathMapping(commands, options);
+    commands = filePathMapping(commands, debugOptions);
+    if (debugOptions.debug) {
+        commands = makeDebugCommand(debugOptions, std::move(commands));
+    }
 
     auto appCache =
       common::dir::getContainerCacheDir(targetItem->commit, runContext.getContainerId());
@@ -1254,7 +1521,7 @@ int Cli::runResolvedContext(runtime::RunContext &runContext,
             return -1;
         }
     }
-    auto res = runOptions.applyCliRunOptions(options);
+    auto res = runOptions.applyCliRunOptions(debugOptions);
     if (!res) {
         this->printer.printErr(res.error());
         return -1;
@@ -1275,8 +1542,11 @@ int Cli::runResolvedContext(runtime::RunContext &runContext,
     }
 
     auto process = ocppi::runtime::config::types::Process{ .args = std::move(commands) };
-    if (!options.workdir.value_or("").empty()) {
-        auto workdir = std::filesystem::path(options.workdir.value());
+    if (debugOptions.debug) {
+        printDebugAttachHint(debugOptions);
+    }
+    if (!debugOptions.workdir.value_or("").empty()) {
+        auto workdir = std::filesystem::path(debugOptions.workdir.value());
         if (!workdir.is_absolute()) {
             auto msg = fmt::format("Workdir must be an absolute path: {}", workdir);
             this->printer.printErr(LINGLONG_ERRV(msg));

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -64,6 +64,10 @@ struct RunOptions
     std::vector<std::string> cdiDevices;
     std::vector<api::types::v1::DeviceOption> deviceOptions;
     std::optional<std::string> instance;
+    bool debug{ false };
+    std::string debugListen{ ":2345" };
+    std::optional<std::string> debugDebuginfod;
+    std::optional<std::string> debugSymbolDir;
 };
 
 struct EnterOptions
@@ -210,7 +214,7 @@ public:
     void setGlobalOptions(const GlobalOptions &options) noexcept { this->globalOptions = options; }
 
 protected:
-    virtual utils::error::Result<repo::OSTreeRepo *> getRepo() noexcept;
+    virtual utils::error::Result<repo::OSTreeRepo *> getRepo(bool forceReload = false) noexcept;
     virtual utils::error::Result<std::unique_ptr<repo::OSTreeRepo>>
     loadRepoFromPath(const std::filesystem::path &repoRoot) noexcept;
     virtual utils::error::Result<void> initializeRepo() noexcept;
@@ -245,6 +249,7 @@ private:
     void updateAM() noexcept;
     utils::error::Result<std::vector<std::string>> getRunningAppContainers(const std::string &id);
     bool isContainerIDMatch(const std::string &containerID, const std::string &shortID);
+    utils::error::Result<void> ensureBaseDevelopModule(runtime::RunContext &runContext);
     int getLayerDir(const InspectOptions &options);
     int getBundleDir(const InspectOptions &options);
     void detectDrivers();

--- a/libs/linglong/src/linglong/runtime/layer.cpp
+++ b/libs/linglong/src/linglong/runtime/layer.cpp
@@ -9,6 +9,8 @@
 
 #include <fmt/ranges.h>
 
+#include <algorithm>
+
 namespace linglong::runtime {
 utils::error::Result<RuntimeLayer> RuntimeLayer::create(package::Reference ref,
                                                         const RunContext &context)
@@ -47,8 +49,10 @@ RuntimeLayer::~RuntimeLayer() noexcept
     }
 }
 
-utils::error::Result<void> RuntimeLayer::resolveLayer(const std::vector<std::string> &modules,
-                                                      const std::optional<std::string> &subRef)
+utils::error::Result<void>
+RuntimeLayer::resolveLayer(const std::optional<std::vector<std::string>> &includeModules,
+                           const std::optional<std::vector<std::string>> &excludeModules,
+                           const std::optional<std::string> &subRef)
 {
     LINGLONG_TRACE("resolve layer");
 
@@ -58,15 +62,40 @@ utils::error::Result<void> RuntimeLayer::resolveLayer(const std::vector<std::str
 
     auto &repo = runContext->getRepo();
     utils::error::Result<package::LayerDir> layer(LINGLONG_ERR("null"));
-    if (modules.empty() || (modules.size() == 1 && modules.at(0) == "binary")) {
+    if (!includeModules && !excludeModules) {
         layer = repo.getMergedModuleDir(reference, true, subRef);
-    } else if (modules.size() > 1) {
-        layer = repo.createTempMergedModuleDir(reference, modules);
-        temporary = true;
-        LogD("create temp merged module dir: {}", layer->path());
     } else {
-        return LINGLONG_ERR(
-          fmt::format("resolve module {} is not supported", fmt::join(modules, ",")));
+        auto normalizeModules = [](std::vector<std::string> modules) {
+            std::sort(modules.begin(), modules.end());
+            modules.erase(std::unique(modules.begin(), modules.end()), modules.end());
+            return modules;
+        };
+
+        const auto installedModules = normalizeModules(repo.getModuleList(reference));
+        auto modules = includeModules ? normalizeModules(*includeModules) : installedModules;
+        if (excludeModules) {
+            const auto &excluded = *excludeModules;
+            auto it = std::remove_if(modules.begin(), modules.end(), [&excluded](const auto &m) {
+                return std::find(excluded.begin(), excluded.end(), m) != excluded.end();
+            });
+            modules.erase(it, modules.end());
+        }
+        if (modules.empty()) {
+            return LINGLONG_ERR("no modules selected to resolve");
+        }
+
+        if (modules == installedModules) {
+            layer = repo.getMergedModuleDir(reference, true, subRef);
+        } else if (modules.size() == 1) {
+            layer = repo.getLayerDir(reference, modules.front(), subRef);
+        } else {
+            layer = repo.createTempMergedModuleDir(reference, modules);
+            if (!layer) {
+                return LINGLONG_ERR(layer);
+            }
+            temporary = true;
+            LogD("create temp merged module dir: {}", layer->path());
+        }
     }
 
     if (!layer) {

--- a/libs/linglong/src/linglong/runtime/layer.h
+++ b/libs/linglong/src/linglong/runtime/layer.h
@@ -38,7 +38,8 @@ public:
     };
 
     utils::error::Result<void>
-    resolveLayer(const std::vector<std::string> &modules = {},
+    resolveLayer(const std::optional<std::vector<std::string>> &includeModules = std::nullopt,
+                 const std::optional<std::vector<std::string>> &excludeModules = std::nullopt,
                  const std::optional<std::string> &subRef = std::nullopt);
 
     [[nodiscard]] const api::types::v1::RepositoryCacheLayersItem &getCachedItem() const noexcept

--- a/libs/linglong/src/linglong/runtime/run_context.cpp
+++ b/libs/linglong/src/linglong/runtime/run_context.cpp
@@ -307,7 +307,7 @@ utils::error::Result<void> RunContext::resolve(const linglong::package::Referenc
     }
 
     // all reference are cleard , we can get actual layer directory now
-    return resolveLayer(opts.depsBinaryOnly, opts.appModules.value_or(std::vector<std::string>{}));
+    return resolveLayer(opts.depsExcludeDev, opts.appModules.value_or(std::vector<std::string>{}));
 }
 
 utils::error::Result<void> RunContext::resolve(const api::types::v1::BuilderProject &target,
@@ -595,7 +595,7 @@ utils::error::Result<void> RunContext::setupCDIDevices(generator::ContainerCfgBu
     return LINGLONG_OK;
 }
 
-utils::error::Result<void> RunContext::resolveLayer(bool depsBinaryOnly,
+utils::error::Result<void> RunContext::resolveLayer(bool depsExcludeDev,
                                                     const std::vector<std::string> &appModules)
 {
     LINGLONG_TRACE("resolve layers");
@@ -608,24 +608,28 @@ utils::error::Result<void> RunContext::resolveLayer(bool depsBinaryOnly,
         }
     }
 
-    std::vector<std::string> depsModules;
-    if (depsBinaryOnly) {
-        depsModules.emplace_back("binary");
+    std::optional<std::vector<std::string>> depsExcludeModules;
+    if (depsExcludeDev) {
+        depsExcludeModules = std::vector<std::string>{ "develop" };
     }
-    auto ref = baseLayer->resolveLayer(depsModules, subRef);
+    auto ref = baseLayer->resolveLayer(std::nullopt, depsExcludeModules, subRef);
     if (!ref.has_value()) {
         return LINGLONG_ERR("failed to resolve base layer", ref);
     }
 
     if (appLayer) {
-        auto ref = appLayer->resolveLayer(appModules);
+        std::optional<std::vector<std::string>> appIncludeModules;
+        if (!appModules.empty()) {
+            appIncludeModules = appModules;
+        }
+        auto ref = appLayer->resolveLayer(appIncludeModules);
         if (!ref.has_value()) {
             return LINGLONG_ERR("failed to resolve app layer", ref);
         }
     }
 
     if (runtimeLayer) {
-        auto ref = runtimeLayer->resolveLayer(depsModules, subRef);
+        auto ref = runtimeLayer->resolveLayer(std::nullopt, depsExcludeModules, subRef);
         if (!ref.has_value()) {
             return LINGLONG_ERR("failed to resolve runtime layer", ref);
         }
@@ -666,10 +670,10 @@ utils::error::Result<void> RunContext::resolveLayer(bool depsBinaryOnly,
                 defaultValue = allowed->second;
             }
 
-            std::string res =
-              common::strings::replaceSubstring(env.second,
-                                                "$PREFIX",
-                                                "/opt/extensions/" + ext.getReference().id);
+            std::string res = common::strings::replaceSubstring(
+              env.second,
+              "$PREFIX",
+              generator::ContainerCfgBuilder::extensionMountPoint(ext.getReference().id).string());
             auto &value = environment[env.first];
             if (value.empty()) {
                 value = defaultValue;
@@ -887,7 +891,7 @@ RunContext::makeManualExtensionDefine(const std::vector<std::string> &refs)
         }
 
         extDefs.emplace_back(api::types::v1::ExtensionDefine{
-          .directory = "/opt/extensions/" + fuzzyRef->id,
+          .directory = generator::ContainerCfgBuilder::extensionMountPoint(fuzzyRef->id).string(),
           .name = fuzzyRef->id,
           .version = fuzzyRef->version.value_or(""),
         });
@@ -999,7 +1003,7 @@ utils::error::Result<void> RunContext::fillContextCfg(
     std::vector<ocppi::runtime::config::types::Mount> extensionMounts{};
     if (extensionOutput) {
         extensionMounts.push_back(ocppi::runtime::config::types::Mount{
-          .destination = "/opt/extensions/" + targetId,
+          .destination = generator::ContainerCfgBuilder::extensionMountPoint(targetId),
           .gidMappings = {},
           .options = { { "rbind" } },
           .source = extensionOutput,
@@ -1027,7 +1031,7 @@ utils::error::Result<void> RunContext::fillContextCfg(
             continue;
         }
         extensionMounts.push_back(ocppi::runtime::config::types::Mount{
-          .destination = "/opt/extensions/" + name,
+          .destination = generator::ContainerCfgBuilder::extensionMountPoint(name),
           .gidMappings = {},
           .options = { { "rbind", "ro" } },
           .source = ext.getLayerDir()->filesDirPath(),

--- a/libs/linglong/src/linglong/runtime/run_context.h
+++ b/libs/linglong/src/linglong/runtime/run_context.h
@@ -32,7 +32,7 @@ namespace linglong::runtime {
 
 struct ResolveOptions
 {
-    bool depsBinaryOnly{ false };
+    bool depsExcludeDev{ false };
     std::optional<std::vector<std::string>> appModules;
     std::optional<std::string> baseRef;
     std::optional<std::vector<api::types::v1::CdiDeviceEntry>> cdiDevices;
@@ -114,7 +114,7 @@ public:
     [[nodiscard]] bool hasRuntime() const noexcept { return !!runtimeLayer; }
 
 private:
-    utils::error::Result<void> resolveLayer(bool depsBinaryOnly,
+    utils::error::Result<void> resolveLayer(bool depsExcludeDev,
                                             const std::vector<std::string> &appModules);
     utils::error::Result<void> resolveLayerExtensions(
       RuntimeLayer &layer,

--- a/libs/linglong/tests/ll-tests/src/linglong/cli/cli_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/cli/cli_test.cpp
@@ -75,7 +75,7 @@ class MockCli : public cli::Cli
 public:
     using cli::Cli::Cli;
 
-    MOCK_METHOD(utils::error::Result<repo::OSTreeRepo *>, getRepo, (), (override, noexcept));
+    MOCK_METHOD(utils::error::Result<repo::OSTreeRepo *>, getRepo, (bool), (override, noexcept));
 };
 
 class RepoAndPackageManagerCli : public cli::Cli
@@ -83,7 +83,10 @@ class RepoAndPackageManagerCli : public cli::Cli
 public:
     using cli::Cli::Cli;
 
-    utils::error::Result<repo::OSTreeRepo *> callGetRepo() noexcept { return cli::Cli::getRepo(); }
+    utils::error::Result<repo::OSTreeRepo *> callGetRepo(bool forceReload = false) noexcept
+    {
+        return cli::Cli::getRepo(forceReload);
+    }
 
     utils::error::Result<void> callInitializeRepo() noexcept { return cli::Cli::initializeRepo(); }
 
@@ -156,8 +159,8 @@ protected:
                                                              false,
                                                              std::move(notifier),
                                                              nullptr);
-        ON_CALL(*cli, getRepo())
-          .WillByDefault(Invoke([this]() -> utils::error::Result<repo::OSTreeRepo *> {
+        ON_CALL(*cli, getRepo(testing::_))
+          .WillByDefault(Invoke([this](bool) -> utils::error::Result<repo::OSTreeRepo *> {
               return repo.get();
           }));
     }
@@ -235,6 +238,35 @@ TEST_F(CliRepoAndPackageManagerTest, getRepoCachesLoadedRepository)
     auto second = cli->callGetRepo();
     ASSERT_TRUE(second.has_value());
     EXPECT_EQ(*second, loadedRepo);
+}
+
+TEST_F(CliRepoAndPackageManagerTest, getRepoForceReloadReloadsRepository)
+{
+    repo::OSTreeRepo *firstRepo = nullptr;
+    repo::OSTreeRepo *secondRepo = nullptr;
+
+    EXPECT_CALL(*cli, loadRepoFromPath(_))
+      .WillOnce(Invoke([&](const std::filesystem::path &path)
+                         -> utils::error::Result<std::unique_ptr<repo::OSTreeRepo>> {
+          auto repo = makeRepo(path);
+          firstRepo = repo.get();
+          return repo;
+      }))
+      .WillOnce(Invoke([&](const std::filesystem::path &path)
+                         -> utils::error::Result<std::unique_ptr<repo::OSTreeRepo>> {
+          auto repo = makeRepo(path);
+          secondRepo = repo.get();
+          return repo;
+      }));
+    EXPECT_CALL(*cli, initializeRepo()).Times(0);
+
+    auto first = cli->callGetRepo();
+    ASSERT_TRUE(first.has_value());
+    EXPECT_EQ(*first, firstRepo);
+
+    auto second = cli->callGetRepo(true);
+    ASSERT_TRUE(second.has_value());
+    EXPECT_EQ(*second, secondRepo);
 }
 
 TEST_F(CliRepoAndPackageManagerTest, getRepoInitializesAndReloadsWhenInitialLoadFails)

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_test.cpp
@@ -65,8 +65,18 @@ public:
                  const std::optional<std::string> &subRef),
                 (override, const, noexcept));
     MOCK_METHOD(utils::error::Result<package::LayerDir>,
+                getLayerDir,
+                (const package::Reference &ref,
+                 const std::string &module,
+                 const std::optional<std::string> &subRef),
+                (override, const, noexcept));
+    MOCK_METHOD(utils::error::Result<package::LayerDir>,
                 createTempMergedModuleDir,
                 (const package::Reference &ref, const std::vector<std::string> &modules),
+                (override, const, noexcept));
+    MOCK_METHOD(std::vector<std::string>,
+                getModuleList,
+                (const package::Reference &ref),
                 (override, const, noexcept));
     MOCK_METHOD(utils::error::Result<package::Reference>,
                 clearReferenceLocal,
@@ -150,10 +160,12 @@ TEST_F(RunContextTest, resolveBinaryModule)
     mockItem.info.arch = { std::string{ "x86_64" } };
 
     EXPECT_CALL(*repo, getLayerItem(testing::_, testing::_, testing::_)).WillOnce(Return(mockItem));
+    EXPECT_CALL(*repo, getModuleList(*ref))
+      .WillOnce(Return(std::vector<std::string>{ "binary", "develop" }));
 
     // Mock successful layer directory retrieval for binary module
-    package::LayerDir mockLayerDir(tempDir->path() / "merged");
-    EXPECT_CALL(*repo, getMergedModuleDir(testing::_, true, testing::_))
+    package::LayerDir mockLayerDir(tempDir->path() / "binary");
+    EXPECT_CALL(*repo, getLayerDir(testing::_, "binary", testing::_))
       .WillOnce(Return(mockLayerDir));
 
     // Create runtime layer
@@ -162,7 +174,7 @@ TEST_F(RunContextTest, resolveBinaryModule)
     ASSERT_TRUE(layer.has_value()) << "Failed to create runtime layer: " << layer.error().message();
 
     // Test resolving binary module
-    auto result = layer->resolveLayer({ "binary" });
+    auto result = layer->resolveLayer(std::vector<std::string>{ "binary" });
     ASSERT_TRUE(result.has_value())
       << "Failed to resolve binary module: " << result.error().message();
 
@@ -185,6 +197,8 @@ TEST_F(RunContextTest, resolveMultiModules)
     mockItem.info.arch = { std::string{ "x86_64" } };
 
     EXPECT_CALL(*repo, getLayerItem(testing::_, testing::_, testing::_)).WillOnce(Return(mockItem));
+    EXPECT_CALL(*repo, getModuleList(*ref))
+      .WillOnce(Return(std::vector<std::string>{ "binary", "debug", "develop" }));
 
     // Mock successful merged module directory retrieval for multiple modules
     package::LayerDir mockLayerDir(tempDir->path() / "merged");
@@ -199,11 +213,142 @@ TEST_F(RunContextTest, resolveMultiModules)
     ASSERT_TRUE(layer.has_value()) << "Failed to create runtime layer: " << layer.error().message();
 
     // Test resolving multiple modules
-    auto result = layer->resolveLayer({ "binary", "debug" });
+    auto result = layer->resolveLayer(std::vector<std::string>{ "binary", "debug" });
     ASSERT_TRUE(result.has_value())
       << "Failed to resolve multiple modules: " << result.error().message();
 
     // Verify layer directory is set
+    EXPECT_TRUE(layer->getLayerDir().has_value());
+}
+
+TEST_F(RunContextTest, resolveExcludeModules)
+{
+    auto ref = package::Reference::parse("stable:org.example.exclude/1.0.0/x86_64");
+    ASSERT_TRUE(ref.has_value()) << "Failed to create reference: " << ref.error().message();
+
+    api::types::v1::RepositoryCacheLayersItem mockItem;
+    mockItem.info.id = "org.example.exclude";
+    mockItem.info.version = "1.0.0";
+    mockItem.info.kind = "base";
+    mockItem.info.channel = "stable";
+    mockItem.info.arch = { std::string{ "x86_64" } };
+
+    EXPECT_CALL(*repo, getLayerItem(testing::_, testing::_, testing::_)).WillOnce(Return(mockItem));
+    EXPECT_CALL(*repo, getModuleList(*ref))
+      .WillOnce(Return(std::vector<std::string>{ "binary", "develop", "lang_zh" }));
+
+    package::LayerDir mockLayerDir(tempDir->path() / "exclude-develop");
+    EXPECT_CALL(
+      *repo,
+      createTempMergedModuleDir(testing::_, std::vector<std::string>{ "binary", "lang_zh" }))
+      .WillOnce(Return(mockLayerDir));
+
+    RunContext context(*this->repo);
+    auto layer = RuntimeLayer::create(*ref, context);
+    ASSERT_TRUE(layer.has_value()) << "Failed to create runtime layer: " << layer.error().message();
+
+    auto result = layer->resolveLayer(std::nullopt, std::vector<std::string>{ "develop" });
+    ASSERT_TRUE(result.has_value())
+      << "Failed to resolve excluding modules: " << result.error().message();
+
+    EXPECT_TRUE(layer->getLayerDir().has_value());
+}
+
+TEST_F(RunContextTest, resolveExcludeModulesReturnsTempMergeError)
+{
+    LINGLONG_TRACE("resolveExcludeModulesReturnsTempMergeError");
+
+    auto ref = package::Reference::parse("stable:org.example.exclude-error/1.0.0/x86_64");
+    ASSERT_TRUE(ref.has_value()) << "Failed to create reference: " << ref.error().message();
+
+    api::types::v1::RepositoryCacheLayersItem mockItem;
+    mockItem.info.id = "org.example.exclude-error";
+    mockItem.info.version = "1.0.0";
+    mockItem.info.kind = "base";
+    mockItem.info.channel = "stable";
+    mockItem.info.arch = { std::string{ "x86_64" } };
+
+    EXPECT_CALL(*repo, getLayerItem(testing::_, testing::_, testing::_)).WillOnce(Return(mockItem));
+    EXPECT_CALL(*repo, getModuleList(*ref))
+      .WillOnce(Return(std::vector<std::string>{ "binary", "develop", "lang_zh" }));
+    EXPECT_CALL(
+      *repo,
+      createTempMergedModuleDir(testing::_, std::vector<std::string>{ "binary", "lang_zh" }))
+      .WillOnce(Return(LINGLONG_ERR("merge failed")));
+
+    RunContext context(*this->repo);
+    auto layer = RuntimeLayer::create(*ref, context);
+    ASSERT_TRUE(layer.has_value()) << "Failed to create runtime layer: " << layer.error().message();
+
+    auto result = layer->resolveLayer(std::nullopt, std::vector<std::string>{ "develop" });
+    EXPECT_FALSE(result.has_value());
+    EXPECT_TRUE(result.error().message().find("merge failed") != std::string::npos);
+    EXPECT_FALSE(layer->getLayerDir().has_value());
+}
+
+TEST_F(RunContextTest, resolveExcludeModulesSameAsInstalledUsesMergedDir)
+{
+    auto ref = package::Reference::parse("stable:org.example.same/1.0.0/x86_64");
+    ASSERT_TRUE(ref.has_value()) << "Failed to create reference: " << ref.error().message();
+
+    api::types::v1::RepositoryCacheLayersItem mockItem;
+    mockItem.info.id = "org.example.same";
+    mockItem.info.version = "1.0.0";
+    mockItem.info.kind = "base";
+    mockItem.info.channel = "stable";
+    mockItem.info.arch = { std::string{ "x86_64" } };
+
+    EXPECT_CALL(*repo, getLayerItem(testing::_, testing::_, testing::_)).WillOnce(Return(mockItem));
+    EXPECT_CALL(*repo, getModuleList(*ref))
+      .WillOnce(Return(std::vector<std::string>{ "binary", "lang_zh" }));
+
+    package::LayerDir mockLayerDir(tempDir->path() / "merged");
+    EXPECT_CALL(*repo, getMergedModuleDir(testing::_, true, testing::_))
+      .WillOnce(Return(mockLayerDir));
+    EXPECT_CALL(*repo, createTempMergedModuleDir(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(*repo, getLayerDir(testing::_, testing::_, testing::_)).Times(0);
+
+    RunContext context(*this->repo);
+    auto layer = RuntimeLayer::create(*ref, context);
+    ASSERT_TRUE(layer.has_value()) << "Failed to create runtime layer: " << layer.error().message();
+
+    auto result = layer->resolveLayer(std::nullopt, std::vector<std::string>{ "develop" });
+    ASSERT_TRUE(result.has_value())
+      << "Failed to resolve excluding modules: " << result.error().message();
+
+    EXPECT_TRUE(layer->getLayerDir().has_value());
+}
+
+TEST_F(RunContextTest, resolveIncludeModulesSameAsInstalledUsesMergedDir)
+{
+    auto ref = package::Reference::parse("stable:org.example.include/1.0.0/x86_64");
+    ASSERT_TRUE(ref.has_value()) << "Failed to create reference: " << ref.error().message();
+
+    api::types::v1::RepositoryCacheLayersItem mockItem;
+    mockItem.info.id = "org.example.include";
+    mockItem.info.version = "1.0.0";
+    mockItem.info.kind = "base";
+    mockItem.info.channel = "stable";
+    mockItem.info.arch = { std::string{ "x86_64" } };
+
+    EXPECT_CALL(*repo, getLayerItem(testing::_, testing::_, testing::_)).WillOnce(Return(mockItem));
+    EXPECT_CALL(*repo, getModuleList(*ref))
+      .WillOnce(Return(std::vector<std::string>{ "binary", "lang_zh" }));
+
+    package::LayerDir mockLayerDir(tempDir->path() / "merged");
+    EXPECT_CALL(*repo, getMergedModuleDir(testing::_, true, testing::_))
+      .WillOnce(Return(mockLayerDir));
+    EXPECT_CALL(*repo, createTempMergedModuleDir(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(*repo, getLayerDir(testing::_, testing::_, testing::_)).Times(0);
+
+    RunContext context(*this->repo);
+    auto layer = RuntimeLayer::create(*ref, context);
+    ASSERT_TRUE(layer.has_value()) << "Failed to create runtime layer: " << layer.error().message();
+
+    auto result = layer->resolveLayer(std::vector<std::string>{ "lang_zh", "binary" });
+    ASSERT_TRUE(result.has_value())
+      << "Failed to resolve including modules: " << result.error().message();
+
     EXPECT_TRUE(layer->getLayerDir().has_value());
 }
 
@@ -226,9 +371,8 @@ TEST_F(RunContextTest, resolveSubRef)
 
     // Mock successful layer directory retrieval with sub-reference
     package::LayerDir mockLayerDir(tempDir->path() / "merged");
-    EXPECT_CALL(
-      *repo,
-      getMergedModuleDir(testing::_, "binary", std::optional<std::string>("test-uuid-12345")))
+    EXPECT_CALL(*repo,
+                getMergedModuleDir(testing::_, true, std::optional<std::string>("test-uuid-12345")))
       .WillOnce(Return(mockLayerDir));
 
     // Create runtime layer
@@ -237,7 +381,7 @@ TEST_F(RunContextTest, resolveSubRef)
     ASSERT_TRUE(layer.has_value()) << "Failed to create runtime layer: " << layer.error().message();
 
     // Test resolving with sub-reference
-    auto result = layer->resolveLayer({}, "test-uuid-12345");
+    auto result = layer->resolveLayer(std::nullopt, std::nullopt, "test-uuid-12345");
     ASSERT_TRUE(result.has_value())
       << "Failed to resolve layer with sub-ref: " << result.error().message();
 

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -727,6 +727,16 @@ ContainerCfgBuilder &ContainerCfgBuilder::addMask(const std::vector<std::string>
     return *this;
 }
 
+std::filesystem::path ContainerCfgBuilder::appMountPoint(const std::string &id) noexcept
+{
+    return std::filesystem::path{ "/opt/apps" } / id / "files";
+}
+
+std::filesystem::path ContainerCfgBuilder::extensionMountPoint(const std::string &id) noexcept
+{
+    return std::filesystem::path{ "/opt/extensions" } / id;
+}
+
 std::string ContainerCfgBuilder::ldConf(const std::string &triplet) const
 {
     std::vector<std::string> factors;
@@ -743,7 +753,7 @@ std::string ContainerCfgBuilder::ldConf(const std::string &triplet) const
     }
 
     if (appPath) {
-        appendLdConf(std::filesystem::path{ "/opt/apps" } / appId / "files");
+        appendLdConf(appMountPoint(appId));
         factors.push_back(appPath->string());
     }
 
@@ -896,7 +906,7 @@ utils::error::Result<void> ContainerCfgBuilder::buildMountApp() noexcept
                         .options = string_list{ "nodev", "nosuid", "mode=700" },
                         .source = "tmpfs",
                         .type = "tmpfs" },
-                 Mount{ .destination = std::filesystem::path{ "/opt/apps" } / appId / "files",
+                 Mount{ .destination = appMountPoint(appId),
                         .options = string_list{ "rbind", appPathRo ? "ro" : "rw", "rslave" },
                         .source = *appPath,
                         .type = "bind" } };

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
@@ -194,6 +194,9 @@ public:
 
     std::string ldConf(const std::string &triplet) const;
 
+    static std::filesystem::path appMountPoint(const std::string &id) noexcept;
+    static std::filesystem::path extensionMountPoint(const std::string &id) noexcept;
+
     utils::error::Result<void> build() noexcept;
 
     const ocppi::runtime::config::types::Config &getConfig() const { return config; }


### PR DESCRIPTION
Add --debug, --debug-listen, --debug-debuginfod, and --debug-symbol-dir options to `ll-cli run`. When --debug is enabled, the base/runtime develop module is installed if missing, the command is wrapped with `gdbserver --once`, and a gdb attach script is generated in a temp directory with debug-file paths derived from the resolved layers.