### PR TITLE
refactor: make runtime config loading accept custom config dirs

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/utils/runtime_config_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/runtime_config_test.cpp
@@ -343,9 +343,9 @@ TEST(RuntimeConfigTest, LoadRuntimeConfigWithInstanceMounts)
     file << j.dump();
     file.close();
 
-    EnvironmentVariableGuard xdgGuard("XDG_CONFIG_HOME", tempDir.path().string());
+    std::vector<std::filesystem::path> configDirs = { tempDir.path() / "linglong" };
 
-    auto loadedDefault = linglong::utils::loadRuntimeConfig("test-app", "");
+    auto loadedDefault = linglong::utils::loadRuntimeConfig(configDirs, "test-app", "");
     ASSERT_TRUE(loadedDefault.has_value());
     EXPECT_TRUE(loadedDefault->has_value());
     auto &defaultConfig = **loadedDefault;
@@ -355,7 +355,7 @@ TEST(RuntimeConfigTest, LoadRuntimeConfigWithInstanceMounts)
     EXPECT_EQ(defaultConfig.mounts->at(0).destination, "/tmp/base");
     EXPECT_FALSE(defaultConfig.instances.has_value());
 
-    auto loadedDev = linglong::utils::loadRuntimeConfig("test-app", "dev");
+    auto loadedDev = linglong::utils::loadRuntimeConfig(configDirs, "test-app", "dev");
     ASSERT_TRUE(loadedDev.has_value());
     EXPECT_TRUE(loadedDev->has_value());
     auto &devConfig = **loadedDev;
@@ -409,9 +409,8 @@ TEST(RuntimeConfigTest, LoadRuntimeConfigWithConfigD)
         file << "runtime config drop-ins must use the .json suffix";
     }
 
-    EnvironmentVariableGuard xdgGuard("XDG_CONFIG_HOME", tempDir.path().string());
-
-    auto loaded = linglong::utils::loadRuntimeConfig("test-config-d", "");
+    std::vector<std::filesystem::path> configDirs = { tempDir.path() / "linglong" };
+    auto loaded = linglong::utils::loadRuntimeConfig(configDirs, "test-config-d", "");
     ASSERT_TRUE(loaded.has_value());
     ASSERT_TRUE(loaded->has_value());
 

--- a/libs/utils/src/linglong/utils/runtime_config.cpp
+++ b/libs/utils/src/linglong/utils/runtime_config.cpp
@@ -75,29 +75,6 @@ loadRuntimeConfigFromDir(const std::filesystem::path &configDir, const std::stri
     return linglong::utils::MergeRuntimeConfig(configs);
 }
 
-linglong::utils::error::Result<std::optional<RuntimeConfigure>>
-loadUserRuntimeConfig(const std::string &appId)
-{
-    LINGLONG_TRACE(
-      fmt::format("load user runtime config for {}", appId.empty() ? "global" : appId));
-
-    auto configDir = linglong::common::dir::getUserRuntimeConfigDir();
-    if (configDir.empty()) {
-        return std::nullopt;
-    }
-
-    return loadRuntimeConfigFromDir(configDir, appId);
-}
-
-linglong::utils::error::Result<std::optional<RuntimeConfigure>>
-loadSystemRuntimeConfig(const std::string &appId)
-{
-    LINGLONG_TRACE(
-      fmt::format("load system runtime config for {}", appId.empty() ? "global" : appId));
-
-    return loadRuntimeConfigFromDir(linglong::common::dir::getSystemRuntimeConfigDir(), appId);
-}
-
 } // namespace
 
 namespace linglong::utils {
@@ -207,38 +184,50 @@ utils::error::Result<std::optional<RuntimeConfigure>> loadRuntimeConfig(const st
     LINGLONG_TRACE("load runtime config for app: " + appId
                    + ", instance: " + (instance.empty() ? "(default)" : instance));
 
+    std::vector<std::filesystem::path> configDirs;
+    auto systemConfigDir = linglong::common::dir::getSystemRuntimeConfigDir();
+    if (!systemConfigDir.empty()) {
+        configDirs.emplace_back(std::move(systemConfigDir));
+    }
+    auto userConfigDir = linglong::common::dir::getUserRuntimeConfigDir();
+    if (!userConfigDir.empty()) {
+        configDirs.emplace_back(std::move(userConfigDir));
+    }
+    return loadRuntimeConfig(configDirs, appId, instance);
+}
+
+utils::error::Result<std::optional<RuntimeConfigure>>
+loadRuntimeConfig(const std::vector<std::filesystem::path> &configDirs,
+                  const std::string &appId,
+                  const std::string &instance)
+{
+    LINGLONG_TRACE("load runtime config for app: " + appId
+                   + ", instance: " + (instance.empty() ? "(default)" : instance));
+
     std::vector<RuntimeConfigure> configs;
 
-    auto systemGlobal = loadSystemRuntimeConfig("");
-    if (!systemGlobal) {
-        return LINGLONG_ERR(systemGlobal);
-    }
-    if (systemGlobal->has_value()) {
-        configs.emplace_back(std::move(systemGlobal->value()));
-    }
+    for (const auto &configDir : configDirs) {
+        if (configDir.empty()) {
+            continue;
+        }
 
-    auto systemApp = loadSystemRuntimeConfig(appId);
-    if (!systemApp) {
-        return LINGLONG_ERR(systemApp);
-    }
-    if (systemApp->has_value()) {
-        configs.emplace_back(std::move(systemApp->value()));
-    }
+        auto global = loadRuntimeConfigFromDir(configDir, "");
+        if (!global) {
+            return LINGLONG_ERR(global);
+        }
+        if (global->has_value()) {
+            configs.emplace_back(std::move(global->value()));
+        }
 
-    auto userGlobal = loadUserRuntimeConfig("");
-    if (!userGlobal) {
-        return LINGLONG_ERR(userGlobal);
-    }
-    if (userGlobal->has_value()) {
-        configs.emplace_back(std::move(userGlobal->value()));
-    }
-
-    auto userApp = loadUserRuntimeConfig(appId);
-    if (!userApp) {
-        return LINGLONG_ERR(userApp);
-    }
-    if (userApp->has_value()) {
-        configs.emplace_back(std::move(userApp->value()));
+        if (!appId.empty()) {
+            auto app = loadRuntimeConfigFromDir(configDir, appId);
+            if (!app) {
+                return LINGLONG_ERR(app);
+            }
+            if (app->has_value()) {
+                configs.emplace_back(std::move(app->value()));
+            }
+        }
     }
 
     if (configs.empty()) {

--- a/libs/utils/src/linglong/utils/runtime_config.h
+++ b/libs/utils/src/linglong/utils/runtime_config.h
@@ -9,6 +9,7 @@
 #include "linglong/utils/error/error.h"
 
 #include <filesystem>
+#include <vector>
 
 namespace linglong::utils {
 
@@ -18,5 +19,10 @@ utils::error::Result<linglong::api::types::v1::RuntimeConfigure>
 loadRuntimeConfig(const std::filesystem::path &path);
 utils::error::Result<std::optional<linglong::api::types::v1::RuntimeConfigure>>
 loadRuntimeConfig(const std::string &appId, const std::string &instance = "");
+
+utils::error::Result<std::optional<linglong::api::types::v1::RuntimeConfigure>>
+loadRuntimeConfig(const std::vector<std::filesystem::path> &configDirs,
+                  const std::string &appId,
+                  const std::string &instance = "");
 
 } // namespace linglong::utils


### PR DESCRIPTION
Refactor `loadRuntimeConfig` to separate config directory collection from loading logic. Introduce a new overload that accepts a vector of config directories, enabling test code to pass custom directories like a temporary test directory. The existing overload now collects system and user config directories and delegates to the new one. Previously, system and user config were loaded in separate hardcoded steps; now the logic iterates over all provided directories to load global and app-specific configs. This improves testability and reduces code duplication.

The test file is updated to use the new overload with a constructed `configDirs` vector, avoiding reliance on environment variables like `XDG_CONFIG_HOME` for test isolation.

Influence:
1. Test the new `loadRuntimeConfig(configDirs, appId, instance)` function with valid and invalid directories.
2. Verify the legacy overload still correctly finds system and user runtime configs.
3. Ensure config loading order respects the provided directory sequence (first matched global, then app-specific per directory).
4. Test with an empty directory list to confirm proper error handling.
5. Run the existing `LoadRuntimeConfigWithInstanceMounts` test to confirm it passes with the changed test code.