### PR TITLE
fix(repo): reject missing default repository

### DIFF
--- a/libs/linglong/src/linglong/repo/config.cpp
+++ b/libs/linglong/src/linglong/repo/config.cpp
@@ -38,8 +38,23 @@ loadConfig(const std::filesystem::path &file) noexcept
                 return LINGLONG_ERR("parse yaml failed");
             }
 
+            // V1 转换会优先访问默认仓库，转换前必须保证查找结果有效。
+            if (configV1->repos.find(configV1->defaultRepo) == configV1->repos.end()) {
+                return LINGLONG_ERR(
+                  fmt::format("default repo '{}' not found in repos", configV1->defaultRepo));
+            }
+
             // 将旧版本配置转换为新版本
             config = convertToV2(*configV1);
+        }
+
+        const auto defaultRepo =
+          std::find_if(config->repos.begin(), config->repos.end(), [&config](const auto &repo) {
+              return repo.alias.value_or(repo.name) == config->defaultRepo;
+          });
+        if (defaultRepo == config->repos.end()) {
+            return LINGLONG_ERR(
+              fmt::format("default repo '{}' not found in repos", config->defaultRepo));
         }
 
         return config;

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/config_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/config_test.cpp
@@ -6,13 +6,64 @@
 
 #include <gtest/gtest.h>
 
+#include "common/tempdir.h"
 #include "linglong/api/types/v1/Repo.hpp"
 #include "linglong/api/types/v1/RepoConfig.hpp"
 #include "linglong/api/types/v1/RepoConfigV2.hpp"
 #include "linglong/repo/config.h"
 
+#include <fstream>
+
 using namespace linglong::repo;
 using namespace linglong::api::types::v1;
+
+namespace {
+
+void writeConfig(const std::filesystem::path &path, const std::string &content)
+{
+    std::ofstream stream(path);
+    ASSERT_TRUE(stream.is_open());
+    stream << content;
+    ASSERT_TRUE(stream.good());
+}
+
+} // namespace
+
+TEST(Repo, LoadV1ConfigWithoutDefaultRepoReturnsError)
+{
+    TempDir tempDir("repo_config_test_");
+    const auto configPath = tempDir.path() / "config-v1.yaml";
+    writeConfig(configPath,
+                "version: 1\n"
+                "defaultRepo: missing\n"
+                "repos:\n"
+                "  repo1: https://example.com/repo1\n");
+
+    const auto result = loadConfig(configPath);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_NE(result.error().message().find("default repo 'missing' not found in repos"),
+              std::string::npos);
+}
+
+TEST(Repo, LoadV2ConfigWithoutDefaultRepoReturnsError)
+{
+    TempDir tempDir("repo_config_test_");
+    const auto configPath = tempDir.path() / "config-v2.yaml";
+    writeConfig(configPath,
+                "version: 2\n"
+                "defaultRepo: missing\n"
+                "repos:\n"
+                "  - name: repo1\n"
+                "    url: https://example.com/repo1\n"
+                "    priority: 0\n");
+
+    const auto result = loadConfig(configPath);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_NE(result.error().message().find("default repo 'missing' not found in repos"),
+              std::string::npos);
+}
 
 TEST(Repo, GetRepoMinPriority)
 {


### PR DESCRIPTION
## 问题证据

当 V1 或 V2 仓库配置的 `defaultRepo` 不存在于 `repos` 时，现有路径会无条件解引用查找结果，产生未定义行为。

## 根因与方案

加载阶段缺少与 `saveConfig()` 既有契约一致的默认仓库存在性校验。本变更在 V1 转换前校验 map，并在 V2 加载后按 alias/name 规则校验；无效输入返回包含缺失仓库名的错误。新增 V1、V2 临时 YAML 回归用例。

## 变更范围

- 修改 `libs/linglong/src/linglong/repo/config.cpp`。
- 扩展现有 `config_test.cpp`。
- 66 行新增，无删除；公开 API 不变。

## 本地验证

- Apple clang-format 17 `--dry-run --Werror`：通过。
- `git diff --check` 与 400 行范围门禁：通过。
- 两个回归测试已加入现有测试目标。

## 未运行

当前 macOS 环境未安装项目所需 CMake、yaml-cpp、GTest 和 nlohmann/json 头，无法构建 `ll-tests`；未运行容器、全仓构建或完整 E2E。

Fixes #1823
