### PR TITLE
fix(builder): handle multiple ldd check paths

### DIFF
--- a/misc/libexec/linglong/builder/helper/ldd-check.sh
+++ b/misc/libexec/linglong/builder/helper/ldd-check.sh
@@ -83,15 +83,23 @@ processExecBin() {
 }
 
 collectDependsLibs() {
-        #support multiple path, split by ':'
-        declare paths
-        paths=$(echo "$1" | tr ':' ' ')
+        # 使用数组传递冒号分隔的多个路径，避免 find 将其视为一个路径。
+        local -a paths=()
+        local -a searchPaths=()
+        local path
+        IFS=':' read -r -a paths <<<"$1"
+        for path in "${paths[@]}"; do
+                # 忽略首尾或连续冒号产生的空字段，避免空路径被解释为当前目录。
+                if [[ -n ${path} ]]; then
+                        searchPaths+=("${path}")
+                fi
+        done
 
-        if [[ -z ${paths} ]]; then
+        if [[ ${#searchPaths[@]} -eq 0 ]]; then
                 logErr "No paths provided"
         fi
 
-        filePaths=$(find "${paths}" -type f)
+        filePaths=$(find "${searchPaths[@]}" -type f)
 
         IFS=$'\n'
         for filePath in ${filePaths}; do


### PR DESCRIPTION
## 问题证据

`ldd-check.sh` 接受 `path1:path2` 时，基线会调用 `find "path1 path2"` 并报单一路径不存在，导致文档声明的多路径扫描不可用。

## 根因与方案

原实现把冒号替换为空格后仍以一个标量参数调用 `find`。本变更改为使用 Bash 数组解析路径，过滤首尾或连续冒号产生的空字段，并把每个目录作为独立参数传入；全空输入继续返回明确错误。

## 变更范围

- 仅修改 `misc/libexec/linglong/builder/helper/ldd-check.sh`。
- 13 行新增、5 行删除。

## 本地验证

- 基线复现：两个真实目录被合并并报错。
- 修复后：两个目录、含空格目录、首尾/连续冒号、全空字段和空参数场景均按预期处理。
- `bash -n misc/libexec/linglong/builder/helper/ldd-check.sh`：通过。
- `shellcheck`：未新增告警；文件保留 5 个与基线一致的既有告警。
- `git diff --check` 与 400 行范围门禁：通过。

## 未运行

未运行容器、全仓构建或完整 E2E；该修复为定向 shell 参数处理变更。

Fixes #1819
