### PR TITLE
fix(http): initialize default client user agent

### DIFF
--- a/external/http/src/apiClient.c
+++ b/external/http/src/apiClient.c
@@ -10,6 +10,7 @@ apiClient_t *apiClient_create() {
     apiClient_t *apiClient = malloc(sizeof(apiClient_t));
     apiClient->basePath = strdup("http://localhost");
     apiClient->sslConfig = NULL;
+    apiClient->userAgent = NULL;
     apiClient->dataReceived = NULL;
     apiClient->dataReceivedLen = 0;
     apiClient->data_callback_func = NULL;

--- a/tools/openapi-c-libcurl-client/apiClient.c.mustache
+++ b/tools/openapi-c-libcurl-client/apiClient.c.mustache
@@ -10,6 +10,7 @@ apiClient_t *apiClient_create() {
     apiClient_t *apiClient = malloc(sizeof(apiClient_t));
     apiClient->basePath = strdup("{{{basePath}}}");
     apiClient->sslConfig = NULL;
+    apiClient->userAgent = NULL;
     apiClient->dataReceived = NULL;
     apiClient->dataReceivedLen = 0;
     apiClient->data_callback_func = NULL;


### PR DESCRIPTION
## 问题证据

`apiClient_create()` 使用 `malloc` 后没有初始化 `userAgent`，而请求路径会读取该字段并可能把垃圾指针传给 libcurl。带 base path 的构造函数已正确初始化，默认构造函数遗漏。

## 根因与方案

自定义 User-Agent 功能加入时只更新了一个构造路径。本变更在 Mustache 模板和当前生成代码中同步将默认值设为 `NULL`。

## 变更范围

- 修改生成模板和 `external/http/src/apiClient.c`。
- 共新增 2 行。

## 本地验证

- 使用系统 C 编译器编译实际 `apiClient.c`、依赖源码和定向断言程序，并链接 libcurl：通过。
- 运行断言 `apiClient_create()->userAgent == NULL`：通过。
- 编译仅出现既有代码的指针符号、赋值条件和无 OpenSSL 提示，本变更未新增告警。
- `git diff --check` 与 400 行范围门禁：通过。

## 未运行

未运行容器、全仓构建或完整 E2E。

Fixes #1822
