### PR TITLE
fix(display): reject trailing X11 display input

### DIFF
--- a/libs/common/src/linglong/common/display.cpp
+++ b/libs/common/src/linglong/common/display.cpp
@@ -64,9 +64,16 @@ utils::error::Result<XOrgDisplayConf> getXOrgDisplay(std::string_view display) n
         if (std::filesystem::exists(sub, ec)) {
             result.host = sub;
             try {
-                result.screenNo = std::stoi(std::string(display.substr(dot + 1)));
+                const auto screen = display.substr(dot + 1);
+                size_t screenLen;
+                result.screenNo = std::stoi(std::string(screen), &screenLen);
                 if (result.screenNo < 0) {
                     return LINGLONG_ERR(fmt::format("invalid screen No: {}", result.screenNo));
+                }
+                if (screenLen != screen.size()) {
+                    return LINGLONG_ERR(
+                      fmt::format("unexpected trailing characters after screen number: {}",
+                                  screen));
                 }
             } catch (const std::exception &e) {
                 return LINGLONG_ERR(fmt::format("failed to get screen No: {}", e.what()));
@@ -102,10 +109,19 @@ utils::error::Result<XOrgDisplayConf> getXOrgDisplay(std::string_view display) n
             return LINGLONG_ERR(fmt::format("invalid display No: {}", result.displayNo));
         }
         display = display.substr(s);
-        if (display.size() > 0 && display[0] == '.') {
-            result.screenNo = std::stoi(std::string(display.substr(1)));
+        if (display.size() > 0) {
+            if (display[0] != '.') {
+                return LINGLONG_ERR(
+                  fmt::format("unexpected trailing characters after display number: {}", display));
+            }
+            size_t screenLen;
+            result.screenNo = std::stoi(std::string(display.substr(1)), &screenLen);
             if (result.screenNo < 0) {
                 return LINGLONG_ERR(fmt::format("invalid screen No: {}", result.screenNo));
+            }
+            if (screenLen + 1 != display.size()) {
+                return LINGLONG_ERR(
+                  fmt::format("unexpected trailing characters after screen number: {}", display));
             }
         }
     } catch (const std::exception &e) {

--- a/libs/linglong/tests/ll-tests/src/linglong/common/display_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/common/display_test.cpp
@@ -4,7 +4,15 @@
 
 #include <gtest/gtest.h>
 
+#include "common/tempdir.h"
 #include "linglong/common/display.h"
+#include "linglong/utils/unique_fd.h"
+
+#include <cerrno>
+#include <cstring>
+
+#include <sys/socket.h>
+#include <sys/un.h>
 
 namespace linglong::common::display {
 
@@ -197,6 +205,47 @@ TEST(DisplayTest, GetXOrgDisplay_NoDisplayNo)
 {
     auto result = getXOrgDisplay("test:");
     ASSERT_FALSE(result.has_value());
+}
+
+TEST(DisplayTest, GetXOrgDisplay_TrailingGarbageAfterDisplayNo)
+{
+    auto result = getXOrgDisplay("localhost:0junk");
+    ASSERT_FALSE(result.has_value())
+      << "trailing non-numeric characters after display number should be rejected";
+}
+
+TEST(DisplayTest, GetXOrgDisplay_TrailingGarbageAfterScreenNo)
+{
+    auto result = getXOrgDisplay("localhost:0.1junk");
+    ASSERT_FALSE(result.has_value())
+      << "trailing non-numeric characters after screen number should be rejected";
+}
+
+TEST(DisplayTest, GetXOrgDisplay_ExtraDotSegment)
+{
+    auto result = getXOrgDisplay("localhost:0.1.2");
+    ASSERT_FALSE(result.has_value())
+      << "extra dot-separated segment after screen number should be rejected";
+}
+
+TEST(DisplayTest, GetXOrgDisplay_TrailingGarbageAfterAbsolutePathScreenNo)
+{
+    TempDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+    const auto socketPath = tempDir.path() / "x11-socket";
+    linglong::utils::fd::UniqueFd socket{ ::socket(AF_UNIX, SOCK_STREAM, 0) };
+    ASSERT_TRUE(socket) << std::strerror(errno);
+
+    struct sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    ASSERT_LT(socketPath.native().size(), sizeof(addr.sun_path));
+    std::strncpy(addr.sun_path, socketPath.c_str(), sizeof(addr.sun_path) - 1);
+    ASSERT_EQ(::bind(socket.get(), reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)), 0)
+      << std::strerror(errno);
+
+    auto result = getXOrgDisplay(socketPath.string() + ".1junk");
+    EXPECT_FALSE(result.has_value())
+      << "trailing characters after an absolute-path screen number should be rejected";
 }
 
 } // namespace linglong::common::display


### PR DESCRIPTION
## Summary

Reject malformed X11 `DISPLAY` values containing trailing characters or extra numeric segments.

## Root cause

`std::stoi()` was used without checking how many characters it consumed. Inputs such as `localhost:0junk` and `localhost:0.1junk` were therefore accepted because their numeric prefixes parsed successfully and the remaining characters were ignored.

## Changes

- Check the consumed length for display and screen numbers.
- Reject unexpected text after the display number.
- Reject trailing characters and extra dot-separated segments after the screen number.
- Add regression tests for host and absolute Unix-socket forms.

## Reproduction

Call `getXOrgDisplay("localhost:0junk")`. Before this change it returns a parsed display number of 0; after this change it returns an error.

## Test plan

- [x] Release build with the complete fix set
- [x] Full CTest suite: 528 passed, 2 unrelated environment-dependent X11 tests skipped, 0 failed
- [x] Added four focused malformed-input cases
- [x] `git diff --check`
