### PR TITLE
fix: Don't mount /etc/passwd and /etc/group in build mode

### DIFF
--- a/libs/linglong/src/linglong/runtime/container_builder.cpp
+++ b/libs/linglong/src/linglong/runtime/container_builder.cpp
@@ -396,7 +396,6 @@ auto ContainerBuilder::configureBuildContainer(PreparedContainer &prepared,
     LINGLONG_TRACE("configure build container");
 
     prepared.cfgBuilder.setBasePath(options.basePath, false)
-      .bindUserGroup()
       .forwardDefaultEnv()
       .appendEnv("LINYAPS_INIT_SINGLE_MODE", "1")
       .disableUserNamespace()


### PR DESCRIPTION
In build mode someone may rely on user/group in base environment