### PR TITLE
fix(dialog): return rejection exit status

### DIFF
--- a/apps/ll-dialog/CMakeLists.txt
+++ b/apps/ll-dialog/CMakeLists.txt
@@ -12,6 +12,7 @@ pfl_add_executable(
   SOURCES
   ./src/cache_dialog_resource.qrc
   ./src/main.cpp
+  ./src/permission_dialog_result.h
   ./src/permissionDialog.h
   ./src/permissionDialog.cpp
   ./src/cache_dialog.h

--- a/apps/ll-dialog/src/permissionDialog.cpp
+++ b/apps/ll-dialog/src/permissionDialog.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 

--- a/apps/ll-dialog/src/permissionDialog.cpp
+++ b/apps/ll-dialog/src/permissionDialog.cpp
@@ -5,10 +5,12 @@
 #include "permissionDialog.h"
 
 #include "linglong/utils/gettext.h"
+#include "permission_dialog_result.h"
 
 #include <nlohmann/json.hpp>
 
 #include <QApplication>
+#include <QCloseEvent>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QPushButton>
@@ -42,13 +44,15 @@ PermissionDialog::PermissionDialog(
     // button
     auto *allowedButton = new QPushButton{ _("Allow") };
     connect(allowedButton, &QPushButton::clicked, [] {
-        QApplication::exit(0);
+        QApplication::exit(
+          linglong::dialog::exitCode(linglong::dialog::PermissionDialogResult::Allowed));
     });
 
     QString deniedButtonText{ _("Deny (%1s)") };
     auto *deniedButton = new QPushButton{ deniedButtonText.arg(15) };
     connect(deniedButton, &QPushButton::clicked, [] {
-        QApplication::exit(0);
+        QApplication::exit(
+          linglong::dialog::exitCode(linglong::dialog::PermissionDialogResult::Denied));
     });
 
     using namespace std::chrono_literals;
@@ -57,7 +61,9 @@ PermissionDialog::PermissionDialog(
     connect(timer, &QTimer::timeout, [timer, deniedButtonText, deniedButton] {
         auto timeOut = std::chrono::seconds{ timer->property("timeOut").toInt() };
         if (timeOut == 0s) {
-            QApplication::exit(0);
+            QApplication::exit(
+              linglong::dialog::exitCode(linglong::dialog::PermissionDialogResult::Denied));
+            return;
         }
 
         auto newTimeOut = timeOut - 1s;
@@ -76,4 +82,11 @@ PermissionDialog::PermissionDialog(
 
     setLayout(layout);
     timer->start(1s);
+}
+
+void PermissionDialog::closeEvent(QCloseEvent *event)
+{
+    event->ignore();
+    QApplication::exit(
+      linglong::dialog::exitCode(linglong::dialog::PermissionDialogResult::Denied));
 }

--- a/apps/ll-dialog/src/permissionDialog.h
+++ b/apps/ll-dialog/src/permissionDialog.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 

--- a/apps/ll-dialog/src/permissionDialog.h
+++ b/apps/ll-dialog/src/permissionDialog.h
@@ -9,6 +9,8 @@
 
 #include <QWidget>
 
+class QCloseEvent;
+
 class PermissionDialog : public QWidget
 {
     Q_OBJECT
@@ -16,4 +18,7 @@ public:
     explicit PermissionDialog(
       const linglong::api::types::v1::ApplicationPermissionsRequest &request);
     ~PermissionDialog() override = default;
+
+protected:
+    void closeEvent(QCloseEvent *event) override;
 };

--- a/apps/ll-dialog/src/permission_dialog_result.h
+++ b/apps/ll-dialog/src/permission_dialog_result.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <cstdlib>
+
+namespace linglong::dialog {
+
+enum class PermissionDialogResult {
+    Denied,
+    Allowed,
+};
+
+[[nodiscard]] constexpr int exitCode(PermissionDialogResult result) noexcept
+{
+    return result == PermissionDialogResult::Allowed ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+} // namespace linglong::dialog

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -83,6 +83,7 @@ pfl_add_executable(
   src/apps/ll-driver-detect/application_singleton_test.cpp
   src/apps/ll-driver-detect/driver_detection_manager_test.cpp
   src/apps/ll-driver-detect/dbus_notifier_test.cpp
+  src/apps/ll-dialog/permission_dialog_result_test.cpp
   COMPILE_FEATURES
   PUBLIC
   cxx_std_17
@@ -103,3 +104,5 @@ target_include_directories(${tests}
                            PUBLIC ${PROJECT_SOURCE_DIR}/apps/uab/header/src)
 target_include_directories(${tests}
                            PUBLIC ${PROJECT_SOURCE_DIR}/apps/ll-driver-detect/src)
+target_include_directories(${tests}
+                           PUBLIC ${PROJECT_SOURCE_DIR}/apps/ll-dialog/src)

--- a/libs/linglong/tests/ll-tests/src/apps/ll-dialog/permission_dialog_result_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/apps/ll-dialog/permission_dialog_result_test.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "permission_dialog_result.h"
+
+namespace linglong::dialog::test {
+
+TEST(PermissionDialogResult, AllowsOnlyExplicitPermission)
+{
+    EXPECT_EQ(exitCode(PermissionDialogResult::Allowed), EXIT_SUCCESS);
+    EXPECT_NE(exitCode(PermissionDialogResult::Denied), EXIT_SUCCESS);
+    EXPECT_NE(exitCode(static_cast<PermissionDialogResult>(-1)), EXIT_SUCCESS);
+}
+
+} // namespace linglong::dialog::test


### PR DESCRIPTION
## 问题

权限协议规定只有退出码 0 表示允许，但 Deny、超时和关闭窗口当前也返回 0，调用方会把拒绝误判为允许。

## 方案

- 增加独立的权限结果到退出码映射。
- 只有 Allowed 返回成功。
- Deny、超时、窗口关闭和未知结果返回失败。
- 关闭事件先忽略窗口关闭，再显式退出，避免默认成功状态覆盖拒绝结果。

## 本地验证

- 结果映射 helper 使用 C++17 `-Wall -Wextra -Werror` 通过语法与独立执行检查。
- 新增允许、拒绝和未知值的 GTest。
- `git diff --check d5faf9e6...HEAD`
- 范围门禁：67/400 行。

未运行完整 Qt UI/GTest 构建：本机缺少 Qt、CMake 和 Linux 项目依赖。

Fixes #1807
