### PR TITLE
fix: make overlayfs mode resolution overridable in RunContext

### DIFF
--- a/libs/linglong/src/linglong/runtime/run_context.cpp
+++ b/libs/linglong/src/linglong/runtime/run_context.cpp
@@ -733,7 +733,7 @@ utils::error::Result<void> RunContext::resolveOverlayMode(std::optional<std::str
         mode = *parsedMode;
     }
 
-    auto resolvedMode = OverlayFSDriver::resolveOverlayMode(mode);
+    auto resolvedMode = selectOverlayMode(mode);
     if (!resolvedMode) {
         return LINGLONG_ERR("resolve overlayfs mode", resolvedMode);
     }
@@ -741,6 +741,12 @@ utils::error::Result<void> RunContext::resolveOverlayMode(std::optional<std::str
     contextCfg.overlayfs = std::string(OverlayFSDriver::modeToString(*resolvedMode));
 
     return LINGLONG_OK;
+}
+
+auto RunContext::selectOverlayMode(utils::OverlayMode requestedMode) const
+  -> utils::error::Result<utils::OverlayMode>
+{
+    return OverlayFSDriver::resolveOverlayMode(requestedMode);
 }
 
 utils::error::Result<void> RunContext::resolveTimeZone()

--- a/libs/linglong/src/linglong/runtime/run_context.h
+++ b/libs/linglong/src/linglong/runtime/run_context.h
@@ -15,6 +15,7 @@
 #include "linglong/repo/ostree_repo.h"
 #include "linglong/runtime/layer.h"
 #include "linglong/utils/error/error.h"
+#include "linglong/utils/overlayfs.h"
 #include "ocppi/runtime/config/types/Generators.hpp"
 
 #include <filesystem>
@@ -59,7 +60,7 @@ public:
     {
     }
 
-    ~RunContext();
+    virtual ~RunContext();
 
     utils::error::Result<void> resolve(const linglong::package::Reference &runnable,
                                        const ResolveOptions &opts = ResolveOptions{});
@@ -112,6 +113,10 @@ public:
     getCachedTargetItem();
 
     [[nodiscard]] bool hasRuntime() const noexcept { return !!runtimeLayer; }
+
+protected:
+    virtual auto selectOverlayMode(utils::OverlayMode requestedMode) const
+      -> utils::error::Result<utils::OverlayMode>;
 
 private:
     utils::error::Result<void> resolveLayer(bool depsExcludeDev,

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_test.cpp
@@ -23,9 +23,27 @@ using ::testing::Return;
 
 namespace {
 
-using RunContext = linglong::runtime::RunContext;
 using RuntimeLayer = linglong::runtime::RuntimeLayer;
 using ResolveOptions = linglong::runtime::ResolveOptions;
+
+class TestRunContext final : public linglong::runtime::RunContext
+{
+public:
+    using linglong::runtime::RunContext::RunContext;
+
+protected:
+    auto selectOverlayMode(utils::OverlayMode requestedMode) const
+      -> utils::error::Result<utils::OverlayMode> override
+    {
+        if (requestedMode == utils::OverlayMode::Auto) {
+            return utils::OverlayMode::FUSE;
+        }
+
+        return requestedMode;
+    }
+};
+
+using RunContext = TestRunContext;
 
 std::string specChecksum(const std::filesystem::path &path)
 {
@@ -535,6 +553,8 @@ TEST_F(RunContextTest, resolveRunnableWithBase)
     EXPECT_FALSE(context.getAppLayer().has_value());
     EXPECT_FALSE(context.getRuntimeLayer().has_value());
     EXPECT_TRUE(context.getBaseLayer().has_value());
+    ASSERT_TRUE(context.getConfig().overlayfs.has_value());
+    EXPECT_EQ(*context.getConfig().overlayfs, "fuse");
 }
 
 TEST_F(RunContextTest, resolveRunnableWithInvalidKind)


### PR DESCRIPTION
Introduce a protected virtual selectOverlayMode method so tests can substitute the environment-dependent overlayfs detection with a deterministic stub.