### PR TITLE
fix: avoid missing task state if task if removed quickly

### DIFF
--- a/api/dbus/org.deepin.linglong.PackageManager1.xml
+++ b/api/dbus/org.deepin.linglong.PackageManager1.xml
@@ -80,6 +80,9 @@ SPDX-License-Identifier: LGPL-3.0-or-later
     </signal>
     <signal name="TaskRemoved">
       <arg name="task" type="o" />
+      <arg name="state" type="i" />
+      <arg name="code" type="i" />
+      <arg name="message" type="s" />
     </signal>
     <signal name="RequestInteraction">
       <arg name="task" type="o" />

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -778,6 +778,7 @@ void Cli::onTaskPropertiesChanged(
         return;
     }
 
+    const auto previousState = taskState.state;
     for (auto entry = changed_properties.cbegin(); entry != changed_properties.cend(); ++entry) {
         const auto &key = entry.key();
         const auto &value = entry.value();
@@ -828,7 +829,7 @@ void Cli::onTaskPropertiesChanged(
         }
     }
 
-    handleTaskState();
+    handleTaskState(previousState);
 }
 
 void Cli::interaction(const QDBusObjectPath &object_path,
@@ -909,11 +910,34 @@ void Cli::onTaskAdded(const QDBusObjectPath &object_path)
     LogD("task added: {}", object_path.path().toStdString());
 }
 
-void Cli::onTaskRemoved(const QDBusObjectPath &object_path)
+void Cli::onTaskRemoved(const QDBusObjectPath &object_path,
+                        int state,
+                        int code,
+                        const QString &message)
 {
     LogD("task removed: {}", object_path.path().toStdString());
     if (object_path.path() != taskObjectPath) {
         return;
+    }
+
+    if (task) {
+        if (auto pkgMan = this->getPkgMan()) {
+            (*pkgMan)->connection().disconnect(
+              (*pkgMan)->service(),
+              taskObjectPath,
+              "org.freedesktop.DBus.Properties",
+              "PropertiesChanged",
+              this,
+              SLOT(onTaskPropertiesChanged(QString, QVariantMap, QStringList)));
+        }
+
+        onTaskPropertiesChanged(task->interface(),
+                                {
+                                  { "State", state },
+                                  { "Code", code },
+                                  { "Message", message },
+                                },
+                                {});
     }
 
     delete task;
@@ -921,7 +945,7 @@ void Cli::onTaskRemoved(const QDBusObjectPath &object_path)
     Q_EMIT taskDone();
 }
 
-void Cli::handleTaskState() noexcept
+void Cli::handleTaskState(api::types::v1::State previousState) noexcept
 {
     if (taskState.state == api::types::v1::State::Unknown) {
         LogW("task state is unknown");
@@ -930,14 +954,18 @@ void Cli::handleTaskState() noexcept
 
     if (taskState.state == api::types::v1::State::Failed
         || taskState.state == api::types::v1::State::Canceled) {
-        this->printer.clearLine();
-        this->printOnTaskFailed();
+        if (taskState.state != previousState) {
+            this->printer.clearLine();
+            this->printOnTaskFailed();
+        }
         return;
     }
 
     if (taskState.state == api::types::v1::State::Succeed) {
-        this->printer.clearLine();
-        this->printOnTaskSuccess();
+        if (taskState.state != previousState) {
+            this->printer.clearLine();
+            this->printOnTaskSuccess();
+        }
         return;
     }
 
@@ -957,6 +985,9 @@ void Cli::printOnTaskFailed()
         handleInstallError(
           error,
           std::get<api::types::v1::PackageManager1InstallParameters>(taskState.params));
+        break;
+    case TaskType::InstallFromFile:
+        handleInstallFromFileError(error);
         break;
     case TaskType::Uninstall:
         handleUninstallError(error);
@@ -1067,7 +1098,7 @@ utils::error::Result<api::dbus::v1::PackageManager *> Cli::getPkgMan()
                       pkgManProxy->interface(),
                       "TaskRemoved",
                       this,
-                      SLOT(onTaskRemoved(QDBusObjectPath)))) {
+                      SLOT(onTaskRemoved(QDBusObjectPath, int, int, QString)))) {
         return LINGLONG_ERR("couldn't connect to package manager signal 'TaskRemoved'");
     }
 
@@ -1815,7 +1846,7 @@ int Cli::installFromFile(const QFileInfo &fileInfo,
                                                    common::serialize::toQVariantMap(commonOptions));
     auto res = waitTaskCreated(pendingReply, TaskType::InstallFromFile);
     if (!res) {
-        this->handleCommonError(res.error());
+        this->handleInstallFromFileError(res.error());
         return -1;
     }
 
@@ -3091,11 +3122,15 @@ utils::error::Result<void> Cli::syncTaskProperties()
     QDBusReply<QVariantMap> reply =
       properties.call("GetAll", QStringLiteral("org.deepin.linglong.Task1"));
     if (!reply.isValid()) {
-        return LINGLONG_ERR(
-          fmt::format("failed to get task properties: {}", reply.error().message().toStdString()));
+        if (reply.error().type() == QDBusError::UnknownObject) {
+            return LINGLONG_OK;
+        }
+
+        return LINGLONG_ERR(reply.error().message().toStdString());
     }
 
     this->onTaskPropertiesChanged(QStringLiteral("org.deepin.linglong.Task1"), reply.value(), {});
+
     return LINGLONG_OK;
 }
 
@@ -3172,10 +3207,7 @@ void Cli::handleInstallError(const utils::error::Error &error,
         this->printer.printMessage(_("The module could not be found remotely."));
         break;
     case utils::error::ErrorCode::AppInstallAlreadyInstalled:
-        this->printer.printMessage(
-          fmt::format(_("Application already installed, If you want to replace it, try using "
-                        "'ll-cli install {} --force'"),
-                      params.package.id));
+        this->printer.printMessage(_("Application already installed"));
         break;
     case utils::error::ErrorCode::AppInstallNotFoundFromRemote:
         this->printer.printMessage(
@@ -3193,6 +3225,25 @@ void Cli::handleInstallError(const utils::error::Error &error,
     case utils::error::ErrorCode::Unknown:
     case utils::error::ErrorCode::AppInstallFailed:
         this->printer.printMessage(_("Install failed"));
+        break;
+    default:
+        if (!handleCommonError(error)) {
+            return;
+        }
+        break;
+    }
+
+    if (this->globalOptions.verbose) {
+        this->printer.printErr(error);
+    }
+}
+
+void Cli::handleInstallFromFileError(const utils::error::Error &error)
+{
+    auto errorCode = static_cast<utils::error::ErrorCode>(error.code());
+    switch (errorCode) {
+    case utils::error::ErrorCode::AppInstallAlreadyInstalled:
+        this->printer.printMessage(_("Application already installed"));
         break;
     default:
         if (!handleCommonError(error)) {

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -282,9 +282,10 @@ private:
                                                TaskType type);
     void waitTaskDone();
 
-    void handleTaskState() noexcept;
+    void handleTaskState(api::types::v1::State previousState) noexcept;
     void handleInstallError(const utils::error::Error &error,
                             const api::types::v1::PackageManager1InstallParameters &params);
+    void handleInstallFromFileError(const utils::error::Error &error);
     void handleUninstallError(const utils::error::Error &error);
     void handleUpgradeError(const utils::error::Error &error);
     bool handleCommonError(const utils::error::Error &error);
@@ -294,7 +295,8 @@ private:
 private Q_SLOTS:
     // maybe use in the future
     void onTaskAdded(const QDBusObjectPath &object_path);
-    void onTaskRemoved(const QDBusObjectPath &object_path);
+    void
+    onTaskRemoved(const QDBusObjectPath &object_path, int state, int code, const QString &message);
     void onTaskPropertiesChanged(const QString &interface,
                                  const QVariantMap &changed_properties,
                                  const QStringList &invalidated_properties);

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -143,7 +143,10 @@ void PackageManager::initDaemonMode(bool peerMode) noexcept
         }
 
         if (PackageTask *task = dynamic_cast<PackageTask *>(&(*ret).get()); task != nullptr) {
-            Q_EMIT TaskRemoved(QDBusObjectPath{ task->taskObjectPath().c_str() });
+            Q_EMIT TaskRemoved(QDBusObjectPath{ task->taskObjectPath().c_str() },
+                               task->getPropertyState(),
+                               task->getPropertyCode(),
+                               task->getPropertyMessage());
         }
     });
 

--- a/libs/linglong/src/linglong/package_manager/package_manager.h
+++ b/libs/linglong/src/linglong/package_manager/package_manager.h
@@ -114,7 +114,7 @@ public
 
 Q_SIGNALS:
     void TaskAdded(QDBusObjectPath object_path);
-    void TaskRemoved(QDBusObjectPath object_path);
+    void TaskRemoved(QDBusObjectPath object_path, int state, int code, QString message);
     void RequestInteraction(QDBusObjectPath object_path,
                             int messageID,
                             QVariantMap additionalMessage);


### PR DESCRIPTION
Extend the TaskRemoved D-Bus signal with state/code/message so the CLI can apply the final task state even when the PropertiesChanged signal is missed. handleTaskState now tracks previousState and only prints the success/failure message on a real state transition.

syncTaskProperties now treats UnknownObject as success (the task is already gone) instead of returning an error.