### PR TITLE
docs(start): use DEB822 format for Ubuntu 24.04 install

### DIFF
--- a/docs/pages/en/guide/start/install.md
+++ b/docs/pages/en/guide/start/install.md
@@ -86,7 +86,13 @@ sudo dnf install linglong-bin linyaps-web-store-installer
 ### Ubuntu 24.04
 
 ```sh
-echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/xUbuntu_24.04/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo rm -f /etc/apt/sources.list.d/linglong.list
+sudo tee /etc/apt/sources.list.d/linglong.sources <<'EOF'
+Types: deb
+URIs: https://ci.deepin.com/repo/obs/linglong:/CI:/release/xUbuntu_24.04/
+Suites: ./
+Trusted: yes
+EOF
 sudo apt update
 sudo apt install linglong-bin linglong-installer
 ```

--- a/docs/pages/guide/start/install.md
+++ b/docs/pages/guide/start/install.md
@@ -86,7 +86,13 @@ sudo dnf install linglong-bin linyaps-web-store-installer
 ### Ubuntu 24.04
 
 ```sh
-echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/xUbuntu_24.04/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+sudo rm -f /etc/apt/sources.list.d/linglong.list
+sudo tee /etc/apt/sources.list.d/linglong.sources <<'EOF'
+Types: deb
+URIs: https://ci.deepin.com/repo/obs/linglong:/CI:/release/xUbuntu_24.04/
+Suites: ./
+Trusted: yes
+EOF
 sudo apt update
 sudo apt install linglong-bin linglong-installer
 ```


### PR DESCRIPTION
## Summary

- replace the legacy one-line Ubuntu 24.04 APT source configuration with a DEB822 `.sources` file
- update both the English and Chinese installation guides
- retain the existing trusted-repository behavior

## Why

Ubuntu 24.04 uses DEB822 sources by default. Documenting the native format makes the installation instructions easier to maintain and resolves #1548.

## Validation

- reviewed the generated DEB822 fields against the existing repository URL and suite
- full project test suite passes in the Debian 12 development container: 470/470 tests
