### PR TITLE
fix(builder): match app IDs literally

### DIFF
--- a/misc/libexec/linglong/builder/helper/config-check.sh
+++ b/misc/libexec/linglong/builder/helper/config-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -51,8 +51,7 @@ fi
 
 for filePath in $(echo -e "$results"); do
         fileName=${filePath##*/}
-        ret=$(echo "$fileName" | grep "^${LINGLONG_APPID}")
-        if [ "$ret" == "" ]; then
+        if [[ "$fileName" != "${LINGLONG_APPID}"* ]]; then
                 invalidList+="$filePath\n"
         fi
 done


### PR DESCRIPTION
## 问题

config-check 把应用 ID 当作 grep 正则，点号和方括号等字符会改变匹配语义，使近似文件名错误通过。

## 方案

使用 Bash 字面量前缀匹配，保持现有“应用 ID 前缀”规则，同时不解释正则元字符。

## 本地验证

- bash -n
- shellcheck
- 定向 fixture 覆盖普通 ID、带点号 ID、带方括号 ID 及对应近似文件名
- git diff --check
- 范围门禁：5/400 行

Fixes #1838