### PR TITLE
feat: prune repo after base/runtime update

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_update.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_update.cpp
@@ -92,7 +92,14 @@ utils::error::Result<void> PackageUpdateAction::doAction(PackageTask &task)
         return LINGLONG_ERR(res.error());
     }
 
-    return postUpdate(task);
+    auto postUpdateRet = postUpdate(task);
+    if (!postUpdateRet) {
+        return LINGLONG_ERR(postUpdateRet.error());
+    }
+
+    task.updateState(linglong::api::types::v1::State::Succeed, "Update applications success");
+
+    return LINGLONG_OK;
 }
 
 utils::error::Result<void> PackageUpdateAction::update(PackageTask &task)
@@ -126,6 +133,8 @@ utils::error::Result<void> PackageUpdateAction::update(PackageTask &task)
         auto res = updateApp(task, app, appOnly, depsOnly);
         if (!res) {
             LogW("failed to update app {}: {}", app.id, res.error());
+            task.sendMessage(
+              fmt::format("failed to update app {}: {}", app.id, res.error().message()));
             continue;
         }
         monitor.pause(true);
@@ -137,8 +146,6 @@ utils::error::Result<void> PackageUpdateAction::update(PackageTask &task)
                             utils::error::ErrorCode::AppUpgradeFailed);
     }
 
-    task.updateState(linglong::api::types::v1::State::Succeed, "Update applications success");
-
     return LINGLONG_OK;
 }
 
@@ -149,6 +156,13 @@ utils::error::Result<void> PackageUpdateAction::postUpdate([[maybe_unused]] Task
     auto res = repo.mergeModules();
     if (!res) {
         LogE("failed to merge modules: {}", res.error());
+    }
+
+    if (baseOrRuntimeUpdated) {
+        auto pruneRet = repo.prune();
+        if (!pruneRet) {
+            LogE("failed to prune: {}", pruneRet.error());
+        }
     }
 
     return LINGLONG_OK;
@@ -233,6 +247,15 @@ utils::error::Result<void> PackageUpdateAction::updateApp(Task &task,
         });
     }
     for (const auto &[refRepo, modules] : refsToInstall) {
+        bool isBaseOrRuntime = false;
+        if (!modules.empty()) {
+            auto info = modules.front().second.getPackageInfo();
+            if (!info) {
+                return LINGLONG_ERR(info);
+            }
+            isBaseOrRuntime = info->kind == "base" || info->kind == "runtime";
+        }
+
         for (const auto &[module, meta] : modules) {
             taskMessage = fmt::format("Updating {}/{}", refRepo.reference.toString(), module);
             task.updateStateMessage(taskMessage);
@@ -241,6 +264,8 @@ utils::error::Result<void> PackageUpdateAction::updateApp(Task &task,
                 return LINGLONG_ERR(res);
             }
         }
+
+        baseOrRuntimeUpdated = baseOrRuntimeUpdated || isBaseOrRuntime;
     }
 
     if (!depsOnly && newAppInfo) {

--- a/libs/linglong/src/linglong/package_manager/package_update.h
+++ b/libs/linglong/src/linglong/package_manager/package_update.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -81,6 +81,7 @@ private:
     uint64_t taskTotalSize;
     uint64_t taskNeededSize;
     uint64_t taskFetchedSize;
+    bool baseOrRuntimeUpdated = false;
 };
 
 } // namespace linglong::service

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -147,7 +147,7 @@ public:
     utils::error::Result<void>
     clean(const std::vector<api::types::v1::RepositoryCacheLayersItem> &reserved) noexcept;
 
-    utils::error::Result<void> prune();
+    virtual utils::error::Result<void> prune();
 
     virtual utils::error::Result<RefMetaData>
     fetchRefMetaData(const package::ReferenceWithRepo &refRepo,

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/package_update_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/package_update_test.cpp
@@ -23,6 +23,7 @@ using ::testing::_;
 using ::testing::AllOf;
 using ::testing::DoAll;
 using ::testing::Field;
+using ::testing::HasSubstr;
 using ::testing::IsSubsetOf;
 using ::testing::Return;
 using ::testing::SetArgReferee;
@@ -179,6 +180,19 @@ public:
                 (override, const, noexcept));
 
     MOCK_METHOD(utils::error::Result<void>, mergeModules, (), (override, const, noexcept));
+
+    MOCK_METHOD(utils::error::Result<void>, prune, (), (override));
+};
+
+class MockPackageTask : public service::PackageTask
+{
+public:
+    MockPackageTask()
+        : service::PackageTask({})
+    {
+    }
+
+    MOCK_METHOD(void, sendMessage, (const std::string &message), (override, noexcept));
 };
 
 class PackageUpdateActionTest : public ::testing::Test
@@ -297,12 +311,65 @@ TEST_F(PackageUpdateActionTest, Update)
     EXPECT_CALL(*repo, mergeModules()).WillOnce([]() {
         return utils::error::Result<void>{};
     });
+    EXPECT_CALL(*repo, prune()).WillOnce([]() -> utils::error::Result<void> {
+        return LINGLONG_OK;
+    });
 
     EXPECT_CALL(*pm, switchAppVersion(_, _, true)).WillOnce(Return(utils::error::Result<void>{}));
 
     service::PackageTask task({});
     res = action->doAction(task);
     ASSERT_TRUE(res.has_value());
+}
+
+TEST_F(PackageUpdateActionTest, SkipPruneWhenBaseAndRuntimeAreNotUpdated)
+{
+    auto action =
+      service::PackageUpdateAction::create(std::vector<api::types::v1::PackageManager1Package>(),
+                                           true,
+                                           false,
+                                           *pm,
+                                           *repo);
+
+    EXPECT_CALL(*repo, listLocalApps())
+      .WillOnce(Return(std::vector<api::types::v1::PackageInfoV2>{ testdata::idV100 }));
+
+    auto res = action->prepare();
+    ASSERT_TRUE(res.has_value());
+
+    EXPECT_CALL(*pm, needToUpgrade(_, _, false)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*repo, mergeModules()).WillOnce(Return(utils::error::Result<void>{}));
+    EXPECT_CALL(*repo, prune()).Times(0);
+
+    service::PackageTask task({});
+    res = action->doAction(task);
+    ASSERT_TRUE(res.has_value());
+}
+
+TEST_F(PackageUpdateActionTest, SendMessageWhenAppUpdateFails)
+{
+    LINGLONG_TRACE("send update failure message");
+
+    auto action =
+      service::PackageUpdateAction::create(std::vector<api::types::v1::PackageManager1Package>(),
+                                           true,
+                                           false,
+                                           *pm,
+                                           *repo);
+
+    EXPECT_CALL(*repo, listLocalApps())
+      .WillOnce(Return(std::vector<api::types::v1::PackageInfoV2>{ testdata::idV100 }));
+
+    auto res = action->prepare();
+    ASSERT_TRUE(res.has_value());
+
+    EXPECT_CALL(*pm, needToUpgrade(_, _, false)).WillOnce(Return(LINGLONG_ERR("update error")));
+
+    MockPackageTask task;
+    EXPECT_CALL(task, sendMessage(HasSubstr("failed to update app id1: update error")));
+
+    res = action->doAction(task);
+    ASSERT_FALSE(res.has_value());
 }
 
 } // namespace


### PR DESCRIPTION
- prune when a base or runtime was updated to reclaim ostree objects.
- Send a task message when an individual app update fails so users see the per-app failure reason.