### PR TITLE
[refactor][utils] Replace thread-unsafe strerror() with C++ standard error message API

### DIFF
--- a/apps/uab/loader/src/main.cpp
+++ b/apps/uab/loader/src/main.cpp
@@ -596,7 +596,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv) // NOLINT
     auto bundleArg = "--bundle=" + containerBundle.string();
     auto pid = fork();
     if (pid < 0) {
-        std::cerr << "fork() err: " << ::strerror(errno) << std::endl;
+        std::cerr << "fork() err: " << std::generic_category().message(errno) << std::endl;
         return -1;
     }
 
@@ -613,7 +613,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv) // NOLINT
 
     int wstatus{ 0 };
     if (auto ret = ::waitpid(pid, &wstatus, 0); ret == -1) {
-        std::cerr << "waitpid() err:" << ::strerror(errno) << std::endl;
+        std::cerr << "waitpid() err:" << std::generic_category().message(errno) << std::endl;
         return -1;
     }
 

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -1443,8 +1443,9 @@ utils::error::Result<void> ContainerCfgBuilder::buildMountNetworkConf() noexcept
                 std::array<char, PATH_MAX + 1> buf{};
                 auto *rpath = realpath(resolvConf.string().c_str(), buf.data());
                 if (rpath == nullptr) {
-                    return LINGLONG_ERR(
-                      fmt::format("Failed to read symlink {}: {}", resolvConf, strerror(errno)));
+                    return LINGLONG_ERR(fmt::format("Failed to read symlink {}: {}",
+                                                    resolvConf,
+                                                    std::generic_category().message(errno)));
                 }
                 target = std::filesystem::path{ rpath };
             }
@@ -2319,8 +2320,9 @@ ContainerCfgBuilder::mountBind(const ocppi::runtime::config::types::Mount &mount
     }
 
     if (::mount(mount.source->c_str(), mount.destination.c_str(), "", flags, nullptr) != 0) {
-        return LINGLONG_ERR(
-          fmt::format("failed to mount {}: {}", mount.source.value(), strerror(errno)));
+        return LINGLONG_ERR(fmt::format("failed to mount {}: {}",
+                                        mount.source.value(),
+                                        std::generic_category().message(errno)));
     }
 
     return LINGLONG_OK;


### PR DESCRIPTION
## Summary
The C `strerror()` function for system error reporting violates C++ idioms and is not thread-safe under multi-threaded environments. This PR refactors all relevant error message generation to use standard C++ error utilities.

## Changes
1. `apps/uab/loader/src/main.cpp`
   Substitute `::strerror(errno)` with `std::generic_category().message(errno)` in error logging paths of `fork()` and `waitpid()`.

2. `libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp`
   Replace `strerror(errno)` with `std::generic_category().message(errno)` for error reporting of `readlink()` and `mount()` invocations.

## Modified Files
- `apps/uab/loader/src/main.cpp`
- `libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp`

## Advantages
1. Aligns with modern C++ error handling practices instead of outdated C interfaces
2. Fixes thread-safety hazards caused by non-reentrant `strerror()`
3. Provides consistent system error descriptions through standard C++ error category APIs