### PR TITLE
fix(runtime): mount locally installed host fonts

### DIFF
--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -587,6 +587,7 @@ ContainerCfgBuilder &ContainerCfgBuilder::bindHostStatics() noexcept
         "/etc/machine-id",
         // FIXME: support for host /etc/ssl, ref https://github.com/p11-glue/p11-kit
         "/usr/lib/locale",
+        "/usr/local/share/fonts",
         "/usr/share/fonts",
         "/usr/share/icons",
         "/usr/share/themes",


### PR DESCRIPTION
## Summary
- include `/usr/local/share/fonts` in the existing host-static bind mounts
- make locally installed system fonts visible to Linglong applications when the directory exists
- retain the existing read-only bind behavior and skip missing paths

## Testing
- `git diff --check`
- `cmake --build --preset debug --target linglong__oci-cfg-generators -j16`

Closes #1549