### PR TITLE
fix: unit test execution failed

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/task_queue_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/task_queue_test.cpp
@@ -408,12 +408,10 @@ TEST(TaskQueue, addTask)
     EXPECT_EQ(task->get().message(), "succeeded");
 
     release.set_value();
-    for (int i = 0; i < 1000 && queue.getTask(taskID); ++i) {
-        QCoreApplication::processEvents();
-        std::this_thread::yield();
-    }
 
-    EXPECT_FALSE(queue.getTask(taskID));
+    ASSERT_TRUE(processEventsUntil([&queue, &taskID]() {
+        return !queue.getTask(taskID);
+    }));
 }
 
 TEST(TaskQueue, joinTask)


### PR DESCRIPTION
Unit test addTask execution failed in mips64, Use processEventsUntil instead of a counted loop.