### PR TITLE
feat: embed prerelease and build metadata in version string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.11.4)
 
 project(
   linglong
-  VERSION 1.13.0
+  VERSION 1.14.0
   DESCRIPTION "a container based application package manager for Linux desktop"
   HOMEPAGE_URL "https://github.com/OpenAtom-Linyaps/linyaps"
   LANGUAGES CXX C)
@@ -15,10 +15,96 @@ set(LINGLONG_VERSION
     ""
     CACHE STRING "The version of linglong project.")
 
-if(NOT ("${LINGLONG_VERSION}" STREQUAL ""))
+if(NOT LINGLONG_VERSION STREQUAL "")
   message(STATUS "Project version has been overridden to ${LINGLONG_VERSION}")
   set(PROJECT_VERSION ${LINGLONG_VERSION})
 endif()
+
+set(LINGLONG_RELEASE
+    OFF
+    CACHE BOOL "Build a release version of the project.")
+set(LINGLONG_GIT_HASH
+    ""
+    CACHE STRING "The Git commit hash included in the build metadata.")
+set(LINGLONG_BUILD_CHANNEL
+    ""
+    CACHE STRING "The build channel included in the build metadata.")
+
+if(NOT PROJECT_VERSION MATCHES "^[0-9]+\\.[0-9]+\\.[0-9]+$")
+  message(FATAL_ERROR "LINGLONG_VERSION must use the major.minor.patch format")
+endif()
+
+if(LINGLONG_GIT_HASH STREQUAL "" AND NOT LINGLONG_RELEASE)
+  execute_process(
+    COMMAND git rev-parse --git-path HEAD
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    OUTPUT_VARIABLE LINGLONG_GIT_HEAD_FILE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE LINGLONG_GIT_HEAD_RESULT
+    ERROR_QUIET)
+  if(LINGLONG_GIT_HEAD_RESULT EQUAL 0)
+    get_filename_component(
+      LINGLONG_GIT_HEAD_FILE "${LINGLONG_GIT_HEAD_FILE}" ABSOLUTE
+      BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+    set_property(
+      DIRECTORY APPEND
+      PROPERTY CMAKE_CONFIGURE_DEPENDS "${LINGLONG_GIT_HEAD_FILE}")
+
+    execute_process(
+      COMMAND git symbolic-ref -q HEAD
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+      OUTPUT_VARIABLE LINGLONG_GIT_REF
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      RESULT_VARIABLE LINGLONG_GIT_REF_RESULT
+      ERROR_QUIET)
+    if(LINGLONG_GIT_REF_RESULT EQUAL 0)
+      execute_process(
+        COMMAND git rev-parse --git-path "${LINGLONG_GIT_REF}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        OUTPUT_VARIABLE LINGLONG_GIT_REF_FILE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE LINGLONG_GIT_REF_FILE_RESULT
+        ERROR_QUIET)
+      if(LINGLONG_GIT_REF_FILE_RESULT EQUAL 0)
+        get_filename_component(
+          LINGLONG_GIT_REF_FILE "${LINGLONG_GIT_REF_FILE}" ABSOLUTE
+          BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+        set_property(
+          DIRECTORY APPEND
+          PROPERTY CMAKE_CONFIGURE_DEPENDS "${LINGLONG_GIT_REF_FILE}")
+      endif()
+    endif()
+  endif()
+
+  execute_process(
+    COMMAND git rev-parse --short=7 HEAD
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    OUTPUT_VARIABLE LINGLONG_GIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET)
+endif()
+
+if(NOT LINGLONG_GIT_HASH STREQUAL ""
+   AND NOT LINGLONG_GIT_HASH MATCHES "^[0-9A-Fa-f]+$")
+  message(FATAL_ERROR "LINGLONG_GIT_HASH must be a Git hash")
+endif()
+
+set(LINGLONG_BUILDINFO "${LINGLONG_GIT_HASH}")
+if(NOT LINGLONG_BUILD_CHANNEL STREQUAL "")
+  if(NOT LINGLONG_BUILDINFO STREQUAL "")
+    string(APPEND LINGLONG_BUILDINFO ".")
+  endif()
+  string(APPEND LINGLONG_BUILDINFO "${LINGLONG_BUILD_CHANNEL}")
+endif()
+set(LINGLONG_VERSION_FULL "${PROJECT_VERSION}")
+if(NOT LINGLONG_RELEASE)
+  string(APPEND LINGLONG_VERSION_FULL "-dev")
+endif()
+if(NOT LINGLONG_BUILDINFO STREQUAL "")
+  string(APPEND LINGLONG_VERSION_FULL "+${LINGLONG_BUILDINFO}")
+endif()
+
+message(STATUS "Linglong version: ${LINGLONG_VERSION_FULL}")
 
 set(ENABLE_LINGLONG_APP_BUILDER_UTILS
     OFF

--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -666,7 +666,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     CLI11_PARSE(commandParser, argc, argv);
 
     if (versionFlag) {
-        std::cout << _("linyaps build tool version ") << LINGLONG_VERSION << std::endl;
+        std::cout << _("linyaps build tool version ") << LINGLONG_VERSION_FULL << std::endl;
         return 0;
     }
 

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -688,9 +688,9 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     // print version if --version flag is set
     if (*versionFlag) {
         if (*jsonFlag) {
-            std::cout << nlohmann::json{ { "version", LINGLONG_VERSION } } << std::endl;
+            std::cout << nlohmann::json{ { "version", LINGLONG_VERSION_FULL } } << std::endl;
         } else {
-            std::cout << _("linyaps CLI version ") << LINGLONG_VERSION << std::endl;
+            std::cout << _("linyaps CLI version ") << LINGLONG_VERSION_FULL << std::endl;
         }
         return 0;
     }

--- a/apps/ll-dialog/src/main.cpp
+++ b/apps/ll-dialog/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -187,7 +187,7 @@ int main(int argc, char *argv[])
     QApplication app{ argc, argv };
     Q_INIT_RESOURCE(cache_dialog_resource);
     QApplication::setApplicationName("ll-dialog");
-    QApplication::setApplicationVersion(LINGLONG_VERSION);
+    QApplication::setApplicationVersion(LINGLONG_VERSION_FULL);
 
     QCommandLineParser parser;
     parser.setApplicationDescription("dialog for interaction");

--- a/configure.h.in
+++ b/configure.h.in
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+ * SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
@@ -14,6 +14,9 @@
 #define LINGLONG_DATA_DIR "@CMAKE_INSTALL_FULL_DATADIR@/linglong"
 #define LINGLONG_USERNAME "@LINGLONG_USERNAME@"
 #define LINGLONG_VERSION "@PROJECT_VERSION@"
+#cmakedefine01 LINGLONG_RELEASE
+#define LINGLONG_BUILDINFO "@LINGLONG_BUILDINFO@"
+#define LINGLONG_VERSION_FULL "@LINGLONG_VERSION_FULL@"
 #define LINGLONG_LIBEXEC_DIR "@CMAKE_INSTALL_FULL_LIBEXECDIR@/linglong"
 #define LINGLONG_DEFAULT_OCI_RUNTIME "@LINGLONG_DEFAULT_OCI_RUNTIME@"
 #define LINGLONG_UAB_DATA_LOCATION "@CMAKE_INSTALL_FULL_LIBDIR@/linglong/builder/uab"

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -2190,7 +2190,7 @@ void Builder::takeTerminalForeground()
 void Builder::printBasicInfo()
 {
     printMessage("[Builder info]");
-    printMessage(std::string("Linglong Builder Version: ") + LINGLONG_VERSION, 2);
+    printMessage(std::string("Linglong Builder Version: ") + LINGLONG_VERSION_FULL, 2);
     printMessage("[Build Target]");
     const auto &project = *this->project;
     printMessage(project.package.id, 2);

--- a/libs/linglong/src/linglong/repo/client_factory.h
+++ b/libs/linglong/src/linglong/repo/client_factory.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+ * SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
@@ -87,7 +87,7 @@ public:
 
 private:
     apiClient_t *client;
-    std::string m_user_agent = "linglong/" LINGLONG_VERSION;
+    std::string m_user_agent = "linglong/" LINGLONG_VERSION_FULL;
 };
 
 class ClientFactory

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -1356,7 +1356,7 @@ GVariantBuilder OSTreeRepo::initOStreePullOptions(const std::string &ref) noexce
     std::array<const char *, 2> refs{ ref.c_str(), nullptr };
     GVariantBuilder builder;
     g_variant_builder_init(&builder, G_VARIANT_TYPE("a{sv}"));
-    std::string userAgent = "linglong/" LINGLONG_VERSION;
+    std::string userAgent = "linglong/" LINGLONG_VERSION_FULL;
     g_variant_builder_add(&builder,
                           "{s@v}",
                           "append-user-agent",


### PR DESCRIPTION
Introduce LINGLONG_PRERELEASE, LINGLONG_GIT_HASH, and LINGLONG_BUILD_CHANNEL CMake cache variables adn derive LINGLONG_VERSION_FULL as major.minor.patch[-prerelease][+buildinfo]. For prerelease builds the git short hash is auto-detected and tracked via CMAKE_CONFIGURE_DEPENDS so CMake reconfigures when HEAD changes.

Start development of version 1.14.0