### PR TITLE
fix(package): fall back to copy on cross-device hard link in UAB export

### DIFF
--- a/libs/linglong/src/linglong/package/uab_packager.cpp
+++ b/libs/linglong/src/linglong/package/uab_packager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -431,10 +431,17 @@ UABPackager::prepareExecutableBundle(const std::filesystem::path &bundleDir) noe
 
                 std::filesystem::create_hard_link(realSource, realDestination, ec);
                 if (ec) {
-                    return LINGLONG_ERR(fmt::format("couldn't link from {} to {} {}",
-                                                    source,
-                                                    realDestination,
-                                                    ec.message()));
+                    // Hard links can't span filesystems (EXDEV); fall back to
+                    // copying so export still works when the project dir and
+                    // the builder cache live on different mounts (see #1605).
+                    ec.clear();
+                    std::filesystem::copy_file(realSource, realDestination, ec);
+                    if (ec) {
+                        return LINGLONG_ERR(fmt::format("couldn't link or copy from {} to {} {}",
+                                                        source,
+                                                        realDestination,
+                                                        ec.message()));
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Background

Closes #1605. `ll-builder export` aborts with `Invalid cross-device link` (EXDEV) when the project directory and the builder cache live on different filesystems.

## Root cause

`UABPackager::prepareExecutableBundle` calls `std::filesystem::create_hard_link` straight from the builder cache into the export bundle dir and returns an error on failure. Hard links can't span filesystems, so any cross-mount layout fails the export — exactly what the reporter hit (`/home` cache vs `/persistent/home` project).

The sibling path `prepareDistributedBundle` already falls back to copying in the same situation (see the `create_hard_link` → `copy` block around `uab_packager.cpp:725`). This PR just makes `prepareExecutableBundle` consistent with it.

## Change

When the hard link fails, clear the error and fall back to `copy_file`:

```cpp
std::filesystem::create_hard_link(realSource, realDestination, ec);
if (ec) {
    ec.clear();
    std::filesystem::copy_file(realSource, realDestination, ec);
    if (ec) {
        return LINGLONG_ERR(...);
    }
}
```

## Verification

Built and tested locally in a Debian 12 container (Qt6):

```
100% tests passed, 0 tests failed out of 470
Total Test time (real) = 40.51 sec
```

No regressions; the 11 skipped tests are unchanged from baseline.
