### PR TITLE
fix(cli): preserve command exec arguments

### DIFF
--- a/apps/ll-cli/CMakeLists.txt
+++ b/apps/ll-cli/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 pfl_add_executable(
   SOURCES
+  ./src/command_line.h
   ./src/main.cpp
   OUTPUT_NAME
   ${LINGLONG_CLI_BIN}

--- a/apps/ll-cli/src/command_line.h
+++ b/apps/ll-cli/src/command_line.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace linglong::cli {
+
+inline std::vector<std::string> transformOldExecArguments(int argc, char **argv) noexcept
+{
+    auto commandSeparator = argc;
+    for (int i = 1; i < argc; ++i) {
+        if (std::string_view{ argv[i] } == "--") {
+            commandSeparator = i;
+            break;
+        }
+    }
+
+    std::vector<std::string> result;
+    result.reserve(static_cast<std::size_t>(argc - 1));
+    for (int i = argc - 1; i > 0; --i) {
+        if (i < commandSeparator && std::string_view{ argv[i] } == "--exec") {
+            result.emplace_back("--");
+        } else {
+            result.emplace_back(argv[i]);
+        }
+    }
+
+    return result;
+}
+
+} // namespace linglong::cli

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 #include "configure.h"
+#include "command_line.h"
 #include "linglong/cli/cli.h"
 #include "linglong/cli/cli_printer.h"
 #include "linglong/cli/dbus_notifier.h"
@@ -46,21 +47,6 @@ using namespace linglong::package;
 using namespace linglong::cli;
 
 namespace {
-
-std::vector<std::string> transformOldExec(int argc, char **argv) noexcept
-{
-    std::vector<std::string> res;
-
-    for (int i = argc - 1; i > 0; --i) {
-        if (std::string_view(argv[i]) == "--exec") {
-            res.emplace_back("--");
-        } else {
-            res.emplace_back(argv[i]);
-        }
-    }
-
-    return res;
-}
 
 // Validator for string inputs
 CLI::Validator validatorString{
@@ -658,7 +644,7 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     addPruneCommand(commandParser, CliAppManagingGroup);
     addInspectCommand(commandParser, inspectOptions, CliHiddenGroup);
 
-    auto res = transformOldExec(argc, argv);
+    auto res = transformOldExecArguments(argc, argv);
     CLI11_PARSE(commandParser, std::move(res));
 
     // print version if --version flag is set

--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
-#include "configure.h"
 #include "command_line.h"
+#include "configure.h"
 #include "linglong/cli/cli.h"
 #include "linglong/cli/cli_printer.h"
 #include "linglong/cli/dbus_notifier.h"

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -12,6 +12,7 @@ pfl_add_executable(
   DISABLE_INSTALL
   SOURCES
   # find -regex '\./src/.+\.[ch]\(pp\)?' -type f -printf '%P\n'| sort
+  src/apps/ll-cli/command_line_test.cpp
   src/common/tempdir.h
   src/linglong/builder/config_test.cpp
   src/linglong/builder/linglong_builder_test.cpp
@@ -103,3 +104,5 @@ target_include_directories(${tests}
                            PUBLIC ${PROJECT_SOURCE_DIR}/apps/uab/header/src)
 target_include_directories(${tests}
                            PUBLIC ${PROJECT_SOURCE_DIR}/apps/ll-driver-detect/src)
+target_include_directories(${tests}
+                           PUBLIC ${PROJECT_SOURCE_DIR}/apps/ll-cli/src)

--- a/libs/linglong/tests/ll-tests/src/apps/ll-cli/command_line_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/apps/ll-cli/command_line_test.cpp
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "command_line.h"
+
+using linglong::cli::transformOldExecArguments;
+using ::testing::ElementsAre;
+
+TEST(CommandLine, ConvertsLegacyExecSeparator)
+{
+    char arg0[] = "ll-cli";
+    char arg1[] = "run";
+    char arg2[] = "org.example.App";
+    char arg3[] = "--exec";
+    char arg4[] = "bash";
+    char *argv[]{ arg0, arg1, arg2, arg3, arg4 };
+
+    EXPECT_THAT(transformOldExecArguments(5, argv),
+                ElementsAre("bash", "--", "org.example.App", "run"));
+}
+
+TEST(CommandLine, PreservesExecArgumentAfterCommandSeparator)
+{
+    char arg0[] = "ll-cli";
+    char arg1[] = "run";
+    char arg2[] = "org.example.App";
+    char arg3[] = "--";
+    char arg4[] = "tool";
+    char arg5[] = "--exec";
+    char arg6[] = "value";
+    char *argv[]{ arg0, arg1, arg2, arg3, arg4, arg5, arg6 };
+
+    EXPECT_THAT(transformOldExecArguments(7, argv),
+                ElementsAre("value", "--exec", "tool", "--", "org.example.App", "run"));
+}


### PR DESCRIPTION
## 问题

旧版 `run --exec` 兼容转换会改写参数列表中的所有 `--exec`，包括显式命令分隔符之后、本应传给容器内程序的参数。

## 方案

- 把参数转换提取为可测试的轻量 helper。
- 只转换首个显式 `--` 之前的旧版 `--exec`。
- 保持 CLI11 所需的反向参数顺序。
- 增加旧语法转换和命令参数透传回归测试。

## 本地验证

- C++17 helper 使用 `-Wall -Wextra -Werror` 通过语法检查。
- 独立 harness 验证显式分隔符后的 `--exec` 保持不变。
- `git diff --check d5faf9e6...HEAD`
- 范围门禁：102/400 行。

未运行完整 GTest 和应用构建：本机缺少项目的 Qt/GTest 与 Linux 构建依赖。

Fixes #1801
