### PR TITLE
fix(driver): filter exact package search results

### DIFF
--- a/apps/ll-driver-detect/src/nvidia_driver_detector.cpp
+++ b/apps/ll-driver-detect/src/nvidia_driver_detector.cpp
@@ -78,29 +78,45 @@ utils::error::Result<GraphicsDriverInfo> NVIDIADriverDetector::detect()
 utils::error::Result<std::pair<bool, GraphicsDriverInfo>>
 NVIDIADriverDetector::getPackageInfoFromRemoteRepo(const std::string &packageName)
 {
-    using json = nlohmann::json;
-
     LINGLONG_TRACE("Check if NVIDIA driver package exists in repository");
 
-    GraphicsDriverInfo driverInfo;
-    driverInfo.identify = getDriverIdentify();
-    driverInfo.packageName = packageName;
     // Execute ll-cli search command to check driver package existence
     auto ret = linglong::utils::Cmd("ll-cli").exec({ "--json", "search", packageName });
     if (!ret) {
         return LINGLONG_ERR("Search command failed: " + ret.error().message());
     }
 
+    return parsePackageSearchResult(*ret, packageName);
+}
+
+utils::error::Result<std::pair<bool, GraphicsDriverInfo>>
+NVIDIADriverDetector::parsePackageSearchResult(const std::string &searchResult,
+                                               const std::string &packageName) const
+{
+    using json = nlohmann::json;
+
+    GraphicsDriverInfo driverInfo;
+    driverInfo.identify = getDriverIdentify();
+    driverInfo.packageName = packageName;
     bool found = false;
 
     try {
-        json j = json::parse(*ret);
+        json j = json::parse(searchResult);
 
         for (const auto &[category, apps] : j.items()) {
             if (!apps.is_array())
                 continue;
 
             for (const auto &item : apps) {
+                if (!item.is_object())
+                    continue;
+
+                auto id = item.find("id");
+                if (id == item.end() || !id->is_string()
+                    || id->get<std::string_view>() != packageName) {
+                    continue;
+                }
+
                 auto it = item.find("version");
                 if (it == item.end() || !it->is_string())
                     continue;

--- a/apps/ll-driver-detect/src/nvidia_driver_detector.cpp
+++ b/apps/ll-driver-detect/src/nvidia_driver_detector.cpp
@@ -93,6 +93,8 @@ utils::error::Result<std::pair<bool, GraphicsDriverInfo>>
 NVIDIADriverDetector::parsePackageSearchResult(const std::string &searchResult,
                                                const std::string &packageName) const
 {
+    LINGLONG_TRACE("Parse NVIDIA driver package search result");
+
     using json = nlohmann::json;
 
     GraphicsDriverInfo driverInfo;

--- a/apps/ll-driver-detect/src/nvidia_driver_detector.h
+++ b/apps/ll-driver-detect/src/nvidia_driver_detector.h
@@ -36,6 +36,8 @@ public:
 
 protected:
     bool compareVersions(std::string_view v1, std::string_view v2) const noexcept;
+    utils::error::Result<std::pair<bool, GraphicsDriverInfo>>
+    parsePackageSearchResult(const std::string &searchResult, const std::string &packageName) const;
 
 private:
     // Get driver version from the specified file path

--- a/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/nvidia_driver_detector_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/apps/ll-driver-detect/nvidia_driver_detector_test.cpp
@@ -29,6 +29,12 @@ public:
         return compareVersions(candidate, current);
     }
 
+    linglong::utils::error::Result<std::pair<bool, GraphicsDriverInfo>>
+    parseSearchResult(const std::string &searchResult, const std::string &packageName) const
+    {
+        return parsePackageSearchResult(searchResult, packageName);
+    }
+
     MOCK_METHOD((linglong::utils::error::Result<std::pair<bool, GraphicsDriverInfo>>),
                 getPackageInfoFromRemoteRepo,
                 (const std::string &packageName),
@@ -63,6 +69,32 @@ TEST_F(NvidiaDriverDetectorTest, CompareVersionsUsesSemanticOrdering)
 
     EXPECT_TRUE(detector.isVersionNewer("510.100.0", "510.99.0"));
     EXPECT_FALSE(detector.isVersionNewer("510.99.0", "510.100.0"));
+}
+
+TEST_F(NvidiaDriverDetectorTest, SearchResultOnlyUsesExactPackageID)
+{
+    TestableNVIDIADriverDetector detector("unused-version-file");
+    const std::string packageName = "org.deepin.driver.display.nvidia.510-85-02";
+    const auto searchResult = R"({
+        "repo-a": [
+            {"id": "org.deepin.driver.display.nvidia.510-85-02.legacy", "version": "999.0.0"},
+            "not-an-object",
+            {"version": "1000.0.0"},
+            {"id": 42, "version": "1001.0.0"},
+            {"id": "org.deepin.driver.display.nvidia.510-85-02", "version": "510.99.0"}
+        ],
+        "repo-b": [
+            {"id": "org.deepin.driver.display.nvidia.510-85-02", "version": "510.100.0"}
+        ]
+    })";
+
+    auto result = detector.parseSearchResult(searchResult, packageName);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(result->first);
+    EXPECT_EQ(result->second.packageName, packageName);
+    EXPECT_EQ(result->second.packageVersion, "510.100.0");
+    EXPECT_EQ(result->second.repoName, "repo-b");
 }
 
 TEST_F(NvidiaDriverDetectorTest, Detect_Success_PackageNotInstalled)


### PR DESCRIPTION
## 问题

NVIDIA 驱动搜索会把模糊匹配到的其他包版本当作目标包版本，可能生成不存在的安装引用。

## 方案

解析搜索结果时仅接受对象、字符串 ID 且 ID 与请求包名完全一致的条目，再进行语义版本选择。

## 本地验证

- 新增定向回归测试，覆盖相似 ID、高版本污染、非对象、缺失 ID、非字符串 ID 和跨仓精确结果
- git diff --check
- 范围门禁：62/400 行

本机缺少 CMake 和 Qt 开发环境，未执行完整 ll-tests。

Fixes #1843