### PR TITLE
fix(package): reject package info without architecture

### DIFF
--- a/libs/linglong/src/linglong/package/reference.cpp
+++ b/libs/linglong/src/linglong/package/reference.cpp
@@ -70,6 +70,10 @@ Reference::fromPackageInfo(const api::types::v1::PackageInfoV2 &info) noexcept
         return LINGLONG_ERR("version .tweak is required");
     }
 
+    if (info.arch.empty()) {
+        return LINGLONG_ERR("missing architecture in package info");
+    }
+
     auto architecture = package::Architecture::parse(info.arch[0]);
     if (!architecture) {
         return LINGLONG_ERR(architecture);

--- a/libs/linglong/tests/ll-tests/src/linglong/package/reference_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/reference_test.cpp
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 
+#include "linglong/api/types/v1/PackageInfoV2.hpp"
 #include "linglong/package/fuzzy_reference.h"
 #include "linglong/package/reference.h"
 
@@ -88,4 +89,18 @@ TEST(Package, ReferenceSemanticMatch)
         ASSERT_TRUE(fuzzy.has_value()) << raw;
         EXPECT_EQ(reference->semanticMatch(*fuzzy), expected) << raw;
     }
+}
+
+TEST(Package, FromPackageInfoRejectsEmptyArchitecture)
+{
+    linglong::api::types::v1::PackageInfoV2 info{};
+    info.channel = "main";
+    info.id = "com.example.App";
+    info.version = "1.0.0.0";
+    info.arch = {};
+
+    auto result = Reference::fromPackageInfo(info);
+    ASSERT_FALSE(result.has_value())
+      << "fromPackageInfo should reject empty arch array instead of crashing";
+    EXPECT_NE(result.error().message().find("architecture"), std::string::npos);
 }


### PR DESCRIPTION
## Summary

Return a validation error when package metadata has no architecture instead of indexing an empty array.

## Root cause

`Reference::fromPackageInfo()` accessed `info.arch[0]` without first checking whether the architecture list was empty. Malformed or incomplete package metadata could therefore trigger undefined behavior instead of returning the function's normal error result.

## Changes

- Validate that `PackageInfoV2::arch` is non-empty before accessing its first item.
- Add a regression test for an empty architecture list.

## Reproduction

Construct a valid `PackageInfoV2` with `arch = {}` and pass it to `Reference::fromPackageInfo()`. Before this change the function indexes past the end of the vector; after this change it returns an error mentioning the missing architecture.

## Test plan

- [x] Release build
- [x] `ll-tests --gtest_filter='Package.FromPackageInfoRejectsEmptyArchitecture'`
- [x] `git diff --check`
