### PR TITLE
fix(codegen): use OCPPI paths

### DIFF
--- a/libs/ocppi/tools/codegen/create-patch.sh
+++ b/libs/ocppi/tools/codegen/create-patch.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 GIT=${GIT:="git"}
 
-repoRoot="$("$GIT" rev-parse --show-toplevel)"
+repoRoot="$("$GIT" rev-parse --show-toplevel)/libs/ocppi"
 cd "$repoRoot"/tools/codegen || exit 255
 
 include="$repoRoot/include"


### PR DESCRIPTION
## 问题

create-patch 以仓库顶层作为 OCPPI 根目录，因而进入不存在的顶层 tools/codegen，并错误定位 include 与补丁输出。

## 方案

将脚本工作根目录设为仓库内的 libs/ocppi，所有派生路径随之指向真实 OCPPI 子树。

## 本地验证

- bash -n
- shellcheck
- 定向路径 fixture 核对工作目录、include、include.orig 和 fix.patch
- git diff --check
- 范围门禁：2/400 行

Fixes #1839