### PR TITLE
feat: resolve resolv.conf target in RunContext

### DIFF
--- a/api/schema/v1.json
+++ b/api/schema/v1.json
@@ -1537,6 +1537,9 @@
         "overlayfs": {
           "type": "string"
         },
+        "resolvConf": {
+          "type": "string"
+        },
         "timezone": {
           "type": "string"
         },

--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -1157,6 +1157,8 @@ $defs:
             type: string
       overlayfs:
         type: string
+      resolvConf:
+        type: string
       timezone:
         type: string
       cdiDevices:

--- a/libs/api/src/linglong/api/types/v1/Generators.hpp
+++ b/libs/api/src/linglong/api/types/v1/Generators.hpp
@@ -1276,6 +1276,7 @@ x.extensions = get_stack_optional<std::map<std::string, std::vector<std::string>
 x.instance = get_stack_optional<std::string>(j, "instance");
 x.mounts = get_stack_optional<std::vector<Mount>>(j, "mounts");
 x.overlayfs = get_stack_optional<std::string>(j, "overlayfs");
+x.resolvConf = get_stack_optional<std::string>(j, "resolvConf");
 x.runtime = get_stack_optional<std::string>(j, "runtime");
 x.timezone = get_stack_optional<std::string>(j, "timezone");
 x.version = j.at("version").get<std::string>();
@@ -1303,6 +1304,9 @@ j["mounts"] = x.mounts;
 }
 if (x.overlayfs) {
 j["overlayfs"] = x.overlayfs;
+}
+if (x.resolvConf) {
+j["resolvConf"] = x.resolvConf;
 }
 if (x.runtime) {
 j["runtime"] = x.runtime;

--- a/libs/api/src/linglong/api/types/v1/RunContextConfig.hpp
+++ b/libs/api/src/linglong/api/types/v1/RunContextConfig.hpp
@@ -34,6 +34,7 @@ std::optional<std::map<std::string, std::vector<std::string>>> extensions;
 std::optional<std::string> instance;
 std::optional<std::vector<Mount>> mounts;
 std::optional<std::string> overlayfs;
+std::optional<std::string> resolvConf;
 std::optional<std::string> runtime;
 std::optional<std::string> timezone;
 std::string version;

--- a/libs/linglong/src/linglong/runtime/run_context.cpp
+++ b/libs/linglong/src/linglong/runtime/run_context.cpp
@@ -296,6 +296,11 @@ utils::error::Result<void> RunContext::resolve(const linglong::package::Referenc
         return LINGLONG_ERR("failed to resolve timezone", timezoneRet);
     }
 
+    auto networkConfRet = resolveNetworkConf();
+    if (!networkConfRet) {
+        return LINGLONG_ERR("failed to resolve network configuration", networkConfRet);
+    }
+
     if (opts.cdiDevices) {
         contextCfg.cdiDevices = opts.cdiDevices.value();
     }
@@ -381,6 +386,11 @@ utils::error::Result<void> RunContext::resolve(const api::types::v1::BuilderProj
     auto timezoneRet = resolveTimeZone();
     if (!timezoneRet) {
         return LINGLONG_ERR("failed to resolve timezone", timezoneRet);
+    }
+
+    auto networkConfRet = resolveNetworkConf();
+    if (!networkConfRet) {
+        return LINGLONG_ERR("failed to resolve network configuration", networkConfRet);
     }
 
     return resolveLayer(false, {});
@@ -556,6 +566,7 @@ utils::error::Result<void> RunContext::resolve(const api::types::v1::RunContextC
     }
 
     contextCfg.overlayfs = config.overlayfs;
+    contextCfg.resolvConf = config.resolvConf;
     contextCfg.timezone = config.timezone;
     contextCfg.instance = config.instance;
     contextCfg.mounts = config.mounts;
@@ -747,6 +758,43 @@ auto RunContext::selectOverlayMode(utils::OverlayMode requestedMode) const
   -> utils::error::Result<utils::OverlayMode>
 {
     return OverlayFSDriver::resolveOverlayMode(requestedMode);
+}
+
+utils::error::Result<void> RunContext::resolveNetworkConf()
+{
+    LINGLONG_TRACE("resolve network configuration");
+
+    const std::filesystem::path path{ "/etc/resolv.conf" };
+    std::error_code ec;
+    auto status = std::filesystem::symlink_status(path, ec);
+    if (ec) {
+        if (ec == std::errc::no_such_file_or_directory) {
+            contextCfg.resolvConf = std::nullopt;
+            return LINGLONG_OK;
+        }
+        return LINGLONG_ERR(fmt::format("failed to get status of {}", path), ec);
+    }
+
+    if (!std::filesystem::exists(status)) {
+        contextCfg.resolvConf = std::nullopt;
+        return LINGLONG_OK;
+    }
+
+    if (std::filesystem::is_symlink(status)) {
+        auto target = std::filesystem::canonical(path, ec);
+        if (ec) {
+            if (ec == std::errc::no_such_file_or_directory) {
+                contextCfg.resolvConf = std::nullopt;
+                return LINGLONG_OK;
+            }
+            return LINGLONG_ERR(fmt::format("failed to resolve symlink {}", path), ec);
+        }
+        contextCfg.resolvConf = target.string();
+        return LINGLONG_OK;
+    }
+
+    contextCfg.resolvConf = path.string();
+    return LINGLONG_OK;
 }
 
 utils::error::Result<void> RunContext::resolveTimeZone()
@@ -982,6 +1030,9 @@ utils::error::Result<void> RunContext::fillContextCfg(
     builder.setContainerId(containerID);
     if (contextCfg.timezone) {
         builder.setTimezone(*contextCfg.timezone);
+    }
+    if (contextCfg.resolvConf) {
+        builder.setResolvConf(*contextCfg.resolvConf);
     }
 
     if (!baseLayer) {

--- a/libs/linglong/src/linglong/runtime/run_context.h
+++ b/libs/linglong/src/linglong/runtime/run_context.h
@@ -140,6 +140,7 @@ private:
         &externalExtensionDefs);
     utils::error::Result<void>
     resolveOverlayMode(std::optional<std::string> requestedMode = std::nullopt);
+    utils::error::Result<void> resolveNetworkConf();
     utils::error::Result<void> resolveTimeZone();
 
     repo::OSTreeRepo &repo;

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_test.cpp
@@ -699,6 +699,7 @@ TEST_F(RunContextTest, resolveFromConfig)
     config.base = baseRef->toString();
     config.runtime = runtimeRef->toString();
     config.app = appRef->toString();
+    config.resolvConf = "/run/systemd/resolve/stub-resolv.conf";
     config.extensions = std::map<std::string, std::vector<std::string>>{
         { appRef->toString(), std::vector<std::string>{ extensionRef->toString() } }
     };
@@ -760,6 +761,8 @@ TEST_F(RunContextTest, resolveFromConfig)
     EXPECT_EQ(retConfig.runtime.value(), runtimeRef->toString());
     EXPECT_TRUE(retConfig.app.has_value());
     EXPECT_EQ(retConfig.app.value(), appRef->toString());
+    ASSERT_TRUE(retConfig.resolvConf.has_value());
+    EXPECT_EQ(*retConfig.resolvConf, "/run/systemd/resolve/stub-resolv.conf");
     ASSERT_TRUE(retConfig.extensions.has_value());
     ASSERT_FALSE(retConfig.extensions->empty());
     ASSERT_EQ(retConfig.extensions->size(), 1);

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -1450,47 +1450,36 @@ utils::error::Result<void> ContainerCfgBuilder::buildMountNetworkConf() noexcept
 
     networkConfMount = std::vector<Mount>{};
 
-    std::filesystem::path resolvConf{ "/etc/resolv.conf" };
+    const std::filesystem::path resolvConfPath{ "/etc/resolv.conf" };
     std::error_code ec;
-    if (std::filesystem::exists(resolvConf, ec)) {
+    if (resolvConf) {
         // /etc/resolv.conf is volatile on host, we create a new symlink in the bundle
-        // directory pointing to the actual target, and then mount it with the
+        // directory pointing to the target resolved by RunContext, and then mount it with the
         // 'copy-symlink' option, which tells the runtime to recreate the symlink inside
         // the container.
-        // NOTE: it's not working if /etc/resolv.conf is a symlink, and points to a
-        // different path after container started.
+        // NOTE: If the host symlink target changes after the container starts, the running
+        // container still uses the old target.
         if (hostRootMount) {
-            auto target = resolvConf;
-            if (std::filesystem::is_symlink(resolvConf, ec)) {
-                std::array<char, PATH_MAX + 1> buf{};
-                auto *rpath = realpath(resolvConf.string().c_str(), buf.data());
-                if (rpath == nullptr) {
-                    return LINGLONG_ERR(
-                      fmt::format("Failed to read symlink {}: {}", resolvConf, strerror(errno)));
-                }
-                target = std::filesystem::path{ rpath };
-            }
-
-            target = std::filesystem::path{ "/run/host/rootfs" } / target.lexically_relative("/");
+            auto target =
+              std::filesystem::path{ "/run/host/rootfs" } / resolvConf->lexically_relative("/");
             auto bundleResolvConf = bundlePath / "resolv.conf";
             std::filesystem::create_symlink(target, bundleResolvConf, ec);
             if (ec) {
                 return LINGLONG_ERR(fmt::format("Failed to create symlink {}", bundleResolvConf),
                                     ec);
             }
-            networkConfMount->emplace_back(Mount{ .destination = resolvConf.string(),
+            networkConfMount->emplace_back(Mount{ .destination = resolvConfPath.string(),
                                                   .options = string_list{ "bind", "copy-symlink" },
                                                   .source = bundleResolvConf,
                                                   .type = "bind" });
         } else {
-            networkConfMount->emplace_back(Mount{ .destination = resolvConf.string(),
+            networkConfMount->emplace_back(Mount{ .destination = resolvConfPath.string(),
                                                   .options = string_list{ "bind", "ro" },
-                                                  .source = resolvConf,
+                                                  .source = *resolvConf,
                                                   .type = "bind" });
         }
     }
 
-    bindIfExist(*networkConfMount, "/etc/resolvconf");
     bindIfExist(*networkConfMount, "/etc/hosts");
     return LINGLONG_OK;
 }

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.h
@@ -101,6 +101,12 @@ public:
         return *this;
     }
 
+    ContainerCfgBuilder &setResolvConf(std::filesystem::path path) noexcept
+    {
+        resolvConf = std::move(path);
+        return *this;
+    }
+
     ContainerCfgBuilder &setAnnotation(ANNOTATION annotation, std::string value) noexcept;
 
     ContainerCfgBuilder &addUIdMapping(int64_t containerID, int64_t hostID, int64_t size) noexcept;
@@ -270,6 +276,7 @@ private:
     std::optional<std::filesystem::path> appCache;
     std::optional<std::filesystem::path> containerXDGRuntimeDir;
     std::optional<std::string> timezone;
+    std::optional<std::filesystem::path> resolvConf;
 
     bool runtimePathRo = true;
     bool appPathRo = true;


### PR DESCRIPTION
Move /etc/resolv.conf symlink resolution from ContainerCfgBuilder into RunContext::resolveNetworkConf(), storing the resolved target path in the run context config. This makes the resolved path persistable and consistent with how timezone resolution works.

The /etc/resolvconf bind mount is dropped