### PR TITLE
fix(driver): report install-only failures

### DIFF
--- a/apps/ll-driver-detect/src/main.cpp
+++ b/apps/ll-driver-detect/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -194,6 +194,7 @@ int main(int argc, char *argv[])
             LogW("Failed to install driver package {}: {}",
                  options.packageName,
                  installResult.error().message());
+            return 1;
         }
 
         std::cout << "Successfully installed driver package" << std::endl;


### PR DESCRIPTION
## 问题

install-only 模式记录安装错误后继续输出成功并返回 0，向用户和脚本报告假成功。

## 方案

安装失败分支立即返回非零，使成功信息只在真实成功路径输出。

## 本地验证

- 控制流检查确认失败路径不会到达成功输出
- git diff --check
- 范围门禁：3/400 行

未运行完整 ll-tests：本机缺少 CMake 和 Qt 开发环境。

Fixes #1841