### PR TITLE
[fix][uab] Fix out-of-bounds read in UABFile::verify() by tracking bundle section remaining length

### DIFF
--- a/libs/linglong/src/linglong/package/uab_file.cpp
+++ b/libs/linglong/src/linglong/package/uab_file.cpp
@@ -168,12 +168,16 @@ utils::error::Result<bool> UABFile::verify() noexcept
         seek(0);
     });
 
-    auto bundleLength = bundleSh->sh_size;
-    auto readBytes = buf.size();
+    auto bundleLength = static_cast<qint64>(bundleSh->sh_size);
     int bytesRead{ 0 };
-    while ((bytesRead = read(buf.data(), readBytes)) != 0) {
+    while (bundleLength > 0) {
+        auto readBytes = std::min(static_cast<qint64>(buf.size()), bundleLength);
+        bytesRead = read(buf.data(), readBytes);
         if (bytesRead == -1) {
             return LINGLONG_ERR(fmt::format("read error: {}", errorString()));
+        }
+        if (bytesRead == 0) {
+            return LINGLONG_ERR("unexpected end of bundle section data");
         }
         cryptor.addData(
 #if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
@@ -184,12 +188,9 @@ utils::error::Result<bool> UABFile::verify() noexcept
 #endif
         );
         bundleLength -= bytesRead;
-        if (bundleLength <= 0) {
-            digest = cryptor.result().toHex().toStdString();
-            break;
-        }
     }
 
+    digest = cryptor.result().toHex().toStdString();
     return (expectedDigest == digest);
 }
 


### PR DESCRIPTION
## Summary
The loop in `UABFile::verify()` used `read(...) != 0` as termination condition without tracking the remaining length of the bundle section.
If the file is corrupted and contains data exceeding `bundleSh->sh_size`, the loop would read excess data and generate incorrect checksum digest.

## Changes
1. Introduce a length tracker variable:
`auto bundleLength = static_cast<qint64>(bundleSh->sh_size)`
2. Update loop condition to `while (bundleLength > 0)`
3. Cap each read size with `std::min(buf.size(), bundleLength)` to avoid overreading
4. Add EOF detection: return error `LINGLONG_ERR("unexpected end of bundle section data")` if `bytesRead == 0`
5. Subtract read bytes from remaining length each iteration: `bundleLength -= bytesRead`
6. Compute digest only after the loop completes: `digest = cryptor.result().toHex().toStdString()`

## Modified File
- `libs/linglong/src/linglong/package/uab_file.cpp`

## Benefits
- Prevent out-of-bounds reading beyond the declared bundle section size
- Avoid invalid hash digest caused by corrupted oversized bundle data
- Early error report for truncated bundle files with unexpected EOF
- Strictly follow the section size defined in bundle header