### PR TITLE
[fix][package-manager] Validate binary/runtime base module before installing additional modules

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -604,8 +604,25 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
       api::types::v1::InteractionMessageType::Install;
 
     additionalMessage.remoteRef = packageRef.toString();
-    // TODO: when install extra module, we should check the same version of main(binary/runtime)
-    // module has been installed or not
+    // When installing an extra module (non-binary, non-runtime), verify that the
+    // corresponding binary module of the same version is already installed.
+    if (packageInfo.packageInfoV2Module != "binary"
+        && packageInfo.packageInfoV2Module != "runtime") {
+        auto mainModuleLayerDir = this->repo->getLayerDir(packageRef, "binary");
+        if (!mainModuleLayerDir || !mainModuleLayerDir->valid()) {
+            // binary module not found, try runtime
+            mainModuleLayerDir = this->repo->getLayerDir(packageRef, "runtime");
+        }
+        if (!mainModuleLayerDir || !mainModuleLayerDir->valid()) {
+            return toDBusReply(
+              utils::error::ErrorCode::AppInstallModuleRequireAppFirst,
+              fmt::format("cannot install module '{}' of {} version {}: "
+                          "the corresponding binary/runtime module is not installed",
+                          packageInfo.packageInfoV2Module,
+                          packageRef.id,
+                          packageRef.version.toString()));
+        }
+    }
 
     // Note: same as InstallRef, we should fuzzy the id instead of version
     auto fuzzyRef = package::FuzzyReference::parse(packageRef.id);


### PR DESCRIPTION
## Summary
Currently, there is no validation to check whether the corresponding `binary` or `runtime` base module is already installed when installing auxiliary modules (modules other than binary/runtime). Users may install extra modules without the required base module, which triggers runtime errors. The original code only contained a TODO placeholder comment for this missing check.

## Changes
Add validation logic inside `installFromLayer()` for modules where `packageInfoV2Module` is neither `binary` nor `runtime`:
1. First attempt to locate the binary module via `this->repo->getLayerDir(packageRef, "binary")`.
2. If the binary module is missing, check for the runtime module with `this->repo->getLayerDir(packageRef, "runtime")`.
3. If neither base module exists, return error code `ErrorCode::AppInstallModuleRequireAppFirst`.
4. The returned error message carries the module name, application ID and version for debugging context.

## Modified File
- `libs/linglong/src/linglong/package_manager/package_manager.cpp`

## Benefits
- Block invalid installation of auxiliary modules without matching binary/runtime base module
- Prevent runtime crashes caused by missing core application layers
- Replace incomplete TODO placeholder with complete production-ready validation logic
- Provide detailed context in error messages for quick troubleshooting