### PR TITLE
fix: disambiguate local files from remote refs in ll-cli install

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -273,9 +273,9 @@ Example:
 # install application by appid
 ll-cli install org.deepin.demo
 # install application by linyaps layer
-ll-cli install demo_0.0.0.1_x86_64_binary.layer
+ll-cli install ./demo_0.0.0.1_x86_64_binary.layer
 # install application by linyaps uab
-ll-cli install demo_x86_64_0.0.0.1_main.uab
+ll-cli install ./demo_x86_64_0.0.0.1_main.uab
 # install specified module of the appid
 ll-cli install org.deepin.demo --module=binary
 # install specified version of the appid

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -2351,11 +2351,39 @@ int Cli::install(const InstallOptions &options)
     params.options.noAutoPrune = options.noAutoPrune;
     params.repo = options.repo;
 
-    QFileInfo info(QString::fromStdString(options.appid));
+    const std::filesystem::path localPath{ options.appid };
+    std::error_code ec;
+    const auto pathExists = std::filesystem::exists(localPath, ec);
+    if (pathExists) {
+        if (!std::filesystem::is_regular_file(localPath, ec)) {
+            this->printer.printErr(
+              LINGLONG_ERRV(fmt::format(_("{} is not a regular file; expected a .layer or .uab "
+                                          "file."),
+                                        options.appid),
+                            utils::error::ErrorCode::AppInstallUnsupportedFileFormat));
+            return -1;
+        }
 
-    // 如果检测是文件，则直接安装
-    if (info.exists() && info.isFile()) {
-        return installFromFile(QFileInfo{ info.absoluteFilePath() }, params.options);
+        const auto extension = localPath.extension();
+        const auto isSupportedPackageFile = extension == ".layer" || extension == ".uab";
+        if (!isSupportedPackageFile) {
+            this->printer.printErr(LINGLONG_ERRV(
+              fmt::format(_("Unsupported file format {}; expected a .layer or .uab file."),
+                          options.appid),
+              utils::error::ErrorCode::AppInstallUnsupportedFileFormat));
+            return -1;
+        }
+
+        return installFromFile(QFileInfo{ QString::fromStdString(options.appid) }, params.options);
+    } else {
+        const auto isExplicitPath = localPath.is_absolute()
+          || common::strings::starts_with(localPath.string(), "./")
+          || common::strings::starts_with(localPath.string(), "../");
+        if (isExplicitPath) {
+            this->printer.printErr(
+              LINGLONG_ERRV(fmt::format(_("Package file {} does not exist."), options.appid)));
+            return -1;
+        }
     }
 
     auto fuzzyRef = package::FuzzyReference::parse(options.appid);

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -565,7 +565,6 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
     Q_ASSERT(*layerFileRet != nullptr);
 
     const auto &layerFile = *layerFileRet;
-    auto realFile = layerFile->symLinkTarget();
     auto metaInfoRet = layerFile->metaInfo();
     if (!metaInfoRet) {
         return toDBusReply(metaInfoRet);
@@ -764,8 +763,7 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
     return common::serialize::toQVariantMap(api::types::v1::PackageManager1PackageTaskResult{
       .taskObjectPath = taskRef.taskObjectPath(),
       .code = 0,
-      .message = (realFile + " is now installing").toStdString(),
-    });
+      .message = "layer file is now installing" });
 }
 
 QVariantMap PackageManager::installFromUAB(const QDBusUnixFileDescriptor &fd,

--- a/libs/linglong/tests/ll-tests/src/linglong/cli/cli_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/cli/cli_test.cpp
@@ -21,6 +21,7 @@
 using namespace linglong;
 using ::testing::_;
 using ::testing::ElementsAre;
+using ::testing::HasSubstr;
 using ::testing::InSequence;
 using ::testing::Invoke;
 using ::testing::IsEmpty;
@@ -64,6 +65,7 @@ public:
 class MockPrinter : public cli::CLIPrinter
 {
 public:
+    MOCK_METHOD(void, printErr, (const utils::error::Error &error), (override));
     MOCK_METHOD(void,
                 printUpgradeList,
                 (std::vector<api::types::v1::UpgradeListResult> &),
@@ -80,6 +82,7 @@ public:
     using cli::Cli::Cli;
 
     MOCK_METHOD(utils::error::Result<repo::OSTreeRepo *>, getRepo, (bool), (override, noexcept));
+    MOCK_METHOD(utils::error::Result<api::dbus::v1::PackageManager *>, getPkgMan, (), (override));
 };
 
 class RepoAndPackageManagerCli : public cli::Cli
@@ -221,6 +224,97 @@ protected:
     std::unique_ptr<runtime::ContainerBuilder> containerBuilder;
     std::unique_ptr<RepoAndPackageManagerCli> cli;
 };
+
+TEST_F(CliTest, installRejectsMissingExplicitLocalPath)
+{
+    const auto packagePath = tempDir->path() / "net.example_1.0_x86_64_binary";
+
+    EXPECT_CALL(*cli, getPkgMan()).Times(0);
+    EXPECT_CALL(*printer, printErr(_))
+      .WillOnce(Invoke([&packagePath](const utils::error::Error &error) {
+          EXPECT_EQ(error.code(), static_cast<int>(utils::error::ErrorCode::Failed));
+          EXPECT_THAT(error.message(), HasSubstr(packagePath.string()));
+          EXPECT_THAT(error.message(), HasSubstr("does not exist"));
+      }));
+
+    EXPECT_EQ(cli->install(cli::InstallOptions{ .appid = packagePath.string() }), -1);
+}
+
+TEST_F(CliTest, installRejectsLocalDirectoryBeforeParsingReference)
+{
+    const auto packagePath = tempDir->path() / "net.example_1.0_x86_64_binary";
+    ASSERT_TRUE(std::filesystem::create_directory(packagePath));
+
+    EXPECT_CALL(*cli, getPkgMan()).Times(0);
+    EXPECT_CALL(*printer, printErr(_))
+      .WillOnce(Invoke([&packagePath](const utils::error::Error &error) {
+          EXPECT_EQ(error.code(),
+                    static_cast<int>(utils::error::ErrorCode::AppInstallUnsupportedFileFormat));
+          EXPECT_THAT(error.message(), HasSubstr(packagePath.string()));
+          EXPECT_THAT(error.message(), HasSubstr("not a regular file"));
+      }));
+
+    EXPECT_EQ(cli->install(cli::InstallOptions{ .appid = packagePath.string() }), -1);
+}
+
+TEST_F(CliTest, installRejectsUnsupportedLocalFileBeforeContactingPackageManager)
+{
+    const auto packagePath = tempDir->path() / "net.example_1.0_x86_64_binary";
+    std::ofstream(packagePath) << "not a package";
+
+    EXPECT_CALL(*cli, getPkgMan()).Times(0);
+    EXPECT_CALL(*printer, printErr(_))
+      .WillOnce(Invoke([&packagePath](const utils::error::Error &error) {
+          EXPECT_EQ(error.code(),
+                    static_cast<int>(utils::error::ErrorCode::AppInstallUnsupportedFileFormat));
+          EXPECT_THAT(error.message(), HasSubstr(packagePath.string()));
+          EXPECT_THAT(error.message(), HasSubstr("Unsupported file format"));
+      }));
+
+    EXPECT_EQ(cli->install(cli::InstallOptions{ .appid = packagePath.string() }), -1);
+}
+
+TEST_F(CliTest, installKeepsRemoteVersionReference)
+{
+    EXPECT_CALL(*cli, getPkgMan())
+      .WillOnce(Invoke([]() -> utils::error::Result<api::dbus::v1::PackageManager *> {
+          return makePackageManagerError("package manager unavailable");
+      }));
+    EXPECT_CALL(*printer, printErr(_)).WillOnce(Invoke([](const utils::error::Error &error) {
+        EXPECT_THAT(error.message(), HasSubstr("package manager unavailable"));
+    }));
+
+    EXPECT_EQ(cli->install(cli::InstallOptions{ .appid = "org.example.App/1.0.0" }), -1);
+}
+
+TEST_F(CliTest, installKeepsRemoteReferencesEndingWithPackageFileSuffix)
+{
+    EXPECT_CALL(*cli, getPkgMan())
+      .Times(2)
+      .WillRepeatedly(Invoke([]() -> utils::error::Result<api::dbus::v1::PackageManager *> {
+          return makePackageManagerError("package manager unavailable");
+      }));
+    EXPECT_CALL(*printer, printErr(_)).Times(2);
+
+    EXPECT_EQ(cli->install(cli::InstallOptions{ .appid = "org.example.layer" }), -1);
+    EXPECT_EQ(cli->install(cli::InstallOptions{ .appid = "org.example.uab/1.0.0" }), -1);
+}
+
+TEST_F(CliTest, installRecognizesExistingLayerFile)
+{
+    const auto packagePath = tempDir->path() / "net.example_1.0_x86_64_binary.layer";
+    std::ofstream(packagePath) << "layer placeholder";
+
+    EXPECT_CALL(*cli, getPkgMan())
+      .WillOnce(Invoke([]() -> utils::error::Result<api::dbus::v1::PackageManager *> {
+          return makePackageManagerError("package manager unavailable");
+      }));
+    EXPECT_CALL(*printer, printErr(_)).WillOnce(Invoke([](const utils::error::Error &error) {
+        EXPECT_THAT(error.message(), HasSubstr("package manager unavailable"));
+    }));
+
+    EXPECT_EQ(cli->install(cli::InstallOptions{ .appid = packagePath.string() }), -1);
+}
 
 TEST_F(CliTest, taskEventsDriveProgressAndTextOutput)
 {


### PR DESCRIPTION
Treat the install argument as a local file when the path exists, or when the path starts with `/`, `./` or `../`.