### PR TITLE
docs(install): warn about ZFS performance

### DIFF
--- a/docs/pages/en/guide/start/install.md
+++ b/docs/pages/en/guide/start/install.md
@@ -18,6 +18,16 @@ The main command-line tools are:
 - `ll-builder` builds and debugs Linyaps applications and is provided by
   `linglong-builder`.
 
+:::warning Storage filesystem
+
+The local Linyaps repository uses OSTree, which currently has severe write
+performance problems on ZFS. Do not place Linyaps repository or data
+directories on a ZFS filesystem; use another Linux filesystem such as ext4 or
+XFS instead. See [Issue #1107](https://github.com/OpenAtom-Linyaps/linyaps/issues/1107)
+and [OpenZFS #11140](https://github.com/openzfs/zfs/issues/11140) for context.
+
+:::
+
 ## Repository usage
 
 ### Release repository

--- a/docs/pages/guide/start/install.md
+++ b/docs/pages/guide/start/install.md
@@ -13,6 +13,20 @@ deepin/UOS 的部分版本已经预装如意玲珑。请先执行 `ll-cli --vers
 - `ll-cli` 管理和运行如意玲珑应用，由 `linglong-bin` 提供。
 - `ll-builder` 用来构建和调试如意玲珑应用，由 `linglong-builder` 提供。
 
+:::warning 存储文件系统
+
+如意玲珑的本地仓库使用 OSTree。目前，OSTree 在 ZFS 上存在严重的写入性能问题。
+
+安装前，请确认如意玲珑的仓库和数据目录不在 ZFS 文件系统上。
+建议使用 ext4、XFS 等其他 Linux 文件系统。
+
+相关背景：
+
+- [Linyaps Issue #1107](https://github.com/OpenAtom-Linyaps/linyaps/issues/1107)
+- [OpenZFS Issue #11140](https://github.com/openzfs/zfs/issues/11140)
+
+:::
+
 ## 仓库使用说明
 
 ### release 仓库


### PR DESCRIPTION
## 问题

安装指南没有说明 Linyaps 的 OSTree 本地仓库在 ZFS 上存在严重的写入性能问题，用户可能在安装后才遇到明显性能劣化。

## 方案

- 在中英文安装指南中增加存储文件系统警告。
- 建议把仓库和数据目录放在 ext4、XFS 等其他 Linux 文件系统上。
- 链接 Linyaps 和 OpenZFS 的原始问题，便于追溯背景。

## 本地验证

- `git diff --check d5faf9e6...HEAD`
- `check-pr-scope.sh d5faf9e6 0811-yuluo-yx 400`（24/400 行）
- 按中文技术文档规范检查标题、段落、术语、标点和引用。
- `markdownlint` 未在新增行报告问题；文件中原有的 MD013 长行警告仍然存在。

未运行文档站点完整构建。

Fixes #1107
