### PR TITLE
fix(smoke): honor sudo flags environment

### DIFF
--- a/tools/test_linglong/executor.py
+++ b/tools/test_linglong/executor.py
@@ -10,11 +10,13 @@
 """
 
 import os
+import shlex
 import subprocess
 import sys
 from typing import Optional
 
-SUDO_FLAGS = "-A"
+DEFAULT_SUDO_FLAGS = "-A"
+
 
 class CommandExecutor:
     """命令执行器，封装 subprocess.run 的调用细节。"""
@@ -57,8 +59,8 @@ class CommandExecutor:
         if env:
             run_env.update(env)
         if sudo:
-            flags = SUDO_FLAGS
-            full_cmd = ["sudo"] + (flags.split() if flags else []) + full_cmd
+            flags = shlex.split(os.environ.get("SUDO_FLAGS", DEFAULT_SUDO_FLAGS))
+            full_cmd = ["sudo", *flags, *full_cmd]
 
         try:
             result = subprocess.run(

--- a/tools/test_linglong/test_executor.py
+++ b/tools/test_linglong/test_executor.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+"""命令执行器的轻量单元测试。"""
+
+import os
+import subprocess
+import unittest
+from unittest import mock
+
+from .executor import CommandExecutor
+
+
+class CommandExecutorSudoFlagsTest(unittest.TestCase):
+    """验证 sudo 参数默认值与环境变量覆盖行为。"""
+
+    def run_with_sudo_flags(self, sudo_flags: str | None) -> list[str]:
+        environment = {} if sudo_flags is None else {"SUDO_FLAGS": sudo_flags}
+        clear_environment = sudo_flags is None
+        completed = subprocess.CompletedProcess([], 0, "", "")
+
+        with mock.patch.dict(os.environ, environment, clear=clear_environment):
+            with mock.patch("subprocess.run", return_value=completed) as run:
+                CommandExecutor().run(["ll-cli", "list"], sudo=True)
+
+        return run.call_args.args[0]
+
+    def test_uses_askpass_by_default(self):
+        self.assertEqual(
+            self.run_with_sudo_flags(None),
+            ["sudo", "-A", "ll-cli", "list"],
+        )
+
+    def test_splits_custom_flags_with_shell_quoting(self):
+        self.assertEqual(
+            self.run_with_sudo_flags('--preserve-env="HTTP PROXY" -n'),
+            ["sudo", "--preserve-env=HTTP PROXY", "-n", "ll-cli", "list"],
+        )
+
+    def test_allows_empty_flags(self):
+        self.assertEqual(
+            self.run_with_sudo_flags(""),
+            ["sudo", "ll-cli", "list"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

Python 冒烟测试执行器把 sudo 参数硬编码为 `-A`，无法适配无 askpass 的 CI 或自定义 sudo 配置。

## 方案

- 未配置时继续使用 `-A`。
- 每次 sudo 调用读取 `SUDO_FLAGS`。
- 使用 `shlex.split` 正确处理带引号参数。
- 允许显式空值不附加 sudo flag。

## 本地验证

- `python3 -m compileall -q tools/test_linglong`
- `python3 -m unittest -v tools.test_linglong.test_executor`（3/3 通过）
- `git diff --check d5faf9e6...HEAD`
- 范围门禁：58/400 行。

未运行依赖真实 sudo、ll-cli 和仓库服务的完整冒烟测试。

Fixes #1806
