### PR TITLE
fix(package): reject trailing reference segments

### DIFF
--- a/libs/linglong/src/linglong/package/reference.cpp
+++ b/libs/linglong/src/linglong/package/reference.cpp
@@ -24,7 +24,7 @@ utils::error::Result<Reference> Reference::parse(const std::string &raw) noexcep
 
     static auto referenceRegExp = []() noexcept {
         QRegularExpression referenceRegExp(
-          R"((?<channel>[^:]+):(?<id>[^\/]+)\/(?<version>[^\/]+)\/(?<architecture>[^\/]+))");
+          R"(^(?<channel>[^:]+):(?<id>[^\/]+)\/(?<version>[^\/]+)\/(?<architecture>[^\/]+)$)");
         referenceRegExp.optimize();
         return referenceRegExp;
     }();

--- a/libs/linglong/tests/ll-tests/src/linglong/package/reference_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/reference_test.cpp
@@ -40,6 +40,8 @@ TEST(Package, Reference)
         "main:2222/1.0.0.0/unknown",
         ":1.0.0.1-beta/arm64",
         ":com.example.App/1.0.0.0/x86_64",
+        // Bug fix: trailing path segments should be rejected
+        "main:com.example.App/1.0.0.0/x86_64/extra",
     };
 
     for (const auto &invalidCase : invalidReferences) {


### PR DESCRIPTION
## Summary

Reject complete package reference strings that contain unexpected trailing path segments.

Previously, `Reference::parse()` accepted a valid reference prefix even when additional segments remained in the input. The extra input was silently discarded when the parsed reference was converted back to a string.

## Root cause

The regular expression used by `Reference::parse()` was not anchored at the start and end of the input. As a result, `QRegularExpression::match()` could succeed without requiring the entire input to match the expected reference format.

For example:

```text
main:com.example.App/1.0.0.0/x86_64/extra
```

was accepted as:

```text
main:com.example.App/1.0.0.0/x86_64
```

## Changes

- Anchor the complete reference regular expression with `^` and `$`.
- Add a regression test covering a valid reference followed by an unexpected path segment.

## Reproduction

1. Call `Reference::parse()` with `main:com.example.App/1.0.0.0/x86_64/extra`.
2. Before this change, parsing succeeds and silently drops `/extra`.
3. After this change, parsing returns an error.

## Test plan

- [x] Run the focused reference test:

  ```bash
  /workspace/build-release/libs/linglong/tests/ll-tests/ll-tests --gtest_filter='Package.Reference'
  ```

- [x] Verify the regression input is rejected.
- [x] Verify existing valid reference inputs continue to pass.
- [x] Run `git diff --check`.

## Compatibility

This only changes the handling of malformed complete references containing unexpected trailing input. Valid references are unaffected.
