### PR TITLE
fix(driver): compare NVIDIA package versions semantically

### DIFF
--- a/apps/ll-driver-detect/src/nvidia_driver_detector.cpp
+++ b/apps/ll-driver-detect/src/nvidia_driver_detector.cpp
@@ -247,7 +247,7 @@ bool NVIDIADriverDetector::compareVersions(std::string_view v1, std::string_view
         return false;
     }
 
-    return v1 > v2;
+    return *ver1 > *ver2;
 }
 
 } // namespace linglong::driver::detect

--- a/apps/ll-driver-detect/src/nvidia_driver_detector.h
+++ b/apps/ll-driver-detect/src/nvidia_driver_detector.h
@@ -34,13 +34,14 @@ public:
     // Get the type of driver this detector handles
     std::string getDriverIdentify() const override { return kNvidiaPackageIdentify; }
 
+protected:
+    bool compareVersions(std::string_view v1, std::string_view v2) const noexcept;
+
 private:
     // Get driver version from the specified file path
     std::string getDriverVersion();
     utils::error::Result<std::pair<bool, GraphicsDriverInfo>>
     getInstalledGraphicsDriverInfo(const std::string &packageName) const;
-    bool compareVersions(std::string_view v1, std::string_view v2) const noexcept;
-
     std::string versionFilePath_;
 };
 

--- a/apps/ll-driver-detect/src/nvidia_driver_detector.h
+++ b/apps/ll-driver-detect/src/nvidia_driver_detector.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 

--- a/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/nvidia_driver_detector_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/nvidia_driver_detector_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 

--- a/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/nvidia_driver_detector_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/nvidia_driver_detector_test.cpp
@@ -24,6 +24,11 @@ public:
     {
     }
 
+    bool isVersionNewer(std::string_view candidate, std::string_view current) const noexcept
+    {
+        return compareVersions(candidate, current);
+    }
+
     MOCK_METHOD((linglong::utils::error::Result<std::pair<bool, GraphicsDriverInfo>>),
                 getPackageInfoFromRemoteRepo,
                 (const std::string &packageName),
@@ -51,6 +56,14 @@ protected:
         file.close();
     }
 };
+
+TEST_F(NvidiaDriverDetectorTest, CompareVersionsUsesSemanticOrdering)
+{
+    TestableNVIDIADriverDetector detector("unused-version-file");
+
+    EXPECT_TRUE(detector.isVersionNewer("510.100.0", "510.99.0"));
+    EXPECT_FALSE(detector.isVersionNewer("510.99.0", "510.100.0"));
+}
 
 TEST_F(NvidiaDriverDetectorTest, Detect_Success_PackageNotInstalled)
 {


### PR DESCRIPTION
## 问题

NVIDIA 驱动检测器解析版本成功后仍比较原始字符串，跨位数版本会得到错误顺序，例如 `510.100.0` 被判定为早于 `510.99.0`。

## 方案

- 使用已解析的 `package::Version` 进行语义比较。
- 增加跨位数版本的正向和反向回归测试。

## 本地验证

- 静态检查确认旧字符串比较已移除，并新增双向测试。
- `git diff --check d5faf9e6...HEAD`
- 范围门禁：20/400 行。

未运行完整 ll-tests：本机缺少 Qt/CMake，且项目命令实现依赖 Linux epoll。

Fixes #1808
