### PR TITLE
docs: add one-click install script to README installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,74 +33,13 @@
 
 ## :gear: Installation
 
-Installation instructions for supported distributions:
-
-### deepin 23
-
-Install:
+One-click installation:
 
 ```sh
-echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Deepin_23/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
-sudo apt update
-sudo apt install linglong-bin
+curl -fsSL https://get.linyaps.org.cn | sh
 ```
 
-### Fedora 41
-
-```sh
-sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_41/linglong%3ACI%3Arelease.repo"
-sudo dnf update
-sudo dnf install linglong-bin
-```
-
-### Ubuntu 24.04
-
-```sh
-echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/xUbuntu_24.04/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
-sudo apt update
-sudo apt install linglong-bin
-```
-
-### Debian 12
-
-```sh
-echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Debian_12/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
-sudo apt update
-sudo apt install linglong-bin
-```
-
-### openEuler 23.09
-
-```sh
-sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_23.09/linglong%3ACI%3Arelease.repo"
-sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
-sudo dnf update
-sudo dnf install linglong-bin
-```
-
-### uos 1070
-
-```sh
-echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/uos_1070/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
-sudo apt update
-sudo apt install linglong-bin
-```
-
-### AnolisOS 8
-
-```sh
-sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/AnolisOS_8/linglong%3ACI%3Arelease.repo"
-sudo dnf update
-sudo dnf install linglong-bin
-```
-
-### openkylin 2.0
-
-```sh
-echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/openkylin_2.0/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
-sudo apt update
-sudo apt install linglong-bin
-```
+You can also install manually for a supported distribution: see [Install Linyaps](https://linyaps.org.cn/guide/start/install.html).
 
 ## :rocket: Quick Start
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -33,74 +33,13 @@
 
 ## :gear: 安装
 
-各个发行版安装方式如下：
-
-### deepin 23
-
-安装：
+一键安装：
 
 ```sh
-echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Deepin_23/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
-sudo apt update
-sudo apt install linglong-bin
+curl -fsSL https://get.linyaps.org.cn | sh
 ```
 
-### Fedora 41
-
-```sh
-sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/Fedora_41/linglong%3ACI%3Arelease.repo"
-sudo dnf update
-sudo dnf install linglong-bin
-```
-
-### Ubuntu 24.04
-
-```sh
-echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/xUbuntu_24.04/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
-sudo apt update
-sudo apt install linglong-bin
-```
-
-### Debian 12
-
-```sh
-echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Debian_12/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
-sudo apt update
-sudo apt install linglong-bin
-```
-
-### openEuler 23.09
-
-```sh
-sudo dnf config-manager --add-repo "https://ci.deepin.com/repo/obs/linglong:/CI:/release/openEuler_23.09/linglong%3ACI%3Arelease.repo"
-sudo sh -c "echo gpgcheck=0 >> /etc/yum.repos.d/linglong%3ACI%3Arelease.repo"
-sudo dnf update
-sudo dnf install linglong-bin
-```
-
-### uos 1070
-
-```sh
-echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/uos_1070/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
-sudo apt update
-sudo apt install linglong-bin
-```
-
-### AnolisOS 8
-
-```sh
-sudo dnf config-manager addrepo --from-repofile "https://ci.deepin.com/repo/obs/linglong:/CI:/release/AnolisOS_8/linglong%3ACI%3Arelease.repo"
-sudo dnf update
-sudo dnf install linglong-bin
-```
-
-### openkylin 2.0
-
-```sh
-echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/openkylin_2.0/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
-sudo apt update
-sudo apt install linglong-bin
-```
+也可以选择手动安装，各发行版手动安装方法见[安装如意玲珑](https://linyaps.org.cn/guide/start/install.html)。
 
 ## :rocket: 快速开始
 


### PR DESCRIPTION
## Summary

Update the README installation guide (both `README.md` and `README.zh_CN.md`) to add the new one-click installation method:

```sh
curl -fsSL https://get.linyaps.org.cn | sh
```

Since the one-click script now covers all supported distributions, the per-distribution commands in the README are replaced by a link to the official manual installation page: <https://linyaps.org.cn/guide/start/install.html>.

## Changes

- `README.md`: lead the Installation section with the one-click command; link manual installation to the official docs.
- `README.zh_CN.md`: same change in Chinese.