### PR TITLE
fix(package-manager): validate deferred timeout

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -53,9 +53,12 @@
 #include <QTimer>
 
 #include <algorithm>
+#include <charconv>
 #include <chrono>
 #include <cstdint>
 #include <functional>
+#include <limits>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 
@@ -207,12 +210,20 @@ void PackageManager::initDaemonMode(bool peerMode) noexcept
     auto deferredTimeOut = 3600s;
     auto *deferredTimeOutEnv = ::getenv("LINGLONG_DEFERRED_TIMEOUT");
     if (deferredTimeOutEnv != nullptr) {
-        try {
-            deferredTimeOut = std::stoi(deferredTimeOutEnv) * 1s;
-        } catch (std::invalid_argument &e) {
-            LogW("failed to parse LINGLONG_DEFERRED_TIMEOUT[{}]: {}", deferredTimeOutEnv, e.what());
-        } catch (std::out_of_range &e) {
-            LogW("failed to parse LINGLONG_DEFERRED_TIMEOUT[{}]: {}", deferredTimeOutEnv, e.what());
+        constexpr auto maxTimeOut =
+          std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::milliseconds{ std::numeric_limits<int>::max() })
+            .count();
+        const auto value = std::string_view{ deferredTimeOutEnv };
+        std::chrono::seconds::rep seconds{};
+        const auto [end, error] = std::from_chars(value.begin(), value.end(), seconds);
+        if (error == std::errc{} && end == value.end() && seconds > 0
+            && seconds <= maxTimeOut) {
+            deferredTimeOut = std::chrono::seconds{ seconds };
+        } else {
+            LogW("invalid LINGLONG_DEFERRED_TIMEOUT[{}], using {}s",
+                 deferredTimeOutEnv,
+                 deferredTimeOut.count());
         }
     }
 

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -210,15 +210,13 @@ void PackageManager::initDaemonMode(bool peerMode) noexcept
     auto deferredTimeOut = 3600s;
     auto *deferredTimeOutEnv = ::getenv("LINGLONG_DEFERRED_TIMEOUT");
     if (deferredTimeOutEnv != nullptr) {
-        constexpr auto maxTimeOut =
-          std::chrono::duration_cast<std::chrono::seconds>(
-            std::chrono::milliseconds{ std::numeric_limits<int>::max() })
-            .count();
+        constexpr auto maxTimeOut = std::chrono::duration_cast<std::chrono::seconds>(
+                                      std::chrono::milliseconds{ std::numeric_limits<int>::max() })
+                                      .count();
         const auto value = std::string_view{ deferredTimeOutEnv };
         std::chrono::seconds::rep seconds{};
         const auto [end, error] = std::from_chars(value.begin(), value.end(), seconds);
-        if (error == std::errc{} && end == value.end() && seconds > 0
-            && seconds <= maxTimeOut) {
+        if (error == std::errc{} && end == value.end() && seconds > 0 && seconds <= maxTimeOut) {
             deferredTimeOut = std::chrono::seconds{ seconds };
         } else {
             LogW("invalid LINGLONG_DEFERRED_TIMEOUT[{}], using {}s",

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -40,6 +40,7 @@ pfl_add_executable(
   src/linglong/package/layer_packager_test.cpp
   src/linglong/package_manager/action_test.cpp
   src/linglong/package_manager/data_monitor_test.cpp
+  src/linglong/package_manager/package_manager_test.cpp
   src/linglong/package_manager/task_test.cpp
   src/linglong/package_manager/task_queue_test.cpp
   src/linglong/package_manager/package_update_test.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/package_manager_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/package_manager_test.cpp
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gtest/gtest.h>
+
+#include "linglong/package_manager/package_manager.h"
+
+#include <QByteArray>
+#include <QTimer>
+
+namespace {
+
+using linglong::service::PackageManager;
+
+class PackageManagerDaemonModeTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        hadDeferredTimeout = qEnvironmentVariableIsSet("LINGLONG_DEFERRED_TIMEOUT");
+        deferredTimeout = qgetenv("LINGLONG_DEFERRED_TIMEOUT");
+    }
+
+    void TearDown() override
+    {
+        if (hadDeferredTimeout) {
+            qputenv("LINGLONG_DEFERRED_TIMEOUT", deferredTimeout);
+        } else {
+            qunsetenv("LINGLONG_DEFERRED_TIMEOUT");
+        }
+    }
+
+    static int timerIntervalFor(const QByteArray &value)
+    {
+        qputenv("LINGLONG_DEFERRED_TIMEOUT", value);
+        PackageManager manager{ nullptr, nullptr, nullptr };
+        manager.initDaemonMode();
+        auto *timer = manager.findChild<QTimer *>();
+        EXPECT_NE(timer, nullptr);
+        return timer == nullptr ? -1 : timer->interval();
+    }
+
+    bool hadDeferredTimeout{ false };
+    QByteArray deferredTimeout;
+};
+
+TEST_F(PackageManagerDaemonModeTest, AcceptsPositiveWholeSeconds)
+{
+    EXPECT_EQ(timerIntervalFor("17"), 17'000);
+}
+
+TEST_F(PackageManagerDaemonModeTest, RejectsNonPositiveValues)
+{
+    EXPECT_EQ(timerIntervalFor("0"), 3'600'000);
+    EXPECT_EQ(timerIntervalFor("-1"), 3'600'000);
+}
+
+TEST_F(PackageManagerDaemonModeTest, RejectsTrailingCharactersAndOverflow)
+{
+    EXPECT_EQ(timerIntervalFor("17seconds"), 3'600'000);
+    EXPECT_EQ(timerIntervalFor("2147484"), 3'600'000);
+}
+
+} // namespace

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/package_manager_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/package_manager_test.cpp
@@ -9,6 +9,7 @@
 #include "linglong/package_manager/package_manager.h"
 
 #include <QByteArray>
+#include <QCoreApplication>
 #include <QTimer>
 
 namespace {
@@ -35,6 +36,8 @@ protected:
 
     static int timerIntervalFor(const QByteArray &value)
     {
+        int argc = 0;
+        QCoreApplication app(argc, nullptr);
         qputenv("LINGLONG_DEFERRED_TIMEOUT", value);
         PackageManager manager{ nullptr, nullptr, nullptr };
         manager.initDaemonMode();


### PR DESCRIPTION
## 问题

`LINGLONG_DEFERRED_TIMEOUT` 通过 `std::stoi` 解析时会接受尾随字符、零和负数。这些值随后直接成为 `QTimer` 间隔，可能停止或破坏 deferred uninstall 调度。

## 方案

- 使用 `std::from_chars` 校验完整输入。
- 只接受 `QTimer` 毫秒范围内的正整数秒数。
- 无效输入记录警告并回退到默认的 3,600 秒。
- 增加有效值、非正值、尾随字符和溢出值的回归测试。

## 本地验证

- `git diff --check d5faf9e6...HEAD`
- `check-pr-scope.sh d5faf9e6 0811-yuluo-yx 400`（91/400 行）

未运行完整 C++ 构建和 GTest：本机 macOS 环境缺少项目要求的 CMake、Qt/GTest 和 Linux 系统依赖。

Fixes #1800
