### PR TITLE
fix(builder): respect config check level

### DIFF
--- a/misc/libexec/linglong/builder/helper/main-check.sh
+++ b/misc/libexec/linglong/builder/helper/main-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -59,6 +59,9 @@ if [[ $skip_config -eq 0 ]]; then
     echo "start application configure check"
     if ! @CMAKE_INSTALL_FULL_LIBEXECDIR@/linglong/builder/helper/config-check.sh; then
             echo "Warning: application configure check failed."
+            if [ $check_level -eq 1 ]; then
+                    exit 1
+            fi
     fi
 else
     echo "Skipping application configure check."


### PR DESCRIPTION
## 问题

严格检查模式会忽略 config-check 的非零退出状态，导致无效应用配置仍通过 main-check。

## 方案

在 config-check 失败时复用现有检查级别语义：level 1 返回失败，level 0 保留警告并继续。

## 本地验证

- bash -n
- shellcheck
- 定向 fixture：level 1 + 失败检查返回 1；level 0 + 失败检查返回 0；成功检查返回 0
- git diff --check
- 范围门禁：5/400 行

Fixes #1837