### PR TITLE
fix(builder): validate project path boundaries

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -10,6 +10,7 @@
 #include "linglong/builder/linglong_builder.h"
 #include "linglong/cli/cli.h"
 #include "linglong/cli/cli_printer.h"
+#include "linglong/common/dir.h"
 #include "linglong/common/global/initialize.h"
 #include "linglong/package/architecture.h"
 #include "linglong/package/version.h"
@@ -858,7 +859,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     }
 
     auto canonicalYamlPath = getProjectYAMLPath(cwd, filePath);
-    if (canonicalYamlPath && canonicalYamlPath->string().rfind(cwd.string(), 0) != 0) {
+    if (canonicalYamlPath && !linglong::common::dir::isPathInDirectory(*canonicalYamlPath, cwd)) {
         LogE("the project file {} is not under the current working directory {}",
              canonicalYamlPath->string(),
              cwd.string());

--- a/libs/common/src/linglong/common/dir.cpp
+++ b/libs/common/src/linglong/common/dir.cpp
@@ -9,6 +9,22 @@
 
 namespace linglong::common::dir {
 
+bool isPathInDirectory(const std::filesystem::path &path,
+                       const std::filesystem::path &directory) noexcept
+{
+    if (path.empty() || directory.empty()) {
+        return false;
+    }
+
+    const auto relative = path.lexically_normal().lexically_relative(directory.lexically_normal());
+    if (relative.empty()) {
+        return false;
+    }
+
+    const auto first = relative.begin();
+    return first == relative.end() || *first != "..";
+}
+
 std::filesystem::path getRuntimeDir() noexcept
 {
     return xdg::getXDGRuntimeDir() / "linglong";

--- a/libs/common/src/linglong/common/dir.h
+++ b/libs/common/src/linglong/common/dir.h
@@ -15,6 +15,12 @@ constexpr auto containerLockPath = "/run/linglong/.lock";
 
 constexpr auto repoLockPath = "/run/linglong/lock";
 
+// Compares normalized paths lexically. Callers that need symlinks resolved must
+// pass canonical paths. Both paths must use the same absolute or relative base.
+// The directory itself is considered to be inside it.
+bool isPathInDirectory(const std::filesystem::path &path,
+                       const std::filesystem::path &directory) noexcept;
+
 std::filesystem::path getRuntimeDir() noexcept;
 
 std::filesystem::path getAppRuntimeDir(const std::string &appId) noexcept;

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -20,6 +20,7 @@ pfl_add_executable(
   src/linglong/builder/source_fetcher_test.cpp
   src/linglong/cli/cli_printer_test.cpp
   src/linglong/cli/cli_test.cpp
+  src/linglong/common/dir_test.cpp
   src/linglong/common/gkeyfile_wrapper_test.cpp
   src/linglong/common/global/initialize_test.cpp
   src/linglong/common/cli/repo_test.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/common/dir_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/common/dir_test.cpp
@@ -7,6 +7,7 @@
 #include "common/scoped_umask.h"
 #include "common/tempdir.h"
 #include "linglong/common/constants.h"
+#include "linglong/common/dir.h"
 #include "linglong/utils/file.h"
 
 #include <filesystem>
@@ -33,3 +34,32 @@ TEST(DirTest, ContainerCacheDirectoryUsesPackageManagerUmask)
     EXPECT_EQ(fs::status(containerDir).permissions() & fs::perms::mask,
               linglong::common::shared_directory_permissions);
 }
+
+namespace linglong::common::dir {
+
+TEST(DirTest, PathInDirectory)
+{
+    const std::filesystem::path directory{ "/tmp/project" };
+
+    EXPECT_TRUE(isPathInDirectory(directory, directory));
+    EXPECT_TRUE(isPathInDirectory("/tmp/project/linglong.yaml", directory));
+    EXPECT_TRUE(isPathInDirectory("/tmp/project/linglong.yaml", "/tmp/project/"));
+    EXPECT_TRUE(isPathInDirectory("/tmp/project/sub/../linglong.yaml", directory));
+    EXPECT_TRUE(isPathInDirectory("linglong.yaml", "."));
+    EXPECT_TRUE(isPathInDirectory("project/linglong.yaml", "project/"));
+}
+
+TEST(DirTest, PathOutsideDirectory)
+{
+    const std::filesystem::path directory{ "/tmp/project" };
+
+    EXPECT_FALSE(isPathInDirectory("/tmp/project-sibling/linglong.yaml", directory));
+    EXPECT_FALSE(isPathInDirectory("/tmp/other/linglong.yaml", directory));
+    EXPECT_FALSE(isPathInDirectory("/tmp/project/../outside/linglong.yaml", directory));
+    EXPECT_FALSE(isPathInDirectory("../outside/linglong.yaml", "."));
+    EXPECT_FALSE(isPathInDirectory("relative/linglong.yaml", directory));
+    EXPECT_FALSE(isPathInDirectory({}, directory));
+    EXPECT_FALSE(isPathInDirectory("/tmp/project/linglong.yaml", {}));
+}
+
+} // namespace linglong::common::dir


### PR DESCRIPTION
## Summary

Use path-component-aware containment checks when validating that a builder project file is under the current working directory.

## Root cause

The existing check compared canonical path strings with `rfind(..., 0)`. A sibling path such as `/tmp/project-other/linglong.yaml` starts with `/tmp/project` textually, so it could be incorrectly accepted as being inside `/tmp/project`.

## Changes

- Add a normalized lexical path containment helper.
- Replace the builder's string-prefix check with the helper.
- Add tests for the directory itself, descendants, sibling-prefix paths, parent traversal, relative paths, and empty inputs.

## Reproduction

Use `/tmp/project` as the current project directory and pass `/tmp/project-other/linglong.yaml`. Before this change the textual prefix check accepts the sibling path; after this change it is rejected.

## Test plan

- [x] Release build with the complete fix set
- [x] Full CTest suite: 528 passed, 2 environment-dependent X11 tests skipped, 0 failed
- [x] Added `DirTest` boundary cases
- [x] `git diff --check`
