### PR TITLE
fix: fix lock message, add O_CLOEXEC, and add tests for transformOldExec

### DIFF
--- a/apps/ll-cli/CMakeLists.txt
+++ b/apps/ll-cli/CMakeLists.txt
@@ -5,6 +5,7 @@
 pfl_add_executable(
   SOURCES
   ./src/main.cpp
+  ./src/transform_old_exec.cpp
   OUTPUT_NAME
   ${LINGLONG_CLI_BIN}
   LINK_LIBRARIES

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -710,7 +710,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
         if (lockOwner > 0) {
             std::cerr << "\r\33[K"
                       << "\033[?25l"
-                      << "repository is being operated by another process, waiting for" << lockOwner
+                      << "repository is being operated by another process, waiting for " << lockOwner
                       << "\033[?25h" << std::endl;
             using namespace std::chrono_literals;
             std::this_thread::sleep_for(1s);

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -66,7 +66,7 @@ int lockCheck() noexcept
 {
     std::error_code ec;
     constexpr auto lock = "/run/linglong/lock";
-    auto fd = ::open(lock, O_RDONLY);
+    auto fd = ::open(lock, O_RDONLY | O_CLOEXEC);
     if (fd == -1) {
         if (errno == ENOENT) {
             return 0;

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 #include "configure.h"
-#include "transform_old_exec.h"
 #include "linglong/cli/cli.h"
 #include "linglong/cli/cli_printer.h"
 #include "linglong/cli/dbus_notifier.h"
@@ -18,6 +17,7 @@
 #include "linglong/utils/gettext.h"
 #include "linglong/utils/log/log.h"
 #include "ocppi/cli/crun/Crun.hpp"
+#include "transform_old_exec.h"
 
 #include <CLI/CLI.hpp>
 #include <sys/file.h>
@@ -65,11 +65,10 @@ int lockCheck() noexcept
         ::close(fd);
     });
 
-    struct flock lock_info{ .l_type = F_RDLCK,
-                            .l_whence = SEEK_SET,
-                            .l_start = 0,
-                            .l_len = 0,
-                            .l_pid = 0 };
+    struct flock lock_info
+    {
+        .l_type = F_RDLCK, .l_whence = SEEK_SET, .l_start = 0, .l_len = 0, .l_pid = 0
+    };
 
     if (::fcntl(fd, F_GETLK, &lock_info) == -1) {
         LogE("failed to get lock {}", lock);
@@ -695,8 +694,8 @@ You can report bugs to the linyaps team under this project: https://github.com/O
         if (lockOwner > 0) {
             std::cerr << "\r\33[K"
                       << "\033[?25l"
-                      << "repository is being operated by another process, waiting for " << lockOwner
-                      << "\033[?25h" << std::endl;
+                      << "repository is being operated by another process, waiting for "
+                      << lockOwner << "\033[?25h" << std::endl;
             using namespace std::chrono_literals;
             std::this_thread::sleep_for(1s);
             continue;

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -67,7 +67,11 @@ int lockCheck() noexcept
 
     struct flock lock_info
     {
-        .l_type = F_RDLCK, .l_whence = SEEK_SET, .l_start = 0, .l_len = 0, .l_pid = 0
+        .l_type = F_RDLCK,
+        .l_whence = SEEK_SET,
+        .l_start = 0,
+        .l_len = 0,
+        .l_pid = 0
     };
 
     if (::fcntl(fd, F_GETLK, &lock_info) == -1) {

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 #include "configure.h"
+#include "transform_old_exec.h"
 #include "linglong/cli/cli.h"
 #include "linglong/cli/cli_printer.h"
 #include "linglong/cli/dbus_notifier.h"
@@ -33,7 +34,6 @@
 #include <functional>
 #include <map>
 #include <memory>
-#include <string_view>
 #include <thread>
 
 #include <fcntl.h>
@@ -46,21 +46,6 @@ using namespace linglong::package;
 using namespace linglong::cli;
 
 namespace {
-
-std::vector<std::string> transformOldExec(int argc, char **argv) noexcept
-{
-    std::vector<std::string> res;
-
-    for (int i = argc - 1; i > 0; --i) {
-        if (std::string_view(argv[i]) == "--exec") {
-            res.emplace_back("--");
-        } else {
-            res.emplace_back(argv[i]);
-        }
-    }
-
-    return res;
-}
 
 int lockCheck() noexcept
 {

--- a/apps/ll-cli/src/transform_old_exec.cpp
+++ b/apps/ll-cli/src/transform_old_exec.cpp
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+#include "transform_old_exec.h"
+
+#include <string_view>
+
+std::vector<std::string> transformOldExec(int argc, char **argv) noexcept
+{
+    if (!argv || argc <= 0) {
+        return {};
+    }
+
+    std::vector<std::string> res;
+
+    for (int i = argc - 1; i > 0; --i) {
+        if (!argv[i]) {
+            continue;
+        }
+        if (std::string_view(argv[i]) == "--exec") {
+            res.emplace_back("--");
+        } else {
+            res.emplace_back(argv[i]);
+        }
+    }
+
+    return res;
+}

--- a/apps/ll-cli/src/transform_old_exec.h
+++ b/apps/ll-cli/src/transform_old_exec.h
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+#ifndef LINGLONG_CLI_TRANSFORM_OLD_EXEC_H_
+#define LINGLONG_CLI_TRANSFORM_OLD_EXEC_H_
+
+#include <string>
+#include <vector>
+
+std::vector<std::string> transformOldExec(int argc, char **argv) noexcept;
+
+#endif

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -83,6 +83,10 @@ pfl_add_executable(
   src/apps/ll-driver-detect/application_singleton_test.cpp
   src/apps/ll-driver-detect/driver_detection_manager_test.cpp
   src/apps/ll-driver-detect/dbus_notifier_test.cpp
+
+  # ll-cli tests
+  ${PROJECT_SOURCE_DIR}/apps/ll-cli/src/transform_old_exec.cpp
+  src/apps/ll-cli/transform_old_exec_test.cpp
   COMPILE_FEATURES
   PUBLIC
   cxx_std_17
@@ -103,3 +107,5 @@ target_include_directories(${tests}
                            PUBLIC ${PROJECT_SOURCE_DIR}/apps/uab/header/src)
 target_include_directories(${tests}
                            PUBLIC ${PROJECT_SOURCE_DIR}/apps/ll-driver-detect/src)
+target_include_directories(${tests}
+                           PUBLIC ${PROJECT_SOURCE_DIR}/apps/ll-cli/src)

--- a/libs/linglong/tests/ll-tests/src/apps/ll-cli/transform_old_exec_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/apps/ll-cli/transform_old_exec_test.cpp
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+#include <gtest/gtest.h>
+
+#include "transform_old_exec.h"
+
+TEST(TransformOldExec, NormalArgs)
+{
+    char arg0[] = "ll-cli";
+    char arg1[] = "run";
+    char arg2[] = "org.deepin.demo";
+    char arg3[] = "bash";
+    char *argv[] = { arg0, arg1, arg2, arg3 };
+
+    auto result = transformOldExec(4, argv);
+
+    // CLI11 processes from back, so order is reversed: argv[3], argv[2], argv[1]
+    ASSERT_EQ(result.size(), 3);
+    EXPECT_EQ(result[0], "bash");
+    EXPECT_EQ(result[1], "org.deepin.demo");
+    EXPECT_EQ(result[2], "run");
+}
+
+TEST(TransformOldExec, ReplacesExecWithDoubleDash)
+{
+    char arg0[] = "ll-cli";
+    char arg1[] = "run";
+    char arg2[] = "org.deepin.demo";
+    char arg3[] = "--exec";
+    char arg4[] = "bash";
+    char *argv[] = { arg0, arg1, arg2, arg3, arg4 };
+
+    auto result = transformOldExec(5, argv);
+
+    ASSERT_EQ(result.size(), 4);
+    EXPECT_EQ(result[0], "bash");
+    EXPECT_EQ(result[1], "--");
+    EXPECT_EQ(result[2], "org.deepin.demo");
+    EXPECT_EQ(result[3], "run");
+}
+
+TEST(TransformOldExec, NullArgv)
+{
+    auto result = transformOldExec(0, nullptr);
+
+    ASSERT_EQ(result.size(), 0);
+}
+
+TEST(TransformOldExec, NegativeArgc)
+{
+    char arg0[] = "ll-cli";
+    char *argv[] = { arg0 };
+
+    auto result = transformOldExec(-1, argv);
+
+    ASSERT_EQ(result.size(), 0);
+}
+
+TEST(TransformOldExec, NoArgsAfterProgramName)
+{
+    char arg0[] = "ll-cli";
+    char *argv[] = { arg0 };
+
+    auto result = transformOldExec(1, argv);
+
+    ASSERT_EQ(result.size(), 0);
+}
+
+TEST(TransformOldExec, OnlyExec)
+{
+    char arg0[] = "ll-cli";
+    char arg1[] = "--exec";
+    char *argv[] = { arg0, arg1 };
+
+    auto result = transformOldExec(2, argv);
+
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0], "--");
+}
+
+TEST(TransformOldExec, MultipleExec)
+{
+    char arg0[] = "ll-cli";
+    char arg1[] = "run";
+    char arg2[] = "--exec";
+    char arg3[] = "cmd1";
+    char arg4[] = "--exec";
+    char arg5[] = "cmd2";
+    char *argv[] = { arg0, arg1, arg2, arg3, arg4, arg5 };
+
+    auto result = transformOldExec(6, argv);
+
+    ASSERT_EQ(result.size(), 5);
+    EXPECT_EQ(result[0], "cmd2");
+    EXPECT_EQ(result[1], "--");
+    EXPECT_EQ(result[2], "cmd1");
+    EXPECT_EQ(result[3], "--");
+    EXPECT_EQ(result[4], "run");
+}


### PR DESCRIPTION
Three changes in separate commits:

1. **fix: add missing space before PID in lock waiting message** - PID was concatenated directly after "waiting for" without a space
2. **fix: add O_CLOEXEC to lock file descriptor for defense-in-depth** - consistent with the project's own filelock.cpp
3. **test: add unit tests for transformOldExec** - factored out the function from main.cpp's anonymous namespace for testability