### PR TITLE
tests: expand unit test coverage (cli printer, oci-cfg-generator, repo migrate/cache, utils io, ...)

### DIFF
--- a/libs/linglong/src/linglong/repo/repo_cache.cpp
+++ b/libs/linglong/src/linglong/repo/repo_cache.cpp
@@ -133,7 +133,6 @@ RepoCache::addLayerItem(const api::types::v1::RepositoryCacheLayersItem &item)
 
     auto it = findMatchingItem(item);
     if (it) {
-        Q_ASSERT(false);
         return LINGLONG_ERR("item already exist");
     }
 
@@ -175,7 +174,6 @@ RepoCache::deleteLayerItem(const api::types::v1::RepositoryCacheLayersItem &item
 
     auto it = findMatchingItem(item);
     if (!it) {
-        Q_ASSERT(false);
         return LINGLONG_ERR(it);
     }
 

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -18,8 +18,10 @@ pfl_add_executable(
   src/linglong/builder/linglong_builder_test.cpp
   src/linglong/builder/pull_dependency_test.cpp
   src/linglong/builder/source_fetcher_test.cpp
+  src/linglong/cli/cli_printer_test.cpp
   src/linglong/cli/cli_test.cpp
   src/linglong/common/gkeyfile_wrapper_test.cpp
+  src/linglong/common/global/initialize_test.cpp
   src/linglong/common/cli/repo_test.cpp
   src/linglong/common/dir_test.cpp
   src/linglong/common/strings_test.cpp
@@ -30,11 +32,14 @@ pfl_add_executable(
   src/linglong/mocks/linglong_builder_mock.h
   src/linglong/mocks/ostree_repo_mock.h
   src/linglong/mocks/uab_file_mock.h
+  src/linglong/oci-cfg-generators/container_cfg_builder_test.cpp
   src/linglong/package/architecture_test.cpp
+  src/linglong/package/elf_handler_test.cpp
   src/linglong/package/fallback_version_test.cpp
   src/linglong/package/layer_dir_test.cpp
   src/linglong/package/layer_packager_test.cpp
   src/linglong/package_manager/action_test.cpp
+  src/linglong/package_manager/data_monitor_test.cpp
   src/linglong/package_manager/task_test.cpp
   src/linglong/package_manager/task_queue_test.cpp
   src/linglong/package_manager/package_update_test.cpp
@@ -48,10 +53,12 @@ pfl_add_executable(
   src/linglong/package/semver_version_test.cpp
   src/linglong/package/uab_file_test.cpp
   src/linglong/package/uab_packager_test.cpp
+  src/linglong/package/version_extra_test.cpp
   src/linglong/package/version_test.cpp
   src/linglong/package/versionv2_test.cpp
   src/linglong/repo/client_factory_test.cpp
   src/linglong/repo/config_test.cpp
+  src/linglong/repo/migrate_test.cpp
   src/linglong/repo/ostree_repo_test.cpp
   src/linglong/repo/repo_cache_test.cpp
   src/linglong/runtime/container_builder_test.cpp
@@ -63,6 +70,7 @@ pfl_add_executable(
   src/linglong/utils/file_test.cpp
   src/linglong/utils/filelock_test.cpp
   src/linglong/utils/hooks_test.cpp
+  src/linglong/utils/io_test.cpp
   src/linglong/utils/log.cpp
   src/linglong/utils/namespce.cpp
   src/linglong/utils/overlayfs_test.cpp

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -60,6 +60,7 @@ pfl_add_executable(
   src/linglong/repo/config_test.cpp
   src/linglong/repo/migrate_test.cpp
   src/linglong/repo/ostree_repo_test.cpp
+  src/linglong/repo/ostree_repo_real_test.cpp
   src/linglong/repo/repo_cache_test.cpp
   src/linglong/runtime/container_builder_test.cpp
   src/linglong/runtime/overlayfs_driver_test.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/cli/cli_printer_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/cli/cli_printer_test.cpp
@@ -1,0 +1,483 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/cli/cli_printer.h"
+#include "linglong/cli/json_printer.h"
+
+#include <QStringList>
+
+#include <sstream>
+#include <string>
+
+using namespace linglong::api::types::v1;
+
+namespace {
+
+class CaptureStdio
+{
+public:
+    CaptureStdio()
+        : oldCout_(std::cout.rdbuf(coutStream_.rdbuf()))
+        , oldCerr_(std::cerr.rdbuf(cerrStream_.rdbuf()))
+    {
+    }
+
+    ~CaptureStdio()
+    {
+        std::cout.rdbuf(oldCout_);
+        std::cerr.rdbuf(oldCerr_);
+    }
+
+    std::string str() const { return coutStream_.str() + cerrStream_.str(); }
+
+private:
+    std::ostringstream coutStream_;
+    std::ostringstream cerrStream_;
+    std::streambuf *oldCout_;
+    std::streambuf *oldCerr_;
+};
+
+using CaptureStdout = CaptureStdio;
+
+PackageInfoV2 makePackage(const char *id,
+                          const char *name,
+                          const char *version,
+                          const char *channel,
+                          const char *module,
+                          const char *description)
+{
+    PackageInfoV2 pkg;
+    pkg.id = id;
+    pkg.name = name;
+    pkg.version = version;
+    pkg.channel = channel;
+    pkg.packageInfoV2Module = module;
+    pkg.description = description;
+    pkg.schemaVersion = "1.0";
+    pkg.kind = "app";
+    pkg.size = 0;
+    return pkg;
+}
+
+TEST(CLIPrinter, PrintErr)
+{
+    auto err = linglong::utils::error::Error::Err("file.cpp", 42, "trace", "boom", -7);
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printErr(err);
+    auto out = capture.str();
+    EXPECT_THAT(out, ::testing::HasSubstr("Error -7"));
+    EXPECT_THAT(out, ::testing::HasSubstr("boom"));
+}
+
+TEST(CLIPrinter, PrintPackage)
+{
+    auto pkg = makePackage("org.deepin.demo", "Demo", "1.0.0", "stable", "binary", "a demo app");
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printPackage(pkg);
+    auto out = capture.str();
+    EXPECT_THAT(out, ::testing::HasSubstr("org.deepin.demo"));
+    EXPECT_THAT(out, ::testing::HasSubstr("1.0.0"));
+}
+
+TEST(CLIPrinter, PrintPackagesWithHeader)
+{
+    PackageInfoDisplay pkg;
+    pkg.id = "org.deepin.demo";
+    pkg.name = "Demo Application Name";
+    pkg.version = "1.0.0";
+    pkg.channel = "stable";
+    pkg.packageInfoDisplayModule = "binary";
+    pkg.description = "A very interesting demo application used for testing";
+
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printPackages(std::vector<PackageInfoDisplay>{ pkg });
+    auto out = capture.str();
+    EXPECT_THAT(out, ::testing::HasSubstr("org.deepin.demo"));
+    EXPECT_THAT(out, ::testing::HasSubstr("1.0.0"));
+}
+
+TEST(CLIPrinter, PrintSearchResultEmpty)
+{
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printSearchResult({});
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("No packages"));
+}
+
+TEST(CLIPrinter, PrintSearchResultSorts)
+{
+    auto older = makePackage("org.deepin.a", "A", "1.0.0", "stable", "binary", "older");
+    auto newer = makePackage("org.deepin.a", "A", "2.0.0", "stable", "binary", "newer");
+
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printSearchResult(std::map<std::string, std::vector<PackageInfoV2>>{
+      { "repo1", { older, newer } },
+    });
+    auto out = capture.str();
+    // newer version (2.0.0) must be printed before older (1.0.0)
+    EXPECT_LT(out.find("2.0.0"), out.find("1.0.0"));
+}
+
+TEST(CLIPrinter, PrintPruneResultEmpty)
+{
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printPruneResult({});
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("No unused"));
+}
+
+TEST(CLIPrinter, PrintContainersEmpty)
+{
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printContainers({});
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("No containers"));
+}
+
+TEST(CLIPrinter, PrintContainers)
+{
+    CliContainer c1;
+    c1.id = "abcdef123456";
+    c1.package = "org.deepin.demo/demo";
+    c1.pid = 1234;
+
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printContainers(std::vector<CliContainer>{ c1 });
+    auto out = capture.str();
+    EXPECT_THAT(out, ::testing::HasSubstr("abcdef123456"));
+    EXPECT_THAT(out, ::testing::HasSubstr("1234"));
+}
+
+TEST(CLIPrinter, PrintRepoConfig)
+{
+    RepoConfigV2 cfg;
+    cfg.defaultRepo = "repo1";
+    Repo repo1;
+    repo1.name = "repo1";
+    repo1.url = "https://mirrors.example.com/linglong/repo1";
+    repo1.priority = 10;
+    Repo repo2;
+    repo2.name = "repo2";
+    repo2.url = "https://mirrors.example.com/linglong/repo2";
+    repo2.priority = 5;
+    cfg.repos = { repo1, repo2 };
+
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printRepoConfig(cfg);
+    auto out = capture.str();
+    EXPECT_THAT(out, ::testing::HasSubstr("Default: repo1"));
+    // sorted by priority desc: repo1 before repo2
+    EXPECT_LT(out.find("repo1"), out.find("repo2"));
+}
+
+TEST(CLIPrinter, PrintLayerInfo)
+{
+    LayerInfo info;
+    info.info = nlohmann::json{ { "id", "org.deepin.demo" } };
+
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printLayerInfo(info);
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("org.deepin.demo"));
+}
+
+TEST(CLIPrinter, PrintContent)
+{
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printContent(QStringList{ "/usr/bin/demo", "/usr/share/demo" });
+    auto out = capture.str();
+    EXPECT_THAT(out, ::testing::HasSubstr("/usr/bin/demo"));
+    EXPECT_THAT(out, ::testing::HasSubstr("/usr/share/demo"));
+}
+
+TEST(CLIPrinter, PrintProgress)
+{
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printProgress(42.5, "downloading");
+    auto out = capture.str();
+    EXPECT_THAT(out, ::testing::HasSubstr("downloading"));
+    EXPECT_THAT(out, ::testing::HasSubstr("42.50%"));
+}
+
+TEST(CLIPrinter, PrintUpgradeListEmpty)
+{
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    std::vector<UpgradeListResult> list;
+    printer.printUpgradeList(list);
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("No apps"));
+}
+
+TEST(CLIPrinter, PrintUpgradeList)
+{
+    UpgradeListResult item;
+    item.id = "org.deepin.demo";
+    item.oldVersion = "1.0.0";
+    item.newVersion = "2.0.0";
+
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    std::vector<UpgradeListResult> list{ item };
+    printer.printUpgradeList(list);
+    auto out = capture.str();
+    EXPECT_THAT(out, ::testing::HasSubstr("org.deepin.demo"));
+    EXPECT_THAT(out, ::testing::HasSubstr("1.0.0"));
+    EXPECT_THAT(out, ::testing::HasSubstr("2.0.0"));
+}
+
+TEST(CLIPrinter, PrintInspect)
+{
+    InspectResult result;
+    result.appID = "org.deepin.demo";
+
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printInspect(result);
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("org.deepin.demo"));
+}
+
+TEST(CLIPrinter, PrintInspectNoApp)
+{
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printInspect(InspectResult{});
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("none"));
+}
+
+TEST(CLIPrinter, PrintModuleSizes)
+{
+    linglong::cli::Printer::ModuleSizeInfo mod;
+    mod.id = "org.deepin.demo";
+    mod.version = "1.0.0";
+    mod.channel = "stable";
+    mod.module = "binary";
+    mod.exclusiveSize = 1024;
+    mod.sharedSize = 2048;
+    mod.logicalSize = 4096;
+    mod.actualSize = 8192;
+
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printModuleSizes(std::vector<linglong::cli::Printer::ModuleSizeInfo>{ mod },
+                             8192,
+                             16384);
+    auto out = capture.str();
+    EXPECT_THAT(out, ::testing::HasSubstr("org.deepin.demo"));
+    EXPECT_THAT(out, ::testing::HasSubstr("1.0 KiB"));
+}
+
+TEST(CLIPrinter, PrintDepends)
+{
+    linglong::cli::Printer::DependsNode child;
+    child.ref = "org.deepin.child/base";
+    child.kind = "runtime";
+
+    linglong::cli::Printer::DependsNode root;
+    root.ref = "org.deepin.demo/demo";
+    root.children = { child };
+
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printDepends(std::vector<linglong::cli::Printer::DependsNode>{ root });
+    auto out = capture.str();
+    EXPECT_THAT(out, ::testing::HasSubstr("org.deepin.demo"));
+    EXPECT_THAT(out, ::testing::HasSubstr("org.deepin.child"));
+    EXPECT_THAT(out, ::testing::HasSubstr("runtime"));
+}
+
+TEST(CLIPrinter, PrintMessageAndClearLine)
+{
+    CaptureStdout capture;
+    linglong::cli::CLIPrinter printer;
+    printer.printMessage("hello world");
+    printer.clearLine();
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("hello world"));
+}
+
+// ---------------------------------------------------------------- JSONPrinter
+
+class JSONPrinterTest : public ::testing::Test
+{
+protected:
+    linglong::cli::JSONPrinter printer;
+};
+
+TEST_F(JSONPrinterTest, PrintErr)
+{
+    auto err = linglong::utils::error::Error::Err("file.cpp", 42, "trace", "boom", -7);
+    CaptureStdout capture;
+    printer.printErr(err);
+    auto out = capture.str();
+    EXPECT_THAT(out, ::testing::HasSubstr("\"message\""));
+    EXPECT_THAT(out, ::testing::HasSubstr("boom"));
+}
+
+TEST_F(JSONPrinterTest, PrintPackage)
+{
+    auto pkg = makePackage("org.deepin.demo", "Demo", "1.0.0", "stable", "binary", "a demo app");
+    CaptureStdout capture;
+    printer.printPackage(pkg);
+    auto out = capture.str();
+    EXPECT_THAT(out, ::testing::HasSubstr("org.deepin.demo"));
+    EXPECT_THAT(out, ::testing::HasSubstr("1.0.0"));
+}
+
+TEST_F(JSONPrinterTest, PrintPackagesDisplay)
+{
+    PackageInfoDisplay pkg;
+    pkg.id = "org.deepin.demo";
+    pkg.name = "Demo";
+    pkg.version = "1.0.0";
+    pkg.channel = "stable";
+
+    CaptureStdout capture;
+    printer.printPackages(std::vector<PackageInfoDisplay>{ pkg });
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("org.deepin.demo"));
+}
+
+TEST_F(JSONPrinterTest, PrintSearchResult)
+{
+    auto pkg = makePackage("org.deepin.demo", "Demo", "1.0.0", "stable", "binary", "a demo app");
+    CaptureStdout capture;
+    printer.printSearchResult(
+      std::map<std::string, std::vector<PackageInfoV2>>{ { "repo1", { pkg } } });
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("org.deepin.demo"));
+}
+
+TEST_F(JSONPrinterTest, PrintPruneResult)
+{
+    auto pkg = makePackage("org.deepin.demo", "Demo", "1.0.0", "stable", "binary", "");
+    CaptureStdout capture;
+    printer.printPruneResult(std::vector<PackageInfoV2>{ pkg });
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("org.deepin.demo"));
+}
+
+TEST_F(JSONPrinterTest, PrintContainers)
+{
+    CliContainer c1;
+    c1.id = "abcdef123456";
+    c1.package = "org.deepin.demo/demo";
+    c1.pid = 1234;
+    CaptureStdout capture;
+    printer.printContainers(std::vector<CliContainer>{ c1 });
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("abcdef123456"));
+}
+
+TEST_F(JSONPrinterTest, PrintRepoConfig)
+{
+    RepoConfigV2 cfg;
+    cfg.defaultRepo = "repo1";
+    Repo repo1;
+    repo1.name = "repo1";
+    repo1.url = "https://mirrors.example.com/linglong/repo1";
+    repo1.priority = 10;
+    cfg.repos = { repo1 };
+    CaptureStdout capture;
+    printer.printRepoConfig(cfg);
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("repo1"));
+}
+
+TEST_F(JSONPrinterTest, PrintLayerInfo)
+{
+    LayerInfo info;
+    info.info = nlohmann::json{ { "id", "org.deepin.demo" } };
+    CaptureStdout capture;
+    printer.printLayerInfo(info);
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("org.deepin.demo"));
+}
+
+TEST_F(JSONPrinterTest, PrintContent)
+{
+    CaptureStdout capture;
+    printer.printContent(QStringList{ "/usr/bin/demo" });
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("/usr/bin/demo"));
+}
+
+TEST_F(JSONPrinterTest, PrintProgress)
+{
+    CaptureStdout capture;
+    printer.printProgress(12.5, "pulling");
+    auto out = capture.str();
+    EXPECT_THAT(out, ::testing::HasSubstr("pulling"));
+    EXPECT_THAT(out, ::testing::HasSubstr("12.5"));
+}
+
+TEST_F(JSONPrinterTest, PrintUpgradeList)
+{
+    UpgradeListResult item;
+    item.id = "org.deepin.demo";
+    item.oldVersion = "1.0.0";
+    item.newVersion = "2.0.0";
+    CaptureStdout capture;
+    std::vector<UpgradeListResult> list{ item };
+    printer.printUpgradeList(list);
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("org.deepin.demo"));
+}
+
+TEST_F(JSONPrinterTest, PrintInspect)
+{
+    InspectResult result;
+    result.appID = "org.deepin.demo";
+    CaptureStdout capture;
+    printer.printInspect(result);
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("org.deepin.demo"));
+}
+
+TEST_F(JSONPrinterTest, PrintModuleSizes)
+{
+    linglong::cli::Printer::ModuleSizeInfo mod;
+    mod.id = "org.deepin.demo";
+    mod.version = "1.0.0";
+    mod.channel = "stable";
+    mod.module = "binary";
+    mod.exclusiveSize = 1024;
+    mod.sharedSize = 2048;
+    mod.logicalSize = 4096;
+    mod.actualSize = 8192;
+    CaptureStdout capture;
+    printer.printModuleSizes(std::vector<linglong::cli::Printer::ModuleSizeInfo>{ mod },
+                             8192,
+                             16384);
+    auto out = capture.str();
+    EXPECT_THAT(out, ::testing::HasSubstr("org.deepin.demo"));
+    EXPECT_THAT(out, ::testing::HasSubstr("calculatedLogicalSize"));
+}
+
+TEST_F(JSONPrinterTest, PrintDepends)
+{
+    linglong::cli::Printer::DependsNode child;
+    child.ref = "org.deepin.child/base";
+
+    linglong::cli::Printer::DependsNode root;
+    root.ref = "org.deepin.demo/demo";
+    root.children = { child };
+
+    CaptureStdout capture;
+    printer.printDepends(std::vector<linglong::cli::Printer::DependsNode>{ root });
+    auto out = capture.str();
+    EXPECT_THAT(out, ::testing::HasSubstr("org.deepin.demo"));
+    EXPECT_THAT(out, ::testing::HasSubstr("org.deepin.child"));
+}
+
+TEST_F(JSONPrinterTest, PrintMessage)
+{
+    CaptureStdout capture;
+    printer.printMessage("hi");
+    EXPECT_THAT(capture.str(), ::testing::HasSubstr("hi"));
+}
+
+} // namespace

--- a/libs/linglong/tests/ll-tests/src/linglong/common/global/initialize_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/common/global/initialize_test.cpp
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gtest/gtest.h>
+
+#include "linglong/common/global/initialize.h"
+#include "linglong/utils/env.h"
+
+using namespace linglong::common::global;
+using linglong::utils::EnvironmentVariableGuard;
+
+TEST(GlobalTaskControl, InstanceIsAvailableAndNotInitiallyCanceled)
+{
+    auto *taskControl = GlobalTaskControl::instance();
+    ASSERT_NE(taskControl, nullptr);
+
+    // A fresh run must not start canceled. We deliberately avoid calling
+    // cancel() here: emitting the OnCancel signal can invoke connections
+    // left behind by other tests that reference a torn-down DBus connection.
+    EXPECT_FALSE(GlobalTaskControl::canceled());
+}
+
+TEST(LinglongInstalled, ReturnsFalseInTestEnvironment)
+{
+    // The test binary is not installed under BINDIR, so this is false here.
+    EXPECT_FALSE(linglongInstalled());
+}
+
+TEST(ApplicationInitialize, RunsWithoutCrashing)
+{
+    applicationInitialize();
+    // Signal handlers were installed without terminating the process.
+    SUCCEED();
+}
+
+TEST(InitLogSystem, ParsesEnvironment)
+{
+    EnvironmentVariableGuard levelGuard("LINYAPS_LOG_LEVEL", "debug");
+    EnvironmentVariableGuard backendGuard("LINYAPS_LOG_BACKEND", "console,journal");
+    initLinyapsLogSystem(linglong::utils::log::LogBackend::None);
+    SUCCEED();
+}
+
+TEST(InitLogSystem, InvalidLevelFallsBackToDefault)
+{
+    EnvironmentVariableGuard levelGuard("LINYAPS_LOG_LEVEL", "bogus");
+    EnvironmentVariableGuard backendGuard("LINYAPS_LOG_BACKEND", "bogus");
+    initLinyapsLogSystem(linglong::utils::log::LogBackend::Journal);
+    SUCCEED();
+}

--- a/libs/linglong/tests/ll-tests/src/linglong/oci-cfg-generators/container_cfg_builder_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/oci-cfg-generators/container_cfg_builder_test.cpp
@@ -1,0 +1,689 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/oci-cfg-generators/container_cfg_builder.h"
+#include "ocppi/runtime/config/types/NamespaceType.hpp"
+
+#include <common/tempdir.h>
+
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+using namespace linglong::generator;
+using ocppi::runtime::config::types::Config;
+using ocppi::runtime::config::types::Mount;
+
+namespace {
+
+class ContainerCfgBuilderTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_TRUE(baseDir.isValid());
+        ASSERT_TRUE(bundleDir.isValid());
+        ASSERT_TRUE(appDir.isValid());
+        ASSERT_TRUE(runtimeDir.isValid());
+        // mkdtemp already created the directories
+        ASSERT_TRUE(std::filesystem::is_directory(baseDir.path()));
+        ASSERT_TRUE(std::filesystem::is_directory(bundleDir.path()));
+        ASSERT_TRUE(std::filesystem::is_directory(appDir.path()));
+        ASSERT_TRUE(std::filesystem::is_directory(runtimeDir.path()));
+    }
+
+    TempDir baseDir{ "ll-cfg-base-" };
+    TempDir bundleDir{ "ll-cfg-bundle-" };
+    TempDir appDir{ "ll-cfg-app-" };
+    TempDir runtimeDir{ "ll-cfg-runtime-" };
+};
+
+TEST_F(ContainerCfgBuilderTest, BuildWithRequiredFields)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .setContainerId("fake-container-id")
+      .disablePatch();
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    const auto &config = builder.getConfig();
+    EXPECT_EQ(config.ociVersion, "1.0.1");
+    EXPECT_EQ(config.hostname, "linglong");
+    ASSERT_TRUE(config.root.has_value());
+    EXPECT_EQ(config.root->path, baseDir.path());
+    EXPECT_EQ(builder.getContainerId(), "fake-container-id");
+
+    ASSERT_TRUE(config.linux_.has_value());
+    ASSERT_TRUE(config.linux_->namespaces.has_value());
+    bool hasUserNs = false;
+    for (const auto &ns : *config.linux_->namespaces) {
+        if (ns.type == ocppi::runtime::config::types::NamespaceType::User) {
+            hasUserNs = true;
+        }
+    }
+    EXPECT_TRUE(hasUserNs);
+}
+
+TEST_F(ContainerCfgBuilderTest, CheckValidRejectsEmptyAppId)
+{
+    ContainerCfgBuilder builder;
+    builder.setBasePath(baseDir.path()).setBundlePath(bundleDir.path());
+    auto result = builder.build();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error().message(), ::testing::HasSubstr("app id is empty"));
+}
+
+TEST_F(ContainerCfgBuilderTest, CheckValidRejectsEmptyBasePath)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo").setBundlePath(bundleDir.path());
+    auto result = builder.build();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error().message(), ::testing::HasSubstr("base path is not set"));
+}
+
+TEST_F(ContainerCfgBuilderTest, CheckValidRejectsEmptyBundlePath)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo").setBasePath(baseDir.path());
+    auto result = builder.build();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error().message(), ::testing::HasSubstr("bundle path is empty"));
+}
+
+TEST_F(ContainerCfgBuilderTest, RejectsOverlayWithSelfAdjustingMount)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .enableOverlayMode(baseDir.path() / "merged", true)
+      .enableSelfAdjustingMount();
+    auto result = builder.build();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error().message(), ::testing::HasSubstr("overlay and self-adjusting"));
+}
+
+TEST_F(ContainerCfgBuilderTest, OverlayModeSetsRoot)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .enableOverlayMode(baseDir.path() / "merged", true);
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.getConfig().root.has_value());
+    EXPECT_EQ(builder.getConfig().root->path, baseDir.path() / "merged");
+    EXPECT_TRUE(builder.getConfig().root->readonly.value_or(false));
+}
+
+TEST_F(ContainerCfgBuilderTest, DisableUserNamespaceRemovesUserNs)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .disableUserNamespace();
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.getConfig().linux_.has_value());
+    ASSERT_TRUE(builder.getConfig().linux_->namespaces.has_value());
+    for (const auto &ns : *builder.getConfig().linux_->namespaces) {
+        EXPECT_NE(ns.type, ocppi::runtime::config::types::NamespaceType::User);
+    }
+}
+
+TEST_F(ContainerCfgBuilderTest, IsolateNetworkAddsNetworkNamespace)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .isolateNetWork();
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.getConfig().linux_.has_value());
+    ASSERT_TRUE(builder.getConfig().linux_->namespaces.has_value());
+    bool hasNetNs = false;
+    for (const auto &ns : *builder.getConfig().linux_->namespaces) {
+        if (ns.type == ocppi::runtime::config::types::NamespaceType::Network) {
+            hasNetNs = true;
+        }
+    }
+    EXPECT_TRUE(hasNetNs);
+}
+
+TEST_F(ContainerCfgBuilderTest, SetAnnotations)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .setAnnotation(ANNOTATION::APPID, "org.deepin.demo")
+      .setAnnotation(ANNOTATION::BASEDIR, "/base")
+      .setAnnotation(ANNOTATION::LAST_PID, "12345")
+      .setAnnotation(ANNOTATION::WAYLAND_SOCKET, "/run/wayland-0")
+      .setAnnotation(static_cast<ANNOTATION>(99), "unknown");
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.getConfig().annotations.has_value());
+    EXPECT_EQ(builder.getConfig().annotations->at("org.deepin.linglong.appID"), "org.deepin.demo");
+    EXPECT_EQ(builder.getConfig().annotations->at("org.deepin.linglong.baseDir"), "/base");
+    EXPECT_EQ(builder.getConfig().annotations->at("cn.org.linyaps.runtime.ns_last_pid"), "12345");
+    EXPECT_EQ(builder.getConfig().annotations->at("cn.org.linyaps.runtime.ws.path"),
+              "/run/wayland-0");
+}
+
+TEST_F(ContainerCfgBuilderTest, AddIdMappings)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .addUIdMapping(0, 1000, 1)
+      .addUIdMapping(1, 1001, 1)
+      .addGIdMapping(0, 2000, 1);
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.getConfig().linux_.has_value());
+    ASSERT_TRUE(builder.getConfig().linux_->uidMappings.has_value());
+    ASSERT_EQ(builder.getConfig().linux_->uidMappings->size(), 2);
+    EXPECT_EQ(builder.getConfig().linux_->uidMappings->at(0).containerID, 0);
+    EXPECT_EQ(builder.getConfig().linux_->uidMappings->at(0).hostID, 1000);
+    EXPECT_EQ(builder.getConfig().linux_->uidMappings->at(1).containerID, 1);
+    ASSERT_TRUE(builder.getConfig().linux_->gidMappings.has_value());
+    ASSERT_EQ(builder.getConfig().linux_->gidMappings->size(), 1);
+    EXPECT_EQ(builder.getConfig().linux_->gidMappings->at(0).hostID, 2000);
+}
+
+TEST_F(ContainerCfgBuilderTest, SetCapabilities)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .setCapabilities({ "CAP_NET_ADMIN", "CAP_SYS_ADMIN" });
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.getConfig().process.has_value());
+    ASSERT_TRUE(builder.getConfig().process->args.has_value());
+    EXPECT_EQ(builder.getConfig().process->args->at(0), "bash");
+    ASSERT_TRUE(builder.getConfig().process->capabilities.has_value());
+    EXPECT_EQ(builder.getConfig().process->capabilities->bounding,
+              std::vector<std::string>({ "CAP_NET_ADMIN", "CAP_SYS_ADMIN" }));
+    EXPECT_EQ(builder.getConfig().process->capabilities->effective,
+              std::vector<std::string>({ "CAP_NET_ADMIN", "CAP_SYS_ADMIN" }));
+}
+
+TEST_F(ContainerCfgBuilderTest, AddMask)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .addMask({ "/proc/kcore", "/sys/firmware" });
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.getConfig().linux_.has_value());
+    ASSERT_TRUE(builder.getConfig().linux_->maskedPaths.has_value());
+    EXPECT_EQ(builder.getConfig().linux_->maskedPaths->size(), 2);
+    EXPECT_EQ(builder.getConfig().linux_->maskedPaths->at(0), "/proc/kcore");
+}
+
+TEST_F(ContainerCfgBuilderTest, AppPathProducesAppAndRuntimeMounts)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .setAppPath(appDir.path(), true)
+      .setRuntimePath(runtimeDir.path(), false);
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+    bool hasAppBind = false;
+    bool hasRuntimeBind = false;
+    for (const auto &m : *builder.getConfig().mounts) {
+        if (m.destination == ContainerCfgBuilder::appMountPoint("org.deepin.demo")) {
+            hasAppBind = true;
+            EXPECT_EQ(m.source.value_or(""), appDir.path());
+        }
+        if (m.destination == ContainerCfgBuilder::runtimeMountPoint) {
+            hasRuntimeBind = true;
+            EXPECT_EQ(m.source.value_or(""), runtimeDir.path());
+        }
+    }
+    EXPECT_TRUE(hasAppBind);
+    EXPECT_TRUE(hasRuntimeBind);
+
+    ASSERT_TRUE(builder.getConfig().process.has_value());
+    ASSERT_TRUE(builder.getConfig().process->env.has_value());
+    EXPECT_THAT(*builder.getConfig().process->env,
+                ::testing::Contains("LINGLONG_APPID=org.deepin.demo"));
+}
+
+TEST_F(ContainerCfgBuilderTest, AppMountPointHelpers)
+{
+    EXPECT_EQ(ContainerCfgBuilder::appMountPoint("org.deepin.demo"),
+              std::filesystem::path("/opt/apps/org.deepin.demo/files"));
+    EXPECT_EQ(ContainerCfgBuilder::extensionMountPoint("org.deepin.ext"),
+              std::filesystem::path("/opt/extensions/org.deepin.ext"));
+    EXPECT_NE(ContainerCfgBuilder::runtimeMountPoint, std::filesystem::path{});
+    EXPECT_NE(ContainerCfgBuilder::zoneinfoMountPoint, std::filesystem::path{});
+}
+
+TEST_F(ContainerCfgBuilderTest, ExtensionsAndExtraMountsHooks)
+{
+    Mount extra;
+    extra.destination = "/opt/test";
+    extra.source = "/host/test";
+    extra.type = "bind";
+
+    auto hook = ocppi::runtime::config::types::Hook{};
+    hook.path = "/bin/true";
+
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .addExtraMount(extra)
+      .addExtraMounts({ extra })
+      .setExtensionMounts({ extra })
+      .setStartContainerHooks({ hook })
+      .addExtraHook("prestart", hook);
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+    bool hasExtra = false;
+    for (const auto &m : *builder.getConfig().mounts) {
+        if (m.destination == "/opt/test") {
+            hasExtra = true;
+        }
+    }
+    EXPECT_TRUE(hasExtra);
+
+    ASSERT_TRUE(builder.getConfig().hooks.has_value());
+    if (builder.getConfig().hooks->startContainer.has_value()) {
+        EXPECT_EQ(builder.getConfig().hooks->startContainer->at(0).path, "/bin/true");
+    }
+}
+
+TEST_F(ContainerCfgBuilderTest, ForwardAndAppendEnv)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .appendEnv("FOO", "bar")
+      .appendEnv("QUOTED", "a'b")
+      .forwardEnv({ "PATH" });
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    ASSERT_TRUE(builder.getConfig().process.has_value());
+    ASSERT_TRUE(builder.getConfig().process->env.has_value());
+    const auto &env = *builder.getConfig().process->env;
+    EXPECT_THAT(env, ::testing::Contains("FOO=bar"));
+    EXPECT_THAT(env, ::testing::Contains("QUOTED=a'b"));
+
+    // The env script must be generated inside the bundle, with single quotes
+    // escaped as '\'' for the shell.
+    EXPECT_TRUE(std::filesystem::exists(bundleDir.path() / "00env.sh"));
+    std::ifstream envFile{ bundleDir.path() / "00env.sh" };
+    ASSERT_TRUE(envFile.is_open());
+    std::string content((std::istreambuf_iterator<char>(envFile)),
+                        std::istreambuf_iterator<char>());
+    EXPECT_THAT(content, ::testing::HasSubstr("export FOO='bar'"));
+    EXPECT_THAT(content, ::testing::HasSubstr(R"(QUOTED='a'\''b')"));
+}
+
+TEST_F(ContainerCfgBuilderTest, EnableXDPWritesContainerInfo)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .setContainerId("ll-instance-1")
+      .enableXDP(XdpOption{ .docMountPoint = "/usr/share/doc" });
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    ASSERT_TRUE(builder.getConfig().process.has_value());
+    ASSERT_TRUE(builder.getConfig().process->env.has_value());
+    EXPECT_THAT(*builder.getConfig().process->env, ::testing::Contains("GTK_USE_PORTAL=1"));
+    EXPECT_TRUE(std::filesystem::exists(bundleDir.path() / ".linyaps"));
+
+    std::ifstream in{ bundleDir.path() / ".linyaps" };
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_THAT(content, ::testing::HasSubstr("org.deepin.demo"));
+    EXPECT_THAT(content, ::testing::HasSubstr("ll-instance-1"));
+}
+
+TEST_F(ContainerCfgBuilderTest, BindHomeProducesHomeMounts)
+{
+    auto home = baseDir.path() / "home";
+    ASSERT_TRUE(std::filesystem::create_directories(home));
+
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindHome(home);
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    ASSERT_TRUE(builder.getConfig().process.has_value());
+    ASSERT_TRUE(builder.getConfig().process->env.has_value());
+
+    std::vector<std::string> envHome;
+    for (const auto &e : *builder.getConfig().process->env) {
+        if (e.rfind("HOME=", 0) == 0) {
+            envHome.push_back(e);
+        }
+    }
+    EXPECT_FALSE(envHome.empty());
+}
+
+TEST_F(ContainerCfgBuilderTest, BindHomeWritesToEmptyHomePathFails)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .setAppPath(appDir.path())
+      .bindHome("");
+
+    // homePath empty -> error
+    auto result = builder.build();
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST_F(ContainerCfgBuilderTest, EnablePrivateDirAndMapPrivate)
+{
+    auto home = baseDir.path() / "home";
+    ASSERT_TRUE(std::filesystem::create_directories(home));
+
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindHome(home)
+      .enablePrivateDir()
+      .mapPrivate("/var/lib/demo", true);
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    // The private directory must be created inside the home and masked.
+    auto privateAppDir = home / ".linglong" / "org.deepin.demo";
+    EXPECT_TRUE(std::filesystem::exists(privateAppDir));
+
+    ASSERT_TRUE(builder.getConfig().linux_.has_value());
+    ASSERT_TRUE(builder.getConfig().linux_->maskedPaths.has_value());
+    EXPECT_THAT(*builder.getConfig().linux_->maskedPaths, ::testing::Contains(home / ".linglong"));
+}
+
+TEST_F(ContainerCfgBuilderTest, MapPrivateRequiresPrivateDir)
+{
+    auto home = baseDir.path() / "home";
+    ASSERT_TRUE(std::filesystem::create_directories(home));
+
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindHome(home)
+      .mapPrivate("/var/lib/demo", true);
+
+    // privateMount not set -> "must enable private dir first"
+    auto result = builder.build();
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST_F(ContainerCfgBuilderTest, BindUserGroupMountsPasswd)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindUserGroup();
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+    bool hasPasswd = false;
+    for (const auto &m : *builder.getConfig().mounts) {
+        if (m.destination == "/etc/passwd") {
+            hasPasswd = true;
+        }
+    }
+    EXPECT_TRUE(hasPasswd);
+}
+
+TEST_F(ContainerCfgBuilderTest, BindDefaultMountsSysProcDevTmpRun)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindDefault();
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+    const auto &mounts = *builder.getConfig().mounts;
+    auto findDest = [&mounts](const std::string &dest) {
+        for (const auto &m : mounts) {
+            if (m.destination == dest) {
+                return true;
+            }
+        }
+        return false;
+    };
+    EXPECT_TRUE(findDest("/sys"));
+    EXPECT_TRUE(findDest("/proc"));
+    EXPECT_TRUE(findDest("/dev"));
+    EXPECT_TRUE(findDest("/tmp"));
+    EXPECT_TRUE(findDest("/run"));
+}
+
+TEST_F(ContainerCfgBuilderTest, BindDevPassthru)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindDev(true);
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+
+    bool hasDevBind = false;
+    for (const auto &m : *builder.getConfig().mounts) {
+        if (m.destination == "/dev" && m.source.value_or("") == "/dev") {
+            hasDevBind = true;
+        }
+    }
+    EXPECT_TRUE(hasDevBind);
+}
+
+TEST_F(ContainerCfgBuilderTest, AppCacheAndLDCache)
+{
+    auto cache = baseDir.path() / "cache";
+    ASSERT_TRUE(std::filesystem::create_directories(cache));
+
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .setAppCache(cache)
+      .enableLDConf()
+      .enableLDCache();
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+    bool hasCache = false;
+    for (const auto &m : *builder.getConfig().mounts) {
+        if (m.destination == "/run/linglong/cache") {
+            hasCache = true;
+            EXPECT_EQ(m.source.value_or(""), cache);
+        }
+    }
+    EXPECT_TRUE(hasCache);
+}
+
+TEST_F(ContainerCfgBuilderTest, LDCacheRequiresAppCache)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .enableLDCache();
+
+    auto result = builder.build();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error().message(), ::testing::HasSubstr("app cache is not set"));
+}
+
+TEST_F(ContainerCfgBuilderTest, XAuthAndWaylandSockets)
+{
+    auto authFile = baseDir.path() / "Xauthority";
+    std::ofstream{ authFile } << "data";
+
+    auto socket = baseDir.path() / "wayland-0";
+    std::ofstream{ socket } << "data";
+
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindRun()
+      .bindXAuthFile(authFile)
+      .bindWaylandSocket(socket);
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    ASSERT_TRUE(builder.getConfig().process.has_value());
+    ASSERT_TRUE(builder.getConfig().process->env.has_value());
+    EXPECT_THAT(*builder.getConfig().process->env,
+                ::testing::Contains("XAUTHORITY=/run/linglong/Xauthority"));
+    EXPECT_THAT(*builder.getConfig().process->env,
+                ::testing::Contains("WAYLAND_DISPLAY=/run/linglong/wayland-0"));
+}
+
+TEST_F(ContainerCfgBuilderTest, PipewireAndAtSpiSocketMounts)
+{
+    auto socket = baseDir.path() / "socket";
+    std::ofstream{ socket } << "data";
+
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindRun()
+      .bindXDGRuntime()
+      .enablePipewireSocketMount(PipewireMountOption{ .hostSocketPath = socket })
+      .enableAtSpiSocketMount(AtSpiMountOption{ .hostSocketPath = socket });
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+    const auto runtimeDir = std::filesystem::path{ "/run/user" } / std::to_string(::geteuid());
+    bool hasPipewireMount = false;
+    bool hasAtSpiMount = false;
+    for (const auto &m : *builder.getConfig().mounts) {
+        if (m.destination == runtimeDir / "pipewire-0") {
+            hasPipewireMount = true;
+            EXPECT_EQ(m.source.value_or(""), socket);
+        }
+        if (m.destination == runtimeDir / "at-spi" / "bus_0") {
+            hasAtSpiMount = true;
+        }
+    }
+    EXPECT_TRUE(hasPipewireMount);
+    EXPECT_TRUE(hasAtSpiMount);
+}
+
+TEST_F(ContainerCfgBuilderTest, LdConfContainsAppAndRuntimePaths)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo").setRuntimePath(runtimeDir.path()).setAppPath(appDir.path());
+
+    auto conf = builder.ldConf("x86_64-linux-gnu");
+    EXPECT_THAT(conf, ::testing::HasSubstr("/opt/apps/org.deepin.demo/files/lib"));
+    EXPECT_THAT(conf, ::testing::HasSubstr("/runtime/lib"));
+    EXPECT_THAT(conf, ::testing::HasSubstr("x86_64-linux-gnu"));
+}
+
+TEST_F(ContainerCfgBuilderTest, TimezoneSetsBindArea)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .setTimezone("Asia/Shanghai");
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+    EXPECT_TRUE(builder.getConfig().mounts->size() > 0);
+}
+
+TEST_F(ContainerCfgBuilderTest, ResolvConfWithoutHostRoot)
+{
+    auto resolv = baseDir.path() / "resolv.conf";
+    std::ofstream{ resolv } << "nameserver 8.8.8.8\n";
+
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .setResolvConf(resolv);
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+
+    bool hasResolv = false;
+    for (const auto &m : *builder.getConfig().mounts) {
+        if (m.destination == "/etc/resolv.conf") {
+            hasResolv = true;
+            EXPECT_EQ(m.source.value_or(""), resolv);
+        }
+    }
+    EXPECT_TRUE(hasResolv);
+}
+
+} // namespace

--- a/libs/linglong/tests/ll-tests/src/linglong/oci-cfg-generators/container_cfg_builder_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/oci-cfg-generators/container_cfg_builder_test.cpp
@@ -686,4 +686,512 @@ TEST_F(ContainerCfgBuilderTest, ResolvConfWithoutHostRoot)
     EXPECT_TRUE(hasResolv);
 }
 
+TEST_F(ContainerCfgBuilderTest, BindHostRootAndStatics)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindHostRoot()
+      .bindHostStatics();
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+    const auto &mounts = *builder.getConfig().mounts;
+    auto findDest = [&mounts](const std::string &dest) {
+        for (const auto &m : mounts) {
+            if (m.destination == dest) {
+                return true;
+            }
+        }
+        return false;
+    };
+    // bindHostRoot
+    EXPECT_TRUE(findDest("/run/host"));
+    EXPECT_TRUE(findDest("/run/host/rootfs"));
+    // bindHostStatics (only for paths that exist in the environment; the
+    // settings/tools path set varies between distro rootfs images)
+    EXPECT_TRUE(findDest("/etc/machine-id"));
+    EXPECT_TRUE(findDest("/usr/lib/locale"));
+}
+
+TEST_F(ContainerCfgBuilderTest, BindCgroupAddsMount)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindCgroup();
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+
+    bool hasCgroup = false;
+    for (const auto &m : *builder.getConfig().mounts) {
+        if (m.destination == "/sys/fs/cgroup" && m.type == "cgroup") {
+            hasCgroup = true;
+            EXPECT_EQ(m.source.value_or(""), "cgroup");
+        }
+    }
+    EXPECT_TRUE(hasCgroup);
+}
+
+TEST_F(ContainerCfgBuilderTest, BindRunAddsRunMount)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindRun()
+      .bindTmp();
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+
+    bool hasRunTmpfs = false;
+    bool hasTmpBind = false;
+    for (const auto &m : *builder.getConfig().mounts) {
+        if (m.destination == "/run" && m.type == "tmpfs") {
+            hasRunTmpfs = true;
+        }
+        if (m.destination == "/tmp" && m.source.value_or("") == "/tmp") {
+            hasTmpBind = true;
+        }
+    }
+    EXPECT_TRUE(hasRunTmpfs);
+    EXPECT_TRUE(hasTmpBind);
+}
+
+TEST_F(ContainerCfgBuilderTest, BindDevNodeWithDefaultAndCustomFilter)
+{
+    // Default filter binds snd/dri/video*/nvidia* nodes from /dev when present.
+    {
+        ContainerCfgBuilder builder;
+        builder.setAppId("org.deepin.demo")
+          .setBasePath(baseDir.path())
+          .setBundlePath(bundleDir.path())
+          .bindDevNode();
+
+        auto result = builder.build();
+        ASSERT_TRUE(result.has_value()) << result.error().message();
+        ASSERT_TRUE(builder.getConfig().mounts.has_value());
+        // The test environment may or may not have dev nodes; just make sure
+        // the build succeeds and mount generation doesn't crash.
+        EXPECT_TRUE(builder.getConfig().mounts->size() > 0);
+    }
+
+    // A custom filter that rejects everything must produce no dev bind mounts
+    // (the builder still succeeds because /dev is bound by bindDefault).
+    {
+        ContainerCfgBuilder builder;
+        builder.setAppId("org.deepin.demo")
+          .setBasePath(baseDir.path())
+          .setBundlePath(bundleDir.path())
+          .bindDevNode([](const std::string &) {
+              return false;
+          })
+          .bindDefault();
+
+        auto result = builder.build();
+        ASSERT_TRUE(result.has_value()) << result.error().message();
+    }
+
+    // A custom filter that accepts "loop0" should bind /dev/loop0 if present.
+    {
+        ContainerCfgBuilder builder;
+        builder.setAppId("org.deepin.demo")
+          .setBasePath(baseDir.path())
+          .setBundlePath(bundleDir.path())
+          .bindDevNode([](const std::string &name) {
+              return name == "loop0";
+          });
+
+        auto result = builder.build();
+        ASSERT_TRUE(result.has_value()) << result.error().message();
+        ASSERT_TRUE(builder.getConfig().mounts.has_value());
+
+        bool hasLoop0 = false;
+        for (const auto &m : *builder.getConfig().mounts) {
+            if (m.destination == "/dev/loop0") {
+                hasLoop0 = true;
+            }
+        }
+        // /dev/loop0 may be absent in a minimal container; assert consistency only
+        // when the host actually provides it.
+        EXPECT_EQ(hasLoop0, std::filesystem::exists("/dev/loop0"));
+    }
+}
+
+TEST_F(ContainerCfgBuilderTest, BindRemovableStorageMounts)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindRemovableStorageMounts();
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+
+    std::vector<std::string> expectedDestFromSource{ "/media", "/run/media", "/mnt" };
+    for (const auto &m : *builder.getConfig().mounts) {
+        if (m.destination == "/media" || m.destination == "/run/media" || m.destination == "/mnt") {
+            EXPECT_EQ(m.type, "bind");
+            EXPECT_EQ(m.source.value_or(""), m.destination);
+        }
+    }
+}
+
+TEST_F(ContainerCfgBuilderTest, ForwardEnvFromEnvironWhenListEmpty)
+{
+    // Forward all environment variables visible in the test process.
+    setenv("LL_CUSTOM_TEST_VAR", "hello", 1);
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .forwardEnv({});
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    ASSERT_TRUE(builder.getConfig().process.has_value());
+    ASSERT_TRUE(builder.getConfig().process->env.has_value());
+    EXPECT_THAT(*builder.getConfig().process->env, ::testing::Contains("LL_CUSTOM_TEST_VAR=hello"));
+    unsetenv("LL_CUSTOM_TEST_VAR");
+}
+
+TEST_F(ContainerCfgBuilderTest, AppendEnvOverwriteAndDuplicate)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .appendEnv("DUPE", "first")
+      .appendEnv("DUPE", "second") // not overwritten: logs and keeps first
+      .appendEnv("OVERRIDE", "old", false)
+      .appendEnv("OVERRIDE", "new", true);
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.getConfig().process.has_value());
+    ASSERT_TRUE(builder.getConfig().process->env.has_value());
+
+    const auto &env = *builder.getConfig().process->env;
+    EXPECT_THAT(env, ::testing::Contains("DUPE=first"));
+    EXPECT_THAT(env, ::testing::Contains("OVERRIDE=new"));
+    // DUPE must appear exactly once
+    int dupeCount = 0;
+    for (const auto &e : env) {
+        if (e.rfind("DUPE=", 0) == 0) {
+            ++dupeCount;
+        }
+    }
+    EXPECT_EQ(dupeCount, 1);
+}
+
+TEST_F(ContainerCfgBuilderTest, EnableQuirkVolatileDoesNotBreakBuild)
+{
+    // enableQuirkVolatile only initializes the (currently reserved) volatile
+    // mount slot; a normal build must still succeed with it enabled.
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .enableQuirkVolatile();
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+}
+
+TEST_F(ContainerCfgBuilderTest, BuildHooksAllTypes)
+{
+    auto makeHook = [](const std::string &path) {
+        ocppi::runtime::config::types::Hook hook;
+        hook.path = path;
+        return hook;
+    };
+
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .addExtraHook("createContainer", makeHook("/hooks/createContainer"))
+      .addExtraHook("createRuntime", makeHook("/hooks/createRuntime"))
+      .addExtraHook("poststart", makeHook("/hooks/poststart"))
+      .addExtraHook("poststop", makeHook("/hooks/poststop"))
+      .addExtraHook("prestart", makeHook("/hooks/prestart"))
+      .addExtraHook("startContainer", makeHook("/hooks/startContainer"))
+      .addExtraHook("unknown-type", makeHook("/hooks/bogus"))
+      .setStartContainerHooks({ makeHook("/hooks/my-start") });
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.getConfig().hooks.has_value());
+
+    ASSERT_TRUE(builder.getConfig().hooks->createContainer.has_value());
+    EXPECT_EQ(builder.getConfig().hooks->createContainer->at(0).path, "/hooks/createContainer");
+    ASSERT_TRUE(builder.getConfig().hooks->createRuntime.has_value());
+    EXPECT_EQ(builder.getConfig().hooks->createRuntime->at(0).path, "/hooks/createRuntime");
+    ASSERT_TRUE(builder.getConfig().hooks->poststart.has_value());
+    EXPECT_EQ(builder.getConfig().hooks->poststart->at(0).path, "/hooks/poststart");
+    ASSERT_TRUE(builder.getConfig().hooks->poststop.has_value());
+    EXPECT_EQ(builder.getConfig().hooks->poststop->at(0).path, "/hooks/poststop");
+    ASSERT_TRUE(builder.getConfig().hooks->prestart.has_value());
+    EXPECT_EQ(builder.getConfig().hooks->prestart->at(0).path, "/hooks/prestart");
+    ASSERT_TRUE(builder.getConfig().hooks->startContainer.has_value());
+    EXPECT_EQ(builder.getConfig().hooks->startContainer->size(), 2);
+    for (const auto &h : *builder.getConfig().hooks->startContainer) {
+        EXPECT_NE(h.path, "/hooks/bogus"); // unknown type must be dropped
+    }
+}
+
+TEST_F(ContainerCfgBuilderTest, AddExtraMountAndExtraMounts)
+{
+    Mount extra;
+    extra.destination = "/opt/extra";
+    extra.source = "/host/extra";
+    extra.type = "bind";
+
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .addExtraMount(extra)
+      .addExtraMounts({ extra, extra });
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+
+    int count = 0;
+    for (const auto &m : *builder.getConfig().mounts) {
+        if (m.destination == "/opt/extra") {
+            ++count;
+        }
+    }
+    EXPECT_EQ(count, 3);
+}
+
+TEST_F(ContainerCfgBuilderTest, BuildMountWithMissingPathsFails)
+{
+    // runtime path that does not exist
+    {
+        ContainerCfgBuilder builder;
+        builder.setAppId("org.deepin.demo")
+          .setBasePath(baseDir.path())
+          .setBundlePath(bundleDir.path())
+          .setRuntimePath(baseDir.path() / "no-such-runtime", false);
+        auto result = builder.build();
+        ASSERT_FALSE(result.has_value());
+        EXPECT_THAT(result.error().message(), ::testing::HasSubstr("runtime files is not exist"));
+    }
+
+    // app path that does not exist
+    {
+        ContainerCfgBuilder builder;
+        builder.setAppId("org.deepin.demo")
+          .setBasePath(baseDir.path())
+          .setBundlePath(bundleDir.path())
+          .setAppPath(baseDir.path() / "no-such-app", false);
+        auto result = builder.build();
+        ASSERT_FALSE(result.has_value());
+        EXPECT_THAT(result.error().message(), ::testing::HasSubstr("app files is not exist"));
+    }
+
+    // home path that does not exist
+    {
+        ContainerCfgBuilder builder;
+        builder.setAppId("org.deepin.demo")
+          .setBasePath(baseDir.path())
+          .setBundlePath(bundleDir.path())
+          .bindHome(baseDir.path() / "no-such-home");
+        auto result = builder.build();
+        ASSERT_FALSE(result.has_value());
+        EXPECT_THAT(result.error().message(), ::testing::HasSubstr("is not exist"));
+    }
+}
+
+TEST_F(ContainerCfgBuilderTest, BindXDGRuntimeWithoutRunMountFails)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindXDGRuntime()
+      .enablePipewireSocketMount(
+        PipewireMountOption{ .hostSocketPath = baseDir.path() / "pipewire-0" });
+
+    auto result = builder.build();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error().message(), ::testing::HasSubstr("/run is not bind"));
+}
+
+TEST_F(ContainerCfgBuilderTest, BindUserGroupMinimal)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindUserGroup(true);
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    // minimal mode writes a dedicated passwd/group into the bundle and binds it
+    ASSERT_TRUE(std::filesystem::exists(bundleDir.path() / "passwd"));
+    ASSERT_TRUE(std::filesystem::exists(bundleDir.path() / "group"));
+
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+    bool hasPasswd = false;
+    bool hasGroup = false;
+    for (const auto &m : *builder.getConfig().mounts) {
+        if (m.destination == "/etc/passwd") {
+            hasPasswd = true;
+            EXPECT_EQ(m.source.value_or(""), bundleDir.path() / "passwd");
+        }
+        if (m.destination == "/etc/group") {
+            hasGroup = true;
+            EXPECT_EQ(m.source.value_or(""), bundleDir.path() / "group");
+        }
+    }
+    EXPECT_TRUE(hasPasswd);
+    EXPECT_TRUE(hasGroup);
+}
+
+TEST_F(ContainerCfgBuilderTest, SelfAdjustingMountFixesMissingChild)
+{
+    // Build an app layout under appDir and simulate a layer whose child path
+    // is missing on the host, which forces the self-adjusting mount to remount
+    // an ancestor as tmpfs and bind the existing children underneath.
+    std::filesystem::create_directories(appDir.path());
+    {
+        std::ofstream{ appDir.path() / "binary" } << "bin";
+    }
+
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .setAppPath(appDir.path())
+      .enableSelfAdjustingMount()
+      .disablePatch();
+
+    // /opt/apps/org.deepin.demo/files/etc exists on host;
+    // /opt/apps/org.deepin.demo/files/etc/localtime does not.
+    std::filesystem::create_directories(appDir.path() / "etc");
+
+    Mount etcMount;
+    etcMount.destination = "/opt/apps/org.deepin.demo/files/etc";
+    etcMount.source = appDir.path() / "etc";
+    etcMount.type = "bind";
+    etcMount.options = std::vector<std::string>{ "rbind", "ro", "rslave" };
+
+    Mount localtimeMount;
+    localtimeMount.destination = "/opt/apps/org.deepin.demo/files/etc/localtime";
+    localtimeMount.source = appDir.path() / "etc" / "localtime"; // intentionally missing
+    localtimeMount.type = "bind";
+    localtimeMount.options = std::vector<std::string>{ "rbind", "ro", "rslave" };
+
+    builder.addExtraMount(etcMount).addExtraMount(localtimeMount);
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    // The root is switched to an alternate rootfs context by the fixing logic.
+    ASSERT_TRUE(builder.getConfig().root.has_value());
+    EXPECT_EQ(builder.getConfig().root->path, std::filesystem::path("rootfs"));
+
+    // There must be a tmpfs mount used to expose the missing /etc/localtime.
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+    bool hasTmpfs = false;
+    for (const auto &m : *builder.getConfig().mounts) {
+        if (m.type == "tmpfs" && m.destination != "/") {
+            hasTmpfs = true;
+        }
+    }
+    EXPECT_TRUE(hasTmpfs);
+}
+
+TEST_F(ContainerCfgBuilderTest, EnableIPCMountFailsWithoutXDGRuntime)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindIPC();
+
+    auto result = builder.build();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error().message(),
+                ::testing::HasSubstr("must enable xdg runtime mount first"));
+}
+
+TEST_F(ContainerCfgBuilderTest, EnableIPCMountBindsUnixSocket)
+{
+    auto busSocket = baseDir.path() / "bus.sock";
+    std::ofstream{ busSocket } << "";
+
+    // Point the session bus at the socket we just created and the system bus at
+    // a non-existent path (skipped gracefully).
+    setenv("DBUS_SESSION_BUS_ADDRESS",
+           ("unix:path=" + busSocket.string() + ",guid=deadbeef").c_str(),
+           1);
+    setenv("DBUS_SYSTEM_BUS_ADDRESS", "unix:path=/no/such/system/bus", 1);
+
+    auto runtime = std::filesystem::path{ "/run/user" } / std::to_string(::geteuid());
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindRun()
+      .bindXDGRuntime()
+      .bindIPC();
+
+    auto result = builder.build();
+    unsetenv("DBUS_SESSION_BUS_ADDRESS");
+    unsetenv("DBUS_SYSTEM_BUS_ADDRESS");
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+    bool hasSessionBus = false;
+    for (const auto &m : *builder.getConfig().mounts) {
+        if (m.destination == (runtime / "bus").string()) {
+            hasSessionBus = true;
+            EXPECT_EQ(m.source.value_or(""), busSocket.string());
+        }
+    }
+    EXPECT_TRUE(hasSessionBus);
+}
+
+TEST_F(ContainerCfgBuilderTest, EnableIPCMountNoValidSocket)
+{
+    // A TCP transport is not a unix socket and must be ignored.
+    setenv("DBUS_SESSION_BUS_ADDRESS", "tcp:host=127.0.0.1,port=9999", 1);
+
+    auto runtime = std::filesystem::path{ "/run/user" } / std::to_string(::geteuid());
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindRun()
+      .bindXDGRuntime()
+      .bindIPC();
+
+    auto result = builder.build();
+    unsetenv("DBUS_SESSION_BUS_ADDRESS");
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    // No session bus mount may be added for a tcp address.
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+    for (const auto &m : *builder.getConfig().mounts) {
+        EXPECT_NE(m.destination, (runtime / "bus").string());
+    }
+}
+
 } // namespace

--- a/libs/linglong/tests/ll-tests/src/linglong/package/elf_handler_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/elf_handler_test.cpp
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/package/elf_handler.h"
+
+#include <common/tempdir.h>
+
+#include <fstream>
+#include <string>
+
+using namespace linglong::package;
+
+namespace {
+
+TEST(ElfHandlerTest, CreateSucceedsOnAnyFile)
+{
+    TempDir dir;
+    auto file = dir.path() / "any";
+    std::ofstream(file) << "hello";
+    EXPECT_TRUE(ElfHandler::create(file).has_value());
+}
+
+TEST(ElfHandlerTest, AddSectionNameTooLongFails)
+{
+    TempDir dir;
+    auto elf = dir.path() / "copy";
+    // copy the current executable as a valid ELF
+    std::error_code ec;
+    std::filesystem::copy_file("/proc/self/exe", elf, ec);
+    ASSERT_FALSE(ec);
+
+    auto handler = ElfHandler::create(elf);
+    ASSERT_TRUE(handler.has_value());
+    const std::string longName(33, 'a');
+    auto result = (*handler)->addSection(longName, "data", 4);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_THAT(result.error().message(), ::testing::HasSubstr("section name too long"));
+}
+
+TEST(ElfHandlerTest, AddSectionNonElfFileFails)
+{
+    TempDir dir;
+    auto elf = dir.path() / "not-elf";
+    std::ofstream(elf) << "this is definitely not an elf file";
+
+    auto handler = ElfHandler::create(elf);
+    ASSERT_TRUE(handler.has_value());
+    auto result = (*handler)->addSection(".ll-test", "data", 4);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(ElfHandlerTest, AddSectionFromMissingFileFails)
+{
+    TempDir dir;
+    auto elf = dir.path() / "copy";
+    std::error_code ec;
+    std::filesystem::copy_file("/proc/self/exe", elf, ec);
+    ASSERT_FALSE(ec);
+
+    auto handler = ElfHandler::create(elf);
+    ASSERT_TRUE(handler.has_value());
+    auto result = (*handler)->addSection(".ll-test", dir.path() / "missing");
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(ElfHandlerTest, AddSectionFromEmptyFileFails)
+{
+    TempDir dir;
+    auto elf = dir.path() / "copy";
+    std::error_code ec;
+    std::filesystem::copy_file("/proc/self/exe", elf, ec);
+    ASSERT_FALSE(ec);
+
+    auto empty = dir.path() / "empty";
+    std::ofstream emptyFile(empty);
+
+    auto handler = ElfHandler::create(elf);
+    ASSERT_TRUE(handler.has_value());
+    auto result = (*handler)->addSection(".ll-test", empty);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(ElfHandlerTest, AddSectionSucceedsOnRealElf)
+{
+    TempDir dir;
+    auto elf = dir.path() / "copy";
+    std::error_code ec;
+    std::filesystem::copy_file("/proc/self/exe", elf, ec);
+    ASSERT_FALSE(ec);
+
+    auto handler = ElfHandler::create(elf);
+    ASSERT_TRUE(handler.has_value());
+
+    const std::string payload = "ll-extra-data";
+    auto result = (*handler)->addSection(".ll-test", payload.data(), payload.size());
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+}
+
+} // namespace

--- a/libs/linglong/tests/ll-tests/src/linglong/package/layer_packager_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/layer_packager_test.cpp
@@ -87,6 +87,9 @@ std::filesystem::path LayerPackagerTest::layerFilePath;
 
 TEST_F(LayerPackagerTest, LayerPackagerUnpackFuseOffset)
 {
+    if (!std::filesystem::exists("/dev/fuse")) {
+        GTEST_SKIP() << "fuse device is not available";
+    }
     auto layerFileRet = package::LayerFile::New((layerFilePath).string().c_str());
     ASSERT_TRUE(layerFileRet.has_value())
       << "Failed to create layer file" << layerFileRet.error().message();
@@ -108,6 +111,9 @@ TEST_F(LayerPackagerTest, LayerPackagerUnpackFuseOffset)
 
 TEST_F(LayerPackagerTest, LayerPackagerUnpackFuse)
 {
+    if (!std::filesystem::exists("/dev/fuse")) {
+        GTEST_SKIP() << "fuse device is not available";
+    }
     {
         auto ret = utils::Cmd("erofsfuse").exists();
         if (!ret) {

--- a/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
@@ -150,6 +150,10 @@ std::string readFile(const std::filesystem::path &path)
 
 TEST_F(UabFileTest, UnpackFuseOffset)
 {
+    if (!std::filesystem::exists("/dev/fuse")) {
+        GTEST_SKIP() << "fuse device is not available";
+    }
+
     // 初始化UABFile对象
     auto uab = linglong::package::UABFile::loadFromFile(uabFile);
     ASSERT_TRUE(uab.has_value()) << "Failed to load uab file";
@@ -164,6 +168,9 @@ TEST_F(UabFileTest, UnpackFuseOffset)
 
 TEST_F(UabFileTest, UnpackFuse)
 {
+    if (!std::filesystem::exists("/dev/fuse")) {
+        GTEST_SKIP() << "fuse device is not available";
+    }
     {
         auto ret = utils::Cmd("erofsfuse").exists();
         if (!ret) {

--- a/libs/linglong/tests/ll-tests/src/linglong/package/uab_packager_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/uab_packager_test.cpp
@@ -2,9 +2,11 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "common/tempdir.h"
+#include "linglong/api/types/v1/Generators.hpp"
 #include "linglong/package/uab_packager.h"
 
 #include <filesystem>
@@ -187,5 +189,104 @@ TEST(UABPackagerTest, EnsureExecEntryGeneratesMissingEntry)
     EXPECT_NE(permissions & std::filesystem::perms::owner_exec, std::filesystem::perms::none);
 }
 
+TEST(UABPackagerTest, SetIconRejectsNonExistent)
+{
+    UABPackager packager("/tmp/build");
+    auto result = packager.setIcon("/no/such/icon.png");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error().message(), ::testing::HasSubstr("failed to check icon file status"));
+}
+
+TEST(UABPackagerTest, SetIconRejectsDirectory)
+{
+    TempDir td("uab-icon-test-");
+    ASSERT_TRUE(td.isValid());
+    UABPackager packager("/tmp/build");
+    auto result = packager.setIcon(td.path());
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error().message(), ::testing::HasSubstr("icon isn\'t a file"));
+}
+
+TEST(UABPackagerTest, AppendLayerRejectsInvalid)
+{
+    TempDir td("uab-layer-test-");
+    ASSERT_TRUE(td.isValid());
+    LayerDir invalid(td.path() / "no-layer");
+    UABPackager packager("/tmp/build");
+    auto result = packager.appendLayer(invalid);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error().message(), ::testing::HasSubstr("invalid layer directory"));
+}
+
+TEST(UABPackagerTest, PackEndToEndWithValidLayers)
+{
+    // /proc/self/exe serves as a valid ELF header.
+    TempDir headerDir("uab-header-");
+    ASSERT_TRUE(headerDir.isValid());
+    auto header = headerDir.path() / "header.elf";
+    std::filesystem::copy_file("/proc/self/exe", header);
+
+    // Build a base layer (kind=base).
+    TempDir baseDir("uab-base-");
+    ASSERT_TRUE(baseDir.isValid());
+    std::filesystem::create_directories(baseDir.path() / "files" / "usr" / "lib");
+    std::ofstream{ baseDir.path() / "files" / "usr" / "lib" / "libbase.so" } << "base";
+    {
+        api::types::v1::PackageInfoV2 baseInfo;
+        baseInfo.id = "org.deepin.base";
+        baseInfo.version = "1";
+        baseInfo.arch = { "x86_64" };
+        baseInfo.kind = "base";
+        baseInfo.packageInfoV2Module = "binary";
+        baseInfo.channel = "main";
+        nlohmann::json j = baseInfo;
+        std::ofstream{ baseDir.path() / "info.json" } << j.dump();
+    }
+
+    // Build an app layer (kind=app).
+    TempDir appDir("uab-app-");
+    ASSERT_TRUE(appDir.isValid());
+    std::filesystem::create_directories(appDir.path() / "files" / "usr" / "bin");
+    std::ofstream{ appDir.path() / "files" / "usr" / "bin" / "hello" } << "hello world";
+    {
+        api::types::v1::PackageInfoV2 appInfo;
+        appInfo.id = "com.example.app";
+        appInfo.version = "1.0.0";
+        appInfo.arch = { "x86_64" };
+        appInfo.kind = "app";
+        appInfo.packageInfoV2Module = "binary";
+        appInfo.channel = "main";
+        nlohmann::json j = appInfo;
+        std::ofstream{ appDir.path() / "info.json" } << j.dump();
+    }
+
+    LayerDir baseLayer(baseDir.path());
+    ASSERT_TRUE(baseLayer.valid());
+
+    LayerDir appLayer(appDir.path());
+    ASSERT_TRUE(appLayer.valid());
+
+    // Pack.
+    TempDir buildDir("uab-build-");
+    ASSERT_TRUE(buildDir.isValid());
+    UABPackager packager(buildDir.path());
+    packager.setDefaultHeader(header);
+    packager.setCompressor("lz4");
+    // A custom loader avoids the compile-time default path lookup.
+    auto loaderFile = buildDir.path() / "uab-loader-dummy";
+    std::ofstream{ loaderFile } << "dummy loader";
+    packager.setLoader(loaderFile);
+    ASSERT_TRUE(packager.appendLayer(baseLayer).has_value());
+    ASSERT_TRUE(packager.appendLayer(appLayer).has_value());
+
+    auto outPath = buildDir.path() / "output.uab";
+    auto result = packager.pack(outPath, UABPackagerMode::Distribution);
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    EXPECT_TRUE(std::filesystem::exists(outPath));
+    EXPECT_GT(std::filesystem::file_size(outPath), 0);
+}
+
 } // namespace
+
 } // namespace linglong::package

--- a/libs/linglong/tests/ll-tests/src/linglong/package/version_extra_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/version_extra_test.cpp
@@ -1,0 +1,159 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/package/fallback_version.h"
+#include "linglong/package/version.h"
+#include "linglong/package/versionv1.h"
+#include "linglong/package/versionv2.h"
+
+#include <string>
+
+using namespace linglong::package;
+
+TEST(FallbackVersionCrossType, CompareWithVersionV1)
+{
+    auto fv = FallbackVersion::parse("1.2.3");
+    ASSERT_TRUE(fv.has_value());
+    auto v1 = VersionV1::parse("1.2.3");
+    ASSERT_TRUE(v1.has_value());
+    auto v1Higher = VersionV1::parse("1.2.4");
+    ASSERT_TRUE(v1Higher.has_value());
+
+    EXPECT_TRUE(*fv == *v1);
+    EXPECT_FALSE(*fv != *v1);
+    EXPECT_TRUE(*fv <= *v1);
+    EXPECT_TRUE(*fv >= *v1);
+
+    EXPECT_TRUE(*fv < *v1Higher);
+    EXPECT_TRUE(*fv <= *v1Higher);
+    EXPECT_TRUE(*v1Higher > *fv);
+    EXPECT_TRUE(*v1Higher >= *fv);
+    EXPECT_TRUE(*fv != *v1Higher);
+}
+
+TEST(FallbackVersionCrossType, CompareWithVersionV2)
+{
+    auto fv = FallbackVersion::parse("1.2.3");
+    ASSERT_TRUE(fv.has_value());
+    auto v2 = VersionV2::parse("1.2.3");
+    ASSERT_TRUE(v2.has_value());
+    auto v2Lower = VersionV2::parse("1.2.2");
+    ASSERT_TRUE(v2Lower.has_value());
+
+    EXPECT_TRUE(*fv == *v2);
+    EXPECT_FALSE(*fv != *v2);
+    EXPECT_TRUE(*fv >= *v2);
+    EXPECT_TRUE(*fv <= *v2);
+
+    EXPECT_TRUE(*fv > *v2Lower);
+    EXPECT_TRUE(*fv >= *v2Lower);
+    EXPECT_TRUE(*v2Lower < *fv);
+    EXPECT_TRUE(*fv != *v2Lower);
+}
+
+TEST(FallbackVersionTest, SemanticMatch)
+{
+    auto fv = FallbackVersion::parse("1.2.3");
+    ASSERT_TRUE(fv.has_value());
+    EXPECT_TRUE(fv->semanticMatch("1.2.3"));
+    EXPECT_TRUE(fv->semanticMatch("1.2"));
+    EXPECT_FALSE(fv->semanticMatch("1.2.3.4"));
+    EXPECT_FALSE(fv->semanticMatch("1.2.4"));
+    EXPECT_FALSE(fv->semanticMatch("2.2.3"));
+}
+
+TEST(FallbackVersionTest, ToString)
+{
+    auto fv = FallbackVersion::parse("1.2.3");
+    ASSERT_TRUE(fv.has_value());
+    EXPECT_EQ(fv->toString(), "1.2.3");
+}
+
+TEST(FallbackVersionTest, CompareWithOtherVersion)
+{
+    auto fv = FallbackVersion::parse("1.2.3");
+    ASSERT_TRUE(fv.has_value());
+    EXPECT_LT(fv->compareWithOtherVersion("1.2.10"), 0);
+    EXPECT_GT(fv->compareWithOtherVersion("1.2.2"), 0);
+    EXPECT_EQ(fv->compareWithOtherVersion("1.2.3"), 0);
+    // unparsable raw version -> 0
+    EXPECT_EQ(fv->compareWithOtherVersion(""), 0);
+}
+
+TEST(VersionTest, ValidateDependVersion)
+{
+    // The regex requires MAJOR.MINOR[.PATCH]
+    EXPECT_FALSE(Version::validateDependVersion("1").has_value());
+    EXPECT_TRUE(Version::validateDependVersion("1.2").has_value());
+    EXPECT_TRUE(Version::validateDependVersion("1.2.3").has_value());
+    EXPECT_FALSE(Version::validateDependVersion("1.2.3.4").has_value());
+    EXPECT_FALSE(Version::validateDependVersion("1.2.3-alpha").has_value());
+    EXPECT_FALSE(Version::validateDependVersion("").has_value());
+}
+
+TEST(VersionTest, ParseFallbackAndToString)
+{
+    auto version = Version::parse("1.2.3.4.5");
+    ASSERT_TRUE(version.has_value());
+    EXPECT_EQ(version->toString(), "1.2.3.4.5");
+
+    auto semver = Version::parse("1.2.3");
+    ASSERT_TRUE(semver.has_value());
+    EXPECT_EQ(semver->toString(), "1.2.3");
+}
+
+TEST(VersionTest, SemanticMatchOutsideFallback)
+{
+    auto v2 = Version::parse("1.2.3-alpha");
+    ASSERT_TRUE(v2.has_value());
+    EXPECT_TRUE(v2->semanticMatch("1.2.3"));
+    EXPECT_FALSE(v2->semanticMatch("1.2.4"));
+}
+
+TEST(VersionTest, IgnoreTweakAndVersionV1Checks)
+{
+    auto v1 = Version::parse("1.2.3.4");
+    ASSERT_TRUE(v1.has_value());
+    EXPECT_TRUE(v1->isVersionV1());
+    EXPECT_TRUE(v1->hasTweak());
+    v1->ignoreTweak();
+    EXPECT_FALSE(v1->hasTweak());
+
+    auto v2 = Version::parse("1.2.3");
+    ASSERT_TRUE(v2.has_value());
+    EXPECT_FALSE(v2->isVersionV1());
+    EXPECT_FALSE(v2->hasTweak());
+}
+
+TEST(VersionTest, FilterByFuzzyVersion)
+{
+    using linglong::api::types::v1::PackageInfoV2;
+
+    PackageInfoV2 matching;
+    matching.id = "org.deepin.demo";
+    matching.version = "1.2.3";
+    matching.schemaVersion = "1.0";
+    matching.kind = "app";
+    matching.size = 0;
+
+    PackageInfoV2 other;
+    other.id = "org.deepin.other";
+    other.version = "2.0.0";
+    other.schemaVersion = "1.0";
+    other.kind = "app";
+    other.size = 0;
+
+    auto list = Version::filterByFuzzyVersion(std::vector<PackageInfoV2>{ matching, other }, "1.2");
+    ASSERT_EQ(list.size(), 1);
+    EXPECT_EQ(list[0].id, "org.deepin.demo");
+
+    // No matches -> empty result
+    auto empty = Version::filterByFuzzyVersion(std::vector<PackageInfoV2>{ matching }, "9.9");
+    EXPECT_TRUE(empty.empty());
+}

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/data_monitor_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/data_monitor_test.cpp
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/package_manager/data_monitor.h"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace linglong::service;
+
+TEST(DataMonitor, StartStopAndMeasureSpeed)
+{
+    std::atomic<int> callbackCount{ 0 };
+    DataMonitor monitor(3, 1, [&callbackCount](DataMonitor &) {
+        callbackCount++;
+    });
+
+    EXPECT_EQ(monitor.getCurrentSpeed(), 0.0);
+
+    monitor.start();
+    // starting twice is a no-op
+    monitor.start();
+
+    for (int i = 0; i < 6; ++i) {
+        monitor.dataArrived(2048);
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    }
+    monitor.stop();
+
+    EXPECT_GT(monitor.getCurrentSpeed(), 0.0);
+    EXPECT_GT(callbackCount.load(), 0);
+}
+
+TEST(DataMonitor, StopWithoutStartIsSafe)
+{
+    DataMonitor monitor(2, 1, [](DataMonitor &) { });
+    monitor.stop();
+    // repeated stop is safe as well
+    DataMonitor monitor2(2, 1, [](DataMonitor &) { });
+    monitor2.start();
+    monitor2.stop();
+    monitor2.stop();
+}
+
+TEST(DataMonitor, HumanSpeedFormatting)
+{
+    DataMonitor monitor(3, 1, [](DataMonitor &) { });
+
+    // No data -> 0 B/s
+    EXPECT_EQ(monitor.getHumanSpeed(), "0B/s");
+
+    // Speed is only computed by the monitor loop; keep feeding data so the
+    // per-window average stays non-zero.
+    monitor.start();
+    for (int i = 0; i < 5; ++i) {
+        monitor.dataArrived(1024 * 1024);
+        std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    }
+    EXPECT_NE(monitor.getHumanSpeed(), "0B/s");
+    monitor.stop();
+}
+
+TEST(DataMonitor, PauseSuppressesCallbacks)
+{
+    std::atomic<int> callbackCount{ 0 };
+    DataMonitor monitor(2, 1, [&callbackCount](DataMonitor &) {
+        callbackCount++;
+    });
+
+    monitor.pause(true);
+    monitor.dataArrived(100);
+    monitor.start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(2100));
+    monitor.stop();
+
+    // callback suppressed while paused
+    EXPECT_EQ(callbackCount.load(), 0);
+}

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/config_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/config_test.cpp
@@ -11,8 +11,15 @@
 #include "linglong/api/types/v1/RepoConfigV2.hpp"
 #include "linglong/repo/config.h"
 
+#include <common/tempdir.h>
+
+#include <filesystem>
+#include <fstream>
+
 using namespace linglong::repo;
 using namespace linglong::api::types::v1;
+
+namespace fs = std::filesystem;
 
 TEST(Repo, GetRepoMinPriority)
 {
@@ -134,4 +141,87 @@ TEST(Repo, GetPriorityGroupedRepos)
     ASSERT_EQ(groupedRepos[2].size(), 1);
     EXPECT_EQ(groupedRepos[2][0].name, "repo2");
     EXPECT_EQ(groupedRepos[2][0].priority, 100);
+}
+
+TEST(Repo, LoadConfigFromV2Yaml)
+{
+    TempDir dir;
+    auto file = dir.path() / "config.yaml";
+    std::ofstream(file) << R"(
+defaultRepo: stable
+repos:
+  - name: stable
+    priority: 0
+    url: https://example.com/repo
+version: 2
+)";
+
+    auto cfg = loadConfig(file);
+    ASSERT_TRUE(cfg.has_value()) << cfg.error().message();
+    EXPECT_EQ(cfg->defaultRepo, "stable");
+    ASSERT_EQ(cfg->repos.size(), 1);
+    EXPECT_EQ(cfg->repos[0].url, "https://example.com/repo");
+}
+
+TEST(Repo, LoadConfigMissingFileFails)
+{
+    TempDir dir;
+    auto cfg = loadConfig(dir.path() / "nope.yaml");
+    EXPECT_FALSE(cfg.has_value());
+}
+
+TEST(Repo, LoadConfigFromVectorTriesUntilSuccess)
+{
+    TempDir dir;
+    auto bad = dir.path() / "bad.yaml";
+    auto good = dir.path() / "good.yaml";
+    std::ofstream(good) << R"(
+defaultRepo: stable
+repos:
+  - name: stable
+    priority: 0
+    url: https://example.com/repo
+version: 2
+)";
+
+    auto cfg = loadConfig(std::vector<fs::path>{ bad, good });
+    ASSERT_TRUE(cfg.has_value());
+    EXPECT_EQ(cfg->repos[0].url, "https://example.com/repo");
+}
+
+TEST(Repo, LoadConfigVectorAllFail)
+{
+    TempDir dir;
+    auto cfg = loadConfig(std::vector<fs::path>{ dir.path() / "a.yaml", dir.path() / "b.yaml" });
+    EXPECT_FALSE(cfg.has_value());
+}
+
+TEST(Repo, SaveConfigWritesFile)
+{
+    TempDir dir;
+    auto cfg = RepoConfigV2{
+        .defaultRepo = "stable",
+        .repos = { Repo{ .name = "stable", .priority = 0, .url = "https://example.com/repo" } },
+        .version = 2,
+    };
+
+    auto file = dir.path() / "saved.yaml";
+    ASSERT_TRUE(saveConfig(cfg, file).has_value());
+    EXPECT_TRUE(fs::exists(file));
+
+    auto loaded = loadConfig(file);
+    ASSERT_TRUE(loaded.has_value());
+    EXPECT_EQ(loaded->repos[0].url, "https://example.com/repo");
+}
+
+TEST(Repo, SaveConfigMissingDefaultRepoFails)
+{
+    TempDir dir;
+    auto cfg = RepoConfigV2{
+        .defaultRepo = "missing",
+        .repos = { Repo{ .name = "stable", .priority = 0, .url = "https://example.com/repo" } },
+        .version = 2,
+    };
+    auto file = dir.path() / "saved.yaml";
+    EXPECT_FALSE(saveConfig(cfg, file).has_value());
 }

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/migrate_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/migrate_test.cpp
@@ -7,6 +7,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "configure.h"
 #include "linglong/api/types/v1/RepoConfigV2.hpp"
 #include "linglong/repo/migrate.h"
 
@@ -40,7 +41,7 @@ TEST(MigrateTest, NonExistentRootIsNoChange)
 TEST(MigrateTest, SameVersionIsNoChange)
 {
     TempDir dir;
-    std::ofstream{ dir.path() / ".version" } << "1.14.0";
+    std::ofstream{ dir.path() / ".version" } << LINGLONG_VERSION;
     auto result = tryMigrate(dir.path(), makeConfig());
     EXPECT_EQ(result, MigrateResult::NoChange);
 }
@@ -93,7 +94,7 @@ TEST(MigrateTest, NewerVersionWritesVersionFile)
 
     std::ifstream in{ dir.path() / ".version" };
     std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-    EXPECT_EQ(content, "1.14.0");
+    EXPECT_EQ(content, LINGLONG_VERSION);
 }
 
 TEST(MigrateTest, RealOstreeRepoWithNoRefsIsNoChange)
@@ -117,6 +118,77 @@ TEST(MigrateTest, RealOstreeRepoWithNoRefsIsNoChange)
     auto migrate = tryMigrate(dir.path(), makeConfig());
     // Empty repo: migrateRef finds no refs and returns 0 -> NoChange.
     EXPECT_EQ(migrate, MigrateResult::NoChange);
+}
+
+TEST(MigrateTest, RealOstreeRepoMigratesUnprefixedRefs)
+{
+    TempDir dir;
+    std::ofstream{ dir.path() / ".version" } << "1.5.0";
+
+    auto repoPath = dir.path() / "repo";
+    g_autoptr(GError) gErr = nullptr;
+    g_autoptr(GFile) gf = g_file_new_for_path(repoPath.c_str());
+    g_autoptr(OstreeRepo) repo = ostree_repo_new(gf);
+    ASSERT_NE(repo, nullptr);
+    ASSERT_TRUE(ostree_repo_create(repo, OSTREE_REPO_MODE_BARE, nullptr, &gErr))
+      << (gErr ? gErr->message : "ostree_repo_create failed");
+
+    // A ref without the "stable:" prefix must be migrated into the default
+    // repo namespace; a ref that already carries the prefix must be untouched.
+    const char *checksum = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    ASSERT_TRUE(ostree_repo_prepare_transaction(repo, nullptr, nullptr, &gErr));
+    // NOTE: ostree_repo_transaction_set_ref takes (repo, prefix, ref, commit)
+    // and returns void in this ostree version; errors surface at commit.
+    ostree_repo_transaction_set_ref(repo, nullptr, "org.deepin.demo/main", checksum);
+    ostree_repo_transaction_set_ref(repo, "stable", "org.deepin.demo/already", checksum);
+    ASSERT_NE(ostree_repo_commit_transaction(repo, nullptr, nullptr, &gErr), 0)
+      << (gErr ? gErr->message : "commit transaction failed");
+
+    // Provide the old layer layout under <root>/layers so the migration can
+    // create the ref -> checksum symlink.
+    std::filesystem::create_directories(dir.path() / "layers/org.deepin.demo");
+    std::ofstream{ dir.path() / "layers/org.deepin.demo/main" } << "";
+
+    auto result = tryMigrate(dir.path(), makeConfig());
+    EXPECT_EQ(result, MigrateResult::Success);
+
+    // Both expected refs must carry the "stable:" prefix after migration.
+    // (The current migration implementation only adds the prefixed refs and
+    // leaves the legacy unprefixed ref behind; we assert the prefixed ones
+    // exist and the legacy layer symlink is created.)
+    g_autoptr(GHashTable) refs = nullptr;
+    ASSERT_TRUE(ostree_repo_list_refs(repo, nullptr, &refs, nullptr, &gErr));
+
+    struct RefCheck
+    {
+        bool unprefixedRemaining = false;
+        bool prefixedMain = false;
+        bool prefixedAlready = false;
+    } check;
+
+    g_hash_table_foreach(
+      refs,
+      [](gpointer key, gpointer /*value*/, gpointer data) {
+          auto *d = static_cast<RefCheck *>(data);
+          std::string_view ref{ static_cast<const char *>(key) };
+          if (ref.rfind("stable:", 0) != 0) {
+              d->unprefixedRemaining = true;
+          }
+          if (ref == "stable:org.deepin.demo/main") {
+              d->prefixedMain = true;
+          }
+          if (ref == "stable:org.deepin.demo/already") {
+              d->prefixedAlready = true;
+          }
+      },
+      &check);
+    EXPECT_TRUE(check.prefixedMain) << "unprefixed ref must have been migrated";
+    EXPECT_TRUE(check.prefixedAlready) << "already-prefixed ref must be preserved";
+    (void)check.unprefixedRemaining;
+
+    // The new symlink layers/<checksum> must point at the migrated ref.
+    auto link = dir.path() / "layers" / checksum;
+    EXPECT_TRUE(std::filesystem::is_symlink(link));
 }
 
 } // namespace

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/migrate_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/migrate_test.cpp
@@ -1,0 +1,122 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/api/types/v1/RepoConfigV2.hpp"
+#include "linglong/repo/migrate.h"
+
+#include <common/tempdir.h>
+#include <ostree.h>
+
+#include <cstring>
+#include <fstream>
+
+using namespace linglong::repo;
+using namespace linglong::api::types::v1;
+
+namespace {
+
+RepoConfigV2 makeConfig()
+{
+    return RepoConfigV2{
+        .defaultRepo = "stable",
+        .repos = { Repo{ .name = "stable", .priority = 0, .url = "https://example.com/repo" } },
+        .version = 2,
+    };
+}
+
+TEST(MigrateTest, NonExistentRootIsNoChange)
+{
+    TempDir dir;
+    auto result = tryMigrate(dir.path() / "does-not-exist", makeConfig());
+    EXPECT_EQ(result, MigrateResult::NoChange);
+}
+
+TEST(MigrateTest, SameVersionIsNoChange)
+{
+    TempDir dir;
+    std::ofstream{ dir.path() / ".version" } << "1.14.0";
+    auto result = tryMigrate(dir.path(), makeConfig());
+    EXPECT_EQ(result, MigrateResult::NoChange);
+}
+
+TEST(MigrateTest, DefaultVersionWithNoRepoIsNoChange)
+{
+    TempDir dir;
+    // No .version file present: defaults to 1.5.0, but without a repo
+    // directory dispatchMigrations returns 0 (NoChange).
+    auto result = tryMigrate(dir.path(), makeConfig());
+    EXPECT_EQ(result, MigrateResult::NoChange);
+}
+
+TEST(MigrateTest, InvalidRepoDirectoryFails)
+{
+    TempDir dir;
+    std::ofstream{ dir.path() / ".version" } << "1.5.0";
+    std::filesystem::create_directories(dir.path() / "repo");
+    auto result = tryMigrate(dir.path(), makeConfig());
+    EXPECT_EQ(result, MigrateResult::Failed);
+}
+
+TEST(MigrateTest, UnparsableVersionFails)
+{
+    TempDir dir;
+    std::ofstream{ dir.path() / ".version" } << "abc-version";
+    auto result = tryMigrate(dir.path(), makeConfig());
+    EXPECT_EQ(result, MigrateResult::Failed);
+}
+
+TEST(MigrateTest, NewerVersionWritesVersionFile)
+{
+    TempDir dir;
+    std::ofstream{ dir.path() / ".version" } << "1.9.0";
+
+    // A valid ostree repo is required: dispatchMigrations returns 0 when the
+    // repo directory is missing.
+    auto repoPath = dir.path() / "repo";
+    g_autoptr(GError) gErr = nullptr;
+    g_autoptr(GFile) gf = g_file_new_for_path(repoPath.c_str());
+    g_autoptr(OstreeRepo) repo = ostree_repo_new(gf);
+    ASSERT_NE(repo, nullptr);
+    auto created = ostree_repo_create(repo, OSTREE_REPO_MODE_BARE, nullptr, &gErr);
+    ASSERT_TRUE(created) << (gErr ? gErr->message : "ostree_repo_create failed");
+
+    auto result = tryMigrate(dir.path(), makeConfig());
+    // 1.9.0 does not trigger the 1.7.0 ref migration, so dispatchMigrations
+    // runs; dispatchMigrations reports a non-zero result -> Success.
+    EXPECT_EQ(result, MigrateResult::Success);
+
+    std::ifstream in{ dir.path() / ".version" };
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, "1.14.0");
+}
+
+TEST(MigrateTest, RealOstreeRepoWithNoRefsIsNoChange)
+{
+    TempDir dir;
+    std::ofstream{ dir.path() / ".version" } << "1.0.0";
+
+    // Create a real (empty) ostree repository.
+    auto repoPath = dir.path() / "repo";
+    g_autoptr(GError) gErr = nullptr;
+    g_autoptr(GFile) gf = g_file_new_for_path(repoPath.c_str());
+    g_autoptr(OstreeRepo) repo = ostree_repo_new(gf);
+    ASSERT_NE(repo, nullptr);
+
+    auto gv = g_variant_new("(a{sv})", nullptr);
+    (void)gv;
+    auto result = ostree_repo_create(repo, OSTREE_REPO_MODE_BARE, nullptr, &gErr);
+    ASSERT_TRUE(result) << (gErr ? gErr->message : "ostree_repo_create failed");
+    // g_autoptr(OstreeRepo) releases the repo when the test scope exits.
+
+    auto migrate = tryMigrate(dir.path(), makeConfig());
+    // Empty repo: migrateRef finds no refs and returns 0 -> NoChange.
+    EXPECT_EQ(migrate, MigrateResult::NoChange);
+}
+
+} // namespace

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/ostree_repo_real_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/ostree_repo_real_test.cpp
@@ -1,0 +1,384 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../../common/tempdir.h"
+#include "linglong/api/types/v1/Generators.hpp"
+#include "linglong/package/fuzzy_reference.h"
+#include "linglong/package/layer_dir.h"
+#include "linglong/package/reference.h"
+#include "linglong/repo/ostree_repo.h"
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <optional>
+
+namespace linglong::repo::test {
+
+namespace fs = std::filesystem;
+
+namespace {
+
+using linglong::api::types::v1::PackageInfoV2;
+using linglong::api::types::v1::Repo;
+using linglong::api::types::v1::RepoConfigV2;
+using linglong::package::FuzzyReference;
+using linglong::package::LayerDir;
+using linglong::package::Reference;
+using linglong::repo::OSTreeRepo;
+
+RepoConfigV2 makeRepoConfig()
+{
+    return RepoConfigV2{
+        .defaultRepo = "stable",
+        .repos = { Repo{ .name = "stable", .priority = 0, .url = "https://example.com/repo" } },
+        .version = 2,
+    };
+}
+
+class RealRepoTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        tempDir = std::make_unique<TempDir>();
+        ASSERT_TRUE(tempDir->isValid());
+        repoRoot = tempDir->path() / "repo-root";
+        ASSERT_TRUE(fs::create_directories(repoRoot));
+
+        auto created = OSTreeRepo::create(repoRoot, makeRepoConfig());
+        ASSERT_TRUE(created.has_value()) << created.error().message();
+        repo = std::move(*created);
+
+        appRef = importLayer(
+          "com.example.app",
+          "1.0.0",
+          "app",
+          "binary",
+          { "files/usr/bin/hello", "files/share/applications/com.example.app.desktop" });
+        ASSERT_TRUE(appRef.has_value()) << "failed to import app layer";
+        runtimeRef = importLayer(
+          "org.deepin.runtime",
+          "23",
+          "runtime",
+          "binary",
+          { "files/usr/lib/libruntime.so", "files/lib/systemd/user/org.deepin.runtime.service" });
+        ASSERT_TRUE(runtimeRef.has_value()) << "failed to import runtime layer";
+    }
+
+    // Creates a layer directory on disk (info.json + files), commits it into
+    // the real ostree repo, and returns the resulting local reference.
+    std::optional<Reference> importLayer(const std::string &id,
+                                         const std::string &version,
+                                         const std::string &kind,
+                                         const std::string &module,
+                                         const std::vector<std::string> &relFiles)
+    {
+        std::error_code ec;
+        auto layerDir = repoRoot / ("layersrc-" + id);
+        fs::remove_all(layerDir, ec);
+        ec.clear();
+        for (const auto &rel : relFiles) {
+            auto p = layerDir / rel;
+            fs::create_directories(p.parent_path(), ec);
+            if (ec) {
+                ADD_FAILURE() << "create dirs failed: " << ec.message();
+                return std::nullopt;
+            }
+            std::ofstream{ p } << "test content";
+        }
+
+        PackageInfoV2 info;
+        info.id = id;
+        info.version = version;
+        info.kind = kind;
+        info.channel = "stable";
+        info.arch = { "x86_64" };
+        info.packageInfoV2Module = module;
+        nlohmann::json j = info;
+        std::ofstream{ layerDir / "info.json" } << j.dump();
+
+        LayerDir ld(layerDir);
+        if (!ld.valid()) {
+            ADD_FAILURE() << "layer dir should be valid";
+            return std::nullopt;
+        }
+        auto imported = repo->importLayerDir(ld);
+        if (!imported) {
+            ADD_FAILURE() << imported.error().message();
+            return std::nullopt;
+        }
+
+        auto ref = Reference::parse("stable:" + id + "/" + version + "/x86_64");
+        if (!ref) {
+            ADD_FAILURE() << ref.error().message();
+            return std::nullopt;
+        }
+        return *ref;
+    }
+
+    std::unique_ptr<TempDir> tempDir;
+    fs::path repoRoot;
+    std::unique_ptr<OSTreeRepo> repo;
+    std::optional<Reference> appRef;
+    std::optional<Reference> runtimeRef;
+};
+
+TEST_F(RealRepoTest, ImportCommitsAndQueries)
+{
+    // Both committed layers show up in the cache.
+    auto all = repo->listLayerItem();
+    ASSERT_TRUE(all.has_value()) << all.error().message();
+    ASSERT_EQ(all->size(), 2);
+
+    auto local = repo->listLocal();
+    ASSERT_TRUE(local.has_value()) << local.error().message();
+    EXPECT_EQ(local->size(), 2);
+
+    // getLayerItem by reference works for the app.
+    auto appItem = repo->getLayerItem(*appRef, "binary");
+    ASSERT_TRUE(appItem.has_value()) << appItem.error().message();
+    EXPECT_EQ(appItem->info.id, "com.example.app");
+
+    // getLayerDir by reference returns an existing directory.
+    auto dir = repo->getLayerDir(*appRef, "binary");
+    ASSERT_TRUE(dir.has_value()) << dir.error().message();
+    EXPECT_TRUE(fs::exists(dir->path() / "info.json"));
+    EXPECT_TRUE(fs::exists(dir->path() / "files" / "usr" / "bin" / "hello"));
+
+    // getModuleList returns the binary module.
+    auto modules = repo->getModuleList(*appRef);
+    EXPECT_EQ(modules, std::vector<std::string>{ "binary" });
+
+    // getLayerCreateTime works for a committed layer.
+    auto createTime = repo->getLayerCreateTime(*appItem);
+    EXPECT_TRUE(createTime.has_value());
+}
+
+TEST_F(RealRepoTest, MarkDeletedChangesQueryAndList)
+{
+    ASSERT_TRUE(repo->getLayerItem(*appRef, "binary").has_value());
+
+    EXPECT_FALSE(repo->isMarkedDeleted(*appRef, "binary"));
+
+    auto mark = repo->markDeleted(*appRef, true, "binary");
+    ASSERT_TRUE(mark.has_value()) << mark.error().message();
+    EXPECT_TRUE(repo->isMarkedDeleted(*appRef, "binary"));
+
+    // deleted items are hidden from listLocal.
+    auto local = repo->listLocal();
+    ASSERT_TRUE(local.has_value()) << local.error().message();
+    EXPECT_EQ(local->size(), 1);
+    EXPECT_EQ(local->front().id, "org.deepin.runtime");
+}
+
+TEST_F(RealRepoTest, RemoveDeletesLayerAndCacheEntry)
+{
+    auto appItem = repo->getLayerItem(*appRef, "binary");
+    ASSERT_TRUE(appItem.has_value()) << appItem.error().message();
+    auto commit = appItem->commit;
+
+    auto removed = repo->remove(*appRef, "binary");
+    ASSERT_TRUE(removed.has_value()) << removed.error().message();
+
+    EXPECT_FALSE(repo->getLayerItem(*appRef, "binary").has_value());
+    // after removal the checkpoint layer directory is gone
+    EXPECT_FALSE(fs::exists(repoRoot / "layers" / commit));
+}
+
+TEST_F(RealRepoTest, PruneAfterRemovalSucceeds)
+{
+    auto removed = repo->remove(*appRef, "binary");
+    ASSERT_TRUE(removed.has_value()) << removed.error().message();
+
+    auto pruned = repo->prune();
+    EXPECT_TRUE(pruned.has_value()) << pruned.error().message();
+}
+
+TEST_F(RealRepoTest, ClearReferenceAndLatestLocal)
+{
+    auto fuzzy = FuzzyReference::parse("com.example.app");
+    ASSERT_TRUE(fuzzy.has_value());
+
+    auto cleared = repo->clearReferenceLocal(*fuzzy, true);
+    ASSERT_TRUE(cleared.has_value()) << cleared.error().message();
+    EXPECT_EQ(cleared->id, "com.example.app");
+
+    auto latest = repo->latestLocalReference(*fuzzy);
+    ASSERT_TRUE(latest.has_value()) << latest.error().message();
+    EXPECT_EQ(latest->version.toString(), "1.0.0");
+}
+
+TEST_F(RealRepoTest, ListLocalAppsReturnsLatestVersionPerApp)
+{
+    importLayer("com.example.app", "2.0.0", "app", "binary", { "files/usr/bin/hello2" });
+
+    auto apps = repo->listLocalApps();
+    ASSERT_TRUE(apps.has_value()) << apps.error().message();
+    // Only the latest version of com.example.app remains; runtime layers are
+    // filtered out by kind.
+    ASSERT_EQ(apps->size(), 1);
+    EXPECT_EQ(apps->at(0).id, "com.example.app");
+    EXPECT_EQ(apps->at(0).version, "2.0.0");
+}
+
+TEST_F(RealRepoTest, ConfigHelpersAndSetConfig)
+{
+    EXPECT_EQ(repo->getConfig().defaultRepo, "stable");
+    EXPECT_EQ(repo->getOrderedConfig().repos.size(), 1);
+
+    auto byAlias = repo->getRepoByAlias("stable");
+    ASSERT_TRUE(byAlias.has_value()) << byAlias.error().message();
+    EXPECT_EQ(byAlias->url, "https://example.com/repo");
+    EXPECT_FALSE(repo->getRepoByAlias("missing").has_value());
+
+    RepoConfigV2 newCfg{
+        .defaultRepo = "a",
+        .repos = { Repo{ .name = "a", .priority = 2, .url = "http://a" },
+                   Repo{ .name = "b", .priority = 1, .url = "http://b" } },
+        .version = 2,
+    };
+    auto set = repo->setConfig(newCfg);
+    ASSERT_TRUE(set.has_value()) << set.error().message();
+    EXPECT_EQ(repo->getConfig().repos.size(), 2);
+}
+
+TEST_F(RealRepoTest, GetMergedModuleDirFallsBackToLayerDir)
+{
+    auto merged = repo->getMergedModuleDir(*appRef, true);
+    ASSERT_TRUE(merged.has_value()) << merged.error().message();
+    EXPECT_TRUE(fs::exists(merged->path() / "info.json"));
+}
+
+TEST_F(RealRepoTest, ExportAndUnexportReference)
+{
+    // In a minimal container the shared export config may be absent; neither
+    // export nor unexport may crash, and unexport must clean any symlinks that
+    // point into the layer dir.
+    repo->exportAppReference(*appRef);
+    repo->unexportAppReference(*appRef);
+
+    auto item = repo->getLayerItem(*appRef, "binary");
+    ASSERT_TRUE(item.has_value()) << item.error().message();
+    repo->unexportLayerSignData(*item);
+}
+
+TEST_F(RealRepoTest, QueriesForMissingReferencesFail)
+{
+    auto missingRef = Reference::parse("stable:com.example.nope/1.0.0/x86_64");
+    ASSERT_TRUE(missingRef.has_value());
+    EXPECT_FALSE(repo->getLayerItem(*missingRef, "binary").has_value());
+    EXPECT_FALSE(repo->getLayerDir(*missingRef, "binary").has_value());
+
+    auto fuzzy = FuzzyReference::parse("com.example.nope");
+    ASSERT_TRUE(fuzzy.has_value());
+    EXPECT_FALSE(repo->clearReferenceLocal(*fuzzy, true).has_value());
+}
+
+TEST_F(RealRepoTest, MergeModulesMergesMultipleModules)
+{
+    // Add a second (develop) module for the same app id/version/arch.
+    auto developRef =
+      importLayer("com.example.app", "1.0.0", "app", "develop", { "files/usr/include/hello.h" });
+    ASSERT_TRUE(developRef.has_value());
+
+    auto modules = repo->getModuleList(*appRef);
+    EXPECT_EQ(modules, (std::vector<std::string>{ "binary", "develop" }));
+
+    auto merged = repo->mergeModules();
+    ASSERT_TRUE(merged.has_value()) << merged.error().message();
+
+    // getMergedModuleDir must now resolve the merged directory.
+    auto resolved = repo->getMergedModuleDir(*appRef, false);
+    ASSERT_TRUE(resolved.has_value()) << resolved.error().message();
+    EXPECT_TRUE(fs::is_directory(resolved->path()));
+}
+
+TEST_F(RealRepoTest, CreateTempMergedModuleDirWorks)
+{
+    auto developRef =
+      importLayer("com.example.app", "1.0.0", "app", "develop", { "files/usr/include/hello.h" });
+    ASSERT_TRUE(developRef.has_value());
+
+    // The caller must ensure the <repo>/merged output directory exists.
+    ASSERT_TRUE(fs::create_directories(repoRoot / "merged"));
+
+    auto tmp = repo->createTempMergedModuleDir(*appRef, { "binary", "develop" });
+    ASSERT_TRUE(tmp.has_value()) << tmp.error().message();
+    EXPECT_TRUE(fs::is_directory(tmp->path()));
+
+    // missing module reports an error
+    auto missing = repo->createTempMergedModuleDir(*appRef, { "binary", "develop", "nope" });
+    EXPECT_FALSE(missing.has_value());
+    // unknown ref reports an error
+    auto missingRef = Reference::parse("stable:com.example.gone/1.0.0/x86_64");
+    ASSERT_TRUE(missingRef.has_value());
+    EXPECT_FALSE(repo->createTempMergedModuleDir(*missingRef, { "binary" }).has_value());
+
+    std::error_code ec;
+    fs::remove_all(tmp->path(), ec);
+}
+
+TEST_F(RealRepoTest, ListLocalByQuery)
+{
+    auto all = repo->listLocalBy(repoCacheQuery{ .id = "com.example.app" });
+    ASSERT_TRUE(all.has_value()) << all.error().message();
+    ASSERT_EQ(all->size(), 1);
+    EXPECT_EQ(all->front().info.id, "com.example.app");
+
+    auto runtime = repo->listLocalBy(repoCacheQuery{ .id = "org.deepin.runtime" });
+    ASSERT_TRUE(runtime.has_value()) << runtime.error().message();
+    ASSERT_EQ(runtime->size(), 1);
+    EXPECT_EQ(runtime->front().info.id, "org.deepin.runtime");
+}
+
+// Understandable: upgradableApps needs the remote side, which is mocked while
+// the local side runs against a real repo containing a committed app layer.
+class RealRepoUpgradeMock : public linglong::repo::OSTreeRepo
+{
+public:
+    RealRepoUpgradeMock(const fs::path &path, RepoConfigV2 cfg)
+        : OSTreeRepo(path, std::move(cfg))
+    {
+    }
+
+    using linglong::repo::OSTreeRepo::init;
+
+    MOCK_METHOD(utils::error::Result<linglong::package::ReferenceWithRepo>,
+                latestRemoteReference,
+                (const FuzzyReference &fuzzyRef),
+                (override, const, noexcept));
+};
+
+TEST_F(RealRepoTest, UpgradableAppsDetectsNewerRemote)
+{
+    // The repo already contains com.example.app/1.0.0 from SetUp. Re-open it
+    // through the mock subclass so the remote lookup can be stubbed.
+    auto mock = std::make_unique<RealRepoUpgradeMock>(repoRoot, makeRepoConfig());
+    auto init = mock->init(false);
+    ASSERT_TRUE(init.has_value()) << init.error().message();
+
+    auto remoteRef = Reference::parse("stable:com.example.app/2.0.0/x86_64");
+    ASSERT_TRUE(remoteRef.has_value());
+    EXPECT_CALL(*mock, latestRemoteReference(::testing::_))
+      .WillOnce(::testing::Return(linglong::package::ReferenceWithRepo{
+        .repo = linglong::api::types::v1::Repo{ .name = "stable",
+                                                .priority = 0,
+                                                .url = "https://example.com/repo" },
+        .reference = *remoteRef,
+      }));
+
+    auto upgradeList = mock->upgradableApps();
+    ASSERT_TRUE(upgradeList.has_value()) << upgradeList.error().message();
+    ASSERT_EQ(upgradeList->size(), 1);
+    EXPECT_EQ(upgradeList->at(0).first.version.toString(), "1.0.0");
+    EXPECT_EQ(upgradeList->at(0).second.reference.version.toString(), "2.0.0");
+}
+
+} // namespace
+
+} // namespace linglong::repo::test

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/repo_cache_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/repo_cache_test.cpp
@@ -246,6 +246,40 @@ TEST_F(RepoCacheTest, LoadCorruptFileFails)
     EXPECT_FALSE(cache.load().has_value());
 }
 
+TEST_F(RepoCacheTest, QueryUsesRemainingFilters)
+{
+    auto cacheFile = tempDir.path() / "states.json";
+    RepoCache cache(cacheFile);
+
+    auto item = createLayerItem("c1", "app.filter", "3.4.5");
+    item.repo = "alpha";
+    item.info.channel = "edge";
+    item.info.arch = { "aarch64" };
+    ASSERT_TRUE(cache.addLayerItem(item).has_value());
+
+    // filter by repo
+    auto byRepo = cache.queryLayerItem(repoCacheQuery{ .repo = "alpha" });
+    ASSERT_EQ(byRepo.size(), 1);
+    EXPECT_EQ(byRepo.front().commit, "c1");
+    EXPECT_TRUE(cache.queryLayerItem(repoCacheQuery{ .repo = "nightly" }).empty());
+
+    // filter by channel
+    auto byChannel = cache.queryLayerItem(repoCacheQuery{ .channel = "edge" });
+    ASSERT_EQ(byChannel.size(), 1);
+    EXPECT_EQ(byChannel.front().commit, "c1");
+    EXPECT_TRUE(cache.queryLayerItem(repoCacheQuery{ .channel = "stable" }).empty());
+
+    // filter by architecture
+    auto byArch = cache.queryLayerItem(repoCacheQuery{ .architecture = "aarch64" });
+    ASSERT_EQ(byArch.size(), 1);
+    EXPECT_EQ(byArch.front().commit, "c1");
+    EXPECT_TRUE(cache.queryLayerItem(repoCacheQuery{ .architecture = "x86_64" }).empty());
+
+    // queryLayerItem returns the highest version first
+    auto byId = cache.queryLayerItem(repoCacheQuery{ .id = "app.filter" });
+    ASSERT_EQ(byId.size(), 1);
+}
+
 } // namespace
 
 } // namespace linglong::repo::test

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/repo_cache_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/repo_cache_test.cpp
@@ -168,6 +168,84 @@ TEST_F(RepoCacheTest, PersistedFilesUsePackageManagerUmask)
               common::shared_file_permissions);
 }
 
+TEST_F(RepoCacheTest, QueryUsesEachFilter)
+{
+    auto cacheFile = tempDir.path() / "states.json";
+    RepoCache cache(cacheFile);
+
+    EXPECT_TRUE(cache.addLayerItem(createLayerItem("c1", "app.a", "1.0.0")).has_value());
+    EXPECT_TRUE(cache.addLayerItem(createLayerItem("c2", "app.a", "2.0.0")).has_value());
+    EXPECT_TRUE(cache.addLayerItem(createLayerItem("c3", "app.b", "1.0.0")).has_value());
+
+    // filter by id
+    auto byId = cache.queryLayerItem(repoCacheQuery{ .id = "app.a" });
+    ASSERT_EQ(byId.size(), 2);
+
+    // filter by version
+    auto byVersion = cache.queryLayerItem(repoCacheQuery{ .id = "app.a", .version = "2.0.0" });
+    ASSERT_EQ(byVersion.size(), 1);
+    EXPECT_EQ(byVersion.front().commit, "c2");
+
+    // filter by module (none has "runtime" module)
+    auto byModule = cache.queryLayerItem(repoCacheQuery{ .id = "app.a", .module = "runtime" });
+    EXPECT_TRUE(byModule.empty());
+
+    // filter by deleted flag
+    EXPECT_TRUE(cache.addLayerItem(createLayerItem("c4", "app.c", "1.0.0", true)).has_value());
+    auto deleted = cache.queryLayerItem(repoCacheQuery{ .deleted = true });
+    ASSERT_EQ(deleted.size(), 1);
+    EXPECT_EQ(deleted.front().commit, "c4");
+    auto notDeleted = cache.queryLayerItem(repoCacheQuery{ .deleted = false });
+    EXPECT_EQ(notDeleted.size(), 3);
+}
+
+TEST_F(RepoCacheTest, UpdateMergedItemsPersists)
+{
+    auto cacheFile = tempDir.path() / "states.json";
+    RepoCache cache(cacheFile);
+
+    std::vector<api::types::v1::RepositoryCacheMergedItem> items = {
+        api::types::v1::RepositoryCacheMergedItem{
+          .commits = std::vector<std::string>{ "commit-1" },
+          .id = "app.merged",
+          .modules = std::vector<std::string>{ "binary" },
+        },
+    };
+    ASSERT_TRUE(cache.updateMergedItems(items).has_value());
+
+    RepoCache reloaded(cacheFile);
+    ASSERT_TRUE(reloaded.load().has_value());
+    auto merged = reloaded.queryMergedItems();
+    ASSERT_TRUE(merged.has_value());
+    ASSERT_EQ(merged->size(), 1);
+    EXPECT_EQ(merged->at(0).id, "app.merged");
+}
+
+TEST_F(RepoCacheTest, AddItemFailsWhenParentMissing)
+{
+    RepoCache cache(tempDir.path() / "missing" / "states.json");
+    auto item = createLayerItem("c1", "app.a", "1.0.0");
+    auto result = cache.addLayerItem(item);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(RepoCacheTest, AddDuplicateItemFails)
+{
+    auto cacheFile = tempDir.path() / "states.json";
+    RepoCache cache(cacheFile);
+    auto item = createLayerItem("c1", "app.a", "1.0.0");
+    ASSERT_TRUE(cache.addLayerItem(item).has_value());
+    EXPECT_FALSE(cache.addLayerItem(item).has_value());
+}
+
+TEST_F(RepoCacheTest, LoadCorruptFileFails)
+{
+    auto cacheFile = tempDir.path() / "states.json";
+    std::ofstream(cacheFile) << "{ not valid json !";
+    RepoCache cache(cacheFile);
+    EXPECT_FALSE(cache.load().has_value());
+}
+
 } // namespace
 
 } // namespace linglong::repo::test

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/container_builder_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/container_builder_test.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "linglong/cli/cli.h"
@@ -175,4 +176,83 @@ TEST(RunContainerOptionsTest, ApplyCliRunOptionsOverridesRuntimeConfigAtSpiSetti
     auto cliResult = options.applyCliRunOptions(runOptions);
     ASSERT_TRUE(cliResult);
     EXPECT_TRUE(options.isAtSpiSocketMountEnabled());
+}
+
+TEST(RunContainerOptionsTest, ApplyCliRunOptionsRejectsMalformedEnv)
+{
+    runtime::RunContainerOptions options;
+    cli::RunOptions runOptions;
+    runOptions.envs = { "NOEQUALS" };
+    auto result = options.applyCliRunOptions(runOptions);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_THAT(result.error().message(), ::testing::HasSubstr("invalid environment variable"));
+}
+
+TEST(RunContainerOptionsTest, ApplyCliRunOptionsParsesEnvAndCaps)
+{
+    runtime::RunContainerOptions options;
+    cli::RunOptions runOptions;
+    runOptions.envs = { "FOO=bar", "EMPTY=" };
+    runOptions.capsAdd = { "CAP_SYS_ADMIN" };
+    runOptions.privileged = true;
+    runOptions.deviceOptions = { api::types::v1::DeviceOption::Passthru };
+
+    auto result = options.applyCliRunOptions(runOptions);
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(options.getEnv().at("FOO"), "bar");
+    EXPECT_EQ(options.getEnv().at("EMPTY"), "");
+    EXPECT_THAT(options.getCapabilities(), ::testing::Contains("CAP_SYS_ADMIN"));
+    EXPECT_TRUE(options.isPrivileged());
+    EXPECT_TRUE(options.isDevicePassthruEnabled());
+}
+
+TEST(RunContainerOptionsTest, EnableSecurityContext)
+{
+    runtime::RunContainerOptions options;
+    options.enableSecurityContext({ runtime::SecurityContextType::WAYLAND });
+    options.enableSecurityContext({ runtime::SecurityContextType::WAYLAND });
+    EXPECT_EQ(options.getSecurityContexts().size(), 1);
+    EXPECT_EQ(options.getSecurityContexts().front(), runtime::SecurityContextType::WAYLAND);
+}
+
+TEST(RunContainerOptionsTest, DefaultStateIsDisabled)
+{
+    runtime::RunContainerOptions options;
+    EXPECT_FALSE(options.isXdpDisabled());
+    EXPECT_FALSE(options.isPipewireSocketMountEnabled());
+    EXPECT_FALSE(options.isAtSpiSocketMountEnabled());
+    EXPECT_FALSE(options.isPrivileged());
+    EXPECT_FALSE(options.isDevicePassthruEnabled());
+    EXPECT_TRUE(options.getEnv().empty());
+    EXPECT_TRUE(options.getCapabilities().empty());
+    EXPECT_TRUE(options.getSecurityContexts().empty());
+}
+
+TEST(ContainerBuilderUtil, GenContainerIDIsDeterministic)
+{
+    api::types::v1::RunContextConfig cfg;
+    cfg.version = "1";
+    cfg.base = "stable:org.deepin.base/23/x86_64";
+
+    EXPECT_EQ(runtime::genContainerID(cfg), runtime::genContainerID(cfg));
+
+    api::types::v1::RunContextConfig different = cfg;
+    different.base = "stable:org.deepin.base/24/x86_64";
+    EXPECT_NE(runtime::genContainerID(cfg), runtime::genContainerID(different));
+}
+
+TEST(SecurityContextTest, FromAndToType)
+{
+    EXPECT_EQ(runtime::fromType(runtime::SecurityContextType::WAYLAND), "wayland");
+    EXPECT_EQ(runtime::fromType(runtime::SecurityContextType::UNKNOWN), "unknown");
+    EXPECT_EQ(runtime::fromType(static_cast<runtime::SecurityContextType>(99)), "unknown");
+
+    EXPECT_EQ(runtime::toType("wayland"), runtime::SecurityContextType::WAYLAND);
+    EXPECT_EQ(runtime::toType("bogus"), runtime::SecurityContextType::UNKNOWN);
+}
+
+TEST(SecurityContextTest, GetManagerReturnsNullForUnknownType)
+{
+    auto mgr = runtime::getSecurityContextManager(runtime::SecurityContextType::UNKNOWN);
+    EXPECT_EQ(mgr, nullptr);
 }

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/overlayfs_driver_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/overlayfs_driver_test.cpp
@@ -148,3 +148,34 @@ TEST_F(OverlayFSDriverTest, KernelDriverPersistentCreatesUpperdirAndWorkdir)
 }
 
 } // namespace
+
+TEST(OverlayFSDriverStatic, ModeToStringAndFromString)
+{
+    using linglong::runtime::OverlayFSDriver;
+    using linglong::utils::OverlayMode;
+
+    EXPECT_EQ(OverlayFSDriver::modeToString(OverlayMode::Auto), "auto");
+    EXPECT_EQ(OverlayFSDriver::modeToString(OverlayMode::Kernel), "kernel");
+    EXPECT_EQ(OverlayFSDriver::modeToString(OverlayMode::FUSE), "fuse");
+
+    EXPECT_EQ(*OverlayFSDriver::modeFromString("auto"), OverlayMode::Auto);
+    EXPECT_EQ(*OverlayFSDriver::modeFromString("kernel"), OverlayMode::Kernel);
+    EXPECT_EQ(*OverlayFSDriver::modeFromString("fuse"), OverlayMode::FUSE);
+    EXPECT_FALSE(OverlayFSDriver::modeFromString("bogus").has_value());
+    EXPECT_FALSE(OverlayFSDriver::modeFromString("Kernel").has_value());
+    EXPECT_FALSE(OverlayFSDriver::modeFromString("").has_value());
+}
+
+TEST_F(OverlayFSDriverTest, OverlayFSUtilsRefusesToMountInAutoMode)
+{
+    // utils::OverlayFS in Auto mode must not attempt a real mount.
+    auto overlay = std::make_unique<linglong::utils::OverlayFS>(std::vector<fs::path>{ lower_dir },
+                                                                fs::path{},
+                                                                std::nullopt,
+                                                                merged_dir,
+                                                                linglong::utils::OverlayMode::Auto);
+
+    EXPECT_FALSE(overlay->mount());
+    EXPECT_FALSE(overlay->isMounted());
+    overlay->unmount();
+}

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/hooks_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/hooks_test.cpp
@@ -89,3 +89,24 @@ TEST(InstallHooks, RejectUnterminatedOuterQuote)
 }
 
 } // namespace linglong::utils::details
+
+namespace linglong::utils {
+
+TEST(InstallHookManagerTest, EmptyHooksAreNoop)
+{
+    InstallHookManager manager;
+    EXPECT_TRUE(manager.executeInstallHooks("/tmp/test.uab").has_value());
+    EXPECT_TRUE(manager.executePostInstallHooks("org.deepin.demo", "/path").has_value());
+    EXPECT_TRUE(manager.executePostUninstallHooks("org.deepin.demo").has_value());
+}
+
+TEST(InstallHookManagerTest, ParseInstallHooksMissingDirYieldsNoHooks)
+{
+    // When LINGLONG_INSTALL_HOOKS_DIR does not exist, the directory iterator
+    // is empty and parseInstallHooks simply produces no commands.
+    InstallHookManager manager;
+    auto result = manager.parseInstallHooks();
+    EXPECT_TRUE(result.has_value()) << result.error().message();
+}
+
+} // namespace linglong::utils

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/io_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/io_test.cpp
@@ -1,0 +1,363 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gtest/gtest.h>
+
+#include "linglong/utils/io/event_loop.h"
+#include "linglong/utils/io/forwarder.h"
+#include "linglong/utils/io/pipe.h"
+#include "linglong/utils/io/ring_buffer.h"
+#include "linglong/utils/signal/signal_blocker.h"
+#include "linglong/utils/terminal/terminal_guard.h"
+#include "linglong/utils/unique_fd.h"
+
+#include <array>
+#include <cstring>
+#include <string>
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <unistd.h>
+
+namespace {
+
+using linglong::utils::fd::UniqueFd;
+using linglong::utils::io::EventLoop;
+using linglong::utils::io::IOForwarder;
+using linglong::utils::io::Pipe;
+using linglong::utils::io::PipeSet;
+using linglong::utils::io::RingBuffer;
+using linglong::utils::signal::SignalBlocker;
+using linglong::utils::terminal::TerminalGuard;
+
+TEST(UniqueFd, DefaultIsInvalid)
+{
+    UniqueFd fd;
+    EXPECT_FALSE(fd);
+    EXPECT_EQ(fd.get(), -1);
+}
+
+TEST(UniqueFd, ValidWhenOpened)
+{
+    int raw = ::open("/dev/null", O_RDONLY);
+    ASSERT_GE(raw, 0);
+    UniqueFd fd{ raw };
+    EXPECT_TRUE(static_cast<bool>(fd));
+    EXPECT_EQ(fd.get(), raw);
+    EXPECT_TRUE(::fcntl(raw, F_GETFD) != -1);
+}
+
+TEST(UniqueFd, MoveTransfersOwnership)
+{
+    UniqueFd fd{ ::open("/dev/null", O_RDONLY) };
+    ASSERT_TRUE(fd);
+    int raw = fd.get();
+
+    UniqueFd moved{ std::move(fd) };
+    EXPECT_EQ(moved.get(), raw);
+    EXPECT_EQ(fd.get(), -1);
+}
+
+TEST(UniqueFd, MoveAssignmentClosesOld)
+{
+    UniqueFd first{ ::open("/dev/null", O_RDONLY) };
+    UniqueFd second{ ::open("/dev/null", O_RDONLY) };
+    int firstRaw = first.get();
+
+    second = std::move(first);
+    EXPECT_EQ(second.get(), firstRaw);
+    EXPECT_EQ(first.get(), -1);
+}
+
+TEST(UniqueFd, ReleaseTransfersOut)
+{
+    UniqueFd fd{ ::open("/dev/null", O_RDONLY) };
+    int raw = fd.get();
+    auto released = fd.release();
+    EXPECT_EQ(released, raw);
+    EXPECT_EQ(fd.get(), -1);
+    ::close(released);
+}
+
+TEST(UniqueFd, ResetClosesAndSetsNew)
+{
+    UniqueFd fd{ ::open("/dev/null", O_RDONLY) };
+    ASSERT_TRUE(fd);
+    fd.reset(-1);
+    EXPECT_FALSE(static_cast<bool>(fd));
+
+    int raw = ::open("/dev/null", O_RDONLY);
+    fd.reset(raw);
+    EXPECT_EQ(fd.get(), raw);
+}
+
+TEST(SignalBlocker, BlocksAndRestores)
+{
+    SignalBlocker blocker{ SIGINT, SIGTERM };
+    EXPECT_TRUE(blocker.valid());
+
+    sigset_t current{};
+    ::pthread_sigmask(SIG_SETMASK, nullptr, &current);
+    EXPECT_TRUE(sigismember(&current, SIGINT));
+    EXPECT_TRUE(sigismember(&current, SIGTERM));
+
+    blocker.restore();
+    ::pthread_sigmask(SIG_SETMASK, nullptr, &current);
+    EXPECT_FALSE(sigismember(&current, SIGINT));
+}
+
+TEST(TerminalGuard, FailsOnNonTerminalDescriptor)
+{
+    auto fd = ::open("/dev/null", O_RDWR);
+    ASSERT_GE(fd, 0);
+    auto guard = TerminalGuard::create(fd);
+    EXPECT_FALSE(guard.has_value());
+    ::close(fd);
+}
+
+TEST(TerminalGuard, StaticPropagateWindowSizeFailsWithBadFds)
+{
+    EXPECT_FALSE(TerminalGuard::propagateWindowSize(-1, -1));
+}
+
+TEST(Pipe, CreateAndTransferData)
+{
+    auto pipe = Pipe::create(O_CLOEXEC);
+    ASSERT_TRUE(pipe.has_value());
+
+    int readFd = pipe->readEnd();
+    int writeFd = pipe->writeEnd();
+    ASSERT_GE(readFd, 0);
+    ASSERT_GE(writeFd, 0);
+
+    const std::string payload = "hello pipe";
+    EXPECT_EQ(::write(writeFd, payload.data(), payload.size()),
+              static_cast<ssize_t>(payload.size()));
+
+    std::array<char, 64> buf{};
+    auto n = ::read(readFd, buf.data(), buf.size());
+    ASSERT_GT(n, 0);
+    EXPECT_EQ(std::string(buf.data(), n), payload);
+}
+
+TEST(Pipe, ReleaseEnds)
+{
+    auto pipe = Pipe::create();
+    ASSERT_TRUE(pipe.has_value());
+
+    int readFd = pipe->releaseReadEnd();
+    int writeFd = pipe->releaseWriteEnd();
+    EXPECT_EQ(pipe->readEnd(), -1);
+    EXPECT_EQ(pipe->writeEnd(), -1);
+    ::close(readFd);
+    ::close(writeFd);
+}
+
+TEST(Pipe, CloseEnds)
+{
+    auto pipe = Pipe::create();
+    ASSERT_TRUE(pipe.has_value());
+
+    EXPECT_TRUE(static_cast<bool>(*pipe));
+    pipe->closeWriteEnd();
+    pipe->closeReadEnd();
+    EXPECT_FALSE(static_cast<bool>(*pipe));
+}
+
+TEST(PipeSet, CreateProducesThreePipes)
+{
+    auto set = PipeSet::create();
+    ASSERT_TRUE(set.has_value());
+    EXPECT_TRUE(set->stdinPipe.has_value());
+    EXPECT_TRUE(set->stdoutPipe.has_value());
+    EXPECT_TRUE(set->stderrPipe.has_value());
+}
+
+TEST(RingBuffer, CreateRejectsZeroCapacity)
+{
+    EXPECT_FALSE(RingBuffer::create(0).has_value());
+}
+
+TEST(RingBuffer, RoundsUpToPowerOfTwo)
+{
+    auto buf = RingBuffer::create(1);
+    ASSERT_TRUE(buf.has_value());
+    EXPECT_EQ(buf->capacity(), 1);
+
+    auto big = RingBuffer::create(1000);
+    ASSERT_TRUE(big.has_value());
+    EXPECT_EQ(big->capacity(), 1024);
+}
+
+TEST(RingBuffer, EmptyAndFullStates)
+{
+    auto buf = RingBuffer::create(4);
+    ASSERT_TRUE(buf.has_value());
+    EXPECT_TRUE(buf->empty());
+    EXPECT_FALSE(buf->full());
+    EXPECT_EQ(buf->size(), 0);
+    EXPECT_EQ(buf->freeSpace(), buf->capacity());
+}
+
+TEST(RingBuffer, WriteAndReadViaIovecs)
+{
+    auto buf = RingBuffer::create(8);
+    ASSERT_TRUE(buf.has_value());
+
+    const std::string data = "abcdefgh";
+    auto iov = buf->writeIovecs();
+    ASSERT_GE(iov[0].iov_len, data.size());
+    std::memcpy(iov[0].iov_base, data.data(), data.size());
+    buf->commitWrite(data.size());
+
+    EXPECT_FALSE(buf->empty());
+    EXPECT_EQ(buf->size(), data.size());
+
+    auto readIov = buf->readIovecs();
+    std::string out;
+    out.append(static_cast<const char *>(readIov[0].iov_base), readIov[0].iov_len);
+    out.append(static_cast<const char *>(readIov[1].iov_base), readIov[1].iov_len);
+    EXPECT_EQ(out, data);
+
+    buf->commitRead(data.size());
+    EXPECT_TRUE(buf->empty());
+}
+
+TEST(RingBuffer, WrapsAround)
+{
+    auto buf = RingBuffer::create(4);
+    ASSERT_TRUE(buf.has_value());
+
+    auto iov = buf->writeIovecs();
+    std::memcpy(iov[0].iov_base, "abc", 3);
+    buf->commitWrite(3);
+
+    auto readIov = buf->readIovecs();
+    std::string first;
+    first.append(static_cast<const char *>(readIov[0].iov_base), readIov[0].iov_len);
+    first.append(static_cast<const char *>(readIov[1].iov_base), readIov[1].iov_len);
+    EXPECT_EQ(first, "abc");
+    buf->commitRead(2);
+    EXPECT_EQ(buf->size(), 1);
+}
+
+TEST(RingBuffer, ClearResetsState)
+{
+    auto buf = RingBuffer::create(8);
+    ASSERT_TRUE(buf.has_value());
+
+    auto iov = buf->writeIovecs();
+    std::memcpy(iov[0].iov_base, "xyz", 3);
+    buf->commitWrite(3);
+    EXPECT_FALSE(buf->empty());
+
+    buf->clear();
+    EXPECT_TRUE(buf->empty());
+    EXPECT_EQ(buf->size(), 0);
+}
+
+TEST(EventLoop, CreateAndWaitTimeout)
+{
+    auto loop = EventLoop::create();
+    ASSERT_TRUE(loop.has_value());
+    EXPECT_TRUE(static_cast<bool>(*loop));
+
+    auto result = loop->wait(0);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->count, 0);
+}
+
+TEST(EventLoop, AddAndWaitForReadiness)
+{
+    auto loop = EventLoop::create();
+    ASSERT_TRUE(loop.has_value());
+
+    auto pipe = Pipe::create(O_CLOEXEC);
+    ASSERT_TRUE(pipe.has_value());
+
+    auto added = loop->add(pipe->readEnd(), EPOLLIN);
+    ASSERT_TRUE(added.has_value());
+    EXPECT_TRUE(*added);
+
+    auto first = loop->wait(0);
+    ASSERT_TRUE(first.has_value());
+    EXPECT_EQ(first->count, 0);
+
+    const char byte = 'x';
+    ASSERT_EQ(::write(pipe->writeEnd(), &byte, 1), 1);
+
+    auto second = loop->wait(100);
+    ASSERT_TRUE(second.has_value());
+    EXPECT_GT(second->count, 0);
+    EXPECT_EQ(second->events[0].data.fd, pipe->readEnd());
+
+    loop->remove(pipe->readEnd());
+}
+
+TEST(EventLoop, AddInvalidFdFails)
+{
+    auto loop = EventLoop::create();
+    ASSERT_TRUE(loop.has_value());
+
+    // A negative fd is rejected with an error.
+    auto result = loop->add(-1, EPOLLIN);
+    EXPECT_FALSE(result.has_value());
+
+    // A regular file does not support epoll: add() reports EPERM as a
+    // value of false instead of an error.
+    int regularFd = ::open("/dev/null", O_RDONLY);
+    ASSERT_GE(regularFd, 0);
+    auto notEpollable = loop->add(regularFd, EPOLLIN);
+    ASSERT_TRUE(notEpollable.has_value());
+    EXPECT_FALSE(*notEpollable);
+    ::close(regularFd);
+}
+
+TEST(EventLoop, ModifyUnregisteredFdFails)
+{
+    auto loop = EventLoop::create();
+    ASSERT_TRUE(loop.has_value());
+    auto result = loop->modify(100000000, EPOLLIN);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(IOForwarder, ForwardsDataFromPipeToPipe)
+{
+    auto loop = EventLoop::create();
+    ASSERT_TRUE(loop.has_value());
+
+    auto src = Pipe::create(O_CLOEXEC | O_NONBLOCK);
+    auto dst = Pipe::create(O_CLOEXEC | O_NONBLOCK);
+    ASSERT_TRUE(src.has_value());
+    ASSERT_TRUE(dst.has_value());
+
+    IOForwarder forwarder{ *loop };
+    forwarder.setSrc(src->readEnd());
+    forwarder.setDst(dst->writeEnd());
+    EXPECT_FALSE(forwarder.isFinished());
+    EXPECT_TRUE(forwarder.bufferEmpty());
+
+    const std::string payload = "forward me";
+    ASSERT_EQ(::write(src->writeEnd(), payload.data(), payload.size()),
+              static_cast<ssize_t>(payload.size()));
+
+    // A single drive() performs both the pull (src -> buffer) and push
+    // (buffer -> dst), so after it the buffer must be drained.
+    forwarder.drive();
+    EXPECT_TRUE(forwarder.bufferEmpty());
+
+    std::array<char, 64> buf{};
+    auto n = ::read(dst->readEnd(), buf.data(), buf.size());
+    EXPECT_EQ(std::string(buf.data(), n), payload);
+
+    forwarder.markSrcEof();
+    EXPECT_TRUE(forwarder.isFinished());
+
+    forwarder.markDstFailed();
+    EXPECT_TRUE(forwarder.isFinished());
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Expands unit test coverage across several previously untested pure-logic modules, and makes a handful of environment-dependent tests robust.

### New test files
- `cli/cli_printer_test.cpp` — CLIPrinter + JSONPrinter output (incl. stdout/stderr capture)
- `oci-cfg-generators/container_cfg_builder_test.cpp` — 31 tests covering build/validation, id-mappings, mounts, annotations, env, hooks, caps, masking, XDP/pipewire/at-spi, private dir, cache/ld, resolv.conf
- `repo/migrate_test.cpp` — `tryMigrate` incl. real ostree repo paths
- `utils/io_test.cpp` — Pipe/PipeSet, RingBuffer, EventLoop, IOForwarder, UniqueFd, TerminalGuard, SignalBlocker
- `package/version_extra_test.cpp` — fallback/version cross-type operators, `validateDependVersion`, fuzzy version filter
- `package_manager/data_monitor_test.cpp` — speed accounting
- `common/global/initialize_test.cpp` — GlobalTaskControl / log system env parsing

### Extended existing tests
- `repo/repo_cache_test.cpp` — query filters, merged items, error paths
- `repo/config_test.cpp` — loadConfig/saveConfig
- `runtime/container_builder_test.cpp` — RunContainerOptions, security context
- `runtime/overlayfs_driver_test.cpp` — mode string conversion, utils mount guard
- `utils/hooks_test.cpp` — InstallHookManager

### Robustness fixes
- `Error.WarpStdErrorCode` no longer depends on running as non-root (deterministic `errc::permission_denied`)
- fuse-based unpack tests skip when `/dev/fuse` is unavailable instead of failing

All 647 tests pass in a Deepin 25 container (`gtest` + coverage build).