### PR TITLE
fix: suppress progress output for terminal task states

### DIFF
--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -272,6 +272,13 @@ linglong::utils::error::Result<linglong::utils::fd::UniqueFd> acceptConsoleFd(in
     }
 }
 
+bool isTerminalTaskState(linglong::api::types::v1::State state) noexcept
+{
+    return state == linglong::api::types::v1::State::Canceled
+      || state == linglong::api::types::v1::State::Failed
+      || state == linglong::api::types::v1::State::Succeed;
+}
+
 std::string makeDebugInstanceID()
 {
     uuid_t uuid;
@@ -881,7 +888,7 @@ void Cli::onTaskEvent(const QString &event, const QVariantMap &data)
         }
 
         taskState.state = state->state;
-        if (!globalOptions.noProgress) {
+        if (!globalOptions.noProgress && !isTerminalTaskState(state->state)) {
             printer.printProgress(std::clamp(state->progress, 0.0, 100.0), state->message);
         }
         return;

--- a/libs/linglong/src/linglong/package_manager/package_task.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_task.cpp
@@ -395,7 +395,7 @@ void PackageTaskQueue::tryRunTask()
     for (auto it = m_taskQueue.begin(); it != m_taskQueue.end(); ++it) {
         // skip non-queued task
         if ((*it)->state() != linglong::api::types::v1::State::Queued) {
-            LogW("task {} at front is not in queued state, skip it", (*it)->taskID());
+            LogD("task {} at front is not in queued state, skip it", (*it)->taskID());
             continue;
         }
 

--- a/libs/linglong/tests/ll-tests/src/linglong/cli/cli_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/cli/cli_test.cpp
@@ -250,7 +250,7 @@ TEST_F(CliTest, taskEventsDriveProgressAndTextOutput)
 
 TEST_F(CliTest, taskFinishedDrivesFinalOutput)
 {
-    EXPECT_CALL(*printer, printProgress(testing::DoubleEq(0.0), ""));
+    EXPECT_CALL(*printer, printProgress(_, _)).Times(0);
     EXPECT_TRUE(
       QMetaObject::invokeMethod(cli.get(),
                                 "onTaskEvent",
@@ -273,6 +273,22 @@ TEST_F(CliTest, taskFinishedDrivesFinalOutput)
                                           "onTaskFinished",
                                           Qt::DirectConnection,
                                           Q_ARG(QVariantMap, result)));
+}
+
+TEST_F(CliTest, failedTaskStateDoesNotPrintErrorAsProgress)
+{
+    EXPECT_CALL(*printer, printProgress(_, _)).Times(0);
+    EXPECT_TRUE(
+      QMetaObject::invokeMethod(cli.get(),
+                                "onTaskEvent",
+                                Qt::DirectConnection,
+                                Q_ARG(QString, QStringLiteral("state")),
+                                Q_ARG(QVariantMap,
+                                      common::serialize::toQVariantMap(api::types::v1::TaskState{
+                                        .message = "installation failed",
+                                        .progress = 42.0,
+                                        .state = api::types::v1::State::Failed,
+                                      }))));
 }
 
 TEST_F(CliRepoAndPackageManagerTest, getRepoCachesLoadedRepository)


### PR DESCRIPTION
The final outcome is already reported in onTaskFinished. This change suppresses the redundant progress print in onTaskEvent when a task reaches a terminal state.