### PR TITLE
fix(release): isolate version bump commit

### DIFF
--- a/release.bash
+++ b/release.bash
@@ -58,7 +58,7 @@ echo "更新成功! 新的 VERSION: $UPDATED_VERSION"
 
 # 提交更改到 Git
 git add "$CMAKE_FILE"
-git commit -m "release $UPDATED_VERSION"
+git commit --only -m "release $UPDATED_VERSION" -- "$CMAKE_FILE"
 
 # 打 Git 标签
 TAG_NAME="$UPDATED_VERSION"


### PR DESCRIPTION
## 问题

发布脚本使用不带路径限制的 `git commit`，会把用户预先暂存的无关文件一并放入版本提交。

## 方案

使用 `git commit --only -- CMakeLists.txt`，只提交版本文件，同时保留其他暂存内容。

## 本地验证

- 临时仓库 fixture 确认提交只包含 `CMakeLists.txt`，无关文件继续保持暂存。
- `bash -n release.bash`
- `shellcheck -e SC2162 release.bash`
- `git diff --check d5faf9e6...HEAD`
- 范围门禁：2/400 行。

未运行实际发布和打标签操作。

Fixes #1803
