### PR TITLE
fix(test): make Error.WarpStdErrorCode independent of filesystem privileges

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/utils/error/error_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/error/error_test.cpp
@@ -11,7 +11,8 @@
 #include "linglong/utils/error/error.h"
 #include "linglong/utils/log/log.h"
 
-#include <filesystem>
+#include <cerrno>
+#include <system_error>
 
 using namespace linglong::utils::error;
 
@@ -103,21 +104,20 @@ TEST(Error, WarpErrorCode)
 TEST(Error, WarpStdErrorCode)
 {
     EnvironmentVariableGuard guard("LINYAPS_BACKTRACE", "1");
-    std::system_error se;
-    auto res = [&se]() -> Result<void> {
+    // Use a std::error_code that always fails instead of a real filesystem
+    // operation, so the result does not depend on whether the test runs as
+    // root (root could create "/no_permission_to_create" and the error path
+    // would never be exercised).
+    std::error_code ec = std::make_error_code(std::errc::permission_denied);
+    std::system_error se(ec);
+    auto res = [&ec]() -> Result<void> {
         LINGLONG_TRACE("test LINGLONG_ERR");
-        std::error_code ec;
-        std::filesystem::create_directory("/no_permission_to_create", ec);
-        if (ec) {
-            se = std::system_error(ec);
-            return LINGLONG_ERR("create directory failed", ec);
-        }
-        return LINGLONG_OK;
+        return LINGLONG_ERR("operation failed", ec);
     }();
     ASSERT_FALSE(res.has_value());
     auto msg = res.error().message();
     ASSERT_TRUE(strings::contains(msg, "test LINGLONG_ERR")) << msg;
-    ASSERT_TRUE(strings::contains(msg, "create directory failed")) << msg;
+    ASSERT_TRUE(strings::contains(msg, "operation failed")) << msg;
     ASSERT_TRUE(strings::contains(msg, se.what())) << msg;
 }
 


### PR DESCRIPTION
## What

Fix `Error.WarpStdErrorCode` failing when the test suite runs as **root**.

## Problem

`Error.WarpStdErrorCode` (`error_test.cpp`) relied on
`std::filesystem::create_directory("/no_permission_to_create")` failing to
exercise the `std::error_code` wrapping path:

```cpp
std::error_code ec;
std::filesystem::create_directory("/no_permission_to_create", ec);
if (ec) {
    se = std::system_error(ec);
    return LINGLONG_ERR("create directory failed", ec);
}
return LINGLONG_OK;
```

That assumption only holds for **non-privileged** users. When the test runs
as root (e.g. in OBS or a root build container), `create_directory` succeeds,
`ec` stays empty, `LINGLONG_OK` is returned, and `ASSERT_FALSE(res.has_value())`
fails.

The project's GitHub Actions CI runs as a non-root `runner`, which is why this
goes unnoticed there.

## Fix

Replace the real filesystem operation with a deterministic `std::error_code`
so the error path is always exercised regardless of privileges:

```cpp
std::error_code ec = std::make_error_code(std::errc::permission_denied);
std::system_error se(ec);
auto res = [&ec]() -> Result<void> {
    LINGLONG_TRACE("test LINGLONG_ERR");
    return LINGLONG_ERR("operation failed", ec);
}();
```

Also drop the now-unused `<filesystem>` include in favor of `<system_error>`
and `<cerrno>`.

## Verification

- Confirmed root cause: `create_directory("/no_permission_to_create")` succeeds
  as root (uid 0, `ec` empty → test fails) and fails as nobody (uid 65534,
  `ec` = EACCES → test passes).
- Standalone reproduction of the fixed test logic passes all assertions when run
  as root:
  - `ASSERT_FALSE(res.has_value())` ✓
  - `contains(msg, "test LINGLONG_ERR")` ✓
  - `contains(msg, "operation failed")` ✓
  - `contains(msg, se.what())` ✓ (`se.what()` = "Permission denied")
  - `res.error().code()` = 13 (EACCES), deterministic
- `g++ -fsyntax-only` on the full test file compiles cleanly with the new
  includes.
