### PR TITLE
fix(display): validate Wayland socket paths

### DIFF
--- a/libs/common/src/linglong/common/display.cpp
+++ b/libs/common/src/linglong/common/display.cpp
@@ -12,6 +12,10 @@ namespace linglong::common::display {
 tl::expected<std::filesystem::path, std::string>
 getWaylandDisplay(std::string_view display) noexcept
 {
+    if (display.empty()) {
+        return tl::unexpected{ std::string{ "empty WAYLAND_DISPLAY" } };
+    }
+
     auto xdgRuntimeDir = xdg::getXDGRuntimeDir();
     std::filesystem::path waylandSocketPath;
     if (display[0] == '/') {
@@ -21,13 +25,19 @@ getWaylandDisplay(std::string_view display) noexcept
     }
 
     std::error_code ec;
-    if (!std::filesystem::exists(waylandSocketPath, ec)) {
-        if (ec) {
-            return tl::unexpected{ "Failed to check Wayland socket path "
-                                   + waylandSocketPath.string() + ": " + ec.message() };
-        }
+    auto status = std::filesystem::status(waylandSocketPath, ec);
+    if (ec) {
+        return tl::unexpected{ "Failed to check Wayland socket path " + waylandSocketPath.string()
+                               + ": " + ec.message() };
+    }
 
+    if (!std::filesystem::exists(status)) {
         return tl::unexpected{ "Wayland socket path not found at " + waylandSocketPath.string() };
+    }
+
+    if (status.type() != std::filesystem::file_type::socket) {
+        return tl::unexpected{ "Wayland display path is not a socket: "
+                               + waylandSocketPath.string() };
     }
 
     return waylandSocketPath;

--- a/libs/linglong/tests/ll-tests/src/linglong/common/display_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/common/display_test.cpp
@@ -4,7 +4,17 @@
 
 #include <gtest/gtest.h>
 
+#include "common/tempdir.h"
 #include "linglong/common/display.h"
+#include "linglong/utils/env.h"
+#include "linglong/utils/unique_fd.h"
+
+#include <cerrno>
+#include <cstring>
+#include <fstream>
+
+#include <sys/socket.h>
+#include <sys/un.h>
 
 namespace linglong::common::display {
 
@@ -197,6 +207,56 @@ TEST(DisplayTest, GetXOrgDisplay_NoDisplayNo)
 {
     auto result = getXOrgDisplay("test:");
     ASSERT_FALSE(result.has_value());
+}
+
+TEST(DisplayTest, GetWaylandDisplay_EmptyString)
+{
+    auto result = getWaylandDisplay("");
+    ASSERT_FALSE(result.has_value()) << "empty WAYLAND_DISPLAY should be rejected";
+}
+
+TEST(DisplayTest, GetWaylandDisplay_RegularFile)
+{
+    TempDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+    const auto file = tempDir.path() / "wayland-file";
+    std::ofstream{ file } << "not a socket";
+
+    EXPECT_FALSE(getWaylandDisplay(file.string()).has_value());
+}
+
+TEST(DisplayTest, GetWaylandDisplay_Directory)
+{
+    TempDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    EXPECT_FALSE(getWaylandDisplay(tempDir.path().string()).has_value());
+}
+
+TEST(DisplayTest, GetWaylandDisplay_RealSocket)
+{
+    TempDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+    const auto socketPath = tempDir.path() / "wayland-test";
+    linglong::utils::fd::UniqueFd socket{ ::socket(AF_UNIX, SOCK_STREAM, 0) };
+    ASSERT_TRUE(socket) << std::strerror(errno);
+
+    struct sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    ASSERT_LT(socketPath.native().size(), sizeof(addr.sun_path));
+    std::strncpy(addr.sun_path, socketPath.c_str(), sizeof(addr.sun_path) - 1);
+    ASSERT_EQ(::bind(socket.get(), reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)), 0)
+      << std::strerror(errno);
+
+    auto absoluteResult = getWaylandDisplay(socketPath.string());
+    ASSERT_TRUE(absoluteResult.has_value());
+    EXPECT_EQ(*absoluteResult, socketPath);
+
+    linglong::utils::EnvironmentVariableGuard runtimeDir{ "XDG_RUNTIME_DIR",
+                                                          tempDir.path().string() };
+    auto relativeResult = getWaylandDisplay(socketPath.filename().string());
+    ASSERT_TRUE(relativeResult.has_value());
+    EXPECT_EQ(*relativeResult, socketPath);
 }
 
 } // namespace linglong::common::display


### PR DESCRIPTION
## Summary

Reject empty Wayland display names and filesystem paths that do not refer to Unix sockets.

## Root cause

`getWaylandDisplay()` indexed `display[0]` without checking for an empty string. It also treated any existing path as a valid display socket, so regular files and directories could be returned to callers.

## Changes

- Reject an empty `WAYLAND_DISPLAY` value before indexing it.
- Inspect the resolved path with `std::filesystem::status()`.
- Require the path type to be a Unix socket.
- Add tests for empty input, regular files, directories, and real absolute/relative sockets.

## Test plan

- [x] Release build with the complete fix set
- [x] Full CTest suite: 528 passed, 2 unrelated environment-dependent X11 tests skipped, 0 failed
- [x] Added four focused Wayland validation cases
- [x] `git diff --check`
