### PR TITLE
[fix][packager] Avoid throwing exceptions in LayerPackager destructor when cleaning work directory

### DIFF
--- a/libs/linglong/src/linglong/package/layer_packager.cpp
+++ b/libs/linglong/src/linglong/package/layer_packager.cpp
@@ -89,8 +89,10 @@ LayerPackager::~LayerPackager()
                  (this->workDir / "unpack").string());
         }
     }
-    if (!std::filesystem::remove_all(this->workDir)) {
-        LogE("failed to remove {}", this->workDir);
+    std::error_code ec;
+    std::filesystem::remove_all(this->workDir, ec);
+    if (ec) {
+        LogE("failed to remove {}: {}", this->workDir, ec.message());
     }
 }
 


### PR DESCRIPTION
## Summary
The call `std::filesystem::remove_all(this->workDir)` inside the LayerPackager destructor is capable of throwing exceptions. Throwing exceptions from a destructor invokes `std::terminate` and results in undefined behavior.

## Changes
1. Use the `std::error_code` overloaded overload of remove_all:
`std::filesystem::remove_all(this->workDir, ec)`
2. Add error judgment logic:
```cpp
if (ec) {
  LogE("failed to remove {}: {}", this->workDir, ec.message());
}