### PR TITLE
fix(namespace): handle missing passwd entries

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/utils/namespce.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/namespce.cpp
@@ -1,11 +1,16 @@
 
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include <gtest/gtest.h>
 
 #include "linglong/utils/namespace.h"
+
+#include <limits>
+
+#include <pwd.h>
+#include <unistd.h>
 
 TEST(NamespaceTest, ParseSubuidRanges)
 {
@@ -62,4 +67,26 @@ TEST(NamespaceTest, ParseSubuidRanges)
     EXPECT_EQ((*ranges6)[0].count, "65536");
     EXPECT_EQ((*ranges6)[1].subuid, "200000");
     EXPECT_EQ((*ranges6)[1].count, "65536");
+}
+
+TEST(NamespaceTest, GetUserNameReturnsCurrentUser)
+{
+    auto result = linglong::utils::detail::getUserName(getuid());
+
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_FALSE(result->empty());
+}
+
+TEST(NamespaceTest, GetUserNameRejectsUnmappedUid)
+{
+    auto uid = std::numeric_limits<uid_t>::max();
+    while (uid > 0 && getpwuid(uid) != nullptr) {
+        --uid;
+    }
+    ASSERT_EQ(getpwuid(uid), nullptr);
+
+    auto result = linglong::utils::detail::getUserName(uid);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_NE(result.error().message().find("user not found for uid"), std::string::npos);
 }

--- a/libs/utils/src/linglong/utils/namespace.cpp
+++ b/libs/utils/src/linglong/utils/namespace.cpp
@@ -44,6 +44,9 @@ utils::error::Result<std::string> getUserName(uid_t uid)
     if (res != 0) {
         return LINGLONG_ERR(fmt::format("failed to get user name {}", res).c_str());
     }
+    if (result == nullptr) {
+        return LINGLONG_ERR(fmt::format("user not found for uid {}", uid).c_str());
+    }
 
     return result->pw_name;
 }


### PR DESCRIPTION
## Summary
- reject a successful `getpwuid_r()` lookup when it returns no passwd record
- avoid dereferencing a null result pointer
- cover both a resolved current user and an unmapped UID with regression tests

## Testing
- `git diff --check`
- `pre-commit run clang-format --files ...`
- `cmake --build --preset debug --target linglong__linglong__ll-tests -j16`
- `ctest --preset debug -R NamespaceTest --output-on-failure` (3/3 passed)

Closes #1738