### PR TITLE
fix(common): ignore relative XDG directory overrides

### DIFF
--- a/libs/common/src/linglong/common/xdg.cpp
+++ b/libs/common/src/linglong/common/xdg.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -12,7 +12,10 @@ std::filesystem::path getXDGRuntimeDir() noexcept
 {
     auto *runtimeDirEnv = std::getenv("XDG_RUNTIME_DIR");
     if (runtimeDirEnv != nullptr && runtimeDirEnv[0] != '\0') {
-        return runtimeDirEnv;
+        std::filesystem::path p{ runtimeDirEnv };
+        if (p.is_absolute()) {
+            return p;
+        }
     }
 
     // fallback to default
@@ -24,7 +27,10 @@ std::filesystem::path getXDGCacheHomeDir() noexcept
 {
     auto *cacheHomeEnv = std::getenv("XDG_CACHE_HOME");
     if (cacheHomeEnv != nullptr && cacheHomeEnv[0] != '\0') {
-        return cacheHomeEnv;
+        std::filesystem::path p{ cacheHomeEnv };
+        if (p.is_absolute()) {
+            return p;
+        }
     }
 
     // fallback to default
@@ -41,7 +47,10 @@ std::filesystem::path getXDGConfigHomeDir() noexcept
 {
     auto *configHomeEnv = std::getenv("XDG_CONFIG_HOME");
     if (configHomeEnv != nullptr && configHomeEnv[0] != '\0') {
-        return configHomeEnv;
+        std::filesystem::path p{ configHomeEnv };
+        if (p.is_absolute()) {
+            return p;
+        }
     }
 
     // fallback to default

--- a/libs/linglong/tests/ll-tests/src/linglong/common/xdg_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/common/xdg_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -52,4 +52,37 @@ TEST_F(XDGTest, GetXDGRuntimeDir)
         auto runtimeDir = linglong::common::xdg::getXDGRuntimeDir();
         checkRuntimeDir(runtimeDir);
     }
+}
+
+TEST_F(XDGTest, GetXDGRuntimeDirRejectsRelativePath)
+{
+    linglong::utils::EnvironmentVariableGuard env("XDG_RUNTIME_DIR", "relative-runtime");
+    auto runtimeDir = linglong::common::xdg::getXDGRuntimeDir();
+    EXPECT_EQ(runtimeDir,
+              std::filesystem::path{ "/tmp" } / ("linglong-runtime-" + std::to_string(::getuid())));
+}
+
+TEST_F(XDGTest, GetXDGCacheHomeDirRejectsRelativePath)
+{
+    linglong::utils::EnvironmentVariableGuard home("HOME", "/tmp/xdg-test-home");
+    linglong::utils::EnvironmentVariableGuard cache("XDG_CACHE_HOME", "relative-cache");
+    auto cacheDir = linglong::common::xdg::getXDGCacheHomeDir();
+    EXPECT_EQ(cacheDir, "/tmp/xdg-test-home/.cache");
+}
+
+TEST_F(XDGTest, GetXDGConfigHomeDirRejectsRelativePath)
+{
+    linglong::utils::EnvironmentVariableGuard home("HOME", "/tmp/xdg-test-home");
+    linglong::utils::EnvironmentVariableGuard config("XDG_CONFIG_HOME", "relative-config");
+    auto configDir = linglong::common::xdg::getXDGConfigHomeDir();
+    EXPECT_EQ(configDir, "/tmp/xdg-test-home/.config");
+}
+
+TEST_F(XDGTest, AbsoluteHomeDirectoriesAreUsed)
+{
+    linglong::utils::EnvironmentVariableGuard cache("XDG_CACHE_HOME", "/tmp/xdg-cache");
+    linglong::utils::EnvironmentVariableGuard config("XDG_CONFIG_HOME", "/tmp/xdg-config");
+
+    EXPECT_EQ(linglong::common::xdg::getXDGCacheHomeDir(), "/tmp/xdg-cache");
+    EXPECT_EQ(linglong::common::xdg::getXDGConfigHomeDir(), "/tmp/xdg-config");
 }


### PR DESCRIPTION
## Summary

Ignore relative values in XDG directory environment variables and use the existing fallback paths.

## Root cause

The XDG base directory specification requires these environment variables to contain absolute paths. The current helpers accepted any non-empty value, so relative configuration could make runtime, cache, or config paths depend on the process working directory.

## Changes

- Use `XDG_RUNTIME_DIR`, `XDG_CACHE_HOME`, and `XDG_CONFIG_HOME` only when absolute.
- Preserve the existing fallback behavior for unset, empty, or relative values.
- Add regression tests for relative and valid absolute overrides.

## Test plan

- [x] Release test target build
- [x] Four focused `XDGTest` regression cases
- [x] `git diff --check`
