### PR TITLE
fix(driver): stop waiting after notification action

### DIFF
--- a/apps/ll-driver-detect/src/dbus_notifier.cpp
+++ b/apps/ll-driver-detect/src/dbus_notifier.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -89,6 +89,7 @@ DBusNotifier::sendInteractiveNotification(const NotificationRequest &request)
               LogD("Notification {} action invoked: {}", id, actionKey.toStdString());
               choice = actionKey;
               userInteracted = true;
+              loop.quit();
           }
       });
 


### PR DESCRIPTION
## 问题

ActionInvoked 已提供用户选择，但事件循环仍等待 NotificationClosed 或 25 秒超时。

## 方案

在匹配通知 ID 的动作回调保存结果后立即退出事件循环。

## 本地验证

- 静态检查确认仅匹配的通知动作调用 loop.quit
- git diff --check
- 范围门禁：3/400 行

未扩展生产接口来注入私有 DBus 发送函数；本机也缺少 CMake 和 Qt 开发环境，未运行完整 ll-tests。

Fixes #1842