### PR TITLE
fix: use weakly_canonical for relative --output path

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -1558,7 +1558,7 @@ utils::error::Result<void> Builder::exportUAB(const ExportOption &option,
             uabFile = outputFile;
         } else {
             std::error_code ec;
-            uabFile = std::filesystem::canonical(outputFile, ec);
+            uabFile = std::filesystem::weakly_canonical(outputFile, ec);
             if (ec) {
                 return LINGLONG_ERR(fmt::format("failed to get canonical path {}", outputFile), ec);
             }

--- a/tools/test-linglong.sh
+++ b/tools/test-linglong.sh
@@ -348,11 +348,17 @@ create_demo_project()
 
 test_demo_build_and_export()
 {
+    local output_file="${DEMO_APP_ID}-custom-output-${BASHPID}-${RANDOM}.uab"
+
     pushd "${DEMO_PROJECT_DIR}" >/dev/null
 
     "${LL_BUILDER}" build
     "${LL_BUILDER}" export --layer
     "${LL_BUILDER}" export
+    [[ ! -e "${output_file}" ]]
+    "${LL_BUILDER}" export --output "${output_file}"
+    [[ -f "${output_file}" ]]
+    rm -f -- "${output_file}"
     "${LL_BUILDER}" run
 }
 


### PR DESCRIPTION
exportUAB resolved a relative --output path with
std::filesystem::canonical, which requires the target to exist. The UAB file has not been created yet at that point, so exporting with a relative --output always failed with "failed to get canonical path ...".

Add a smoke test that exports to a custom relative output file.