### PR TITLE
[refactor][uab] Rework signal handling with atomic flag, sigsuspend and pre-fork signal check

### DIFF
--- a/apps/uab/header/src/main.cpp
+++ b/apps/uab/header/src/main.cpp
@@ -34,6 +34,7 @@ namespace {
 
 std::atomic_bool mountFlag{ false };  // NOLINT
 std::atomic_bool createFlag{ false }; // NOLINT
+volatile sig_atomic_t signalReceived{ 0 }; // NOLINT
 std::filesystem::path mountPoint;     // NOLINT
 constexpr std::size_t default_page_size = 4096;
 
@@ -372,8 +373,7 @@ void handleSig() noexcept
     struct sigaction sa{};
 
     sa.sa_handler = [](int sig) -> void {
-        // TODO: maybe not async safe, find a better way to handle signal
-        cleanAndExit(128 + sig);
+        signalReceived = sig;
     };
     sa.sa_mask = blocking_mask;
     sa.sa_flags = 0;
@@ -381,6 +381,12 @@ void handleSig() noexcept
     for (auto sig : quitSignals) {
         sigaction(sig, &sa, nullptr);
     }
+
+    // Block the signals so they are not delivered until we call sigsuspend.
+    // This prevents the race condition between checking signalReceived and
+    // calling pause(), where a signal arriving between the check and pause()
+    // would cause pause() to block indefinitely.
+    sigprocmask(SIG_BLOCK, &blocking_mask, nullptr);
 }
 
 int createMountPoint(std::string_view uuid) noexcept
@@ -684,9 +690,17 @@ int main(int argc, char **argv)
 
     bool mountOnly = !opts.mountPath.empty();
     if (mountOnly) {
-        while (true) {
-            pause();
+        // Use sigsuspend instead of pause() to avoid a race condition.
+        // Signals are already blocked by handleSig() via sigprocmask(SIG_BLOCK).
+        // sigsuspend atomically unblocks the signals and waits, so no signal
+        // can be missed between checking signalReceived and waiting.
+        sigset_t empty_mask;
+        sigemptyset(&empty_mask);
+        while (signalReceived == 0) {
+            sigsuspend(&empty_mask);
         }
+        // Signal received - perform cleanup in a safe context (not from signal handler)
+        cleanAndExit(128 + signalReceived);
     }
 
     if (!opts.extractPath.empty()) {

--- a/apps/uab/header/src/main.cpp
+++ b/apps/uab/header/src/main.cpp
@@ -32,10 +32,10 @@ extern "C" int erofsfuse_main(int argc, char **argv);
 
 namespace {
 
-std::atomic_bool mountFlag{ false };  // NOLINT
-std::atomic_bool createFlag{ false }; // NOLINT
+std::atomic_bool mountFlag{ false };       // NOLINT
+std::atomic_bool createFlag{ false };      // NOLINT
 volatile sig_atomic_t signalReceived{ 0 }; // NOLINT
-std::filesystem::path mountPoint;     // NOLINT
+std::filesystem::path mountPoint;          // NOLINT
 constexpr std::size_t default_page_size = 4096;
 
 constexpr auto usage = u8R"(Linglong Universal Application Bundle
@@ -90,7 +90,9 @@ std::size_t getChunkSize(std::size_t bundleSize) noexcept
     }
 
     std::size_t block_size{ 0 };
+
     struct statvfs fs_info{};
+
     if (statvfs(".", &fs_info) > 0) {
         block_size = fs_info.f_bsize;
     }
@@ -320,7 +322,8 @@ void cleanResource() noexcept
 
     auto pid = fork();
     if (pid < 0) {
-        std::cerr << "fork() error" << ": " << ::strerror(errno) << std::endl;
+        std::cerr << "fork() error"
+                  << ": " << ::strerror(errno) << std::endl;
         return;
     }
 
@@ -502,7 +505,8 @@ int runAppLoader(const std::vector<std::string_view> &loaderArgs) noexcept
 
     auto loaderPid = fork();
     if (loaderPid < 0) {
-        std::cerr << "fork() error" << ": " << ::strerror(errno) << std::endl;
+        std::cerr << "fork() error"
+                  << ": " << ::strerror(errno) << std::endl;
         return errno;
     }
 

--- a/apps/uab/loader/src/main.cpp
+++ b/apps/uab/loader/src/main.cpp
@@ -31,6 +31,8 @@ namespace {
 
 std::filesystem::path containerBundle;
 
+volatile sig_atomic_t signalReceived{ 0 };
+
 std::string genRandomString() noexcept
 {
     std::random_device rd;
@@ -86,7 +88,7 @@ void handleSig() noexcept
     struct sigaction sa{};
 
     sa.sa_handler = [](int sig) -> void {
-        cleanAndExit(128 + sig);
+        signalReceived = sig;
     };
     sa.sa_mask = blocking_mask;
     sa.sa_flags = 0;
@@ -94,6 +96,11 @@ void handleSig() noexcept
     for (auto sig : quitSignals) {
         sigaction(sig, &sa, nullptr);
     }
+
+    // Block the signals so they are not delivered until we explicitly check.
+    // This prevents race conditions where a signal arrives between checking
+    // signalReceived and a blocking call.
+    sigprocmask(SIG_BLOCK, &blocking_mask, nullptr);
 }
 
 std::optional<linglong::api::types::v1::PackageInfoV2>
@@ -593,6 +600,10 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv) // NOLINT
         std::cout << json.dump(4) << std::endl;
     }
 
+    if (signalReceived != 0) {
+        cleanAndExit(128 + signalReceived);
+    }
+
     auto bundleArg = "--bundle=" + containerBundle.string();
     auto pid = fork();
     if (pid < 0) {
@@ -613,6 +624,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv) // NOLINT
 
     int wstatus{ 0 };
     if (auto ret = ::waitpid(pid, &wstatus, 0); ret == -1) {
+        if (signalReceived != 0) {
+            cleanAndExit(128 + signalReceived);
+        }
         std::cerr << "waitpid() err:" << ::strerror(errno) << std::endl;
         return -1;
     }


### PR DESCRIPTION
## Summary
Refactor the signal processing logic of UAB to resolve race conditions and improve signal safety, using atomic flag and POSIX signal API standardization.

## Core Changes
1. Introduce a global volatile sig_atomic_t flag `signalReceived{0}`; signal handlers only assign value to this flag without heavy logic.
2. Block incoming signals at the end of `handleSig()` via `sigprocmask(SIG_BLOCK, &blocking_mask, nullptr)`.
3. Replace unsafe `pause()` with atomic waiting `sigsuspend(&empty_mask)` under mount-only mode.
4. Trigger cleanup and exit routine `cleanAndExit(128 + signalReceived)` after catching signal, passing signal number to exit code.
5. Add pre-fork signal detection in loader: skip fork operation immediately if signal has already been received.
6. Check signal flag after `waitpid()` in loader; terminate child process and exit the whole program if signal caught.

## Modified Files
- `apps/uab/header/src/main.cpp`
- `apps/uab/loader/src/main.cpp`

## Benefits
- Avoid undefined behavior caused by non-async-signal-safe operations inside signal handlers
- Eliminate race window between pause() and signal delivery with sigsuspend atomic wait
- Early abort fork logic when shutdown signal arrives in advance
- Uniform exit code convention combining standard exit code base and signal number
- Prevent orphan child processes after signal reception