### PR TITLE
fix(cli): wait out slow PackageManager1 activation (closes #1338)

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -330,14 +330,29 @@ Result<void> waitForDBusPeerReady(const QString &service,
 {
     LINGLONG_TRACE("wait for dbus peer ready");
 
-    auto peer = linglong::api::dbus::v1::DBusPeer(service, path, connection);
-    auto reply = peer.Ping();
-    reply.waitForFinished();
-    if (!reply.isValid()) {
-        return LINGLONG_ERR(reply.error().message().toStdString());
-    }
+    using namespace std::chrono_literals;
 
-    return LINGLONG_OK;
+    constexpr auto perCallTimeout = 5s;
+    constexpr auto retryInterval = 1s;
+    constexpr auto totalDeadline = 90s;
+
+    const auto startedAt = std::chrono::steady_clock::now();
+    while (true) {
+        auto peer = linglong::api::dbus::v1::DBusPeer(service, path, connection);
+        peer.setTimeout(static_cast<int>(std::chrono::milliseconds(perCallTimeout).count()));
+
+        auto reply = peer.Ping();
+        reply.waitForFinished();
+        if (reply.isValid()) {
+            return LINGLONG_OK;
+        }
+
+        if (std::chrono::steady_clock::now() - startedAt >= totalDeadline) {
+            return LINGLONG_ERR(reply.error().message().toStdString());
+        }
+
+        std::this_thread::sleep_for(retryInterval);
+    }
 }
 
 std::vector<std::string> getAutoModuleList() noexcept
@@ -1201,7 +1216,10 @@ Cli::initializeDBusPackageManager()
                                           "/org/deepin/linglong/PackageManager1",
                                           pkgManConn);
     if (!peerReady) {
-        return LINGLONG_ERR("Failed to activate org.deepin.linglong.PackageManager1", peerReady);
+        return LINGLONG_ERR("Failed to activate org.deepin.linglong.PackageManager1; check the "
+                            "daemon with 'systemctl status org.deepin.linglong.PackageManager' and "
+                            "'journalctl -u org.deepin.linglong.PackageManager -e'",
+                            peerReady);
     }
 
     return std::make_unique<api::dbus::v1::PackageManager>("org.deepin.linglong.PackageManager1",


### PR DESCRIPTION
## Summary

`ll-cli` failed with `Failed to activate org.deepin.linglong.PackageManager1 QDBusError("org.freedesktop.DBus.Error.NoReply", ...)` on systems such as Ubuntu Kylin 25.04 and Arch Linux (#1338), preventing installs from working even though the package itself was installed.

## Root cause

`Cli::initializeDBusPackageManager()` waits for the package manager daemon to be reachable by issuing a single `org.freedesktop.DBus.Peer.Ping()` (`libs/linglong/src/linglong/cli/cli.cpp`, `waitForDBusPeerReady`) using the default D-Bus call timeout of 25s.

The daemon (`org.deepin.linglong.PackageManager1`) is **D-Bus activated**: the first `Ping()` asks systemd to start `org.deepin.linglong.PackageManager.service` (`Type=dbus`), and the daemon only acquires its well-known bus name *after* starting up and initializing the local ostree repository. On a cold start (and on slower systems/distros), this whole sequence can take longer than the single 25s window, so the one-shot `Ping()` times out and `ll-cli` reports a hard, cryptic `NoReply` failure and aborts.

## Fix

`waitForDBusPeerReady` now **polls** instead of giving up on the first timeout:

- retry `Ping()` with a short per-call timeout (5s) up to an overall deadline of **90s**, which matches systemd's default `Type=dbus` unit timeout — so a slow but successful activation is waited out rather than treated as a failure;
- on success it returns immediately; on terminal failure after the deadline it surfaces the underlying error.

The `initializeDBusPackageManager()` error message now also points the user at the daemon service status and journal, so a genuinely broken daemon can be diagnosed:

```
Failed to activate org.deepin.linglong.PackageManager1; check the daemon with
'systemctl status org.deepin.linglong.PackageManager' and
'journalctl -u org.deepin.linglong.PackageManager -e'
```

The change applies to both activation paths (system bus and `--no-dbus` peer mode) since both go through `waitForDBusPeerReady`.

## Files changed

- `libs/linglong/src/linglong/cli/cli.cpp`
  - `waitForDBusPeerReady`: bounded retry loop with a per-call timeout and a 90s total deadline.
  - `Cli::initializeDBusPackageManager`: clearer, actionable activation error message.

## Verification

Built from source on Debian/trixie with the project's `debug` CMake preset (Qt5, ostree, systemd, etc.):

- `cmake --preset debug -G Ninja` configured cleanly.
- Built `linglong` lib, `ll-cli`, `ll-package-manager`, and `ll-tests` — all link successfully; no new warnings in the edited regions (remaining `-Wmissing-field-initializers` warnings are pre-existing in unrelated functions).
- `clang-format` (repo `.clang-format`) produces **zero** changes on the edited file.
- Targeted tests pass: `ll-tests --gtest_filter='Cli*:*RepoAndPackageManager*'` → **20/20 PASSED**.
- The 1 failing test (`Error.WarpStdErrorCode`) and the `LayerPackagerTest`/`UabFileTest` suite-setup failures are **pre-existing and environmental**: they reproduce identically on the unmodified tree (verified via `git stash`/rebuild) and are caused by running as root and missing FUSE tooling in this container, not by this change.

## Notes / assumptions

- The 90s overall deadline intentionally matches systemd's default `Type=dbus` `TimeoutSec` so the client waits at least as long as the daemon's supervisor does.
- `waitForDBusPeerReady` is a file-local helper, so the retry logic is covered indirectly by the existing `CliRepoAndPackageManager*` tests (which exercise the surrounding `getPkgMan`/`getRepo` flow). A direct unit test would require mocking a `QDBusConnection`, which is out of scope for this minimal fix.

Closes #1338.