### PR TITLE
feat: make base field optional, derive from runtime when unspecified

### DIFF
--- a/api/schema/v1.json
+++ b/api/schema/v1.json
@@ -294,8 +294,7 @@
       "required": [
         "version",
         "package",
-        "build",
-        "base"
+        "build"
       ],
       "properties": {
         "version": {

--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -242,7 +242,6 @@ $defs:
       - version
       - package
       - build
-      - base
     properties:
       version:
         type: string

--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -34,6 +34,7 @@
 #include <optional>
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <wordexp.h>
@@ -77,25 +78,39 @@ parseProjectConfig(const std::filesystem::path &filename)
           "'command' field is missing, app should have command as the default startup command");
     }
 
-    // 校验bese和runtime版本是否合法
-    auto baseFuzzyRef = linglong::package::FuzzyReference::parse(project->base.c_str());
-    if (!baseFuzzyRef) {
-        return LINGLONG_ERR("failed to parse base field", baseFuzzyRef);
+    if (!project->base && !project->runtime) {
+        return LINGLONG_ERR("at least one of 'base' or 'runtime' must be specified");
     }
-    auto ret = linglong::package::Version::validateDependVersion(baseFuzzyRef->version.value());
-    if (!ret) {
-        return LINGLONG_ERR("base version is not valid", ret);
-    }
-    if (project->runtime) {
-        auto runtimeFuzzyRef =
-          linglong::package::FuzzyReference::parse(project->runtime.value().c_str());
-        if (!runtimeFuzzyRef) {
-            return LINGLONG_ERR("failed to parse runtime field", runtimeFuzzyRef);
+
+    // 校验 base 和 runtime 版本是否合法
+    auto validateDependency = [&](const std::optional<std::string> &dependency,
+                                  std::string_view field) -> linglong::utils::error::Result<void> {
+        if (!dependency) {
+            return LINGLONG_OK;
         }
-        ret = linglong::package::Version::validateDependVersion(runtimeFuzzyRef->version.value());
+
+        auto fuzzyRef = linglong::package::FuzzyReference::parse(*dependency);
+        if (!fuzzyRef) {
+            return LINGLONG_ERR(fmt::format("failed to parse {} field", field), fuzzyRef);
+        }
+        if (!fuzzyRef->version) {
+            return LINGLONG_ERR(fmt::format("{} version is missing", field));
+        }
+
+        auto ret = linglong::package::Version::validateDependVersion(*fuzzyRef->version);
         if (!ret) {
-            return LINGLONG_ERR("runtime version is not valid", ret);
+            return LINGLONG_ERR(fmt::format("{} version is not valid", field), ret);
         }
+        return LINGLONG_OK;
+    };
+
+    auto ret = validateDependency(project->base, "base");
+    if (!ret) {
+        return LINGLONG_ERR(ret);
+    }
+    ret = validateDependency(project->runtime, "runtime");
+    if (!ret) {
+        return LINGLONG_ERR(ret);
     }
     return project;
 }

--- a/libs/api/src/linglong/api/types/v1/BuilderProject.hpp
+++ b/libs/api/src/linglong/api/types/v1/BuilderProject.hpp
@@ -40,7 +40,7 @@ struct BuilderProject {
 /**
 * used base of package
 */
-std::string base;
+std::optional<std::string> base;
 /**
 * build script of builder project
 */

--- a/libs/api/src/linglong/api/types/v1/Generators.hpp
+++ b/libs/api/src/linglong/api/types/v1/Generators.hpp
@@ -510,7 +510,7 @@ j["version"] = x.version;
 }
 
 inline void from_json(const json & j, BuilderProject& x) {
-x.base = j.at("base").get<std::string>();
+x.base = get_stack_optional<std::string>(j, "base");
 x.build = j.at("build").get<std::string>();
 x.buildext = get_stack_optional<BuilderProjectBuildEXT>(j, "buildext");
 x.command = get_stack_optional<std::vector<std::string>>(j, "command");
@@ -527,7 +527,9 @@ x.version = j.at("version").get<std::string>();
 
 inline void to_json(json & j, const BuilderProject & x) {
 j = json::object();
+if (x.base) {
 j["base"] = x.base;
+}
 j["build"] = x.build;
 if (x.buildext) {
 j["buildext"] = x.buildext;

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -550,6 +550,10 @@ utils::error::Result<void> Builder::buildStagePullDependency() noexcept
 {
     LINGLONG_TRACE("build stage pull dependency");
 
+    if (!this->project->base && !this->project->runtime) {
+        return LINGLONG_ERR("at least one of base or runtime must be specified");
+    }
+
     printMessage("[Processing Dependency]");
     printMessage(QString("%1%2%3%4")
                    .arg("Package", -35) // NOLINT
@@ -559,7 +563,8 @@ utils::error::Result<void> Builder::buildStagePullDependency() noexcept
                    .toStdString(),
                  2);
 
-    auto handleDependency = [this](const std::string &refStr) -> utils::error::Result<void> {
+    auto handleDependency =
+      [this](const std::string &refStr) -> utils::error::Result<package::Reference> {
         LINGLONG_TRACE("handle dependency " + refStr);
 
         auto printStatus = [](const package::Reference &ref,
@@ -619,7 +624,7 @@ utils::error::Result<void> Builder::buildStagePullDependency() noexcept
 
                 printStatus(*localRef, "develop", layerDir ? "complete" : "missing");
 
-                return LINGLONG_OK;
+                return *localRef;
             }
             printStatus(refRepo->reference, "binary", "complete");
 
@@ -634,18 +639,50 @@ utils::error::Result<void> Builder::buildStagePullDependency() noexcept
         auto layerDir = this->repo.getLayerDir(*resolvedRef, "develop");
         printStatus(*resolvedRef, "develop", layerDir ? "complete" : "missing");
 
-        return LINGLONG_OK;
+        return *resolvedRef;
     };
 
-    auto res = handleDependency(this->project->base);
+    std::optional<std::string> runtimeBase;
+    std::optional<package::Reference> runtimeRef;
+    if (this->project->runtime) {
+        auto resolvedRuntime = handleDependency(*this->project->runtime);
+        if (!resolvedRuntime) {
+            return LINGLONG_ERR(resolvedRuntime);
+        }
+        runtimeRef = *resolvedRuntime;
+
+        auto runtimeItem = this->repo.getLayerItem(*runtimeRef);
+        if (!runtimeItem) {
+            return LINGLONG_ERR("failed to get runtime information", runtimeItem);
+        }
+        if (this->project->base) {
+            runtimeBase = runtimeItem->info.base;
+        } else {
+            this->project->base = runtimeItem->info.base;
+        }
+    }
+
+    auto res = handleDependency(*this->project->base);
     if (!res) {
         return LINGLONG_ERR(res);
     }
 
-    if (this->project->runtime) {
-        res = handleDependency(*this->project->runtime);
-        if (!res) {
-            return LINGLONG_ERR(res);
+    if (runtimeBase) {
+        auto runtimeBaseFuzzyRef = package::FuzzyReference::parse(*runtimeBase);
+        if (!runtimeBaseFuzzyRef) {
+            return LINGLONG_ERR("failed to parse base required by runtime", runtimeBaseFuzzyRef);
+        }
+        if (!runtimeBaseFuzzyRef->version) {
+            return LINGLONG_ERR("base version required by runtime is missing");
+        }
+
+        if (!res->semanticMatch(*runtimeBaseFuzzyRef)) {
+            return LINGLONG_ERR(
+              fmt::format("base is not compatible with runtime. \n - Current base: {}\n - "
+                          "Current runtime: {}\n - base required by runtime: {}",
+                          res->toString(),
+                          runtimeRef->toString(),
+                          *runtimeBase));
         }
     }
 
@@ -1235,7 +1272,7 @@ utils::error::Result<void> Builder::commitToLocalRepo() noexcept
         .version = project.package.version,
     };
 
-    info.base = project.base;
+    info.base = *project.base;
     if (project.runtime) {
         info.runtime = project.runtime;
     }
@@ -1626,7 +1663,24 @@ utils::error::Result<void> Builder::exportUAB(const ExportOption &option,
         }
     }
 
-    auto baseRef = detail::clearDependency(this->project->base, this->repo, false);
+    std::optional<package::Reference> runtimeReference;
+    if (this->project->runtime) {
+        auto runtimeRef = detail::clearDependency(*this->project->runtime, this->repo, false);
+        if (!runtimeRef) {
+            return LINGLONG_ERR(runtimeRef);
+        }
+        runtimeReference = std::move(*runtimeRef).second.value();
+
+        if (!this->project->base) {
+            auto runtimeItem = this->repo.getLayerItem(*runtimeReference);
+            if (!runtimeItem) {
+                return LINGLONG_ERR("failed to get runtime information", runtimeItem);
+            }
+            this->project->base = runtimeItem->info.base;
+        }
+    }
+
+    auto baseRef = detail::clearDependency(*this->project->base, this->repo, false);
     if (!baseRef) {
         return LINGLONG_ERR(baseRef);
     }
@@ -1646,15 +1700,8 @@ utils::error::Result<void> Builder::exportUAB(const ExportOption &option,
         packager.setCompressor(option.compressor.c_str());
     }
 
-    if (this->project->runtime) {
-        auto runtimeRef =
-          detail::clearDependency(this->project->runtime.value(), this->repo, false);
-        if (!runtimeRef) {
-            return LINGLONG_ERR(runtimeRef);
-        }
-        auto runtimeReference = std::move(*runtimeRef).second.value();
-
-        auto runtimeDir = this->repo.getLayerDir(runtimeReference);
+    if (runtimeReference) {
+        auto runtimeDir = this->repo.getLayerDir(*runtimeReference);
         if (!runtimeDir) {
             return LINGLONG_ERR(runtimeDir);
         }

--- a/libs/linglong/src/linglong/package/reference.cpp
+++ b/libs/linglong/src/linglong/package/reference.cpp
@@ -1,10 +1,12 @@
 /*
- * SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.:
+ * SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.:
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
 #include "linglong/package/reference.h"
+
+#include "linglong/package/fuzzy_reference.h"
 
 #include <fmt/format.h>
 
@@ -112,6 +114,13 @@ Reference::Reference(const std::string &channel,
 std::string Reference::toString() const noexcept
 {
     return fmt::format("{}:{}/{}/{}", channel, id, version.toString(), arch.toString());
+}
+
+bool Reference::semanticMatch(const FuzzyReference &fuzzy) const noexcept
+{
+    return this->id == fuzzy.id && (!fuzzy.channel || *fuzzy.channel == this->channel)
+      && (!fuzzy.arch || *fuzzy.arch == this->arch)
+      && (!fuzzy.version || this->version.semanticMatch(*fuzzy.version));
 }
 
 bool operator!=(const Reference &lhs, const Reference &rhs) noexcept

--- a/libs/linglong/src/linglong/package/reference.h
+++ b/libs/linglong/src/linglong/package/reference.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.:
+ * SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.:
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
@@ -13,6 +13,8 @@
 #include "linglong/package/version.h"
 
 namespace linglong::package {
+
+class FuzzyReference;
 
 // This class is a reference to a tier, use as a tier ID.
 class Reference final
@@ -34,6 +36,7 @@ public:
     Architecture arch;
 
     [[nodiscard]] std::string toString() const noexcept;
+    [[nodiscard]] bool semanticMatch(const FuzzyReference &fuzzy) const noexcept;
     friend bool operator!=(const Reference &lhs, const Reference &rhs) noexcept;
     friend bool operator==(const Reference &lhs, const Reference &rhs) noexcept;
 

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -362,29 +362,22 @@ utils::error::Result<bool> semanticMatch(const package::FuzzyReference &fuzzy,
 {
     LINGLONG_TRACE("semanticMatch");
 
-    if (fuzzy.id != record.id) {
-        return false;
+    auto version = package::Version::parse(record.version);
+    if (!version) {
+        return LINGLONG_ERR(version);
     }
 
-    if (fuzzy.channel && fuzzy.channel != record.channel) {
-        return false;
+    auto arch = package::Architecture::parse(record.arch[0]);
+    if (!arch) {
+        return LINGLONG_ERR(arch);
     }
 
-    if (fuzzy.arch && fuzzy.arch->toString() != record.arch[0]) {
-        return false;
+    auto reference = package::Reference::create(record.channel, record.id, *version, *arch);
+    if (!reference) {
+        return LINGLONG_ERR(reference);
     }
 
-    if (fuzzy.version) {
-        auto version = package::Version::parse(record.version);
-        if (!version) {
-            return LINGLONG_ERR(version);
-        }
-        if (!version->semanticMatch(*fuzzy.version)) {
-            return false;
-        }
-    }
-
-    return true;
+    return reference->semanticMatch(fuzzy);
 }
 
 } // namespace

--- a/libs/linglong/src/linglong/runtime/run_context.cpp
+++ b/libs/linglong/src/linglong/runtime/run_context.cpp
@@ -336,7 +336,33 @@ utils::error::Result<void> RunContext::resolve(const api::types::v1::BuilderProj
         return LINGLONG_ERR("can't resolve run context from package kind " + target.package.kind);
     }
 
-    auto baseFuzzyRef = package::FuzzyReference::parse(target.base);
+    auto base = target.base;
+    if (target.runtime) {
+        auto runtimeFuzzyRef = package::FuzzyReference::parse(*target.runtime);
+        if (!runtimeFuzzyRef) {
+            return LINGLONG_ERR(runtimeFuzzyRef);
+        }
+
+        auto ref = repo.clearReferenceLocal(*runtimeFuzzyRef, true);
+        if (!ref) {
+            return LINGLONG_ERR("ref doesn't exist " + runtimeFuzzyRef->toString());
+        }
+        auto res = RuntimeLayer::create(std::move(ref).value(), *this);
+        if (!res) {
+            return LINGLONG_ERR(res);
+        }
+        runtimeLayer = std::move(res).value();
+
+        if (!base) {
+            base = runtimeLayer->getCachedItem().info.base;
+        }
+    }
+
+    if (!base) {
+        return LINGLONG_ERR("at least one of base or runtime must be specified");
+    }
+
+    auto baseFuzzyRef = package::FuzzyReference::parse(*base);
     if (!baseFuzzyRef) {
         return LINGLONG_ERR(baseFuzzyRef);
     }
@@ -350,38 +376,6 @@ utils::error::Result<void> RunContext::resolve(const api::types::v1::BuilderProj
         return LINGLONG_ERR(res);
     }
     baseLayer = std::move(res).value();
-
-    if (target.runtime) {
-        auto runtimeFuzzyRef = package::FuzzyReference::parse(*target.runtime);
-        if (!runtimeFuzzyRef) {
-            return LINGLONG_ERR(runtimeFuzzyRef);
-        }
-
-        ref = repo.clearReferenceLocal(*runtimeFuzzyRef, true);
-        if (!ref) {
-            return LINGLONG_ERR("ref doesn't exist " + runtimeFuzzyRef->toString());
-        }
-        auto res = RuntimeLayer::create(std::move(ref).value(), *this);
-        if (!res) {
-            return LINGLONG_ERR(res);
-        }
-        runtimeLayer = std::move(res).value();
-
-        const auto &info = runtimeLayer->getCachedItem().info;
-        auto fuzzyRef = package::FuzzyReference::parse(info.base);
-        if (!fuzzyRef) {
-            return LINGLONG_ERR(fuzzyRef);
-        }
-        auto ref = repo.clearReferenceLocal(*fuzzyRef, true);
-        if (!ref || *ref != baseLayer->getReference()) {
-            auto msg = fmt::format("Base is not compatible with runtime. \n - Current base: {}\n - "
-                                   "Current runtime: {}\n - Base required by runtime: {}",
-                                   baseLayer->getReference().toString(),
-                                   runtimeLayer->getReference().toString(),
-                                   info.base);
-            return LINGLONG_ERR(msg);
-        }
-    }
 
     auto timezoneRet = resolveTimeZone();
     if (!timezoneRet) {

--- a/libs/linglong/tests/ll-tests/src/linglong/builder/pull_dependency_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/builder/pull_dependency_test.cpp
@@ -47,6 +47,12 @@ public:
                 clearReferenceLocal,
                 (const package::FuzzyReference &fuzzy, bool semanticMatching),
                 (override, const, noexcept));
+    MOCK_METHOD(utils::error::Result<api::types::v1::RepositoryCacheLayersItem>,
+                getLayerItem,
+                (const package::Reference &ref,
+                 std::string module,
+                 const std::optional<std::string> &subRef),
+                (override, const, noexcept));
     MOCK_METHOD(utils::error::Result<package::ReferenceWithRepo>,
                 latestRemoteReference,
                 (const package::FuzzyReference &fuzzyRef),
@@ -417,6 +423,136 @@ TEST_F(PullDependencyTest, buildStagePullDependency_continues_when_local_develop
     EXPECT_CALL(*m_repo, getLayerDir(_, "develop", _))
       .WillOnce(Return(LINGLONG_ERR("not found")))
       .WillOnce(Return(LINGLONG_ERR("not found")));
+    EXPECT_CALL(*m_repo, mergeModules()).WillOnce(Return(utils::error::Result<void>{}));
+
+    auto result = builder.buildStagePullDependency();
+    EXPECT_TRUE(result.has_value()) << result.error().message();
+}
+
+TEST_F(PullDependencyTest, buildStagePullDependency_resolves_base_from_runtime)
+{
+    LINGLONG_TRACE("buildStagePullDependency_resolves_base_from_runtime");
+
+    auto runtimeRef = package::Reference::parse("main:org.deepin.runtime/23.0.0.0/x86_64");
+    auto baseRef = package::Reference::parse("main:org.deepin.base/23.0.0.0/x86_64");
+    ASSERT_TRUE(runtimeRef.has_value());
+    ASSERT_TRUE(baseRef.has_value());
+
+    auto project = builderProject("org.deepin.runtime/23.0.0.0/x86_64");
+    project.base.reset();
+    builder::Builder builder(std::move(project),
+                             m_tmpDir.path(),
+                             *m_repo,
+                             containerBuilder(),
+                             builderConfig());
+    builder.setBuildOptions(builder::BuilderBuildOptions{ .skipPullDepend = true });
+
+    {
+        InSequence seq;
+        EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(*runtimeRef));
+        EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(*baseRef));
+    }
+    EXPECT_CALL(*m_repo, getLayerDir(_, "develop", _))
+      .Times(2)
+      .WillRepeatedly(
+        [](const package::Reference &,
+           const std::string &,
+           const std::optional<std::string> &) -> utils::error::Result<package::LayerDir> {
+            return layerCached();
+        });
+
+    api::types::v1::RepositoryCacheLayersItem runtimeItem;
+    runtimeItem.info.base = "org.deepin.base/23.0.0.0/x86_64";
+    EXPECT_CALL(*m_repo, getLayerItem(*runtimeRef, "binary", _))
+      .WillOnce(Return(std::move(runtimeItem)));
+    EXPECT_CALL(*m_repo, mergeModules()).WillOnce(Return(utils::error::Result<void>{}));
+
+    auto result = builder.buildStagePullDependency();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.project->base);
+    EXPECT_EQ(*builder.project->base, "org.deepin.base/23.0.0.0/x86_64");
+}
+
+TEST_F(PullDependencyTest, buildStagePullDependency_rejects_incompatible_base_and_runtime)
+{
+    LINGLONG_TRACE("buildStagePullDependency_rejects_incompatible_base_and_runtime");
+
+    auto runtimeRef = package::Reference::parse("main:org.deepin.runtime/23.0.0.0/x86_64");
+    auto configuredBaseRef = package::Reference::parse("main:org.example.base/23.0.0.0/x86_64");
+    ASSERT_TRUE(runtimeRef.has_value());
+    ASSERT_TRUE(configuredBaseRef.has_value());
+
+    auto project = builderProject("org.deepin.runtime/23.0.0.0/x86_64");
+    project.base = "org.example.base/23.0.0/x86_64";
+    builder::Builder builder(std::move(project),
+                             m_tmpDir.path(),
+                             *m_repo,
+                             containerBuilder(),
+                             builderConfig());
+    builder.setBuildOptions(builder::BuilderBuildOptions{ .skipPullDepend = true });
+
+    {
+        InSequence seq;
+        EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(*runtimeRef));
+        EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(*configuredBaseRef));
+    }
+    EXPECT_CALL(*m_repo, getLayerDir(_, "develop", _))
+      .Times(2)
+      .WillRepeatedly(
+        [](const package::Reference &,
+           const std::string &,
+           const std::optional<std::string> &) -> utils::error::Result<package::LayerDir> {
+            return layerCached();
+        });
+
+    api::types::v1::RepositoryCacheLayersItem runtimeItem;
+    runtimeItem.info.base = "org.deepin.base/23.0.0.0/x86_64";
+    EXPECT_CALL(*m_repo, getLayerItem(*runtimeRef, "binary", _))
+      .WillOnce(Return(std::move(runtimeItem)));
+    EXPECT_CALL(*m_repo, mergeModules()).Times(0);
+
+    auto result = builder.buildStagePullDependency();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error().message(),
+                testing::HasSubstr("base is not compatible with runtime"));
+}
+
+TEST_F(PullDependencyTest, buildStagePullDependency_accepts_semantically_compatible_base)
+{
+    LINGLONG_TRACE("buildStagePullDependency_accepts_semantically_compatible_base");
+
+    auto runtimeRef = package::Reference::parse("main:org.deepin.runtime/23.0.0.0/x86_64");
+    auto baseRef = package::Reference::parse("main:org.deepin.base/23.0.0.1/x86_64");
+    ASSERT_TRUE(runtimeRef.has_value());
+    ASSERT_TRUE(baseRef.has_value());
+
+    auto project = builderProject("org.deepin.runtime/23.0.0/x86_64");
+    project.base = "org.deepin.base/23.0.0/x86_64";
+    builder::Builder builder(std::move(project),
+                             m_tmpDir.path(),
+                             *m_repo,
+                             containerBuilder(),
+                             builderConfig());
+    builder.setBuildOptions(builder::BuilderBuildOptions{ .skipPullDepend = true });
+
+    {
+        InSequence seq;
+        EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(*runtimeRef));
+        EXPECT_CALL(*m_repo, clearReferenceLocal(_, true)).WillOnce(Return(*baseRef));
+    }
+    EXPECT_CALL(*m_repo, getLayerDir(_, "develop", _))
+      .Times(2)
+      .WillRepeatedly(
+        [](const package::Reference &,
+           const std::string &,
+           const std::optional<std::string> &) -> utils::error::Result<package::LayerDir> {
+            return layerCached();
+        });
+
+    api::types::v1::RepositoryCacheLayersItem runtimeItem;
+    runtimeItem.info.base = "org.deepin.base/23.0.0/x86_64";
+    EXPECT_CALL(*m_repo, getLayerItem(*runtimeRef, "binary", _))
+      .WillOnce(Return(std::move(runtimeItem)));
     EXPECT_CALL(*m_repo, mergeModules()).WillOnce(Return(utils::error::Result<void>{}));
 
     auto result = builder.buildStagePullDependency();

--- a/libs/linglong/tests/ll-tests/src/linglong/package/reference_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/reference_test.cpp
@@ -1,5 +1,5 @@
 /*
- ; SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+ ; SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
@@ -66,5 +66,26 @@ TEST(Package, Reference)
           << validCase.first << " is valid fuzz reference. Error: "
           << (refer.has_value() ? "no error" : refer.error().message());
         ASSERT_EQ(refer->toString(), validCase.second);
+    }
+}
+
+TEST(Package, ReferenceSemanticMatch)
+{
+    auto reference = Reference::parse("main:org.deepin.base/23.0.0.1/x86_64");
+    ASSERT_TRUE(reference.has_value());
+
+    const std::vector<std::pair<std::string, bool>> cases = {
+        { "main:org.deepin.base/23.0.0/x86_64", true },
+        { "org.deepin.base/23.0.0/x86_64", true },
+        { "main:org.example.base/23.0.0/x86_64", false },
+        { "stable:org.deepin.base/23.0.0/x86_64", false },
+        { "main:org.deepin.base/23.0.0/arm64", false },
+        { "main:org.deepin.base/24.0.0/x86_64", false },
+    };
+
+    for (const auto &[raw, expected] : cases) {
+        auto fuzzy = FuzzyReference::parse(raw);
+        ASSERT_TRUE(fuzzy.has_value()) << raw;
+        EXPECT_EQ(reference->semanticMatch(*fuzzy), expected) << raw;
     }
 }


### PR DESCRIPTION
Allow BuilderProject to omit `base` when `runtime` is specified. The base is automatically resolved from the runtime's required base during dependency pull. When both are present, validate compatibility via semantic matching.