### PR TITLE
[fix][dbus] Improve vague error messages for D-Bus service register/unregister failures

### DIFF
--- a/libs/linglong/src/linglong/common/dbus/register.h
+++ b/libs/linglong/src/linglong/common/dbus/register.h
@@ -44,13 +44,15 @@ inline void unregisterDBusObject(QDBusConnection conn, const QString &path)
         return LINGLONG_OK;
     }
 
-    // FIXME: use real ERROR CODE defined in API.
     if (conn.lastError().isValid()) {
-        return LINGLONG_ERR(
-          fmt::format("{}: {}", conn.lastError().name(), conn.lastError().message()));
+        return LINGLONG_ERR(fmt::format("failed to register D-Bus service '{}': {}",
+                                        serviceName,
+                                        conn.lastError().message()),
+                            utils::error::ErrorCode::Failed);
     }
 
-    return LINGLONG_ERR("service name existed.");
+    return LINGLONG_ERR(fmt::format("D-Bus service name '{}' already registered", serviceName),
+                        utils::error::ErrorCode::Failed);
 }
 
 [[nodiscard]] inline auto unregisterDBusService(QDBusConnection conn, const QString &serviceName)
@@ -63,13 +65,15 @@ inline void unregisterDBusObject(QDBusConnection conn, const QString &path)
         return LINGLONG_OK;
     }
 
-    // FIXME: use real ERROR CODE defined in API.
     if (conn.lastError().isValid()) {
-        return LINGLONG_ERR(
-          fmt::format("{}: {}", conn.lastError().name(), conn.lastError().message()));
+        return LINGLONG_ERR(fmt::format("failed to unregister D-Bus service '{}': {}",
+                                        serviceName,
+                                        conn.lastError().message()),
+                            utils::error::ErrorCode::Failed);
     }
 
-    return LINGLONG_ERR("unknown");
+    return LINGLONG_ERR(fmt::format("D-Bus service name '{}' not found", serviceName),
+                        utils::error::ErrorCode::Failed);
 }
 
 } // namespace linglong::common::dbus


### PR DESCRIPTION
## Summary
Original error messages for D-Bus service registration and unregistration failures were overly generic and lack necessary context:
1. Registration conflict only showed `service name existed.`
2. Unregistration failure only showed `unknown`
Both messages missed the target service name and corresponding error code.

## Changes
1. Registration conflict error in `registerDBusService`
   Replace plain text `service name existed.` with formatted message:
   `fmt::format("D-Bus service name '{}' already registered", serviceName)`
   Attach `ErrorCode::Failed` to the error.

2. Not-found error in `unregisterDBusService`
   Replace plain text `unknown` with formatted message:
   `fmt::format("D-Bus service name '{}' not found", serviceName)`
   Attach `ErrorCode::Failed` to the error.

## Modified File
- `libs/linglong/src/linglong/common/dbus/register.h`

## Benefits
- Error logs include exact D-Bus service name for quick troubleshooting
- Distinct human-readable text differentiates duplicate registration vs missing unregister cases
- Standardized error code attached uniformly for upstream error handling