### PR TITLE
fix(http): handle empty backward list iteration

### DIFF
--- a/external/http/src/list.c
+++ b/external/http/src/list.c
@@ -70,11 +70,13 @@ void list_iterateThroughListBackward(list_t *list,
                                      void *additionalDataNeededForCallbackFunction)
 {
     listEntry_t *currentListEntry = list->lastEntry;
-    listEntry_t *nextListEntry = currentListEntry->prevListEntry;
+    listEntry_t *nextListEntry;
 
     if(currentListEntry == NULL) {
         return;
     }
+
+    nextListEntry = currentListEntry->prevListEntry;
 
     operationToPerform(currentListEntry,
                        additionalDataNeededForCallbackFunction);

--- a/external/http/unit-test/test_list.c
+++ b/external/http/unit-test/test_list.c
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "../include/list.h"
+
+#include <assert.h>
+
+static void count_entry(listEntry_t *entry, void *data)
+{
+    (void)entry;
+    ++*(int *)data;
+}
+
+int main(void)
+{
+    list_t *list = list_createList();
+    int visited = 0;
+
+    assert(list != NULL);
+    list_iterateThroughListBackward(list, count_entry, &visited);
+    assert(visited == 0);
+
+    list_freeList(list);
+    return 0;
+}

--- a/tools/openapi-c-libcurl-client/list.c.mustache
+++ b/tools/openapi-c-libcurl-client/list.c.mustache
@@ -70,11 +70,13 @@ void list_iterateThroughListBackward(list_t *list,
                                      void *additionalDataNeededForCallbackFunction)
 {
     listEntry_t *currentListEntry = list->lastEntry;
-    listEntry_t *nextListEntry = currentListEntry->prevListEntry;
+    listEntry_t *nextListEntry;
 
     if(currentListEntry == NULL) {
         return;
     }
+
+    nextListEntry = currentListEntry->prevListEntry;
 
     operationToPerform(currentListEntry,
                        additionalDataNeededForCallbackFunction);


### PR DESCRIPTION
## 问题

空链表反向遍历在判空之前读取 `lastEntry->prevListEntry`，会立即触发空指针解引用。

## 方案

- 在读取前一个节点前检查 `lastEntry`。
- 同步修改 OpenAPI 模板和当前生成代码。
- 增加空链表回归测试，确认回调不会执行。

## 本地验证

- 修复前最小复现退出码为 139。
- `cc -std=c11 -Wall -Wextra -Wno-unused-parameter external/http/src/list.c external/http/unit-test/test_list.c` 编译通过。
- 回归测试执行通过。
- 模板和生成文件保持一致。
- 范围门禁：34/400 行。

未运行完整项目构建。

Fixes #1802
