### PR TITLE
fix: ensure XDG_DATA_DIRS contains system dirs so Vulkan drivers load

### DIFF
--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -47,6 +47,7 @@ pfl_add_executable(
   src/linglong/package/uab_file_test.cpp
   src/linglong/package/version_test.cpp
   src/linglong/package/versionv2_test.cpp
+  src/linglong/oci_cfg_generators/container_cfg_builder_test.cpp
   src/linglong/repo/client_factory_test.cpp
   src/linglong/repo/config_test.cpp
   src/linglong/repo/ostree_repo_test.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/oci_cfg_generators/container_cfg_builder_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/oci_cfg_generators/container_cfg_builder_test.cpp
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "../../common/tempdir.h"
+#include "linglong/common/strings.h"
+#include "linglong/oci-cfg-generators/container_cfg_builder.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <optional>
+#include <string>
+
+using namespace linglong;
+
+namespace {
+
+std::optional<std::string> getEnvValue(const ocppi::runtime::config::types::Config &config,
+                                       const std::string &key)
+{
+    if (!config.process.has_value() || !config.process->env.has_value()) {
+        return std::nullopt;
+    }
+
+    const std::string prefix = key + "=";
+    for (const auto &entry : *config.process->env) {
+        if (entry.size() >= prefix.size() && entry.compare(0, prefix.size(), prefix) == 0) {
+            return entry.substr(prefix.size());
+        }
+    }
+    return std::nullopt;
+}
+
+bool containsPart(std::string_view value, std::string_view part)
+{
+    auto parts = common::strings::split(value, ':', common::strings::splitOption::SkipEmpty);
+    return std::find(parts.begin(), parts.end(), part) != parts.end();
+}
+
+std::ptrdiff_t countPart(std::string_view value, std::string_view part)
+{
+    auto parts = common::strings::split(value, ':', common::strings::splitOption::SkipEmpty);
+    return std::count(parts.begin(), parts.end(), part);
+}
+
+} // namespace
+
+// Regression test for issue #1457: the Vulkan ICD loader discovers driver
+// manifests by scanning each XDG_DATA_DIRS entry for a "vulkan/icd.d"
+// subdirectory. When XDG_DATA_DIRS is not present in the container environment,
+// build() must still expose the conventional system data directories so that
+// system provided drivers (e.g. the Mesa Turnip/freedreno Vulkan driver under
+// /usr/share/vulkan/icd.d) remain discoverable.
+TEST(ContainerCfgBuilderEnvTest, XdgDataDirsUnsetGetsSystemDefaults)
+{
+    TempDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    std::filesystem::create_directories(tmp.path() / "bundle");
+
+    generator::ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.base")
+      .setBasePath(tmp.path() / "base")
+      .setBundlePath(tmp.path() / "bundle")
+      .disablePatch();
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    auto xdg = getEnvValue(builder.getConfig(), "XDG_DATA_DIRS");
+    ASSERT_TRUE(xdg.has_value());
+    EXPECT_TRUE(containsPart(*xdg, "/usr/share"));
+    EXPECT_TRUE(containsPart(*xdg, "/usr/local/share"));
+}
+
+// Regression test for issue #1457: a host XDG_DATA_DIRS that only points at
+// Linyaps specific paths may be forwarded into the container, overriding the
+// Vulkan loader default search path. The forwarded value must be preserved
+// while the standard system data directories are appended so that the loader
+// still finds /usr/share/vulkan/icd.d.
+TEST(ContainerCfgBuilderEnvTest, XdgDataDirsForwardedHostValueKeepsSystemDefaults)
+{
+    TempDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    std::filesystem::create_directories(tmp.path() / "bundle");
+
+    generator::ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.base")
+      .setBasePath(tmp.path() / "base")
+      .setBundlePath(tmp.path() / "bundle")
+      .disablePatch()
+      .appendEnv("XDG_DATA_DIRS", "/var/lib/linglong/entries/share");
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    auto xdg = getEnvValue(builder.getConfig(), "XDG_DATA_DIRS");
+    ASSERT_TRUE(xdg.has_value());
+    EXPECT_TRUE(containsPart(*xdg, "/var/lib/linglong/entries/share"));
+    EXPECT_TRUE(containsPart(*xdg, "/usr/share"));
+    EXPECT_TRUE(containsPart(*xdg, "/usr/local/share"));
+}
+
+TEST(ContainerCfgBuilderEnvTest, XdgDataDirsDoesNotDuplicateSystemDefaults)
+{
+    TempDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    std::filesystem::create_directories(tmp.path() / "bundle");
+
+    generator::ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.base")
+      .setBasePath(tmp.path() / "base")
+      .setBundlePath(tmp.path() / "bundle")
+      .disablePatch()
+      .appendEnv("XDG_DATA_DIRS", "/usr/share:/usr/local/share");
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    auto xdg = getEnvValue(builder.getConfig(), "XDG_DATA_DIRS");
+    ASSERT_TRUE(xdg.has_value());
+    EXPECT_EQ(*xdg, "/usr/share:/usr/local/share");
+    EXPECT_EQ(countPart(*xdg, "/usr/share"), 1);
+    EXPECT_EQ(countPart(*xdg, "/usr/local/share"), 1);
+}

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -1513,6 +1513,41 @@ utils::error::Result<void> ContainerCfgBuilder::buildEnv() noexcept
         environment.try_emplace("QT_QPA_PLATFORMTHEME", "xdgdesktopportal");
     }
 
+    // Ensure the conventional system data directories stay reachable through
+    // XDG_DATA_DIRS. The host environment (for example a host XDG_DATA_DIRS that
+    // only points at Linyaps specific paths) may be forwarded into the container,
+    // overriding the default search path relied on by XDG-data consumers. When
+    // that happens the Vulkan ICD loader no longer scans /usr/share/vulkan/icd.d
+    // and fails to discover system provided driver manifests such as the Mesa
+    // Turnip (freedreno) driver, while OpenGL keeps working because Mesa locates
+    // DRI drivers through the compiled-in library path. Always keep the standard
+    // system data directories in XDG_DATA_DIRS so those consumers keep working.
+    {
+        const std::vector<std::string> systemDataDirs{ "/usr/local/share", "/usr/share" };
+        auto xdgIt = environment.find("XDG_DATA_DIRS");
+        std::string currentValue = (xdgIt != environment.end()) ? xdgIt->second : std::string{};
+        auto entries =
+          common::strings::split(currentValue, ':', common::strings::splitOption::SkipEmpty);
+
+        std::vector<std::string> dirs;
+        dirs.reserve(entries.size() + systemDataDirs.size());
+        for (auto entry : entries) {
+            dirs.emplace_back(entry);
+        }
+
+        bool changed = (xdgIt == environment.end());
+        for (const auto &dir : systemDataDirs) {
+            if (std::find(dirs.begin(), dirs.end(), dir) == dirs.end()) {
+                dirs.push_back(dir);
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            environment["XDG_DATA_DIRS"] = common::strings::join(dirs, ':');
+        }
+    }
+
     auto envShFile = bundlePath / "00env.sh";
     std::ofstream ofs(envShFile);
     if (!ofs.is_open()) {


### PR DESCRIPTION
## Summary

Fixes #1457 — Mesa3D Snapdragon Turnip (freedreno) Vulkan driver fails to load inside Linglong containers, while OpenGL works.

## Root cause

The Vulkan ICD loader discovers driver manifests by scanning each entry of `XDG_DATA_DIRS` for a `vulkan/icd.d` subdirectory, and only falls back to `/usr/local/share:/usr/share` when `XDG_DATA_DIRS` is **unset**.

Inside a Linglong container the host `XDG_DATA_DIRS` — which on a Linyaps session points at Linyaps specific paths such as `/var/lib/linglong/entries/share` — can be forwarded into the container environment (e.g. via `forwardEnv()`). That overrides the loader's default search path, so the loader never scans `/usr/share/vulkan/icd.d` and enumerates no GPU.

This perfectly matches the reported symptoms:
- **OpenGL works** — Mesa locates DRI drivers through the compiled-in library path, independent of `XDG_DATA_DIRS`.
- **Vulkan fails** — the loader relies on `XDG_DATA_DIRS`-based discovery.
- **`VK_ICD_FILENAMES=...` works around it** (as the maintainer confirmed), because that variable bypasses the directory search.

## Fix

In `ContainerCfgBuilder::buildEnv()` (the central place where the container environment is assembled, used by both the `ll-cli` and UAB paths), ensure the conventional system data directories `/usr/share` and `/usr/local/share` are always part of `XDG_DATA_DIRS`:

- preserve any existing/forwarded value (host specific paths are kept),
- append the standard system directories when missing,
- avoid duplicates and avoid rewriting the value when nothing changes.

This lets the Vulkan loader (and any other XDG-data consumer) keep discovering system-provided data such as the Mesa Turnip driver manifest at `/usr/share/vulkan/icd.d`, without requiring users to export `VK_ICD_FILENAMES`.

## Files changed

- `libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp` — normalize `XDG_DATA_DIRS` in `buildEnv()`.
- `libs/linglong/tests/ll-tests/src/linglong/oci_cfg_generators/container_cfg_builder_test.cpp` — new regression tests.
- `libs/linglong/tests/ll-tests/CMakeLists.txt` — register the new test source.

## Verification

Configured with `cmake --preset debug` and built `linglong::linglong::ll-tests`:

```
cmake --build build --target linglong__linglong__ll-tests
```

Ran the new tests plus the surrounding runtime/env suites:

```
./ll-tests --gtest_filter='ContainerCfgBuilderEnvTest.*:RunContextTest.*:RunContainerOptionsTest.*'
```

Result: 23/23 passed. The three new tests cover:
1. `XDG_DATA_DIRS` unset → defaults added (`/usr/share`, `/usr/local/share`).
2. host value forwarded → preserved, with system dirs appended.
3. system dirs already present → no duplication, value untouched.

Full suite: 460 passed, 12 skipped (FUSE/display), 1 failure (`Error.WarpStdErrorCode`) which is pre-existing and environmental — it expects a non-root runner, while the CI sandbox runs as root so `create_directory("/no_permission_to_create")` succeeds.

`clang-format --dry-run --Werror` passes on both changed source files.

## Risk / assumptions

- The change only ever **adds** the standard system data directories to `XDG_DATA_DIRS`; it never removes existing entries, so application/desktop-entry data discovery is unaffected.
- This addresses ICD *discovery*. It assumes the runtime/base layer actually ships the driver manifest (the base runtime's `mesa-vulkan-drivers` provides the freedreno ICD, as confirmed by the maintainer's test showing driver `Mesa 24.3.0-1deepin1`).