### PR TITLE
fix(build): set build types in CMake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,7 +12,9 @@
             "description": "Configure linglong for installing from source.",
             "binaryDir": "${sourceDir}/build-release",
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "-Wall -Wextra -Wpedantic -Wno-c++20-extensions -Wno-pessimizing-move -O2"
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_CXX_FLAGS": "-Wall -Wextra -Wpedantic -Wno-c++20-extensions -Wno-pessimizing-move",
+                "CMAKE_CXX_FLAGS_RELEASE": "-O2 -DNDEBUG"
             }
         },
         {
@@ -21,7 +23,9 @@
             "description": "Configure linglong for development and debugging.",
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "-Wall -Wextra -Wpedantic -Wno-c++20-extensions -Wno-pessimizing-move -Og -g -fsanitize=undefined",
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_CXX_FLAGS": "-Wall -Wextra -Wpedantic -Wno-c++20-extensions -Wno-pessimizing-move",
+                "CMAKE_CXX_FLAGS_DEBUG": "-Og -g -fsanitize=undefined",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": true,
                 "ENABLE_TESTING": true,
                 "CMAKE_INSTALL_PREFIX": "/usr"


### PR DESCRIPTION
## Summary
- set `CMAKE_BUILD_TYPE=Release` for the release preset
- set `CMAKE_BUILD_TYPE=Debug` for the debug preset so debug-only project logic is selected
- keep common warning flags separate from configuration-specific optimization and sanitizer flags

## Testing
- `python3 -m json.tool CMakePresets.json`
- `cmake --list-presets`
- configured both presets on the Debian 12 build server and verified their cache values
- verified `_FORTIFY_SOURCE` remains enabled for release and is no longer enabled for debug

This prevents the debug preset from being treated as a non-Debug build by the top-level CMake logic.