### PR TITLE
feat: enable AT-SPI socket mount by default in sandbox

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -149,9 +149,9 @@ ll-cli run org.deepin.demo -- bash -x /path/to/bash/script)"));
                  _("Enable PipeWire socket mount inside the sandbox"))
       ->take_last();
     cliRun
-      ->add_flag("--enable-atspi",
+      ->add_flag("--enable-atspi{false},!--disable-atspi{true}",
                  runOptions.enableAtSpiSocketMount,
-                 _("Enable AT SPI socket mount inside the sandbox"))
+                 _("Enable (default) or disable AT SPI socket mount inside the sandbox"))
       ->take_last();
     cliRun->add_option("--run-context", runOptions.runContext, _("Run context json string"))
       ->group("");

--- a/libs/linglong/src/linglong/runtime/container_builder.h
+++ b/libs/linglong/src/linglong/runtime/container_builder.h
@@ -63,7 +63,7 @@ struct RunContainerOptions
     std::string lockName;
     bool disableXdp{ false };
     bool enablePipewireSocketMount{ false };
-    bool enableAtSpiSocketMount{ false };
+    bool enableAtSpiSocketMount{ true };
     bool privileged{ false };
     bool devicePassthru{ false };
     std::map<std::string, std::string> env;


### PR DESCRIPTION
目的：AT-SPI 是 Linux 桌面无障碍的标准总线。屏幕阅读器、
读屏工具以及桌面上自动化 / AI 智能体都是通过 AT-SPI 来读取应用界面结构
（控件、按钮、文本、可操作元素）并调用执行动作（点击、聚焦、滚动等）。

玲珑沙箱默认不挂载宿主机 AT-SPI socket（/run/user/<uid>/at-spi/bus_0）， 导致沙箱内应用的 AT-SPI 总线不可见，依赖 AT-SPI 的智能体/无障碍工具
完全无法读取或操作玲珑应用界面。

改动：
- container_builder.h：enableAtSpiSocketMount 默认 false -> true
- ll-cli run：--enable-atspi{false},!--disable-atspi{true} （复用已有 --enable-xdp{false},!--disable-xdp{true} 模式）

调用方式：
- 默认（不传参）：沙箱应用可见宿主 AT-SPI，智能体/无障碍工具可直接读取与操作
- --enable-atspi：显式开启（= 默认行为）
- --disable-atspi：显式关闭，用于需要严格隔离的应用（回退到旧的无 at-spi）

安全/回退：默认开启会给沙箱应用 AT-SPI 访问权限；需要严格隔离的应用
可用 --disable-atspi 回退。向后兼容：不传 flag 走新默认，传了可覆盖。

验证：开启时沙箱内可见 /run/user/<uid>/at-spi/bus_0；--disable-atspi 时无。