### PR TITLE
feat(package-manager): require matching main module when installing an extra module

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -607,8 +607,35 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
       api::types::v1::InteractionMessageType::Install;
 
     additionalMessage.remoteRef = packageRef.toString();
-    // TODO: when install extra module, we should check the same version of main(binary/runtime)
-    // module has been installed or not
+    // When installing an extra module (anything other than the main binary/runtime
+    // module), make sure the main module of the same version is already installed;
+    // an extra module is unusable on its own.
+    if (packageInfo.packageInfoV2Module != "binary"
+        && packageInfo.packageInfoV2Module != "runtime") {
+        linglong::repo::repoCacheQuery mainQuery{ .id = packageRef.id,
+                                                  .channel = packageRef.channel,
+                                                  .version = packageRef.version.toString() };
+        auto installed = this->repo->listLocalBy(mainQuery);
+        if (installed) {
+            bool hasMainModule = false;
+            for (const auto &item : *installed) {
+                if (item.info.packageInfoV2Module == "binary"
+                    || item.info.packageInfoV2Module == "runtime") {
+                    hasMainModule = true;
+                    break;
+                }
+            }
+            if (!hasMainModule) {
+                return toDBusReply(utils::error::ErrorCode::Failed,
+                                   fmt::format("can't install module '{}' of {}: the main module "
+                                               "(binary/runtime) of version {} is not installed, "
+                                               "please install it first",
+                                               packageInfo.packageInfoV2Module,
+                                               packageRef.id,
+                                               packageRef.version.toString()));
+            }
+        }
+    }
 
     // Note: same as InstallRef, we should fuzzy the id instead of version
     auto fuzzyRef = package::FuzzyReference::parse(packageRef.id);


### PR DESCRIPTION
## Problem

`installFromLayer` allowed installing an extra module (e.g. `develop`) even when the matching main module (`binary` / `runtime`) of the same version was not installed, leaving an unusable package. This was a known gap, marked `// TODO: when install extra module, we should check the same version of main(binary/runtime) module has been installed or not` at `package_manager.cpp:607`.

## Change

When the module being installed is not `binary` or `runtime`, query the local repo for a `binary`/`runtime` module of the same id + version. If none exists, refuse the install with a clear message ("please install it first"). This reuses the same main-module detection (`module == "binary" || "runtime"`) and the same `repo->listLocalBy(...)` query already used by the **uninstall** path (`package_manager.cpp:984`).

If the local-list query itself fails, the check is skipped so the install isn't blocked by a query error.

## Notes

Behavior choice is to **refuse** (consistent with the file's other install-time rejections, e.g. arch mismatch / "already installed"). Happy to switch to a warning if a softer behavior is preferred.

Resolves the TODO at `package_manager.cpp:607`.
