### PR TITLE
fix: bind default gdbserver to loopback

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -67,7 +67,7 @@ struct RunOptions
     std::vector<api::types::v1::DeviceOption> deviceOptions;
     std::optional<std::string> instance;
     bool debug{ false };
-    std::string debugListen{ ":2345" };
+    std::string debugListen{ "127.0.0.1:2345" };
     std::optional<std::string> debugDebuginfod;
     std::optional<std::string> debugSymbolDir;
 };


### PR DESCRIPTION
The previous default ":2345" made gdbserver listen on all interfaces, exposing the debug session to the local network. Bind to 127.0.0.1 so the session is reachable only from localhost.