### PR TITLE
[fix][utils] Remove incorrect exists() check after symlink_status to avoid skipping broken symlinks

### DIFF
--- a/libs/utils/src/linglong/utils/file.cpp
+++ b/libs/utils/src/linglong/utils/file.cpp
@@ -232,10 +232,6 @@ moveFiles(const std::filesystem::path &src,
             LogD("failed to get symlink status of {}: {}", fromPath, ec.message());
             continue;
         }
-        if (!std::filesystem::exists(status)) {
-            LogD("{} does not exist, skip it", fromPath);
-            continue;
-        }
 
         std::filesystem::create_directories(toPath.parent_path(), ec);
         if (ec) {


### PR DESCRIPTION
## Summary
In the `moveFiles()` function, after fetching file metadata with `symlink_status()`, the code called `exists(status)` to validate file existence.
`symlink_status()` returns attributes of the symlink itself, while `exists()` checks the reachability of the symlink's target. This mismatch caused broken dangling symlinks to be mistakenly skipped during file moving.

## Changes
Remove the redundant `exists(status)` judgment block after `symlink_status()`:
```cpp
// Removed code block:
// if (!std::filesystem::exists(status)) {
//     LogD("{} does not exist, skip it", fromPath);
//     continue;
// }