### PR TITLE
fix(utils): require executable command files

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/utils/cmd_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/cmd_test.cpp
@@ -1,10 +1,15 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include <gtest/gtest.h>
 
+#include "common/tempdir.h"
 #include "linglong/utils/cmd.h"
+#include "linglong/utils/env.h"
+
+#include <filesystem>
+#include <fstream>
 
 namespace {
 
@@ -27,6 +32,30 @@ TEST(command, Exec)
     // 测试exec出错时
     auto ret4 = linglong::utils::Cmd("ls").exec({ "/linglong/nonexistent" });
     EXPECT_FALSE(ret4.has_value());
+}
+
+TEST(command, ExistsRequiresExecutableRegularFile)
+{
+    TempDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    const auto nonExecutable = tempDir.path() / "non-executable-command";
+    std::ofstream(nonExecutable) << "#!/bin/sh\n";
+    std::filesystem::permissions(nonExecutable,
+                                 std::filesystem::perms::owner_read
+                                   | std::filesystem::perms::owner_write,
+                                 std::filesystem::perm_options::replace);
+
+    linglong::utils::EnvironmentVariableGuard pathGuard("PATH", tempDir.path().string());
+    EXPECT_FALSE(linglong::utils::Cmd(nonExecutable.filename().string()).exists());
+    EXPECT_FALSE(linglong::utils::Cmd(nonExecutable.string()).exists());
+    EXPECT_FALSE(linglong::utils::Cmd(tempDir.path().string()).exists());
+
+    std::filesystem::permissions(nonExecutable,
+                                 std::filesystem::perms::owner_exec,
+                                 std::filesystem::perm_options::add);
+    EXPECT_TRUE(linglong::utils::Cmd(nonExecutable.filename().string()).exists());
+    EXPECT_TRUE(linglong::utils::Cmd(nonExecutable.string()).exists());
 }
 
 TEST(command, setEnv)

--- a/libs/utils/src/linglong/utils/cmd.cpp
+++ b/libs/utils/src/linglong/utils/cmd.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+ * SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
@@ -41,10 +41,16 @@ bool Cmd::exists() noexcept
 
 std::filesystem::path Cmd::getCommandPath()
 {
-    // Check if command is an absolute path
     std::error_code ec;
+    auto isExecutableRegularFile = [&ec](const std::filesystem::path &candidate) {
+        ec.clear();
+        return std::filesystem::is_regular_file(candidate, ec) && !ec
+          && ::access(candidate.c_str(), X_OK) == 0;
+    };
+
+    // Check if command is an absolute path
     std::filesystem::path path{ m_command };
-    if (path.is_absolute() && std::filesystem::exists(path, ec)) {
+    if (path.is_absolute() && isExecutableRegularFile(path)) {
         return path;
     }
 
@@ -60,8 +66,7 @@ std::filesystem::path Cmd::getCommandPath()
 
     for (const auto &pathDir : pathDirs) {
         std::filesystem::path fullPath = std::filesystem::path{ pathDir } / m_command;
-        if (std::filesystem::exists(fullPath, ec)
-            && std::filesystem::is_regular_file(fullPath, ec)) {
+        if (isExecutableRegularFile(fullPath)) {
             return fullPath;
         }
     }


### PR DESCRIPTION
## 问题

Cmd 会把不可执行文件和绝对目录识别为命令，导致 exists 假阳性，并可能阻断外部工具回退。

## 方案

绝对路径和 PATH 候选统一要求是常规文件且通过 X_OK 检查。

## 本地验证

- 新增测试覆盖 PATH 中不可执行文件、绝对不可执行文件、绝对目录及增加执行权限后的正向结果
- git diff --check
- 范围门禁：46/400 行

本机为 macOS，项目实现依赖 Linux epoll，且缺少 CMake/GTest，未执行完整 ll-tests。

Fixes #1845