### PR TITLE
test(utils): cover buffered write failures in writeFile

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/utils/file_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/file_test.cpp
@@ -449,6 +449,19 @@ TEST_F(FileTest, WriteFile)
     EXPECT_FALSE(result.has_value()); // Should fail because parent directory doesn't exist
 }
 
+TEST_F(FileTest, WriteFileToDevFull)
+{
+    // /dev/full accepts open but rejects writes with ENOSPC
+    const std::string devFull = "/dev/full";
+    if (!fs::exists(devFull)) {
+        GTEST_SKIP() << "/dev/full not available on this platform";
+    }
+
+    auto result = linglong::utils::writeFile(devFull, "test data");
+    EXPECT_FALSE(result.has_value())
+      << "writeFile to /dev/full should return an error, not success";
+}
+
 TEST_F(FileTest, ReadFile)
 {
     // Test reading an existing file


### PR DESCRIPTION
## Summary

Add the missing regression test for buffered write failures in `writeFile`.

## Root cause

`writeFile` buffered the content and only reported a failure from the final stream state, so a write that failed during the flush on close (e.g. ENOSPC) could still be reported as success. The implementation now closes the stream and reports the failure (upstream commit); this PR pins the behavior with a test, since the repository had no coverage for it.

## Changes

- `FileTest`: write to `/dev/full`, which accepts opens but fails every write with ENOSPC, and expect an error result (skipped when `/dev/full` is unavailable).

## Test plan

- [x] Rebased onto current master; implementation diff vs master is empty (upstream fix kept)
- [x] `ctest -R FileTest`: 31/31 pass, including the new `/dev/full` case
- [x] `clang-format --dry-run --Werror`