### PR TITLE
fix(ocppi): keep IWYU output in build directory

### DIFF
--- a/libs/ocppi/tools/iwyu.sh
+++ b/libs/ocppi/tools/iwyu.sh
@@ -31,7 +31,7 @@ mv build-iwyu/{new-,}compile_commands.json
 # shellcheck disable=SC2046
 "$IWYU_TOOL" -p build-iwyu \
 	$(find . -path './libs*' \( -name '*.c' -o -name '*.cpp' \) -printf "%p ") |
-	tee build/iwyu.out
+	tee build-iwyu/iwyu.out
 
 IWYU_FIX_INCLUDES=${IWYU_FIX_INCLUDES:=$({
 	command -v fix_include &>/dev/null && echo "fix_include" && exit
@@ -44,7 +44,7 @@ IWYU_FIX_INCLUDES=${IWYU_FIX_INCLUDES:=$({
 	'(\.cache|build|src\/ocppi\/runtime\/(config|features|state)\/types)\/*' \
 	--nocomments \
 	--nosafe_headers \
-	<build/iwyu.out
+	<build-iwyu/iwyu.out
 
 CLANG_FORMAT=${CLANG_FORMAT:=$({
 	command -v clang-format-16 &>/dev/null && echo "clang-format-16" && exit


### PR DESCRIPTION
## 问题

IWYU 脚本创建 build-iwyu，却把分析输出写到可能不存在的 build 目录，干净工作树会在 tee 阶段失败。

## 方案

将 IWYU 输出的写入和读取统一为 build-iwyu/iwyu.out。

## 本地验证

- bash -n
- shellcheck
- 路径引用 fixture 确认没有残留 build/iwyu.out
- git diff --check
- 范围门禁：4/400 行

未运行完整 IWYU，以避免下载依赖和生成大范围修改。

Fixes #1840