### PR TITLE
fix(filelock): report compatible relock success

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/utils/filelock_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/filelock_test.cpp
@@ -368,6 +368,7 @@ TEST_F(FileLockTest, TryLockAlreadyLockedSameType)
 
     auto try_result = lock.tryLock(LockType::Read);
     ASSERT_TRUE(try_result);
+    EXPECT_TRUE(*try_result);
 }
 
 // Test lock when already locked different type

--- a/libs/utils/src/linglong/utils/filelock.cpp
+++ b/libs/utils/src/linglong/utils/filelock.cpp
@@ -208,7 +208,7 @@ utils::error::Result<bool> FileLock::tryLock(LockType type) noexcept
     auto isCompatible = compatibleWith(type);
     if (isLocked()) {
         if (isCompatible) {
-            return LINGLONG_OK;
+            return true;
         }
 
         return LINGLONG_ERR(


### PR DESCRIPTION
## 问题

已持有兼容锁时，tryLock 返回的 Result<bool> 被默认构造为 false，调用方会误以为没有获得锁。

## 方案

兼容的已加锁分支明确返回 true，并强化现有回归测试检查布尔值。

## 本地验证

- 现有 TryLockAlreadyLockedSameType 测试新增真值断言
- git diff --check
- 范围门禁：3/400 行

本机缺少 CMake 和 GTest，未执行完整 ll-tests。

Fixes #1844