### PR TITLE
feat: auto-prune unused dependencies after package operations

### DIFF
--- a/api/schema/v1.json
+++ b/api/schema/v1.json
@@ -889,6 +889,10 @@
         "force": {
           "description": "force to overwrite",
           "type": "boolean"
+        },
+        "noAutoPrune": {
+          "description": "do not automatically remove unused dependencies",
+          "type": "boolean"
         }
       }
     },
@@ -1073,6 +1077,10 @@
         "appOnly": {
           "type": "boolean",
           "description": "upgrade applications only"
+        },
+        "noAutoPrune": {
+          "type": "boolean",
+          "description": "do not automatically remove unused dependencies"
         }
       }
     },

--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -690,6 +690,9 @@ $defs:
       force:
         description: force to overwrite
         type: boolean
+      noAutoPrune:
+        description: do not automatically remove unused dependencies
+        type: boolean
   CommonResult:
     title: CommonResult
     description: this is common error result of ll-cli command --json
@@ -820,6 +823,9 @@ $defs:
       appOnly:
         type: boolean
         description: upgrade applications only
+      noAutoPrune:
+        type: boolean
+        description: do not automatically remove unused dependencies
   PackageManager1ModifyRepoParameters:
     type: object
     required:

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -299,6 +299,9 @@ ll-cli install stable:org.deepin.demo/0.0.0.1/x86_64
     cliInstall->add_flag("-y",
                          installOptions.confirmOpt,
                          _("Automatically answer yes to all questions"));
+    cliInstall->add_flag("--no-auto-prune",
+                         installOptions.noAutoPrune,
+                         _("Do not automatically remove unused dependencies"));
 }
 
 // Function to add the uninstall subcommand
@@ -320,6 +323,9 @@ void addUninstallCommand(CLI::App &commandParser,
     cliUninstall->add_flag("--force",
                            uninstallOptions.forceOpt,
                            _("Force uninstall base or runtime"));
+    cliUninstall->add_flag("--no-auto-prune",
+                           uninstallOptions.noAutoPrune,
+                           _("Do not automatically remove unused dependencies"));
 
     // below options are used for compatibility with old ll-cli
     const auto &pruneDescription = std::string{ _("Remove all unused modules") };
@@ -351,6 +357,9 @@ void addUpgradeCommand(CLI::App &commandParser,
                                          _("Only upgrade dependencies of application"));
     cliUpgrade->add_flag("--app-only", upgradeOptions.appOnly, _("Only upgrade application"))
       ->excludes(depsOnly);
+    cliUpgrade->add_flag("--no-auto-prune",
+                         upgradeOptions.noAutoPrune,
+                         _("Do not automatically remove unused dependencies"));
 }
 
 // Function to add the search subcommand

--- a/docs/pages/en/guide/reference/commands/ll-cli/install.md
+++ b/docs/pages/en/guide/reference/commands/ll-cli/install.md
@@ -32,6 +32,9 @@ The `ll-cli install` command is used to install Linyaps applications. This comma
 **-y**
 : Automatically answer yes to all questions
 
+**--no-auto-prune**
+: Do not automatically remove unused dependencies after installing or replacing an application
+
 ## POSITIONAL ARGUMENTS
 
 **APP** _TEXT_ _REQUIRED_

--- a/docs/pages/en/guide/reference/commands/ll-cli/uninstall.md
+++ b/docs/pages/en/guide/reference/commands/ll-cli/uninstall.md
@@ -26,6 +26,9 @@ The `ll-cli uninstall` command removes installed Linyaps applications. Base and 
 **--force**
 : Force the uninstallation of a Base or Runtime
 
+**--no-auto-prune**
+: Do not automatically remove unused dependencies after uninstalling an application
+
 ## POSITIONAL ARGUMENTS
 
 **APP** _TEXT_ _REQUIRED_

--- a/docs/pages/en/guide/reference/commands/ll-cli/upgrade.md
+++ b/docs/pages/en/guide/reference/commands/ll-cli/upgrade.md
@@ -26,6 +26,9 @@ The `ll-cli upgrade` command can update Linyaps applications. This command is us
 **--app-only**
 : Upgrade only the specified application itself; mutually exclusive with `--deps-only`
 
+**--no-auto-prune**
+: Do not automatically remove unused dependencies after upgrading applications
+
 ## POSITIONAL ARGUMENTS
 
 **APP** _TEXT_

--- a/docs/pages/guide/reference/commands/ll-cli/install.md
+++ b/docs/pages/guide/reference/commands/ll-cli/install.md
@@ -32,6 +32,9 @@ ll\-cli\-install - 安装应用程序或运行时
 **-y**
 : 自动对所有问题回答是
 
+**--no-auto-prune**
+: 安装或替换应用后不自动清理未使用的依赖
+
 ## POSITIONAL ARGUMENTS
 
 **APP** _TEXT_ _REQUIRED_

--- a/docs/pages/guide/reference/commands/ll-cli/uninstall.md
+++ b/docs/pages/guide/reference/commands/ll-cli/uninstall.md
@@ -26,6 +26,9 @@ ll\-cli\-uninstall - 卸载应用程序或运行时
 **--force**
 : 强制卸载基础环境（Base）或运行时（Runtime）
 
+**--no-auto-prune**
+: 卸载应用后不自动清理未使用的依赖
+
 ## POSITIONAL ARGUMENTS
 
 **APP** _TEXT_ _REQUIRED_

--- a/docs/pages/guide/reference/commands/ll-cli/upgrade.md
+++ b/docs/pages/guide/reference/commands/ll-cli/upgrade.md
@@ -26,6 +26,9 @@ ll\-cli\-upgrade - 升级应用程序或运行时
 **--app-only**
 : 仅升级指定应用本身，与 `--deps-only` 互斥
 
+**--no-auto-prune**
+: 升级应用后不自动清理未使用的依赖
+
 ## POSITIONAL ARGUMENTS
 
 **APP** _TEXT_

--- a/libs/api/src/linglong/api/types/v1/CommonOptions.hpp
+++ b/libs/api/src/linglong/api/types/v1/CommonOptions.hpp
@@ -36,6 +36,10 @@ struct CommonOptions {
 */
 bool force;
 /**
+* do not automatically remove unused dependencies
+*/
+std::optional<bool> noAutoPrune;
+/**
 * skip interaction, such as 'apt install aa -y'
 */
 bool skipInteraction;

--- a/libs/api/src/linglong/api/types/v1/Generators.hpp
+++ b/libs/api/src/linglong/api/types/v1/Generators.hpp
@@ -601,12 +601,16 @@ j["pid"] = x.pid;
 
 inline void from_json(const json & j, CommonOptions& x) {
 x.force = j.at("force").get<bool>();
+x.noAutoPrune = get_stack_optional<bool>(j, "noAutoPrune");
 x.skipInteraction = j.at("skipInteraction").get<bool>();
 }
 
 inline void to_json(json & j, const CommonOptions & x) {
 j = json::object();
 j["force"] = x.force;
+if (x.noAutoPrune) {
+j["noAutoPrune"] = x.noAutoPrune;
+}
 j["skipInteraction"] = x.skipInteraction;
 }
 
@@ -1156,6 +1160,7 @@ j["package"] = x.package;
 inline void from_json(const json & j, PackageManager1UpdateParameters& x) {
 x.appOnly = j.at("appOnly").get<bool>();
 x.depsOnly = j.at("depsOnly").get<bool>();
+x.noAutoPrune = get_stack_optional<bool>(j, "noAutoPrune");
 x.packages = j.at("packages").get<std::vector<PackageManager1Package>>();
 }
 
@@ -1163,6 +1168,9 @@ inline void to_json(json & j, const PackageManager1UpdateParameters & x) {
 j = json::object();
 j["appOnly"] = x.appOnly;
 j["depsOnly"] = x.depsOnly;
+if (x.noAutoPrune) {
+j["noAutoPrune"] = x.noAutoPrune;
+}
 j["packages"] = x.packages;
 }
 

--- a/libs/api/src/linglong/api/types/v1/PackageManager1UpdateParameters.hpp
+++ b/libs/api/src/linglong/api/types/v1/PackageManager1UpdateParameters.hpp
@@ -42,6 +42,10 @@ bool appOnly;
 */
 bool depsOnly;
 /**
+* do not automatically remove unused dependencies
+*/
+std::optional<bool> noAutoPrune;
+/**
 * packages of package manager update
 */
 std::vector<PackageManager1Package> packages;

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -2341,6 +2341,7 @@ int Cli::install(const InstallOptions &options)
                                                                      .skipInteraction = false } };
     params.options.force = options.forceOpt;
     params.options.skipInteraction = options.confirmOpt;
+    params.options.noAutoPrune = options.noAutoPrune;
     params.repo = options.repo;
 
     QFileInfo info(QString::fromStdString(options.appid));
@@ -2431,6 +2432,7 @@ int Cli::upgrade(const UpgradeOptions &options)
     api::types::v1::PackageManager1UpdateParameters params;
     params.appOnly = options.appOnly;
     params.depsOnly = options.depsOnly;
+    params.noAutoPrune = options.noAutoPrune;
     for (const auto &ref : toUpgrade) {
         api::types::v1::PackageManager1Package package;
         package.id = ref.id;
@@ -2581,6 +2583,7 @@ int Cli::uninstall(const UninstallOptions &options)
         .force = options.forceOpt,
         .skipInteraction = false,
     };
+    params.options.noAutoPrune = options.noAutoPrune;
     params.package.id = fuzzyRef->id;
     if (fuzzyRef->channel) {
         params.package.channel = fuzzyRef->channel;

--- a/libs/linglong/src/linglong/cli/cli.h
+++ b/libs/linglong/src/linglong/cli/cli.h
@@ -97,6 +97,7 @@ struct InstallOptions
     std::optional<std::string> repo;
     bool forceOpt{ false };
     bool confirmOpt{ false };
+    bool noAutoPrune{ false };
 };
 
 struct UpgradeOptions
@@ -104,6 +105,7 @@ struct UpgradeOptions
     std::string appid; // 可选，为空时升级所有应用
     bool appOnly{ false };
     bool depsOnly{ false };
+    bool noAutoPrune{ false };
 };
 
 struct SearchOptions
@@ -120,6 +122,7 @@ struct UninstallOptions
     std::string appid;
     std::string module;
     bool forceOpt{ false };
+    bool noAutoPrune{ false };
 };
 
 struct ListOptions

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -429,6 +429,7 @@ void PackageManager::deferredUninstall() noexcept
         return;
     }
 
+    bool refsRemoved = false;
     for (const auto &[ref, items] : uninstalledLayers) {
         for (const auto &item : items) {
             // The app was already unapplied before being marked for lazy deletion.
@@ -442,6 +443,7 @@ void PackageManager::deferredUninstall() noexcept
                 LogE("failed to remove lazy deleted layer {}", ret.error());
                 continue;
             }
+            refsRemoved = true;
         }
     }
 
@@ -449,6 +451,20 @@ void PackageManager::deferredUninstall() noexcept
     if (!mergeRet) {
         LogE("failed to merge modules: {}", mergeRet.error());
     }
+
+    if (!refsRemoved) {
+        return;
+    }
+
+    // Deferred removal only releases the deleted layers and unreachable OSTree objects.
+    // Dependency-aware pruning is intentionally left to an explicit prune or a later package
+    // operation, because the originating auto-prune option is not retained for deferred work.
+    auto pruneRet = this->repo->prune();
+    if (pruneRet) {
+        return;
+    }
+
+    LogE("failed to prune after lazy uninstall: {}", pruneRet.error());
 }
 
 auto PackageManager::getConfiguration() const noexcept -> QVariantMap
@@ -695,6 +711,7 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
                   return;
               }
 
+              bool appReplaced = false;
               auto ret = executePostInstallHooks(*newRef);
               if (!ret) {
                   taskRef.reportError(std::move(ret).error());
@@ -716,7 +733,19 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
                                localRef->toString(),
                                packageRef.toString(),
                                ret.error().message());
+                      } else {
+                          appReplaced = true;
                       }
+                  }
+              }
+
+              if (appReplaced) {
+                  auto pruneRet =
+                    options.noAutoPrune.value_or(false) ? this->repo->prune() : pruneUnused();
+                  if (!pruneRet) {
+                      LogE("failed to prune after installing {}: {}",
+                           newRef->toString(),
+                           pruneRet.error());
                   }
               }
           }
@@ -1026,12 +1055,16 @@ QVariantMap PackageManager::uninstallImpl(const QVariantMap &parameters,
                                curModule);
 
     auto taskRet = tasks.addPackageTask(
-      [this, mainRef = *mainRef, curModule](Task &taskRef) {
+      [this,
+       mainRef = *mainRef,
+       curModule,
+       noAutoPrune = paras->options.noAutoPrune.value_or(false)](Task &taskRef) {
           if (taskRef.isTaskDone()) {
               return;
           }
 
-          auto res = this->Uninstall(dynamic_cast<PackageTask &>(taskRef), mainRef, curModule);
+          auto res =
+            this->Uninstall(dynamic_cast<PackageTask &>(taskRef), mainRef, curModule, noAutoPrune);
           if (!res) {
               LogE("uninstall failed: {}", res.error());
               taskRef.reportError(std::move(res.error()));
@@ -1053,7 +1086,8 @@ QVariantMap PackageManager::uninstallImpl(const QVariantMap &parameters,
 
 utils::error::Result<void> PackageManager::Uninstall(PackageTask &taskContext,
                                                      const package::Reference &ref,
-                                                     const std::string &module) noexcept
+                                                     const std::string &module,
+                                                     bool noAutoPrune) noexcept
 {
     LINGLONG_TRACE(fmt::format("uninstall ref {} {}", ref.toString(), module));
 
@@ -1061,6 +1095,7 @@ utils::error::Result<void> PackageManager::Uninstall(PackageTask &taskContext,
                             fmt::format("Uninstalling {}", ref.toString()));
 
     std::vector<std::string> removedModules{ module };
+    bool mayHaveUnusedDependencies = false;
 
     if (module == "binary" || module == "runtime") {
         // remove main module means remove all modules
@@ -1076,6 +1111,7 @@ utils::error::Result<void> PackageManager::Uninstall(PackageTask &taskContext,
             if (!res) {
                 return LINGLONG_ERR(res);
             }
+            mayHaveUnusedDependencies = true;
         }
     }
 
@@ -1089,9 +1125,9 @@ utils::error::Result<void> PackageManager::Uninstall(PackageTask &taskContext,
         LogE("merge modules failed: {}", mergeRet.error());
     }
 
-    auto pruneRet = this->repo->prune();
+    auto pruneRet = mayHaveUnusedDependencies && !noAutoPrune ? pruneUnused() : this->repo->prune();
     if (!pruneRet) {
-        return LINGLONG_ERR(pruneRet);
+        LogE("failed to prune after uninstalling {}: {}", ref.toString(), pruneRet.error());
     }
 
     taskContext.updateState(linglong::api::types::v1::State::Succeed,
@@ -1143,8 +1179,12 @@ QVariantMap PackageManager::updateImpl(const QVariantMap &parameters,
         return toDBusReply(utils::error::ErrorCode::AppUpgradeFailed, paras.error().message());
     }
 
-    auto action =
-      PackageUpdateAction::create(paras->packages, paras->appOnly, paras->depsOnly, *this, *repo);
+    auto action = PackageUpdateAction::create(paras->packages,
+                                              paras->appOnly,
+                                              paras->depsOnly,
+                                              paras->noAutoPrune.value_or(false),
+                                              *this,
+                                              *repo);
     if (!action) {
         return toDBusReply(utils::error::ErrorCode::AppUpgradeFailed,
                            "failed to create update action");
@@ -1771,6 +1811,12 @@ PackageManager::Prune(std::vector<api::types::v1::PackageInfoV2> &removed) noexc
         return LINGLONG_ERR(pruneRet);
     }
     return LINGLONG_OK;
+}
+
+utils::error::Result<void> PackageManager::pruneUnused() noexcept
+{
+    std::vector<api::types::v1::PackageInfoV2> removed;
+    return Prune(removed);
 }
 
 auto PackageManager::InitRunContext(const QString &runContextCfg,

--- a/libs/linglong/src/linglong/package_manager/package_manager.h
+++ b/libs/linglong/src/linglong/package_manager/package_manager.h
@@ -70,6 +70,8 @@ public
     virtual utils::error::Result<void> switchAppVersion(const package::Reference &oldRef,
                                                         const package::Reference &newRef,
                                                         bool removeOldRef = false) noexcept;
+    // Scan installed application dependencies and remove unreferenced packages.
+    virtual utils::error::Result<void> pruneUnused() noexcept;
     virtual utils::error::Result<void> tryGenerateCache(const package::Reference &ref) noexcept;
     utils::error::Result<void> executePostInstallHooks(const package::Reference &ref) noexcept;
     utils::error::Result<void> executePostUninstallHooks(const package::Reference &ref) noexcept;
@@ -96,7 +98,8 @@ public
                                                         const std::string &module) noexcept;
     utils::error::Result<void> Uninstall(PackageTask &taskContext,
                                          const package::Reference &ref,
-                                         const std::string &module) noexcept;
+                                         const std::string &module,
+                                         bool noAutoPrune = false) noexcept;
     virtual utils::error::Result<bool> tryUninstallRef(const package::Reference &ref) noexcept;
     utils::error::Result<void>
     uninstallRef(const package::Reference &ref,

--- a/libs/linglong/src/linglong/package_manager/package_update.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_update.cpp
@@ -18,10 +18,12 @@ std::shared_ptr<PackageUpdateAction>
 PackageUpdateAction::create(std::vector<api::types::v1::PackageManager1Package> toUpgrade,
                             bool appOnly,
                             bool depsOnly,
+                            bool noAutoPrune,
                             PackageManager &pm,
                             repo::OSTreeRepo &repo)
 {
-    auto p = new PackageUpdateAction(std::move(toUpgrade), appOnly, depsOnly, pm, repo);
+    auto p =
+      new PackageUpdateAction(std::move(toUpgrade), appOnly, depsOnly, noAutoPrune, pm, repo);
     return std::shared_ptr<PackageUpdateAction>(p);
 }
 
@@ -29,12 +31,14 @@ PackageUpdateAction::PackageUpdateAction(
   std::vector<api::types::v1::PackageManager1Package> toUpgrade,
   bool appOnly,
   bool depsOnly,
+  bool noAutoPrune,
   PackageManager &pm,
   repo::OSTreeRepo &repo)
     : Action(pm, repo, api::types::v1::CommonOptions{})
     , toUpgrade(std::move(toUpgrade))
     , appOnly(appOnly)
     , depsOnly(depsOnly)
+    , noAutoPrune(noAutoPrune)
     , taskTotalSize(0)
     , taskNeededSize(0)
     , taskFetchedSize(0)
@@ -158,10 +162,10 @@ utils::error::Result<void> PackageUpdateAction::postUpdate([[maybe_unused]] Task
         LogE("failed to merge modules: {}", res.error());
     }
 
-    if (baseOrRuntimeUpdated) {
-        auto pruneRet = repo.prune();
+    if (repositoryChanged) {
+        auto pruneRet = noAutoPrune ? repo.prune() : pm.pruneUnused();
         if (!pruneRet) {
-            LogE("failed to prune: {}", pruneRet.error());
+            LogE("failed to prune after update: {}", pruneRet.error());
         }
     }
 
@@ -247,15 +251,6 @@ utils::error::Result<void> PackageUpdateAction::updateApp(Task &task,
         });
     }
     for (const auto &[refRepo, modules] : refsToInstall) {
-        bool isBaseOrRuntime = false;
-        if (!modules.empty()) {
-            auto info = modules.front().second.getPackageInfo();
-            if (!info) {
-                return LINGLONG_ERR(info);
-            }
-            isBaseOrRuntime = info->kind == "base" || info->kind == "runtime";
-        }
-
         for (const auto &[module, meta] : modules) {
             taskMessage = fmt::format("Updating {}/{}", refRepo.reference.toString(), module);
             task.updateStateMessage(taskMessage);
@@ -263,9 +258,8 @@ utils::error::Result<void> PackageUpdateAction::updateApp(Task &task,
             if (!res) {
                 return LINGLONG_ERR(res);
             }
+            repositoryChanged = true;
         }
-
-        baseOrRuntimeUpdated = baseOrRuntimeUpdated || isBaseOrRuntime;
     }
 
     if (!depsOnly && newAppInfo) {

--- a/libs/linglong/src/linglong/package_manager/package_update.h
+++ b/libs/linglong/src/linglong/package_manager/package_update.h
@@ -29,6 +29,7 @@ public:
     create(std::vector<api::types::v1::PackageManager1Package> toUpgrade,
            bool appOnly,
            bool depsOnly,
+           bool noAutoPrune,
            PackageManager &pm,
            repo::OSTreeRepo &repo);
 
@@ -47,6 +48,7 @@ private:
     PackageUpdateAction(std::vector<api::types::v1::PackageManager1Package> toUpgrade,
                         bool appOnly,
                         bool depsOnly,
+                        bool noAutoPrune,
                         PackageManager &pm,
                         repo::OSTreeRepo &repo);
 
@@ -72,6 +74,7 @@ private:
     std::vector<api::types::v1::PackageManager1Package> toUpgrade;
     bool appOnly;
     bool depsOnly;
+    bool noAutoPrune;
 
     std::string taskName;
     std::string taskMessage;
@@ -81,7 +84,7 @@ private:
     uint64_t taskTotalSize;
     uint64_t taskNeededSize;
     uint64_t taskFetchedSize;
-    bool baseOrRuntimeUpdated = false;
+    bool repositoryChanged = false;
 };
 
 } // namespace linglong::service

--- a/libs/linglong/src/linglong/package_manager/ref_installation.cpp
+++ b/libs/linglong/src/linglong/package_manager/ref_installation.cpp
@@ -392,6 +392,15 @@ utils::error::Result<void> RefInstallationAction::postInstall(Task &task)
         LogE("failed to merge modules: {}", mergeRet.error());
     }
 
+    if (operation.kind == "app" && operation.oldRef && !extraModuleOnly(modules)) {
+        auto pruneRet = options.noAutoPrune.value_or(false) ? this->repo.prune() : pm.pruneUnused();
+        if (!pruneRet) {
+            LogE("failed to prune after installing {}: {}",
+                 operation.newRef->reference.toString(),
+                 pruneRet.error());
+        }
+    }
+
     auto &repo = operation.newRef->repo;
     task.updateState(linglong::api::types::v1::State::Succeed,
                      fmt::format("Install {} (from repo: {}) success",

--- a/libs/linglong/src/linglong/package_manager/uab_installation.cpp
+++ b/libs/linglong/src/linglong/package_manager/uab_installation.cpp
@@ -343,6 +343,14 @@ utils::error::Result<void> UabInstallationAction::postInstall(PackageTask &task)
     }
 
     transaction.commit();
+
+    if (operation.kind == "app" && operation.oldRef && !extraModuleOnly(checkedLayers.first)) {
+        auto pruneRet = options.noAutoPrune.value_or(false) ? repo.prune() : pm.pruneUnused();
+        if (!pruneRet) {
+            LogE("failed to prune after installing {}: {}", newRef.toString(), pruneRet.error());
+        }
+    }
+
     task.updateState(linglong::api::types::v1::State::Succeed, "install uab successfully");
 
     return LINGLONG_OK;

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/package_update_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/package_update_test.cpp
@@ -146,6 +146,8 @@ public:
                  const package::Reference &newRef,
                  bool removeOld),
                 (override, noexcept));
+
+    MOCK_METHOD(utils::error::Result<void>, pruneUnused, (), (override, noexcept));
 };
 
 class MockRepo : public repo::OSTreeRepo
@@ -231,6 +233,7 @@ TEST_F(PackageUpdateActionTest, Update)
       service::PackageUpdateAction::create(std::vector<api::types::v1::PackageManager1Package>(),
                                            false,
                                            false,
+                                           false,
                                            *pm,
                                            *repo);
 
@@ -311,7 +314,7 @@ TEST_F(PackageUpdateActionTest, Update)
     EXPECT_CALL(*repo, mergeModules()).WillOnce([]() {
         return utils::error::Result<void>{};
     });
-    EXPECT_CALL(*repo, prune()).WillOnce([]() -> utils::error::Result<void> {
+    EXPECT_CALL(*pm, pruneUnused()).WillOnce([]() -> utils::error::Result<void> {
         return LINGLONG_OK;
     });
 
@@ -322,11 +325,12 @@ TEST_F(PackageUpdateActionTest, Update)
     ASSERT_TRUE(res.has_value());
 }
 
-TEST_F(PackageUpdateActionTest, SkipPruneWhenBaseAndRuntimeAreNotUpdated)
+TEST_F(PackageUpdateActionTest, SkipPruneWhenNothingChanged)
 {
     auto action =
       service::PackageUpdateAction::create(std::vector<api::types::v1::PackageManager1Package>(),
                                            true,
+                                           false,
                                            false,
                                            *pm,
                                            *repo);
@@ -339,6 +343,83 @@ TEST_F(PackageUpdateActionTest, SkipPruneWhenBaseAndRuntimeAreNotUpdated)
 
     EXPECT_CALL(*pm, needToUpgrade(_, _, false)).WillOnce(Return(std::nullopt));
     EXPECT_CALL(*repo, mergeModules()).WillOnce(Return(utils::error::Result<void>{}));
+    EXPECT_CALL(*pm, pruneUnused()).Times(0);
+    EXPECT_CALL(*repo, prune()).Times(0);
+
+    service::PackageTask task({});
+    res = action->doAction(task);
+    ASSERT_TRUE(res.has_value());
+}
+
+TEST_F(PackageUpdateActionTest, PruneRepositoryWhenAutoPruneDisabled)
+{
+    auto action =
+      service::PackageUpdateAction::create(std::vector<api::types::v1::PackageManager1Package>(),
+                                           true,
+                                           false,
+                                           true,
+                                           *pm,
+                                           *repo);
+
+    EXPECT_CALL(*repo, listLocalApps())
+      .WillOnce(Return(std::vector<api::types::v1::PackageInfoV2>{ testdata::id2V100 }));
+
+    auto res = action->prepare();
+    ASSERT_TRUE(res.has_value());
+
+    EXPECT_CALL(*pm, needToUpgrade(_, _, false))
+      .WillOnce(Return(std::make_pair(
+        package::ReferenceWithRepo{ .repo = api::types::v1::Repo{ .name = "repo" },
+                                    .reference =
+                                      package::Reference::parse("main:id2/1.1.0/x86_64").value() },
+        std::vector<std::string>{ "binary" })));
+    EXPECT_CALL(*repo, fetchRefMetaData(_, "binary", true))
+      .WillOnce(Return(repo::RefMetaData{ "rev1", nlohmann::json(testdata::id2V110).dump() }));
+    EXPECT_CALL(*repo, getRefStatistics(_))
+      .WillOnce(Return(repo::RefStatistics{ .archived = 1024, .needed_archived = 512 }));
+    EXPECT_CALL(*pm, installRefModule(_, _, "binary"))
+      .WillOnce(Return(utils::error::Result<void>{}));
+    EXPECT_CALL(*pm, switchAppVersion(_, _, true)).WillOnce(Return(utils::error::Result<void>{}));
+    EXPECT_CALL(*repo, mergeModules()).WillOnce(Return(utils::error::Result<void>{}));
+    EXPECT_CALL(*pm, pruneUnused()).Times(0);
+    EXPECT_CALL(*repo, prune()).WillOnce(Return(utils::error::Result<void>{}));
+
+    service::PackageTask task({});
+    res = action->doAction(task);
+    ASSERT_TRUE(res.has_value());
+}
+
+TEST_F(PackageUpdateActionTest, PruneUnusedWhenOnlyAppUpdated)
+{
+    auto action =
+      service::PackageUpdateAction::create(std::vector<api::types::v1::PackageManager1Package>(),
+                                           true,
+                                           false,
+                                           false,
+                                           *pm,
+                                           *repo);
+
+    EXPECT_CALL(*repo, listLocalApps())
+      .WillOnce(Return(std::vector<api::types::v1::PackageInfoV2>{ testdata::id2V100 }));
+
+    auto res = action->prepare();
+    ASSERT_TRUE(res.has_value());
+
+    EXPECT_CALL(*pm, needToUpgrade(_, _, false))
+      .WillOnce(Return(std::make_pair(
+        package::ReferenceWithRepo{ .repo = api::types::v1::Repo{ .name = "repo" },
+                                    .reference =
+                                      package::Reference::parse("main:id2/1.1.0/x86_64").value() },
+        std::vector<std::string>{ "binary" })));
+    EXPECT_CALL(*repo, fetchRefMetaData(_, "binary", true))
+      .WillOnce(Return(repo::RefMetaData{ "rev1", nlohmann::json(testdata::id2V110).dump() }));
+    EXPECT_CALL(*repo, getRefStatistics(_))
+      .WillOnce(Return(repo::RefStatistics{ .archived = 1024, .needed_archived = 512 }));
+    EXPECT_CALL(*pm, installRefModule(_, _, "binary"))
+      .WillOnce(Return(utils::error::Result<void>{}));
+    EXPECT_CALL(*pm, switchAppVersion(_, _, true)).WillOnce(Return(utils::error::Result<void>{}));
+    EXPECT_CALL(*repo, mergeModules()).WillOnce(Return(utils::error::Result<void>{}));
+    EXPECT_CALL(*pm, pruneUnused()).WillOnce(Return(utils::error::Result<void>{}));
     EXPECT_CALL(*repo, prune()).Times(0);
 
     service::PackageTask task({});
@@ -354,6 +435,7 @@ TEST_F(PackageUpdateActionTest, SendMessageWhenAppUpdateFails)
       service::PackageUpdateAction::create(std::vector<api::types::v1::PackageManager1Package>(),
                                            true,
                                            false,
+                                           false,
                                            *pm,
                                            *repo);
 
@@ -364,6 +446,7 @@ TEST_F(PackageUpdateActionTest, SendMessageWhenAppUpdateFails)
     ASSERT_TRUE(res.has_value());
 
     EXPECT_CALL(*pm, needToUpgrade(_, _, false)).WillOnce(Return(LINGLONG_ERR("update error")));
+    EXPECT_CALL(*pm, pruneUnused()).Times(0);
 
     MockPackageTask task;
     EXPECT_CALL(task, sendMessage(HasSubstr("failed to update app id1: update error")));

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/ref_installation_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/ref_installation_test.cpp
@@ -60,6 +60,8 @@ public:
                 needToInstall,
                 (const std::string &refStr, std::optional<std::string> channel),
                 (override));
+
+    MOCK_METHOD(utils::error::Result<void>, pruneUnused, (), (override, noexcept));
 };
 
 class MockRepo : public repo::OSTreeRepo
@@ -110,6 +112,8 @@ public:
                 (override, const, noexcept));
 
     MOCK_METHOD(utils::error::Result<void>, mergeModules, (), (override, const, noexcept));
+
+    MOCK_METHOD(utils::error::Result<void>, prune, (), (override));
 };
 
 class RefInstallationTest : public ::testing::Test
@@ -189,6 +193,7 @@ TEST_F(RefInstallationTest, InstallApp)
     EXPECT_CALL(*pm, needToInstall("runtime", _)).WillOnce(Return(std::nullopt));
 
     EXPECT_CALL(*pm, applyApp(_)).WillOnce(Return(utils::error::Result<void>{}));
+    EXPECT_CALL(*pm, pruneUnused()).Times(0);
     EXPECT_CALL(*repo, mergeModules()).WillOnce([]() {
         return utils::error::Result<void>{};
     });
@@ -281,6 +286,7 @@ TEST_F(RefInstallationTest, InstallExtraOnly)
     EXPECT_CALL(*pm, needToInstall("runtime", _)).WillOnce(Return(std::nullopt));
 
     EXPECT_CALL(*pm, applyApp(_)).WillOnce(Return(utils::error::Result<void>{}));
+    EXPECT_CALL(*pm, pruneUnused()).Times(0);
     EXPECT_CALL(*repo, mergeModules()).WillOnce([]() {
         return utils::error::Result<void>{};
     });
@@ -354,6 +360,7 @@ TEST_F(RefInstallationTest, InstallMultipleModules)
     EXPECT_CALL(*pm, needToInstall("runtime", _)).WillOnce(Return(std::nullopt));
 
     EXPECT_CALL(*pm, applyApp(_)).WillOnce(Return(utils::error::Result<void>{}));
+    EXPECT_CALL(*pm, pruneUnused()).Times(0);
     EXPECT_CALL(*repo, mergeModules()).WillOnce([]() {
         return utils::error::Result<void>{};
     });
@@ -369,7 +376,11 @@ TEST_F(RefInstallationTest, InstallDowngrade)
 
     auto fuzzy = package::FuzzyReference::parse("main:id/1.0.0/x86_64").value();
     std::vector<std::string> modules{ "binary" };
-    api::types::v1::CommonOptions opts{ .force = true, .skipInteraction = true };
+    api::types::v1::CommonOptions opts{
+        .force = true,
+        .noAutoPrune = true,
+        .skipInteraction = true,
+    };
     auto action =
       service::RefInstallationAction::create(fuzzy, modules, *pm, *repo, opts, std::nullopt);
 
@@ -425,6 +436,8 @@ TEST_F(RefInstallationTest, InstallDowngrade)
     EXPECT_CALL(*pm, needToInstall("runtime", _)).WillOnce(Return(std::nullopt));
 
     EXPECT_CALL(*pm, switchAppVersion(_, _, true)).WillOnce(Return(utils::error::Result<void>{}));
+    EXPECT_CALL(*pm, pruneUnused()).Times(0);
+    EXPECT_CALL(*repo, prune()).WillOnce(Return(utils::error::Result<void>{}));
     EXPECT_CALL(*repo, mergeModules()).WillOnce([]() {
         return utils::error::Result<void>{};
     });
@@ -526,6 +539,7 @@ TEST_F(RefInstallationTest, InstallDowngradeKeepsInstalledModules)
     EXPECT_CALL(*pm, needToInstall("runtime", _)).WillOnce(Return(std::nullopt));
 
     EXPECT_CALL(*pm, switchAppVersion(_, _, true)).WillOnce(Return(utils::error::Result<void>{}));
+    EXPECT_CALL(*pm, pruneUnused()).WillOnce(Return(utils::error::Result<void>{}));
     EXPECT_CALL(*repo, mergeModules()).WillOnce([]() {
         return utils::error::Result<void>{};
     });
@@ -598,6 +612,7 @@ TEST_F(RefInstallationTest, InstallDowngradeDeduplicatesRuntimeFallback)
     EXPECT_CALL(*pm, needToInstall("runtime", _)).WillOnce(Return(std::nullopt));
 
     EXPECT_CALL(*pm, switchAppVersion(_, _, true)).WillOnce(Return(utils::error::Result<void>{}));
+    EXPECT_CALL(*pm, pruneUnused()).WillOnce(Return(utils::error::Result<void>{}));
     EXPECT_CALL(*repo, mergeModules()).WillOnce([]() {
         return utils::error::Result<void>{};
     });


### PR DESCRIPTION
Run a dependency-aware prune after package operations, skip it if `--no-auto-prune` flag is set.