### PR TITLE
fix(ocppi): wait for the spawned process

### DIFF
--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -70,6 +70,7 @@ pfl_add_executable(
   src/linglong/utils/transaction_test.cpp
   src/linglong/utils/xdg/directory_test.cpp
   src/linglong/utils/xdp_test.cpp
+  src/ocppi/process_test.cpp
   src/main.cpp
 
 
@@ -92,6 +93,7 @@ pfl_add_executable(
   GTest::gtest
   GTest::gmock
   linglong::linglong
+  linglong::ocppi
   linglong::oci-cfg-generators
   PkgConfig::CRYPTO)
 
@@ -104,3 +106,5 @@ target_include_directories(${tests}
                            PUBLIC ${PROJECT_SOURCE_DIR}/apps/uab/header/src)
 target_include_directories(${tests}
                            PUBLIC ${PROJECT_SOURCE_DIR}/apps/ll-driver-detect/src)
+target_include_directories(${tests}
+                           PRIVATE ${PROJECT_SOURCE_DIR}/libs/ocppi/src)

--- a/libs/linglong/tests/ll-tests/src/ocppi/process_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/ocppi/process_test.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "ocppi/cli/Process.hpp"
+
+#include <functional>
+#include <string>
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace {
+
+void expectRunProcessWaitsForItsOwnChild(const std::function<int()> &run)
+{
+    const auto unrelatedChild = ::fork();
+    ASSERT_GE(unrelatedChild, 0);
+    if (unrelatedChild == 0) {
+        ::_exit(42);
+    }
+
+    siginfo_t childInfo{};
+    ASSERT_EQ(::waitid(P_PID, unrelatedChild, &childInfo, WEXITED | WNOWAIT), 0);
+
+    EXPECT_EQ(run(), 0);
+
+    int status{};
+    ASSERT_EQ(::waitpid(unrelatedChild, &status, 0), unrelatedChild);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 42);
+}
+
+TEST(OcppiProcess, WaitsForOwnChildWithoutOutput)
+{
+    expectRunProcessWaitsForItsOwnChild([]() {
+        return runProcess("/bin/sh", { "-c", "sleep 0.1" });
+    });
+}
+
+TEST(OcppiProcess, WaitsForOwnChildWithOutput)
+{
+    expectRunProcessWaitsForItsOwnChild([]() {
+        std::string output;
+        return runProcess("/bin/sh", { "-c", "exec 1>&-; sleep 0.1" }, output);
+    });
+}
+
+} // namespace

--- a/libs/ocppi/src/ocppi/cli/Process.cpp
+++ b/libs/ocppi/src/ocppi/cli/Process.cpp
@@ -68,7 +68,7 @@ int runProcess(const std::string &binaryPath,
 
         int interruptTimes = 0;
         while (true) {
-                if (::wait(&ret) != -1) {
+                if (::waitpid(childId, &ret, 0) != -1) {
                         break;
                 }
 
@@ -112,7 +112,7 @@ int runProcess(const std::string &binaryPath,
 
         int interruptTimes = 0;
         while (true) {
-                if (::wait(&ret) != -1) {
+                if (::waitpid(childId, &ret, 0) != -1) {
                         break;
                 }
 


### PR DESCRIPTION
## 问题

runProcess 使用 wait 等待任意子进程，可能回收无关子进程并返回错误状态。

## 方案

两个重载都使用保存的 childId 调用 waitpid，只等待各自创建的进程。

## 本地验证

- 新增有输出和无输出两个并发子进程回归测试
- 独立 harness 对照：基线稳定退出 11，修复版连续 3 次通过
- clang++ 语法检查通过（为适配原文件在 macOS 的既有头文件差异，验证命令使用 -include signal.h）
- git diff --check
- 范围门禁：59/400 行

本机缺少 CMake/GTest，未执行完整 ll-tests。

Fixes #1846