### PR TITLE
feat: add AT SPI socket mount support for sandbox

### DIFF
--- a/api/schema/v1.json
+++ b/api/schema/v1.json
@@ -1461,6 +1461,9 @@
         "enable_pipewire": {
           "type": "boolean"
         },
+        "enable_atspi": {
+          "type": "boolean"
+        },
         "mounts": {
           "type": "array",
           "items": {

--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -1105,6 +1105,8 @@ $defs:
         type: boolean
       enable_pipewire:
         type: boolean
+      enable_atspi:
+        type: boolean
       mounts:
         type: array
         items:

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -184,6 +184,11 @@ ll-cli run org.deepin.demo -- bash -x /path/to/bash/script)"));
                  runOptions.enablePipewireSocketMount,
                  _("Enable PipeWire socket mount inside the sandbox"))
       ->take_last();
+    cliRun
+      ->add_flag("--enable-atspi",
+                 runOptions.enableAtSpiSocketMount,
+                 _("Enable AT SPI socket mount inside the sandbox"))
+      ->take_last();
     cliRun->add_option("--run-context", runOptions.runContext, _("Run context json string"))
       ->group("");
     cliRun

--- a/libs/api/src/linglong/api/types/v1/Generators.hpp
+++ b/libs/api/src/linglong/api/types/v1/Generators.hpp
@@ -1313,6 +1313,7 @@ inline void from_json(const json & j, RuntimeConfigure& x) {
 x.deviceMode = get_stack_optional<std::vector<DeviceOption>>(j, "device_mode");
 x.devices = get_stack_optional<std::vector<std::string>>(j, "devices");
 x.disableXdp = get_stack_optional<bool>(j, "disable_xdp");
+x.enableAtspi = get_stack_optional<bool>(j, "enable_atspi");
 x.enablePipewire = get_stack_optional<bool>(j, "enable_pipewire");
 x.env = get_stack_optional<std::map<std::string, std::string>>(j, "env");
 x.extDefs = get_stack_optional<std::map<std::string, std::vector<ExtensionDefine>>>(j, "ext_defs");
@@ -1330,6 +1331,9 @@ j["devices"] = x.devices;
 }
 if (x.disableXdp) {
 j["disable_xdp"] = x.disableXdp;
+}
+if (x.enableAtspi) {
+j["enable_atspi"] = x.enableAtspi;
 }
 if (x.enablePipewire) {
 j["enable_pipewire"] = x.enablePipewire;

--- a/libs/api/src/linglong/api/types/v1/RuntimeConfigure.hpp
+++ b/libs/api/src/linglong/api/types/v1/RuntimeConfigure.hpp
@@ -40,6 +40,7 @@ struct RuntimeConfigure {
 std::optional<std::vector<DeviceOption>> deviceMode;
 std::optional<std::vector<std::string>> devices;
 std::optional<bool> disableXdp;
+std::optional<bool> enableAtspi;
 std::optional<bool> enablePipewire;
 std::optional<std::map<std::string, std::string>> env;
 /**

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -59,6 +59,7 @@ struct RunOptions
     std::vector<std::string> extensions;
     std::optional<bool> disableXdp;
     std::optional<bool> enablePipewireSocketMount;
+    std::optional<bool> enableAtSpiSocketMount;
     bool privileged{ false };
     std::vector<std::string> capsAdd;
     std::vector<std::string> cdiSpecDir = { "/etc/cdi", "/var/run/cdi" };

--- a/libs/linglong/src/linglong/runtime/container_builder.cpp
+++ b/libs/linglong/src/linglong/runtime/container_builder.cpp
@@ -135,6 +135,10 @@ auto RunContainerOptions::applyRuntimeConfig(
         this->enablePipewireSocketMount = *runtimeConfig.enablePipewire;
     }
 
+    if (runtimeConfig.enableAtspi.has_value()) {
+        this->enableAtSpiSocketMount = *runtimeConfig.enableAtspi;
+    }
+
     if (runtimeConfig.deviceMode) {
         for (const auto &option : *runtimeConfig.deviceMode) {
             if (option == api::types::v1::DeviceOption::Passthru) {
@@ -181,6 +185,10 @@ auto RunContainerOptions::applyCliRunOptions(const cli::RunOptions &options) noe
     if (options.enablePipewireSocketMount.has_value()) {
         this->enablePipewireSocketMount = *options.enablePipewireSocketMount;
     }
+
+    if (options.enableAtSpiSocketMount.has_value()) {
+        this->enableAtSpiSocketMount = *options.enableAtSpiSocketMount;
+    }
     this->privileged = options.privileged;
     this->capabilities.insert(this->capabilities.end(),
                               options.capsAdd.begin(),
@@ -223,6 +231,11 @@ auto RunContainerOptions::isDevicePassthruEnabled() const noexcept -> bool
 auto RunContainerOptions::isPipewireSocketMountEnabled() const noexcept -> bool
 {
     return this->enablePipewireSocketMount;
+}
+
+auto RunContainerOptions::isAtSpiSocketMountEnabled() const noexcept -> bool
+{
+    return this->enableAtSpiSocketMount;
 }
 
 auto RunContainerOptions::isXdpDisabled() const noexcept -> bool
@@ -608,6 +621,11 @@ auto ContainerBuilder::configureRunContainer(PreparedContainer &prepared,
         auto pwSocketPath = common::xdg::getXDGRuntimeDir() / "pipewire-0";
         prepared.cfgBuilder.enablePipewireSocketMount(
           generator::PipewireMountOption{ .hostSocketPath = std::move(pwSocketPath) });
+    }
+    if (options.isAtSpiSocketMountEnabled()) {
+        auto atSpiSocketPath = common::xdg::getXDGRuntimeDir() / "at-spi" / "bus_0";
+        prepared.cfgBuilder.enableAtSpiSocketMount(
+          generator::AtSpiMountOption{ .hostSocketPath = std::move(atSpiSocketPath) });
     }
 
     if (options.isDevicePassthruEnabled()) {

--- a/libs/linglong/src/linglong/runtime/container_builder.h
+++ b/libs/linglong/src/linglong/runtime/container_builder.h
@@ -55,12 +55,14 @@ struct RunContainerOptions
     [[nodiscard]] auto isDevicePassthruEnabled() const noexcept -> bool;
     [[nodiscard]] auto isXdpDisabled() const noexcept -> bool;
     [[nodiscard]] auto isPipewireSocketMountEnabled() const noexcept -> bool;
+    [[nodiscard]] auto isAtSpiSocketMountEnabled() const noexcept -> bool;
     [[nodiscard]] auto isPrivileged() const noexcept -> bool;
 
     CommonContainerOptions common;
 
     bool disableXdp{ false };
     bool enablePipewireSocketMount{ false };
+    bool enableAtSpiSocketMount{ false };
     bool privileged{ false };
     bool devicePassthru{ false };
     std::map<std::string, std::string> env;

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/container_builder_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/container_builder_test.cpp
@@ -128,3 +128,51 @@ TEST(RunContainerOptionsTest, ApplyCliRunOptionsOverridesRuntimeConfigPipewireSe
     ASSERT_TRUE(cliResult);
     EXPECT_TRUE(options.isPipewireSocketMountEnabled());
 }
+
+TEST(RunContainerOptionsTest, ApplyRuntimeConfigEnablesAtSpiSocketMount)
+{
+    runtime::RunContainerOptions options;
+
+    api::types::v1::RuntimeConfigure runtimeConfig;
+    runtimeConfig.enableAtspi = true;
+
+    auto result = options.applyRuntimeConfig(runtimeConfig);
+    ASSERT_TRUE(result);
+    EXPECT_TRUE(options.isAtSpiSocketMountEnabled());
+}
+
+TEST(RunContainerOptionsTest, ApplyCliRunOptionsPreservesRuntimeConfigAtSpiSettingByDefault)
+{
+    runtime::RunContainerOptions options;
+
+    api::types::v1::RuntimeConfigure runtimeConfig;
+    runtimeConfig.enableAtspi = true;
+
+    auto runtimeResult = options.applyRuntimeConfig(runtimeConfig);
+    ASSERT_TRUE(runtimeResult);
+    ASSERT_TRUE(options.isAtSpiSocketMountEnabled());
+
+    cli::RunOptions runOptions;
+    auto cliResult = options.applyCliRunOptions(runOptions);
+    ASSERT_TRUE(cliResult);
+    EXPECT_TRUE(options.isAtSpiSocketMountEnabled());
+}
+
+TEST(RunContainerOptionsTest, ApplyCliRunOptionsOverridesRuntimeConfigAtSpiSettingWhenSpecified)
+{
+    runtime::RunContainerOptions options;
+
+    api::types::v1::RuntimeConfigure runtimeConfig;
+    runtimeConfig.enableAtspi = false;
+
+    auto runtimeResult = options.applyRuntimeConfig(runtimeConfig);
+    ASSERT_TRUE(runtimeResult);
+    ASSERT_FALSE(options.isAtSpiSocketMountEnabled());
+
+    cli::RunOptions runOptions;
+    runOptions.enableAtSpiSocketMount = true;
+
+    auto cliResult = options.applyCliRunOptions(runOptions);
+    ASSERT_TRUE(cliResult);
+    EXPECT_TRUE(options.isAtSpiSocketMountEnabled());
+}

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/runtime_config_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/runtime_config_test.cpp
@@ -29,6 +29,7 @@ TEST(RuntimeConfigTest, LoadFromPath)
     RuntimeConfigure config;
     config.disableXdp = true;
     config.enablePipewire = true;
+    config.enableAtspi = true;
     config.deviceMode = std::vector<DeviceOption>{ DeviceOption::Passthru };
     config.env =
       std::map<std::string, std::string>{ { "PATH", "/usr/bin" }, { "HOME", "/home/user" } };
@@ -86,6 +87,7 @@ TEST(RuntimeConfigTest, MergeConfigs)
     config1.disableXdp = false;
     config1.deviceMode = std::vector<DeviceOption>{ DeviceOption::Passthru };
     config1.enablePipewire = false;
+    config1.enableAtspi = false;
     config1.devices = std::vector<std::string>{ "vendor.com/device=gpu0" };
     config1.env =
       std::map<std::string, std::string>{ { "PATH", "/usr/bin" }, { "HOME", "/home/user1" } };
@@ -101,6 +103,7 @@ TEST(RuntimeConfigTest, MergeConfigs)
     config2.disableXdp = true;
     config2.deviceMode = std::vector<DeviceOption>{ DeviceOption::Passthru };
     config2.enablePipewire = true;
+    config2.enableAtspi = true;
     config2.devices = std::vector<std::string>{ "vendor.com/device=gpu1" };
     config2.env =
       std::map<std::string, std::string>{ { "PATH", "/usr/local/bin" }, { "USER", "testuser" } };
@@ -120,6 +123,8 @@ TEST(RuntimeConfigTest, MergeConfigs)
 
     ASSERT_TRUE(merged.enablePipewire.has_value());
     EXPECT_TRUE(*merged.enablePipewire);
+    ASSERT_TRUE(merged.enableAtspi.has_value());
+    EXPECT_TRUE(*merged.enableAtspi);
     ASSERT_TRUE(merged.disableXdp.has_value());
     EXPECT_TRUE(*merged.disableXdp);
 
@@ -160,6 +165,7 @@ TEST(RuntimeConfigTest, MergeEmptyConfigs)
     auto merged = linglong::utils::MergeRuntimeConfig(empty_configs);
 
     EXPECT_FALSE(merged.enablePipewire);
+    EXPECT_FALSE(merged.enableAtspi);
     EXPECT_FALSE(merged.disableXdp);
     EXPECT_FALSE(merged.deviceMode);
     EXPECT_FALSE(merged.env);
@@ -172,6 +178,7 @@ TEST(RuntimeConfigTest, MergePartialConfigs)
     RuntimeConfigure config1;
     config1.disableXdp = false;
     config1.enablePipewire = false;
+    config1.enableAtspi = false;
     config1.deviceMode = std::vector<DeviceOption>{ DeviceOption::Passthru };
     config1.env = std::map<std::string, std::string>{ { "PATH", "/usr/bin" } };
 
@@ -194,6 +201,8 @@ TEST(RuntimeConfigTest, MergePartialConfigs)
     LogD("{}", j.dump());
     ASSERT_TRUE(merged.enablePipewire.has_value());
     EXPECT_FALSE(*merged.enablePipewire);
+    ASSERT_TRUE(merged.enableAtspi.has_value());
+    EXPECT_FALSE(*merged.enableAtspi);
 
     ASSERT_TRUE(merged.disableXdp.has_value());
     EXPECT_FALSE(*merged.disableXdp);

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -362,6 +362,12 @@ utils::error::Result<void> ContainerCfgBuilder::buildXDGRuntime() noexcept
                     *containerXDGRuntimeDir / "pipewire-0",
                     false);
     }
+    if (atSpiMountOption) {
+        bindIfExist(*runMount,
+                    atSpiMountOption->hostSocketPath,
+                    *containerXDGRuntimeDir / "at-spi" / "bus_0",
+                    false);
+    }
 
     return LINGLONG_OK;
 }
@@ -1573,6 +1579,12 @@ ContainerCfgBuilder &
 ContainerCfgBuilder::enablePipewireSocketMount(PipewireMountOption option) noexcept
 {
     pipewireMountOption = std::move(option);
+    return *this;
+}
+
+ContainerCfgBuilder &ContainerCfgBuilder::enableAtSpiSocketMount(AtSpiMountOption option) noexcept
+{
+    atSpiMountOption = std::move(option);
     return *this;
 }
 

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
@@ -28,6 +28,11 @@ struct PipewireMountOption
     std::filesystem::path hostSocketPath;
 };
 
+struct AtSpiMountOption
+{
+    std::filesystem::path hostSocketPath;
+};
+
 enum class ANNOTATION {
     APPID,
     BASEDIR,
@@ -145,6 +150,7 @@ public:
 
     ContainerCfgBuilder &enableXDP(XdpOption option) noexcept;
     ContainerCfgBuilder &enablePipewireSocketMount(PipewireMountOption option) noexcept;
+    ContainerCfgBuilder &enableAtSpiSocketMount(AtSpiMountOption option) noexcept;
 
     ContainerCfgBuilder &
       setExtensionMounts(std::vector<ocppi::runtime::config::types::Mount>) noexcept;
@@ -337,6 +343,7 @@ private:
     // this 'mounts' is used internally, distinct from config.mounts
     std::vector<ocppi::runtime::config::types::Mount> mounts;
     std::optional<PipewireMountOption> pipewireMountOption;
+    std::optional<AtSpiMountOption> atSpiMountOption;
 
     std::optional<std::pair<std::filesystem::path, bool>> overlayMerged;
 

--- a/libs/utils/src/linglong/utils/runtime_config.cpp
+++ b/libs/utils/src/linglong/utils/runtime_config.cpp
@@ -92,6 +92,10 @@ RuntimeConfigure MergeRuntimeConfig(const std::vector<RuntimeConfigure> &configs
             result.enablePipewire = config.enablePipewire;
         }
 
+        if (config.enableAtspi.has_value()) {
+            result.enableAtspi = config.enableAtspi;
+        }
+
         if (config.deviceMode) {
             if (!result.deviceMode) {
                 result.deviceMode = config.deviceMode;


### PR DESCRIPTION
1. Add enable_atSpi field to API schema (v1.json, v1.yaml)
2. Add --enable-atspi CLI flag to ll-cli run command
3. Add enableAtSPI to RuntimeConfigure type with serialization
4. Enable AT SPI socket mount in container builder when option is set
5. Implement AtSpiMountOption in OCI config generator and bind mount
6. Update MergeRuntimeConfig to handle enableAtSPI field
7. Add unit tests for AT SPI socket mount logic

Log: Added support for mounting AT SPI socket inside sandbox

Influence:
1. Test running an application with --enable-atspi flag and verify AT SPI socket is mounted inside sandbox (check /run/user/UID/at-spi/bus_0)
2. Test running without the flag to ensure no unwanted AT SPI socket mount
3. Test runtime config with enable_atSpi=true in JSON/YAML to verify it works via configuration
4. Test CLI override of runtime config (--enable-atspi should override runtime config)
5. Verify backward compatibility: existing configurations without enable_atSpi should not break
6. Test merging multiple runtime configurations with different enable_atSpi values