### PR TITLE
fix(repo): prevent unsafe repository downgrades

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -760,6 +760,9 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     }
 
     auto result = linglong::repo::tryMigrate(builderCfg->repo, *repoCfg);
+    if (result == linglong::repo::MigrateResult::Incompatible) {
+        return -1;
+    }
     if (result == linglong::repo::MigrateResult::Failed) {
         if (!backupFailedMigrationRepo(builderCfg->repo)) {
             return -1;

--- a/apps/ll-package-manager/src/main.cpp
+++ b/apps/ll-package-manager/src/main.cpp
@@ -93,11 +93,14 @@ auto createRepoForDaemon(bool migrateRepo)
         return LINGLONG_ERR("failed to create repository directory", std::move(res));
     }
 
-    if (migrateRepo) {
-        auto ret = linglong::repo::tryMigrate(LINGLONG_ROOT, *config);
-        if (ret == linglong::repo::MigrateResult::Failed) {
-            return LINGLONG_ERR("failed to migrate repository");
-        }
+    auto ret = migrateRepo ? linglong::repo::tryMigrate(LINGLONG_ROOT, *config)
+                           : linglong::repo::checkRepoCompatibility(LINGLONG_ROOT);
+    if (ret == linglong::repo::MigrateResult::Incompatible) {
+        return LINGLONG_ERR("repository version is newer than the package manager version");
+    }
+    if (ret == linglong::repo::MigrateResult::Failed) {
+        return LINGLONG_ERR(migrateRepo ? "failed to migrate repository"
+                                        : "failed to check repository compatibility");
     }
 
     auto repo = linglong::repo::OSTreeRepo::create(repoRoot, *config);

--- a/libs/linglong/src/linglong/repo/migrate.cpp
+++ b/libs/linglong/src/linglong/repo/migrate.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -7,16 +7,23 @@
 #include "configure.h"
 #include "linglong/package/version.h"
 #include "linglong/repo/config.h"
+#include "linglong/utils/filelock.h"
 
 #include <gio/gio.h>
 #include <glib.h>
 #include <ostree.h>
 
+#include <QFile>
+#include <QSaveFile>
+
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <mutex>
 #include <optional>
 #include <unordered_map>
+
+namespace {
 
 struct MigrateRefData
 {
@@ -32,9 +39,23 @@ struct Version
 
     friend bool operator<(const Version &lhs, const Version &rhs) noexcept
     {
-        return lhs.major < rhs.major || lhs.minor < rhs.minor || lhs.patch < rhs.patch;
+        if (lhs.major != rhs.major) {
+            return lhs.major < rhs.major;
+        }
+        if (lhs.minor != rhs.minor) {
+            return lhs.minor < rhs.minor;
+        }
+        return lhs.patch < rhs.patch;
     }
 };
+
+struct RepositoryVersion
+{
+    std::string raw;
+    Version parsed;
+};
+
+std::mutex migrationMutex;
 
 std::optional<Version> parseVersion(std::string_view version)
 try {
@@ -60,6 +81,110 @@ try {
 } catch (std::exception &e) {
     std::cerr << e.what() << " cause an exception" << std::endl;
     return std::nullopt;
+}
+
+std::optional<RepositoryVersion> readRepositoryVersion(const std::filesystem::path &root)
+{
+    std::error_code ec;
+    const auto versionPath = root / ".version";
+    std::optional<std::string> version;
+    if (std::filesystem::exists(versionPath, ec)) {
+        std::ifstream in{ versionPath };
+        if (!in.is_open()) {
+            std::cerr << "couldn't open " << versionPath << std::endl;
+            return std::nullopt;
+        }
+
+        std::stringstream buffer;
+        buffer << in.rdbuf();
+        if (in.bad()) {
+            std::cerr << "couldn't read " << versionPath << std::endl;
+            return std::nullopt;
+        }
+        version = buffer.str();
+    } else if (ec) {
+        std::cerr << "couldn't get status of " << versionPath << std::endl;
+        return std::nullopt;
+    }
+
+    auto raw = version.value_or("1.5.0");
+    auto parsed = parseVersion(raw);
+    if (!parsed) {
+        std::cerr << "failed to parse repo version " << raw << std::endl;
+        return std::nullopt;
+    }
+
+    return RepositoryVersion{ .raw = std::move(raw), .parsed = *parsed };
+}
+
+std::optional<Version> currentVersion()
+{
+    auto current = parseVersion(LINGLONG_VERSION);
+    if (!current) {
+        std::cerr << "failed to parse current version " << LINGLONG_VERSION << std::endl;
+    }
+    return current;
+}
+
+linglong::utils::error::Result<linglong::utils::filelock::FileLock>
+lockMigration(const std::filesystem::path &root)
+{
+    LINGLONG_TRACE("lock repository migration");
+
+    using linglong::utils::filelock::FileLock;
+    using linglong::utils::filelock::LockType;
+
+    auto lock = FileLock::create(root / ".migration.lock", LockType::ReadWrite);
+    if (!lock) {
+        return LINGLONG_ERR(lock);
+    }
+
+    auto result = lock->lock(LockType::Write);
+    if (!result) {
+        return LINGLONG_ERR(result);
+    }
+
+    return std::move(*lock);
+}
+
+bool writeRepositoryVersion(const std::filesystem::path &versionPath)
+{
+    QSaveFile out{ QFile::decodeName(versionPath.c_str()) };
+    out.setDirectWriteFallback(false);
+    if (!out.open(QIODevice::WriteOnly)) {
+        std::cerr << "couldn't open " << versionPath << ": " << out.errorString().toStdString()
+                  << std::endl;
+        return false;
+    }
+
+    constexpr auto versionLength = sizeof(LINGLONG_VERSION) - 1;
+    if (out.write(LINGLONG_VERSION, versionLength) != versionLength) {
+        std::cerr << "couldn't write " << versionPath << ": " << out.errorString().toStdString()
+                  << std::endl;
+        out.cancelWriting();
+        return false;
+    }
+
+    if (!out.commit()) {
+        std::cerr << "couldn't commit " << versionPath << ": " << out.errorString().toStdString()
+                  << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+linglong::repo::MigrateResult checkCompatibility(const RepositoryVersion &repositoryVersion,
+                                                 const Version &current)
+{
+    if (current < repositoryVersion.parsed) {
+        std::cerr << "repository version " << repositoryVersion.raw
+                  << " is newer than current program version " << LINGLONG_VERSION
+                  << ", refusing to migrate" << std::endl;
+        return linglong::repo::MigrateResult::Incompatible;
+    }
+
+    return linglong::repo::MigrateResult::NoChange;
 }
 
 int migrateRef(OstreeRepo *repo, const MigrateRefData &data)
@@ -214,10 +339,43 @@ int dispatchMigrations(const Version &from,
     return ret;
 }
 
+} // namespace
+
 namespace linglong::repo {
+MigrateResult checkRepoCompatibility(const std::filesystem::path &root) noexcept
+{
+    std::lock_guard processLock{ migrationMutex };
+
+    std::error_code ec;
+    if (!std::filesystem::exists(root, ec)) {
+        if (ec) {
+            std::cerr << "couldn't get status of " << root << std::endl;
+            return MigrateResult::Failed;
+        }
+        return MigrateResult::NoChange;
+    }
+
+    auto migrationLock = lockMigration(root);
+    if (!migrationLock) {
+        std::cerr << "couldn't lock repository " << root << ": " << migrationLock.error().message()
+                  << std::endl;
+        return MigrateResult::Failed;
+    }
+
+    auto repositoryVersion = readRepositoryVersion(root);
+    auto current = currentVersion();
+    if (!repositoryVersion || !current) {
+        return MigrateResult::Failed;
+    }
+
+    return checkCompatibility(*repositoryVersion, *current);
+}
+
 MigrateResult tryMigrate(const std::filesystem::path &root,
                          const linglong::api::types::v1::RepoConfigV2 &cfg) noexcept
 {
+    std::lock_guard processLock{ migrationMutex };
+
     std::error_code ec;
     if (!std::filesystem::exists(root, ec)) {
         if (ec) {
@@ -228,46 +386,38 @@ MigrateResult tryMigrate(const std::filesystem::path &root,
         return MigrateResult::NoChange;
     }
 
-    std::optional<std::string> repoVersion;
-    std::filesystem::path version = std::filesystem::path{ root } / ".version";
-    if (std::filesystem::exists(version, ec)) {
-        std::ifstream in{ version };
-        if (!in.is_open()) {
-            std::cerr << "couldn't open " << version << std::endl;
-            return MigrateResult::Failed;
-        }
-
-        std::stringstream buffer;
-        buffer << in.rdbuf();
-        repoVersion = buffer.str();
-    }
-
-    auto repoVer = repoVersion.value_or("1.5.0");
-    if (repoVer == LINGLONG_VERSION) {
-        return MigrateResult::NoChange;
-    }
-
-    auto from = parseVersion(repoVer);
-    if (!from) {
-        std::cerr << "failed to parse repo version " << repoVer << std::endl;
+    auto migrationLock = lockMigration(root);
+    if (!migrationLock) {
+        std::cerr << "couldn't lock repository " << root << ": " << migrationLock.error().message()
+                  << std::endl;
         return MigrateResult::Failed;
     }
 
-    auto ret = dispatchMigrations(*from, root, cfg);
+    auto repositoryVersion = readRepositoryVersion(root);
+    auto current = currentVersion();
+    if (!repositoryVersion || !current) {
+        return MigrateResult::Failed;
+    }
+
+    if (repositoryVersion->raw == LINGLONG_VERSION) {
+        return MigrateResult::NoChange;
+    }
+
+    auto compatibility = checkCompatibility(*repositoryVersion, *current);
+    if (compatibility == MigrateResult::Incompatible) {
+        return compatibility;
+    }
+
+    auto ret = dispatchMigrations(repositoryVersion->parsed, root, cfg);
     if (ret == -1) {
         return MigrateResult::Failed;
     }
 
     auto result = ret == 0 ? MigrateResult::NoChange : MigrateResult::Success;
 
-    std::ofstream out;
-    out.open(version, std::ios_base::out | std::ios_base::trunc);
-    if (!out.is_open()) {
-        std::cerr << "couldn't open " << version << std::endl;
+    if (!writeRepositoryVersion(root / ".version")) {
         return MigrateResult::Failed;
     }
-    out << LINGLONG_VERSION;
-    out.close();
 
     return result;
 }

--- a/libs/linglong/src/linglong/repo/migrate.h
+++ b/libs/linglong/src/linglong/repo/migrate.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -9,7 +9,9 @@
 #include <filesystem>
 
 namespace linglong::repo {
-enum class MigrateResult { Success, Failed, NoChange };
+enum class MigrateResult { Success, Failed, NoChange, Incompatible };
+
+MigrateResult checkRepoCompatibility(const std::filesystem::path &root) noexcept;
 
 MigrateResult tryMigrate(const std::filesystem::path &root,
                          const linglong::api::types::v1::RepoConfigV2 &cfg) noexcept;

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/migrate_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/migrate_test.cpp
@@ -7,15 +7,25 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "common/tempdir.h"
 #include "configure.h"
 #include "linglong/api/types/v1/RepoConfigV2.hpp"
 #include "linglong/repo/migrate.h"
+#include "linglong/utils/filelock.h"
 
-#include <common/tempdir.h>
 #include <ostree.h>
 
+#include <chrono>
+#include <cstdio>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
+#include <memory>
+#include <sstream>
+#include <thread>
+
+#include <sys/wait.h>
+#include <unistd.h>
 
 using namespace linglong::repo;
 using namespace linglong::api::types::v1;
@@ -189,6 +199,200 @@ TEST(MigrateTest, RealOstreeRepoMigratesUnprefixedRefs)
     // The new symlink layers/<checksum> must point at the migrated ref.
     auto link = dir.path() / "layers" / checksum;
     EXPECT_TRUE(std::filesystem::is_symlink(link));
+}
+
+namespace fs = std::filesystem;
+
+class MigrateDowngradeTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        tempDir = std::make_unique<TempDir>("linglong-migrate-test-");
+        ASSERT_TRUE(tempDir->isValid());
+        root = tempDir->path();
+    }
+
+    void TearDown() override { tempDir.reset(); }
+
+    // Write a .version file with the given content
+    void writeVersionFile(const std::string &version)
+    {
+        std::ofstream out(root / ".version");
+        out << version;
+    }
+
+    // Read the .version file
+    std::string readVersionFile()
+    {
+        std::ifstream in(root / ".version");
+        std::stringstream buf;
+        buf << in.rdbuf();
+        return buf.str();
+    }
+
+    // Create a minimal valid config for tryMigrate
+    linglong::api::types::v1::RepoConfigV2 makeConfig()
+    {
+        linglong::api::types::v1::RepoConfigV2 cfg{};
+        linglong::api::types::v1::Repo repo{};
+        repo.name = "test";
+        repo.url = "https://example.com";
+        cfg.repos.push_back(repo);
+        cfg.defaultRepo = "test";
+        cfg.version = 1;
+        return cfg;
+    }
+
+    fs::path root;
+    std::unique_ptr<TempDir> tempDir;
+};
+
+TEST_F(MigrateDowngradeTest, NewerRepoVersionIsNotDowngraded)
+{
+    int major{};
+    int minor{};
+    int patch{};
+    char trailing{};
+    ASSERT_EQ(std::sscanf(LINGLONG_VERSION, "%d.%d.%d%c", &major, &minor, &patch, &trailing), 3);
+    const auto newerVersion = std::to_string(major + 1) + ".0.0";
+
+    writeVersionFile(newerVersion);
+    ASSERT_TRUE(fs::create_directory(root / "repo"));
+    auto cfg = makeConfig();
+
+    auto result = linglong::repo::tryMigrate(root, cfg);
+    EXPECT_EQ(result, linglong::repo::MigrateResult::Incompatible)
+      << "tryMigrate should refuse when repo version is newer than program version";
+
+    EXPECT_EQ(readVersionFile(), newerVersion);
+}
+
+TEST_F(MigrateDowngradeTest, CompatibilityCheckRejectsNewerVersion)
+{
+    int major{};
+    int minor{};
+    int patch{};
+    char trailing{};
+    ASSERT_EQ(std::sscanf(LINGLONG_VERSION, "%d.%d.%d%c", &major, &minor, &patch, &trailing), 3);
+    const auto newerVersion = std::to_string(major + 1) + ".0.0";
+    writeVersionFile(newerVersion);
+
+    auto result = linglong::repo::checkRepoCompatibility(root);
+
+    EXPECT_EQ(result, linglong::repo::MigrateResult::Incompatible);
+    EXPECT_EQ(readVersionFile(), newerVersion);
+}
+
+TEST_F(MigrateDowngradeTest, CompatibilityCheckDoesNotMigrateOlderVersion)
+{
+    writeVersionFile("1.5.0");
+
+    auto result = linglong::repo::checkRepoCompatibility(root);
+
+    EXPECT_EQ(result, linglong::repo::MigrateResult::NoChange);
+    EXPECT_EQ(readVersionFile(), "1.5.0");
+}
+
+TEST_F(MigrateDowngradeTest, OlderVersionWithLargerPatchIsMigrated)
+{
+    int major{};
+    int minor{};
+    int patch{};
+    char trailing{};
+    ASSERT_EQ(std::sscanf(LINGLONG_VERSION, "%d.%d.%d%c", &major, &minor, &patch, &trailing), 3);
+
+    std::string olderVersion;
+    if (minor > 0) {
+        olderVersion =
+          std::to_string(major) + "." + std::to_string(minor - 1) + "." + std::to_string(patch + 1);
+    } else {
+        ASSERT_GT(major, 0);
+        olderVersion = std::to_string(major - 1) + ".1." + std::to_string(patch + 1);
+    }
+
+    writeVersionFile(olderVersion);
+    auto result = linglong::repo::tryMigrate(root, makeConfig());
+
+    EXPECT_EQ(result, linglong::repo::MigrateResult::NoChange);
+    EXPECT_EQ(readVersionFile(), LINGLONG_VERSION);
+}
+
+TEST_F(MigrateDowngradeTest, SameVersionReturnsNoChange)
+{
+    writeVersionFile(LINGLONG_VERSION);
+    auto cfg = makeConfig();
+
+    auto result = linglong::repo::tryMigrate(root, cfg);
+    EXPECT_EQ(result, linglong::repo::MigrateResult::NoChange)
+      << "tryMigrate should return NoChange when versions match";
+
+    EXPECT_EQ(readVersionFile(), LINGLONG_VERSION);
+}
+
+TEST_F(MigrateDowngradeTest, NonExistentRootReturnsNoChange)
+{
+    auto nonExistentRoot = root / "does_not_exist";
+    auto cfg = makeConfig();
+
+    auto result = linglong::repo::tryMigrate(nonExistentRoot, cfg);
+    EXPECT_EQ(result, linglong::repo::MigrateResult::NoChange)
+      << "tryMigrate should return NoChange for non-existent root";
+}
+
+TEST_F(MigrateDowngradeTest, VersionUpdateLeavesNoTemporaryFile)
+{
+    writeVersionFile("1.5.0");
+
+    auto result = linglong::repo::tryMigrate(root, makeConfig());
+
+    EXPECT_NE(result, linglong::repo::MigrateResult::Failed);
+    EXPECT_EQ(readVersionFile(), LINGLONG_VERSION);
+    for (const auto &entry : fs::directory_iterator(root)) {
+        EXPECT_EQ(entry.path().filename().string().rfind(".version.", 0), std::string::npos)
+          << "temporary version file was not cleaned up: " << entry.path();
+    }
+}
+
+TEST_F(MigrateDowngradeTest, CompatibilityCheckWaitsForMigrationLock)
+{
+    using linglong::utils::filelock::FileLock;
+    using linglong::utils::filelock::LockType;
+
+    writeVersionFile("99.0.0");
+    auto lock = FileLock::create(root / ".migration.lock", LockType::ReadWrite);
+    ASSERT_TRUE(lock.has_value());
+    ASSERT_TRUE(lock->lock(LockType::Write).has_value());
+
+    int readyPipe[2]{};
+    ASSERT_EQ(::pipe(readyPipe), 0);
+    const auto child = ::fork();
+    ASSERT_NE(child, -1);
+    if (child == 0) {
+        ::close(readyPipe[0]);
+        const char ready = '1';
+        if (::write(readyPipe[1], &ready, sizeof(ready)) != sizeof(ready)) {
+            _exit(2);
+        }
+        ::close(readyPipe[1]);
+        const auto result = linglong::repo::checkRepoCompatibility(root);
+        _exit(result == linglong::repo::MigrateResult::Incompatible ? 0 : 3);
+    }
+
+    ::close(readyPipe[1]);
+    char ready{};
+    ASSERT_EQ(::read(readyPipe[0], &ready, sizeof(ready)), sizeof(ready));
+    ::close(readyPipe[0]);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    int status{};
+    EXPECT_EQ(::waitpid(child, &status, WNOHANG), 0)
+      << "compatibility check did not wait for the migration lock";
+
+    ASSERT_TRUE(lock->unlock().has_value());
+    ASSERT_EQ(::waitpid(child, &status, 0), child);
+    EXPECT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Refuse to migrate or open repositories created by a newer Linyaps version, and make repository version updates safe against concurrent or interrupted migration.

## Root cause

Repository versions were compared with a non-lexicographic component check, so version ordering could be incorrect. `tryMigrate()` also dispatched migrations without first rejecting a repository version newer than the running program, then rewrote `.version` using a truncating stream.

In addition, package-manager startup skipped all compatibility checks when migration was disabled, and concurrent migration attempts were not serialized.

## Changes

- Compare semantic version components in major/minor/patch order.
- Return a distinct `Incompatible` result for repositories from newer versions.
- Check compatibility even when package-manager migration is disabled.
- Stop builder startup instead of backing up an incompatible newer repository.
- Serialize migration in-process and with a repository lock file.
- Update `.version` atomically with `QSaveFile`.
- Add regression tests for downgrade prevention, version ordering, no-op cases, atomic updates, and migration locking.

## Reproduction

1. Create a repository root containing `.version` with a version newer than `LINGLONG_VERSION`.
2. Call `tryMigrate()`.
3. Before this change, migration can proceed and overwrite the marker with the older program version.
4. After this change, it returns `MigrateResult::Incompatible` and preserves the original version file.

## Test plan

- [x] Independent Release build, including `ll-builder` and `ll-package-manager`
- [x] `ll-tests --gtest_filter='MigrateTest.*'` — 8 passed
- [x] Full CTest suite with the complete fix set: 528 passed, 2 environment-dependent X11 tests skipped, 0 failed
- [x] `git diff --check`
