### PR TITLE
feat(builder): auto-compile GSettings schemas during build

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -2064,10 +2064,11 @@ set -e
     }
     scriptContent.append(project.build);
     scriptContent.push_back('\n');
+    scriptContent.append("# POST BUILD PROCESS\n");
     if (!this->buildOptions.skipStripSymbols) {
-        scriptContent.append("# POST BUILD PROCESS\n");
         scriptContent.append(LINGLONG_BUILDER_HELPER "/symbols-strip.sh\n");
     }
+    scriptContent.append(LINGLONG_BUILDER_HELPER "/compile-schemas.sh\n");
 
     auto res = utils::writeFile(entry, scriptContent);
     if (!res) {

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -14,6 +14,7 @@ configure_files(
   # find -regex '\.\/\(script\|share\|lib\|libexec\)\/.*' -type f -printf '%P\n'
   # | sort
   libexec/linglong/app-conf-generator
+  libexec/linglong/builder/helper/compile-schemas.sh
   libexec/linglong/builder/helper/config-check.sh
   libexec/linglong/builder/helper/ldd-check.sh
   libexec/linglong/builder/helper/main-check.sh
@@ -100,6 +101,7 @@ install(
 set(LIBEXEC_LINGLONG_BUILDER_DIR ${LIBEXEC_LINGLONG_DIR}/builder)
 install(
   PROGRAMS
+    ${CMAKE_CURRENT_BINARY_DIR}/libexec/linglong/builder/helper/compile-schemas.sh
     ${CMAKE_CURRENT_BINARY_DIR}/libexec/linglong/builder/helper/config-check.sh
     ${CMAKE_CURRENT_BINARY_DIR}/libexec/linglong/builder/helper/ldd-check.sh
     ${CMAKE_CURRENT_BINARY_DIR}/libexec/linglong/builder/helper/main-check.sh

--- a/misc/libexec/linglong/builder/helper/compile-schemas.sh
+++ b/misc/libexec/linglong/builder/helper/compile-schemas.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# Automatically compile GSettings schemas during the build so that the
+# resulting gschemas.compiled is shipped inside the package. Apps that
+# depend on gsettings need this compiled binary to function at runtime
+# without requiring glib-compile-schemas on the user's machine.
+
+schema_dir="$PREFIX/share/glib-2.0/schemas"
+
+if [ ! -d "$schema_dir" ]; then
+    exit 0
+fi
+
+if ! command -v glib-compile-schemas >/dev/null 2>&1; then
+    echo "Warning: glib-compile-schemas not found, skip compiling schemas" >&2
+    exit 0
+fi
+
+glib-compile-schemas "$schema_dir"


### PR DESCRIPTION
## Summary

Resolves #679.

Applications that depend on gsettings require a compiled `gschemas.compiled` binary in `share/glib-2.0/schemas` to function at runtime. Until now linglong only ran `glib-compile-schemas` at install time (`OSTreeRepo::updateSharedInfo`), which forced the tool to be present on every end-user machine.

This PR makes `ll-builder` automatically compile GSettings schemas **at build time** so the compiled binary is shipped inside the package.

## Changes

- **`misc/libexec/linglong/builder/helper/compile-schemas.sh`** *(new)* — helper script that:
  - Does nothing when `$PREFIX/share/glib-2.0/schemas` does not exist (no overhead for apps without gsettings).
  - Skips with a warning when `glib-compile-schemas` is unavailable.
  - Otherwise runs `glib-compile-schemas` on the schemas directory.
- **`misc/CMakeLists.txt`** — registers the new script in `configure_files` and the `install(PROGRAMS …)` list (kept in sorted order alongside the other builder helpers).
- **`libs/linglong/src/linglong/builder/linglong_builder.cpp`** (`generateEntryScript`) — appends `compile-schemas.sh` to the POST BUILD PROCESS section of the generated `entry.sh`, immediately after the user build script and optional symbol stripping. The call runs unconditionally (not gated on `skipStripSymbols`).

## How it works

During `ll-builder build`, the generated entry script now ends with:

```bash
# POST BUILD PROCESS
<builder-helper>/symbols-strip.sh   # only when strip is enabled
<builder-helper>/compile-schemas.sh  # always; no-op without schemas
```

The script runs inside the build container where `glib-compile-schemas` is part of the glib development packages, so no extra host dependency is introduced.

## Verification

- `bash -n compile-schemas.sh` — syntax OK.
- Manual functional tests:
  - No schemas dir → exit 0, no output.
  - Schemas dir exists, `glib-compile-schemas` missing → warning on stderr, exit 0.
  - Schemas dir exists, `glib-compile-schemas` present → `gschemas.compiled` created, exit 0.
- `git diff --check` — no whitespace errors.

Full CMake build and CTest could not be executed in this environment (no compiler toolchain installed); the change is limited to a new shell script, two CMake list entries, and a three-line C++ edit that follows existing patterns.