### PR TITLE
docs: update install script URL to get.linyaps.org.cn

### DIFF
--- a/docs/pages/en/guide/start/build_your_first_app.md
+++ b/docs/pages/en/guide/start/build_your_first_app.md
@@ -17,7 +17,7 @@ ll-builder --version
 If it is not found, use the installer's `full` mode to install Linyaps and `ll-builder` together:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/OpenAtom-Linyaps/linyaps/master/install.sh | sh -s -- full
+curl -fsSL https://get.linyaps.org.cn | sh -s -- full
 ```
 
 If the installer does not support your distribution, follow the manual steps in [Install Linyaps](./install.md) to install `ll-builder`.

--- a/docs/pages/en/guide/start/install.md
+++ b/docs/pages/en/guide/start/install.md
@@ -48,7 +48,7 @@ for production systems.
 Review the script before running it, then install Linyaps with:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/OpenAtom-Linyaps/linyaps/master/install.sh | sh
+curl -fsSL https://get.linyaps.org.cn | sh
 ```
 
 The script uses the distribution's native package when it is tracked by the

--- a/docs/pages/en/guide/start/quick-start.md
+++ b/docs/pages/en/guide/start/quick-start.md
@@ -19,7 +19,7 @@ ll-cli --version
 If the command is not found, use the following one-line command for a quick installation:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/OpenAtom-Linyaps/linyaps/master/install.sh | sh
+curl -fsSL https://get.linyaps.org.cn | sh
 ```
 
 The installer detects the current Linux distribution and requests `sudo` privileges when necessary. After installation, you can begin using Linyaps applications.
@@ -27,7 +27,7 @@ The installer detects the current Linux distribution and requests `sudo` privile
 Application developers can use the following command to install the `ll-builder` build tool as well:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/OpenAtom-Linyaps/linyaps/master/install.sh | sh -s -- full
+curl -fsSL https://get.linyaps.org.cn | sh -s -- full
 ```
 
 If your distribution is not supported or you need to configure a repository manually, see [Install Linyaps](./install.md).

--- a/docs/pages/guide/start/build_your_first_app.md
+++ b/docs/pages/guide/start/build_your_first_app.md
@@ -17,7 +17,7 @@ ll-builder --version
 如果命令找不到，推荐使用安装脚本的 `full` 模式，同时安装如意玲珑和 `ll-builder` 构建工具：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/OpenAtom-Linyaps/linyaps/master/install.sh | sh -s -- full
+curl -fsSL https://get.linyaps.org.cn | sh -s -- full
 ```
 
 如果您的发行版不受安装脚本支持，请按照[安装如意玲珑](./install.md)中的手动步骤安装 `ll-builder`。

--- a/docs/pages/guide/start/quick-start.md
+++ b/docs/pages/guide/start/quick-start.md
@@ -19,7 +19,7 @@ ll-cli --version
 如果提示找不到命令，可以使用下面的一行命令快速安装：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/OpenAtom-Linyaps/linyaps/master/install.sh | sh
+curl -fsSL https://get.linyaps.org.cn | sh
 ```
 
 安装脚本会识别当前 Linux 发行版，并在需要时请求 `sudo` 权限。安装完成后，就可以开始体验如意玲珑应用了。
@@ -27,7 +27,7 @@ curl -fsSL https://raw.githubusercontent.com/OpenAtom-Linyaps/linyaps/master/ins
 如果您是应用开发者，使用下面命令快速安装，会同时安装 `ll-builder` 构建工具：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/OpenAtom-Linyaps/linyaps/master/install.sh | sh -s -- full
+curl -fsSL https://get.linyaps.org.cn | sh -s -- full
 ```
 
 如果您的发行版不受支持或者需要手动配置仓库，请参阅[安装如意玲珑](./install.md)。


### PR DESCRIPTION
Replace raw.githubusercontent.com/OpenAtom-Linyaps/linyaps/master/install.sh with the new shorter domain get.linyaps.org.cn across both English and Chinese documentation.