### PR TITLE
fix(tools): clean up layer icon mounts

### DIFF
--- a/tools/layer-icon-checker.sh
+++ b/tools/layer-icon-checker.sh
@@ -25,6 +25,20 @@ prepareEnv() {
 	fi
 }
 
+cleanup() {
+	status=$?
+	trap - EXIT HUP INT TERM
+
+	if [ "${mounted}" = true ]; then
+		umount -- "${dest}" >/dev/null 2>&1 || true
+	fi
+	if [ -n "${dest}" ] && [ -d "${dest}" ]; then
+		rmdir -- "${dest}" >/dev/null 2>&1 || true
+	fi
+
+	exit "${status}"
+}
+
 getLayerOffset() {
 	layerPath=$1
 	layerHeader="<<< deepin linglong layer archive >>>"
@@ -33,13 +47,13 @@ getLayerOffset() {
 	declare -i infoLength=4
 	declare -i infoSize offset
 
-	fileHeader=$(hexdump -n ${layerHeaderLength} -e '1/40 "%s\n"' ${layerPath})
+	fileHeader=$(hexdump -n ${layerHeaderLength} -e '1/40 "%s\n"' "${layerPath}")
 	if [ "${fileHeader}" != "${layerHeader}" ]; then
 		echo "${layerPath} is not a layer file, exit checking process ..."
 		exit 255
 	fi
 
-	infoSize=$(hexdump -n ${infoLength} -s ${layerHeaderLength} -e '1/4 "%u\n"' ${layerPath})
+	infoSize=$(hexdump -n ${infoLength} -s ${layerHeaderLength} -e '1/4 "%u\n"' "${layerPath}")
 	if [ ! ${infoSize} -gt 0 ]; then
 		echo "broken layer file, exit checking process ..."
 		exit 255
@@ -53,9 +67,9 @@ getDesktopIcons() {
 	path=$1
 	declare desktopIcons
 
-	desktopList=$(find $path -name "*.desktop")
+	desktopList=$(find "${path}" -name "*.desktop")
 	for desktop in ${desktopList}; do
-		desktopIcons+=$(sed -n 's/^Icon=\(.*\)/\1/p' ${desktop})
+		desktopIcons+=$(sed -n 's/^Icon=\(.*\)/\1/p' "${desktop}")
 		desktopIcons+="\n"
 	done
 	echo -e "${desktopIcons}"
@@ -86,7 +100,7 @@ iconCheck() {
 	echo "IconPath:"
 
 	for icon in ${icons}; do
-		result=$(find ${iconPath} -name "${icon}*")
+		result=$(find "${iconPath}" -name "${icon}*")
 		if [ "${result}" == "" ]; then
 			formatPrintIconPath "${icon}" "not found"
 			return 255
@@ -99,7 +113,6 @@ iconCheck() {
 main() {
 	RED='\033[0;31m'
 	YELLOW='\033[1;33m'
-	GREEN='\033[0;32m'
 	NC='\033[0m' # No Color
 
 	declare arg1="$1"
@@ -109,7 +122,7 @@ main() {
 		return 0
 	fi
 
-	if [ ! -f ${arg1} ]; then
+	if [ ! -f "${arg1}" ]; then
 		echo "${arg1} is not a regular file or not exists."
 		return 255
 	fi
@@ -119,33 +132,36 @@ main() {
 
 	offset=$(getLayerOffset "${arg1}")
 
-	# mount data from layer
+	# 挂载 layer 数据；trap 同时覆盖失败与信号退出路径
+	dest=""
+	mounted=false
+	trap cleanup EXIT
+	trap 'exit 129' HUP
+	trap 'exit 130' INT
+	trap 'exit 143' TERM
+
 	dest=$(mktemp --tmpdir=/tmp -d linglong-layer-XXXXXXXX)
-	erofsfuse --offset=${offset} ${arg1} ${dest} >/dev/null 2>&1
-	if [ ! $? -eq 0 ]; then
+	mounted=true
+	if ! erofsfuse --offset="${offset}" "${arg1}" "${dest}" >/dev/null 2>&1; then
 		echo "Extract layer failed!"
 		return 255
 	fi
 
 	# check desktop file, quit normally if no Icon set
-	icons=$(getDesktopIcons ${dest})
+	icons=$(getDesktopIcons "${dest}")
 	if [ "${icons}" == "" ]; then
 		echo "No icon set in desktop file, nothing need to check ..."
 		return 0
 	fi
 
 	# check whether icon exists
-	iconCheck "${dest}" "${icons}"
-	if [ ! $? -eq 0 ]; then
+	if ! iconCheck "${dest}" "${icons}"; then
 		echo "---------------------------------------------------"
 		echo -e "Icon check ${RED}failed${NC} ..."
 		return 255
 	fi
 	echo "--------------------------------------------------"
 	echo -e "Icon check ${YELLOW}passed${NC} ..."
-
-	# clean data
-	umount ${dest} && rm ${dest} -rf
 
 	return 0
 }

--- a/tools/layer-icon-checker_test.sh
+++ b/tools/layer-icon-checker_test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+set -eu
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+checker="${script_dir}/layer-icon-checker.sh"
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/layer-icon-checker-test.XXXXXXXX")
+fake_bin="${test_root}/bin"
+log_file="${test_root}/calls.log"
+layer_file="${test_root}/example.layer"
+
+cleanup_test() {
+	find "${test_root}" -depth -delete
+}
+trap cleanup_test EXIT
+
+mkdir "${fake_bin}"
+touch "${layer_file}"
+
+cat >"${fake_bin}/fake-tool" <<'EOF'
+#!/usr/bin/env bash
+set -eu
+
+case "${0##*/}" in
+hexdump)
+	case "$*" in
+	*'1/40'*) printf '%s\n' '<<< deepin linglong layer archive >>>' ;;
+	*) printf '%s\n' 1 ;;
+	esac
+	;;
+erofsfuse)
+	dest="${*: -1}"
+	mkdir -p "${dest}/entries/applications"
+	case "${LAYER_ICON_TEST_CASE}" in
+	no-icon)
+		printf '%s\n' '[Desktop Entry]' >"${dest}/entries/applications/app.desktop"
+		;;
+	fail)
+		printf '%s\n' '[Desktop Entry]' 'Icon=missing' >"${dest}/entries/applications/app.desktop"
+		;;
+	success | signal)
+		mkdir -p "${dest}/entries/share/icons"
+		printf '%s\n' '[Desktop Entry]' 'Icon=present' >"${dest}/entries/applications/app.desktop"
+		touch "${dest}/entries/share/icons/present.png"
+		;;
+	esac
+	printf 'mount %s\n' "${dest}" >>"${LAYER_ICON_TEST_LOG}"
+	if [ "${LAYER_ICON_TEST_CASE}" = signal ]; then
+		kill -TERM "${PPID}"
+	fi
+	;;
+umount)
+	if [ "${1:-}" = -- ]; then
+		shift
+	fi
+	printf 'umount %s\n' "$1" >>"${LAYER_ICON_TEST_LOG}"
+	/usr/bin/find "$1" -mindepth 1 -delete
+	;;
+esac
+EOF
+chmod +x "${fake_bin}/fake-tool"
+ln -s fake-tool "${fake_bin}/hexdump"
+ln -s fake-tool "${fake_bin}/erofsfuse"
+ln -s fake-tool "${fake_bin}/umount"
+
+run_case() {
+	case_name=$1
+	expected_status=$2
+	: >"${log_file}"
+
+	set +e
+	LAYER_ICON_TEST_CASE="${case_name}" LAYER_ICON_TEST_LOG="${log_file}" \
+		PATH="${fake_bin}:${PATH}" bash "${checker}" "${layer_file}" >/dev/null 2>&1
+	actual_status=$?
+	set -e
+
+	if [ "${actual_status}" -ne "${expected_status}" ]; then
+		echo "${case_name}: expected status ${expected_status}, got ${actual_status}" >&2
+		return 1
+	fi
+	mount_point=$(sed -n 's/^mount //p' "${log_file}")
+	if ! grep -Fx "umount ${mount_point}" "${log_file}" >/dev/null; then
+		echo "${case_name}: mount was not unmounted" >&2
+		return 1
+	fi
+	if [ -e "${mount_point}" ]; then
+		echo "${case_name}: temporary mount directory still exists" >&2
+		return 1
+	fi
+}
+
+run_case no-icon 0
+run_case fail 255
+run_case success 0
+run_case signal 143
+
+echo "layer-icon-checker cleanup tests passed"


### PR DESCRIPTION
## 问题

layer 图标检查器只在成功路径清理 FUSE 挂载。无图标、检查失败或信号退出会遗留挂载点和临时目录。

## 方案

- 使用统一的 EXIT 清理函数覆盖所有返回路径。
- 为 HUP、INT 和 TERM 保留对应退出状态。
- 卸载失败时不删除仍可能挂载的目录。
- 增加无图标、检查失败、成功和 TERM 四条回归测试。

## 本地验证

- `bash -n tools/layer-icon-checker.sh tools/layer-icon-checker_test.sh`
- `shellcheck tools/layer-icon-checker.sh tools/layer-icon-checker_test.sh`
- `bash tools/layer-icon-checker_test.sh`
- `git diff --check d5faf9e6...HEAD`
- 范围门禁：149/400 行。

未运行真实 erofsfuse 内核挂载集成测试；回归测试使用 PATH fake 验证清理控制流。

Fixes #1805
