### PR TITLE
fix(ocppi): force JSON output for list

### DIFF
--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -70,6 +70,7 @@ pfl_add_executable(
   src/linglong/utils/xdg/directory_test.cpp
   src/linglong/utils/xdp_test.cpp
   src/main.cpp
+  src/ocppi/cli/common_cli_test.cpp
 
 
   # ll-driver-detect tests

--- a/libs/linglong/tests/ll-tests/src/ocppi/cli/common_cli_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/ocppi/cli/common_cli_test.cpp
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gtest/gtest.h>
+
+#include "../../common/tempdir.h"
+#include "ocppi/cli/crun/Crun.hpp"
+#include "ocppi/runtime/ListOption.hpp"
+#include "ocppi/types/ContainerListItem.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+TEST(CommonCLITest, ListForcesJsonOutput)
+{
+    TempDir tempDir("ocppi-common-cli-");
+    ASSERT_TRUE(tempDir.isValid());
+
+    const auto runtimePath = tempDir.path() / "runtime";
+    {
+        std::ofstream runtime(runtimePath);
+        ASSERT_TRUE(runtime.is_open());
+        runtime << "#!/bin/sh\n"
+                   "printf '%s\\n' \"$@\" > \"$0.args\"\n"
+                   "printf '[]\\n'\n";
+    }
+    std::filesystem::permissions(runtimePath,
+                                 std::filesystem::perms::owner_read
+                                   | std::filesystem::perms::owner_write
+                                   | std::filesystem::perms::owner_exec,
+                                 std::filesystem::perm_options::replace);
+
+    auto cli = ocppi::cli::crun::Crun::New(runtimePath);
+    ASSERT_TRUE(cli.has_value());
+
+    ocppi::runtime::ListOption option{};
+    option.format = ocppi::runtime::ListOption::OutputFormat::Text;
+    option.root = tempDir.path() / "root";
+    option.extra.emplace_back("--quiet");
+    auto containers = cli.value()->list(option);
+    ASSERT_TRUE(containers.has_value());
+    EXPECT_TRUE(containers.value().empty());
+
+    std::ifstream argumentsFile(runtimePath.string() + ".args");
+    ASSERT_TRUE(argumentsFile.is_open());
+    std::vector<std::string> arguments;
+    for (std::string argument; std::getline(argumentsFile, argument);) {
+        arguments.emplace_back(argument);
+    }
+    const std::vector<std::string> expectedArguments{
+        "--root", option.root->string(), "list", "--quiet", "-f", "json",
+    };
+    EXPECT_EQ(arguments, expectedArguments);
+}

--- a/libs/ocppi/src/ocppi/cli/CommonCLI.cpp
+++ b/libs/ocppi/src/ocppi/cli/CommonCLI.cpp
@@ -316,8 +316,8 @@ try {
 #ifdef OCPPI_WITH_SPDLOG
                 this->logger(),
 #endif
-                this->generateGlobalOptions(option), "list",
-                this->generateSubcommandOptions(option), {});
+                this->generateGlobalOptions(new_option), "list",
+                this->generateSubcommandOptions(new_option), {});
 } catch (...) {
         return tl::unexpected(std::current_exception());
 }


### PR DESCRIPTION
## 问题证据

`CommonCLI::list()` 创建了强制 JSON 格式的选项副本，但生成全局与子命令参数时仍使用原始选项。文本格式输出随后被 JSON 解析，列表调用失败。

## 根因与方案

两处调用传错了对象。本变更统一传入 `new_option`，并新增假 runtime 回归测试：捕获 argv、返回合法空 JSON，验证文本输入最终仍执行 `--root <path> list --quiet -f json` 且解析成功。

## 变更范围

- 修改 `CommonCLI.cpp` 两处实参。
- 注册并新增一个定向 GoogleTest。
- 62 行新增、2 行删除。

## 本地验证

- Apple clang-format 17 `--dry-run --Werror`：通过。
- `git diff --check` 与 400 行范围门禁：通过。
- 回归测试源码已注册到现有 `ll-tests` 目标。

## 未运行

当前 macOS 环境未安装项目所需 CMake、GTest 和 nlohmann/json 头，无法构建 `ll-tests`；未运行容器、全仓构建或完整 E2E。

Fixes #1821
