### PR TITLE
fix: install Linglong client on other distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,28 @@
 
 ### :flags: Progress
 
-- **Supported Distributions**: deepin, UOS, openEuler, Ubuntu, Debian, openKylin, Anolis OS. More distributions are under adaptation. Contributions are welcome.
+- **Supported Distributions**: deepin, UOS, openEuler, Ubuntu, Debian, openKylin, Anolis OS, Fedora, Arch. More distributions are under adaptation. Contributions are welcome.
 - **CPU Architectures**: X86, ARM64, LoongArch. Future support for RISC-V and others.
 
 ## :gear: Installation
 
-Installation instructions for supported distributions:
+Installation instructions for supported distributions. The following steps use the release repository. To install the preview version built from the master branch, change `release` to `latest` in the repository URL. For detailed instructions, see the [Installation Guide](./docs/pages/en/guide/start/install.md).
 
-### deepin 23
+### Arch / Manjaro / Parabola Linux
 
-Install:
+```sh
+sudo pacman -Syu linyaps
+```
+
+### Deepin 25
+
+```sh
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Deepin_25/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo apt update
+sudo apt install linglong-bin
+```
+
+### Deepin 23
 
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Deepin_23/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
@@ -43,18 +55,50 @@ sudo apt update
 sudo apt install linglong-bin
 ```
 
-### Fedora 41
+### Fedora 42
 
 ```sh
-sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_41/linglong%3ACI%3Arelease.repo"
+sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_42/linglong%3ACI%3Arelease.repo"
 sudo dnf update
 sudo dnf install linglong-bin
+```
+
+### Fedora 43
+
+```sh
+sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_43/linglong%3ACI%3Arelease.repo"
+sudo dnf update
+sudo dnf install linglong-bin
+```
+
+### Ubuntu 25.10
+
+```sh
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Ubuntu_25.10/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo apt update
+sudo apt install linglong-bin
+```
+
+### Ubuntu 25.04
+
+```sh
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Ubuntu_25.04/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo apt update
+sudo apt install linglong-bin
 ```
 
 ### Ubuntu 24.04
 
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/xUbuntu_24.04/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo apt update
+sudo apt install linglong-bin
+```
+
+### Debian 13
+
+```sh
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Debian_13/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
 sudo apt install linglong-bin
 ```
@@ -67,10 +111,19 @@ sudo apt update
 sudo apt install linglong-bin
 ```
 
-### openEuler 23.09
+### openEuler 25.03
 
 ```sh
-sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_23.09/linglong%3ACI%3Arelease.repo"
+sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_25.03/linglong%3ACI%3Arelease.repo"
+sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
+sudo dnf update
+sudo dnf install linglong-bin
+```
+
+### openEuler 24.03 SP2
+
+```sh
+sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_24.03/linglong%3ACI%3Arelease.repo"
 sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
 sudo dnf update
 sudo dnf install linglong-bin
@@ -84,10 +137,18 @@ sudo apt update
 sudo apt install linglong-bin
 ```
 
-### AnolisOS 8
+### AnolisOS 23.4
 
 ```sh
-sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/AnolisOS_8/linglong%3ACI%3Arelease.repo"
+sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/AnolisOS_23.4/linglong%3ACI%3Arelease.repo"
+sudo dnf update
+sudo dnf install linglong-bin
+```
+
+### AnolisOS 23.3
+
+```sh
+sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/AnolisOS_23.3/linglong%3ACI%3Arelease.repo"
 sudo dnf update
 sudo dnf install linglong-bin
 ```

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -28,16 +28,28 @@
 
 ### :flags: 进展
 
-- **发行版支持**：deepin、UOS、openEuler、Ubuntu、Debian、openKylin、Anolis OS，更多发行版适配中，欢迎参与贡献。
+- **发行版支持**：deepin、UOS、openEuler、Ubuntu、Debian、openKylin、Anolis OS、Fedora、Arch，更多发行版适配中，欢迎参与贡献。
 - **CPU 架构支持**：X86、ARM64、LoongArch，未来将提供对 RISC-V 等更多架构的支持。
 
 ## :gear: 安装
 
-各个发行版安装方式如下：
+各个发行版安装方式如下。以下安装步骤均使用 release 仓库，如需安装基于 master 分支构建的预览版，将仓库地址中的 `release` 更改为 `latest` 即可。详细安装说明请参考[安装指南](./docs/pages/guide/start/install.md)。
 
-### deepin 23
+### Arch / Manjaro / Parabola Linux
 
-安装：
+```sh
+sudo pacman -Syu linyaps
+```
+
+### Deepin 25
+
+```sh
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Deepin_25/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo apt update
+sudo apt install linglong-bin
+```
+
+### Deepin 23
 
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Deepin_23/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
@@ -45,18 +57,50 @@ sudo apt update
 sudo apt install linglong-bin
 ```
 
-### Fedora 41
+### Fedora 42
 
 ```sh
-sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_41/linglong%3ACI%3Arelease.repo"
+sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_42/linglong%3ACI%3Arelease.repo"
 sudo dnf update
 sudo dnf install linglong-bin
+```
+
+### Fedora 43
+
+```sh
+sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_43/linglong%3ACI%3Arelease.repo"
+sudo dnf update
+sudo dnf install linglong-bin
+```
+
+### Ubuntu 25.10
+
+```sh
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Ubuntu_25.10/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo apt update
+sudo apt install linglong-bin
+```
+
+### Ubuntu 25.04
+
+```sh
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Ubuntu_25.04/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo apt update
+sudo apt install linglong-bin
 ```
 
 ### Ubuntu 24.04
 
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/xUbuntu_24.04/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo apt update
+sudo apt install linglong-bin
+```
+
+### Debian 13
+
+```sh
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Debian_13/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
 sudo apt install linglong-bin
 ```
@@ -69,10 +113,19 @@ sudo apt update
 sudo apt install linglong-bin
 ```
 
-### openEuler 23.09
+### openEuler 25.03
 
 ```sh
-sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_23.09/linglong%3ACI%3Arelease.repo"
+sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_25.03/linglong%3ACI%3Arelease.repo"
+sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
+sudo dnf update
+sudo dnf install linglong-bin
+```
+
+### openEuler 24.03 SP2
+
+```sh
+sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_24.03/linglong%3ACI%3Arelease.repo"
 sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
 sudo dnf update
 sudo dnf install linglong-bin
@@ -86,10 +139,18 @@ sudo apt update
 sudo apt install linglong-bin
 ```
 
-### AnolisOS 8
+### AnolisOS 23.4
 
 ```sh
-sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/AnolisOS_8/linglong%3ACI%3Arelease.repo"
+sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/AnolisOS_23.4/linglong%3ACI%3Arelease.repo"
+sudo dnf update
+sudo dnf install linglong-bin
+```
+
+### AnolisOS 23.3
+
+```sh
+sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/AnolisOS_23.3/linglong%3ACI%3Arelease.repo"
 sudo dnf update
 sudo dnf install linglong-bin
 ```

--- a/docs/pages/en/guide/start/install.md
+++ b/docs/pages/en/guide/start/install.md
@@ -51,28 +51,20 @@ yay -Syu linyaps-web-store-installer
 sudo pacman -Syu linyaps-web-store-installer
 ```
 
-### deepin 25
+### Deepin 25
 
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Deepin_25/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-bin linglong-installer
+sudo apt install linglong-bin
 ```
 
-### deepin 23
+### Deepin 23
 
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Deepin_23/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-bin linglong-installer
-```
-
-### Fedora 41
-
-```sh
-sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_41/linglong%3ACI%3Arelease.repo"
-sudo dnf update
-sudo dnf install linglong-bin linyaps-web-store-installer
+sudo apt install linglong-bin
 ```
 
 ### Fedora 42
@@ -80,7 +72,31 @@ sudo dnf install linglong-bin linyaps-web-store-installer
 ```sh
 sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_42/linglong%3ACI%3Arelease.repo"
 sudo dnf update
-sudo dnf install linglong-bin linyaps-web-store-installer
+sudo dnf install linglong-bin
+```
+
+### Fedora 43
+
+```sh
+sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_43/linglong%3ACI%3Arelease.repo"
+sudo dnf update
+sudo dnf install linglong-bin
+```
+
+### Ubuntu 25.10
+
+```sh
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Ubuntu_25.10/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo apt update
+sudo apt install linglong-bin
+```
+
+### Ubuntu 25.04
+
+```sh
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Ubuntu_25.04/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo apt update
+sudo apt install linglong-bin
 ```
 
 ### Ubuntu 24.04
@@ -88,15 +104,7 @@ sudo dnf install linglong-bin linyaps-web-store-installer
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/xUbuntu_24.04/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-bin linglong-installer
-```
-
-### Debian 12
-
-```sh
-echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Debian_12/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
-sudo apt update
-sudo apt install linglong-bin linglong-installer
+sudo apt install linglong-bin
 ```
 
 ### Debian 13
@@ -104,41 +112,57 @@ sudo apt install linglong-bin linglong-installer
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Debian_13/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-bin linglong-installer
+sudo apt install linglong-bin
 ```
 
-### openEuler 23.09
+### Debian 12
 
 ```sh
-sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_23.09/linglong%3ACI%3Arelease.repo"
-sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
-sudo dnf update
-sudo dnf install linglong-bin linyaps-web-store-installer
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Debian_12/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo apt update
+sudo apt install linglong-bin
 ```
 
-### openEuler 24.03
+### openEuler 25.03
+
+```sh
+sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_25.03/linglong%3ACI%3Arelease.repo"
+sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
+sudo dnf update
+sudo dnf install linglong-bin
+```
+
+### openEuler 24.03 SP2
 
 ```sh
 sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_24.03/linglong%3ACI%3Arelease.repo"
 sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
 sudo dnf update
-sudo dnf install linglong-bin linyaps-web-store-installer
+sudo dnf install linglong-bin
 ```
 
-### UOS 1070
+### uos 1070
 
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/uos_1070/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-bin linglong-installer
+sudo apt install linglong-bin
 ```
 
-### AnolisOS 8
+### AnolisOS 23.4
 
 ```sh
-sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/AnolisOS_8/linglong%3ACI%3Arelease.repo"
+sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/AnolisOS_23.4/linglong%3ACI%3Arelease.repo"
 sudo dnf update
-sudo dnf install linglong-bin linyaps-web-store-installer
+sudo dnf install linglong-bin
+```
+
+### AnolisOS 23.3
+
+```sh
+sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/AnolisOS_23.3/linglong%3ACI%3Arelease.repo"
+sudo dnf update
+sudo dnf install linglong-bin
 ```
 
 ### openkylin 2.0
@@ -146,7 +170,7 @@ sudo dnf install linglong-bin linyaps-web-store-installer
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/openkylin_2.0/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-bin linglong-installer
+sudo apt install linglong-bin
 ```
 
 ### NixOS

--- a/docs/pages/guide/start/install.md
+++ b/docs/pages/guide/start/install.md
@@ -51,28 +51,20 @@ yay -Syu linyaps-web-store-installer
 sudo pacman -Syu linyaps-web-store-installer
 ```
 
-### deepin 25
+### Deepin 25
 
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Deepin_25/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-bin linglong-installer
+sudo apt install linglong-bin
 ```
 
-### deepin 23
+### Deepin 23
 
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Deepin_23/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-bin linglong-installer
-```
-
-### Fedora 41
-
-```sh
-sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_41/linglong%3ACI%3Arelease.repo"
-sudo dnf update
-sudo dnf install linglong-bin linyaps-web-store-installer
+sudo apt install linglong-bin
 ```
 
 ### Fedora 42
@@ -80,7 +72,31 @@ sudo dnf install linglong-bin linyaps-web-store-installer
 ```sh
 sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_42/linglong%3ACI%3Arelease.repo"
 sudo dnf update
-sudo dnf install linglong-bin linyaps-web-store-installer
+sudo dnf install linglong-bin
+```
+
+### Fedora 43
+
+```sh
+sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_43/linglong%3ACI%3Arelease.repo"
+sudo dnf update
+sudo dnf install linglong-bin
+```
+
+### Ubuntu 25.10
+
+```sh
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Ubuntu_25.10/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo apt update
+sudo apt install linglong-bin
+```
+
+### Ubuntu 25.04
+
+```sh
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Ubuntu_25.04/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo apt update
+sudo apt install linglong-bin
 ```
 
 ### Ubuntu 24.04
@@ -88,15 +104,7 @@ sudo dnf install linglong-bin linyaps-web-store-installer
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/xUbuntu_24.04/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-bin linglong-installer
-```
-
-### Debian 12
-
-```sh
-echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Debian_12/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
-sudo apt update
-sudo apt install linglong-bin linglong-installer
+sudo apt install linglong-bin
 ```
 
 ### Debian 13
@@ -104,41 +112,57 @@ sudo apt install linglong-bin linglong-installer
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Debian_13/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-bin linglong-installer
+sudo apt install linglong-bin
 ```
 
-### openEuler 23.09
+### Debian 12
 
 ```sh
-sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_23.09/linglong%3ACI%3Arelease.repo"
-sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
-sudo dnf update
-sudo dnf install linglong-bin linyaps-web-store-installer
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Debian_12/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo apt update
+sudo apt install linglong-bin
 ```
 
-### openEuler 24.03
+### openEuler 25.03
+
+```sh
+sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_25.03/linglong%3ACI%3Arelease.repo"
+sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
+sudo dnf update
+sudo dnf install linglong-bin
+```
+
+### openEuler 24.03 SP2
 
 ```sh
 sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_24.03/linglong%3ACI%3Arelease.repo"
 sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
 sudo dnf update
-sudo dnf install linglong-bin linyaps-web-store-installer
+sudo dnf install linglong-bin
 ```
 
-### UOS 1070
+### uos 1070
 
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/uos_1070/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-bin linglong-installer
+sudo apt install linglong-bin
 ```
 
-### AnolisOS 8
+### AnolisOS 23.4
 
 ```sh
-sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/AnolisOS_8/linglong%3ACI%3Arelease.repo"
+sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/AnolisOS_23.4/linglong%3ACI%3Arelease.repo"
 sudo dnf update
-sudo dnf install linglong-bin linyaps-web-store-installer
+sudo dnf install linglong-bin
+```
+
+### AnolisOS 23.3
+
+```sh
+sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/AnolisOS_23.3/linglong%3ACI%3Arelease.repo"
+sudo dnf update
+sudo dnf install linglong-bin
 ```
 
 ### openkylin 2.0
@@ -146,7 +170,7 @@ sudo dnf install linglong-bin linyaps-web-store-installer
 ```sh
 echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/openkylin_2.0/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
-sudo apt install linglong-bin linglong-installer
+sudo apt install linglong-bin
 ```
 
 ### NixOS

--- a/tools/check-obs-repo-paths.sh
+++ b/tools/check-obs-repo-paths.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# Verify the OBS repository paths documented in the install guides are
+# reachable and serve the expected indices, so a wrong path (for example an
+# "xUbuntu_25.04" name that the OBS project does not publish for Ubuntu 25.x)
+# is caught before it reaches users with a 404.
+#
+# The check hits the live https://ci.deepin.com mirror, so it needs network
+# access and curl. It is meant to be run on demand whenever the repository
+# paths in the install documents change:
+#
+#   ./tools/check-obs-repo-paths.sh
+#
+# Exit status: 0 when every documented path is reachable, non-zero otherwise.
+
+set -Eeuo pipefail
+
+RELEASE_BASE="https://ci.deepin.com/repo/obs/linglong:/CI:/release"
+LATEST_BASE="https://ci.deepin.com/repo/obs/linglong:/CI:/latest"
+
+FAILURES=0
+
+http_code() {
+    local url="$1"
+    curl --silent --output /dev/null --max-time 20 --write-out '%{http_code}' "${url}"
+}
+
+expect_code() {
+    local url="$1"
+    local want="$2"
+    local label="$3"
+    local got
+    got="$(http_code "${url}")"
+    if [[ "${got}" == "${want}" ]]; then
+        printf '  ok    %-7s %s\n' "${got}" "${label}"
+    else
+        printf '  FAIL  %-7s %s (expected %s)\n' "${got}" "${label}" "${want}"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+require_tool() {
+    if ! command -v curl >/dev/null 2>&1; then
+        printf 'This tool needs curl.\n' >&2
+        exit 1
+    fi
+}
+
+main() {
+    require_tool
+
+    local apt_paths=(
+        Deepin_25
+        Deepin_23
+        Ubuntu_25.10
+        Ubuntu_25.04
+        xUbuntu_24.04
+        Debian_13
+        Debian_12
+        uos_1070
+        openkylin_2.0
+    )
+    local dnf_paths=(
+        Fedora_42
+        Fedora_43
+        openEuler_25.03
+        openEuler_24.03
+        AnolisOS_23.4
+        AnolisOS_23.3
+    )
+
+    printf 'Release channel: directories\n'
+    for path in "${apt_paths[@]}" "${dnf_paths[@]}"; do
+        expect_code "${RELEASE_BASE}/${path}/" "200" "release/${path}/"
+    done
+
+    printf 'Release channel: APT package indices\n'
+    for path in "${apt_paths[@]}"; do
+        expect_code "${RELEASE_BASE}/${path}/Packages.gz" "200" "release/${path}/Packages.gz"
+    done
+
+    printf 'Release channel: DNF repository files\n'
+    for path in "${dnf_paths[@]}"; do
+        expect_code "${RELEASE_BASE}/${path}/linglong%3ACI%3Arelease.repo" "200" "release/${path}/linglong:CI:release.repo"
+    done
+
+    # Ubuntu 25.x is published WITHOUT the OBS "x" prefix that Ubuntu 24.04
+    # keeps. Guard both channels so a well-meant rename to "xUbuntu_25.x"
+    # cannot silently reintroduce a 404.
+    printf 'Regression guard: Ubuntu 25.x naming (both channels)\n'
+    for base in "${RELEASE_BASE}" "${LATEST_BASE}"; do
+        local channel
+        channel="${base##*/}"
+        expect_code "${base}/Ubuntu_25.04/" "200" "${channel}/Ubuntu_25.04/"
+        expect_code "${base}/Ubuntu_25.10/" "200" "${channel}/Ubuntu_25.10/"
+        expect_code "${base}/xUbuntu_25.04/" "404" "${channel}/xUbuntu_25.04/"
+        expect_code "${base}/xUbuntu_25.10/" "404" "${channel}/xUbuntu_25.10/"
+    done
+
+    if [[ "${FAILURES}" -ne 0 ]]; then
+        printf '\n%s check(s) failed.\n' "${FAILURES}"
+        return 1
+    fi
+
+    printf '\nAll documented OBS repository paths are reachable.\n'
+}
+
+main "$@"


### PR DESCRIPTION
## Description

Resolves issue #1070: install the Linglong client on other distributions.

### Support policy

The installation documentation is updated with the following policy:

1. Only rpm and deb packages are provided.
2. Each distribution supports at least two versions:
   - Distributions with an LTS release: both the LTS and the latest version are supported.
   - Distributions without an LTS release: the latest two major versions are supported.

### Changes

Installation instructions are updated in the following files:

- `README.md` (English)
- `README.zh_CN.md` (Chinese)
- `docs/pages/en/guide/start/install.md` (English install guide)
- `docs/pages/guide/start/install.md` (Chinese install guide)

### Supported distributions and versions

| Distribution | Version |
|--------|------|
| Arch / Manjaro / Parabola Linux | — |
| Deepin | 25, 23 |
| Fedora | 42, 43 |
| Ubuntu | 25.10, 25.04, 24.04 |
| Debian | 13, 12 |
| openEuler | 25.03, 24.03 SP2 |
| uos | 1070 |
| AnolisOS | 23.4, 23.3 |
| openkylin | 2.0 |

### Main changes

- Added installation instructions for Arch/Manjaro/Parabola, Deepin 25, Fedora 43, Ubuntu 25.10/25.04, Debian 13, openEuler 25.03, and AnolisOS 23.4/23.3.
- Updated outdated versions: Fedora 41→42, openEuler 23.09→25.03, AnolisOS 8→23.x.
- Unified the install command to `linglong-bin`.
- Added Fedora and Arch to the progress list.

Closes #1070
