### PR TITLE
feat(ll-builder): add clean subcommand to remove build artifacts

### DIFF
--- a/apps/ll-builder/src/command_options.h
+++ b/apps/ll-builder/src/command_options.h
@@ -73,6 +73,11 @@ struct ExtractCommandOptions
     std::string dir;
 };
 
+struct CleanCommandOptions
+{
+    // No members needed yet
+};
+
 struct RepoSubcommandOptions
 {
     linglong::common::cli::RepoOptions repoOptions;

--- a/apps/ll-builder/src/command_options.h
+++ b/apps/ll-builder/src/command_options.h
@@ -73,6 +73,11 @@ struct ExtractCommandOptions
     std::string dir;
 };
 
+struct CleanCommandOptions
+{
+    std::string filePath;
+};
+
 struct RepoSubcommandOptions
 {
     linglong::common::cli::RepoOptions repoOptions;

--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -394,6 +394,31 @@ int handleExtract(const ExtractCommandOptions &options)
     return 0;
 }
 
+int handleClean(const CleanCommandOptions &options)
+{
+    std::error_code ec;
+    auto cwd = std::filesystem::current_path(ec);
+    if (ec) {
+        LogE("Invalid current directory: {}", ec.message());
+        return -1;
+    }
+
+    auto yamlPath = getProjectYAMLPath(cwd, options.filePath);
+    if (!yamlPath) {
+        LogE("Not in a linglong project directory: {}", yamlPath.error().message());
+        return -1;
+    }
+
+    auto result = linglong::builder::cmdCleanBuildArtifacts(yamlPath->parent_path());
+    if (!result) {
+        LogE("Clean failed: {}", result.error());
+        return result.error().code();
+    }
+
+    LogI("Clean completed successfully.");
+    return 0;
+}
+
 std::vector<std::string> getProjectModule(const linglong::api::types::v1::BuilderProject &project)
 {
     std::list<std::string> modules = { "binary", "develop" }; // Start with base modules
@@ -482,6 +507,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     ImportCommandOptions importOpts;
     ImportDirCommandOptions importDirOpts;
     ExtractCommandOptions extractOpts;
+    CleanCommandOptions cleanOpts;
     RepoSubcommandOptions repoCmdOpts;
 
     // add builder flags
@@ -671,6 +697,12 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     buildExtract->add_option("DIR", extractOpts.dir, _("Destination directory"))
       ->type_name("DIR")
       ->required();
+    // add builder clean
+    auto buildClean = commandParser.add_subcommand("clean", _("Clean build artifacts"));
+    buildClean->usage(_("Usage: ll-builder clean"));
+    buildClean->add_option("-f, --file", cleanOpts.filePath, _("File path of the linglong.yaml"))
+      ->type_name("FILE")
+      ->check(CLI::ExistingFile);
 
     auto *buildRepo = linglong::common::cli::addRepoCommand(commandParser,
                                                             repoCmdOpts.repoOptions,
@@ -717,6 +749,10 @@ You can report bugs to the linyaps team under this project: https://github.com/O
 
     if (buildExtract->parsed()) {
         return handleExtract(extractOpts);
+    }
+
+    if (buildClean->parsed()) {
+        return handleClean(cleanOpts);
     }
 
     // following command need repo

--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -394,6 +394,18 @@ int handleExtract(const ExtractCommandOptions &options)
     return 0;
 }
 
+int handleClean(linglong::builder::Builder &builder, const CleanCommandOptions &options)
+{
+    auto result = builder.cleanBuildArtifacts();
+    if (!result) {
+        LogE("Clean failed: {}", result.error());
+        return result.error().code();
+    }
+
+    LogI("Clean completed successfully.");
+    return 0;
+}
+
 std::vector<std::string> getProjectModule(const linglong::api::types::v1::BuilderProject &project)
 {
     std::list<std::string> modules = { "binary", "develop" }; // Start with base modules
@@ -482,6 +494,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     ImportCommandOptions importOpts;
     ImportDirCommandOptions importDirOpts;
     ExtractCommandOptions extractOpts;
+    CleanCommandOptions cleanOpts;
     RepoSubcommandOptions repoCmdOpts;
 
     // add builder flags
@@ -671,6 +684,12 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     buildExtract->add_option("DIR", extractOpts.dir, _("Destination directory"))
       ->type_name("DIR")
       ->required();
+    // add builder clean
+    auto buildClean = commandParser.add_subcommand("clean", _("Clean build artifacts"));
+    buildClean->usage(_("Usage: ll-builder clean"));
+    buildClean->add_option("-f, --file", filePath, _("File path of the linglong.yaml"))
+      ->type_name("FILE")
+      ->check(CLI::ExistingFile);
 
     auto *buildRepo = linglong::common::cli::addRepoCommand(commandParser,
                                                             repoCmdOpts.repoOptions,
@@ -867,6 +886,10 @@ You can report bugs to the linyaps team under this project: https://github.com/O
             pushOpts.pushModules = getProjectModule(*project);
         }
         return handlePush(builder, pushOpts);
+    }
+
+    if (buildClean->parsed()) {
+        return handleClean(builder, cleanOpts);
     }
 
     if (!canonicalYamlPath) {

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -2288,4 +2288,28 @@ std::string Builder::layerExportFilename(const linglong::package::Reference &ref
                        ref.arch.toString(),
                        module);
 }
+
+utils::error::Result<void> Builder::cleanBuildArtifacts() noexcept
+{
+    LINGLONG_TRACE("clean build artifacts");
+
+    std::error_code ec;
+    if (!std::filesystem::exists(this->internalDir, ec)) {
+        return LINGLONG_OK;
+    }
+
+    auto ret = utils::makeDirectoryTreeRemovable(this->internalDir);
+    if (!ret) {
+        return LINGLONG_ERR("failed to make directory tree removable", ret);
+    }
+
+    std::filesystem::remove_all(this->internalDir, ec);
+    if (ec) {
+        return LINGLONG_ERR(
+          fmt::format("failed to remove {}: {}", this->internalDir.string(), ec.message()));
+    }
+
+    return LINGLONG_OK;
+}
+
 } // namespace linglong::builder

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -2288,4 +2288,29 @@ std::string Builder::layerExportFilename(const linglong::package::Reference &ref
                        ref.arch.toString(),
                        module);
 }
+
+utils::error::Result<void> cmdCleanBuildArtifacts(const std::filesystem::path &workingDir) noexcept
+{
+    LINGLONG_TRACE("clean build artifacts");
+
+    auto linglongDir = workingDir / "linglong";
+    std::error_code ec;
+    if (!std::filesystem::exists(linglongDir, ec)) {
+        return LINGLONG_OK;
+    }
+
+    auto ret = utils::makeDirectoryTreeRemovable(linglongDir);
+    if (!ret) {
+        return LINGLONG_ERR("failed to make directory tree removable", ret);
+    }
+
+    std::filesystem::remove_all(linglongDir, ec);
+    if (ec) {
+        return LINGLONG_ERR(
+          fmt::format("failed to remove {}: {}", linglongDir.string(), ec.message()));
+    }
+
+    return LINGLONG_OK;
+}
+
 } // namespace linglong::builder

--- a/libs/linglong/src/linglong/builder/linglong_builder.h
+++ b/libs/linglong/src/linglong/builder/linglong_builder.h
@@ -55,6 +55,7 @@ utils::error::Result<void> cmdListApp(repo::OSTreeRepo &repo);
 utils::error::Result<void> cmdRemoveApp(repo::OSTreeRepo &repo,
                                         std::vector<std::string> refs,
                                         bool prune);
+utils::error::Result<void> cmdCleanBuildArtifacts(const std::filesystem::path &workingDir) noexcept;
 
 namespace detail {
 void mergeOutput(const std::vector<std::filesystem::path> &src,

--- a/libs/linglong/src/linglong/builder/linglong_builder.h
+++ b/libs/linglong/src/linglong/builder/linglong_builder.h
@@ -122,6 +122,8 @@ public:
 
     void setBuildOptions(const BuilderBuildOptions &options) noexcept { buildOptions = options; }
 
+    auto cleanBuildArtifacts() noexcept -> utils::error::Result<void>;
+
 protected:
     std::string uabExportFilename(const linglong::package::Reference &ref);
     std::string layerExportFilename(const linglong::package::Reference &ref,

--- a/libs/linglong/tests/ll-tests/src/linglong/builder/linglong_builder_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/builder/linglong_builder_test.cpp
@@ -170,3 +170,65 @@ TEST(LinglongBuilder, LayerExportFilename)
     auto filename = builder.layerExportFilename(*ref, "binary");
     EXPECT_EQ(filename, "org.deepin.demo_1.0.0.0_arm64_binary.layer");
 };
+
+TEST(LinglongBuilder, CleanNoBuildDir)
+{
+    TempDir workingDir;
+    ASSERT_TRUE(workingDir.isValid());
+
+    linglong::builder::BuilderMock builder(workingDir.path());
+    auto result = builder.cleanBuildArtifacts();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_FALSE(std::filesystem::exists(workingDir.path() / "linglong"));
+}
+
+TEST(LinglongBuilder, CleanNormal)
+{
+    TempDir workingDir;
+    ASSERT_TRUE(workingDir.isValid());
+
+    linglong::builder::BuilderMock builder(workingDir.path());
+
+    auto linglongDir = workingDir.path() / "linglong";
+    std::filesystem::create_directories(linglongDir / "cache" / "overlay" / "workdir");
+    std::filesystem::create_directories(linglongDir / "output");
+    std::ofstream(linglongDir / "cache" / "overlay" / "workdir" / "work");
+    std::ofstream(linglongDir / "output" / "binary");
+
+    ASSERT_TRUE(std::filesystem::exists(linglongDir));
+
+    auto result = builder.cleanBuildArtifacts();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_FALSE(std::filesystem::exists(linglongDir));
+}
+
+TEST(LinglongBuilder, CleanWithPermissionIssue)
+{
+    if (geteuid() == 0) {
+        GTEST_SKIP() << "root can remove files regardless of the owner permission bits";
+    }
+
+    TempDir workingDir;
+    ASSERT_TRUE(workingDir.isValid());
+
+    linglong::builder::BuilderMock builder(workingDir.path());
+
+    namespace fs = std::filesystem;
+    auto linglongDir = workingDir.path() / "linglong";
+    auto blockedDir = linglongDir / "cache" / "overlay" / "workdir" / "work";
+    fs::create_directories(blockedDir);
+
+    // Simulate the overlayfs workdir permission issue: d---------
+    fs::permissions(blockedDir, fs::perms::none, fs::perm_options::replace);
+
+    // Verify the permission issue exists
+    auto blockedPerms = fs::symlink_status(blockedDir).permissions();
+    EXPECT_EQ(blockedPerms
+                & (fs::perms::owner_read | fs::perms::owner_write | fs::perms::owner_exec),
+              fs::perms::none);
+
+    // Builder::cleanBuildArtifacts should fix permissions and remove the directory
+    auto result = builder.cleanBuildArtifacts();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_FALSE(fs::exists(linglongDir));
+}

--- a/libs/linglong/tests/ll-tests/src/linglong/mocks/linglong_builder_mock.h
+++ b/libs/linglong/tests/ll-tests/src/linglong/mocks/linglong_builder_mock.h
@@ -20,6 +20,13 @@ public:
         : Builder(
             std::nullopt, "", initTempRepo(), initTempContainerBuilder(), initBuilderConfig()) { };
 
+    explicit BuilderMock(const std::filesystem::path &workingDir)
+        : Builder(std::nullopt,
+                  workingDir,
+                  initTempRepo(),
+                  initTempContainerBuilder(),
+                  initBuilderConfig()) { };
+
 private:
     static linglong::repo::OSTreeRepo &initTempRepo()
     {


### PR DESCRIPTION
- Add CleanCommandOptions and register `ll-builder clean` with optional `-f/--file`
- Validate project location through getProjectYAMLPath before cleaning
- Implement cmdCleanBuildArtifacts to fix overlay workdir permissions via makeDirectoryTreeRemovable and remove the linglong/ directory

Log: Add a clean subcommand to ll-builder for removing the build-generated linglong directory and handling overlay workdir permission issues