### PR TITLE
fix(deps): align vendored dependency versions

### DIFF
--- a/tools/update-external.sh
+++ b/tools/update-external.sh
@@ -1,6 +1,6 @@
 #!/bin/env bash
 
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 

--- a/tools/update-external.sh
+++ b/tools/update-external.sh
@@ -23,9 +23,9 @@ unzip "$zip_file" || exit 255
 
 mv ytj-master external/ytj || exit 255
 
-zip_file="$tmpdir"/external/github-TartanLlama-expected-v1.2.0.zip
+zip_file="$tmpdir"/external/github-TartanLlama-expected-v1.3.1.zip
 
-wget https://github.com/TartanLlama/expected/archive/refs/tags/v1.2.0.zip \
+wget https://github.com/TartanLlama/expected/archive/refs/tags/v1.3.1.zip \
         -O "$zip_file" || exit 255
 
 rm -rf external/tl-expected
@@ -33,12 +33,12 @@ rm -rf external/tl-expected
 unzip "$zip_file" || exit 255
 
 mkdir -p external/tl-expected || exit 255
-mv expected-1.2.0/include external/tl-expected || exit 255
-rm -rf expected-1.2.0 || exit 255
+mv expected-1.3.1/include external/tl-expected || exit 255
+rm -rf expected-1.3.1 || exit 255
 
 cli11_file="$tmpdir"/external/CLI.hpp
 
-wget https://github.com/CLIUtils/CLI11/releases/download/v2.5.0/CLI11.hpp \
+wget https://github.com/CLIUtils/CLI11/releases/download/v2.6.1/CLI11.hpp \
         -O "$cli11_file" || exit 255
 
 rm -rf external/CLI11


### PR DESCRIPTION
## 问题证据

顶层 CMake 和当前 fallback 头文件使用 tl-expected `v1.3.1`、CLI11 `v2.6.1`，但 `tools/update-external.sh` 仍下载 `v1.2.0`、`v2.5.0`。运行脚本会把 vendored 依赖降级，并使 CPM 与离线构建版本不一致。

## 根因与方案

两次依赖升级只更新了 CMake 和已提交的 vendored 文件，没有同步维护更新脚本。本变更更新下载 URL、压缩包名和解压目录，使脚本与当前构建 tag 一致。

## 变更范围

- 仅修改 `tools/update-external.sh`。
- 6 行新增、6 行删除（包含按 CI 要求更新 SPDX 年份）。

## 本地验证

- `bash -n tools/update-external.sh`：通过。
- `shellcheck tools/update-external.sh`：通过。
- 版本一致性扫描：脚本和 CMake 均为 `v1.3.1` / `v2.6.1`，脚本中无旧 tag 残留。
- `git diff --check` 与 400 行范围门禁：通过。

## 未运行

为避免删除并重新下载整个 `external/` 目录，未实际运行更新脚本；未运行容器、全仓构建或完整 E2E。

Fixes #1820
