### PR TITLE
fix(codegen): detect missing quicktype correctly

### DIFF
--- a/tools/codegen.sh
+++ b/tools/codegen.sh
@@ -18,7 +18,7 @@ QUICKTYPE=${QUICKTYPE:=$(command -v quicktype || true)}
 
 if [ -z "$QUICKTYPE" ]; then
         pushd quicktype
-        if not npx quicktype --version &>/dev/null; then
+        if ! npx quicktype --version &>/dev/null; then
                 echo "Installing quicktype"
                 npm i
                 npm run build


### PR DESCRIPTION
## 问题

代码生成脚本使用 Bash 不支持的 `if not command` 语法。`not` 被当作命令执行，导致 quicktype 缺失时错误进入“已经安装”分支。

## 方案

改用 Bash 原生的 `if ! command` 否定语法，不改变其他代码生成行为。

## 本地验证

- PATH fixture 确认缺失 quicktype 时依次执行 `npm i` 和 `npm run build`。
- `bash -n tools/codegen.sh`
- `shellcheck -e SC2016 tools/codegen.sh`
- `git diff --check d5faf9e6...HEAD`
- 范围门禁：2/400 行。

未运行完整代码生成，避免产生大范围生成文件噪音。

Fixes #1804
