### PR TITLE
feat: embed UAB bundle digest in ELF note section

### DIFF
--- a/apps/uab/header/CMakeLists.txt
+++ b/apps/uab/header/CMakeLists.txt
@@ -56,8 +56,12 @@ pfl_add_executable(
 set(UAB_HEADER_TARGET)
 get_real_target_name(UAB_HEADER_TARGET linglong::header)
 
-target_link_options(${UAB_HEADER_TARGET} PRIVATE -static -static-libgcc
-                    -static-libstdc++)
+set(UAB_HEADER_LINKER_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/uab-header.ld)
+set_property(
+  TARGET ${UAB_HEADER_TARGET} APPEND
+  PROPERTY LINK_DEPENDS ${UAB_HEADER_LINKER_SCRIPT})
+target_link_options(${UAB_HEADER_TARGET} PRIVATE -static -static-libgcc -static-libstdc++
+                    -Wl,-T,${UAB_HEADER_LINKER_SCRIPT})
 
 if(${AGGRESSIVE_UAB_SIZE})
   message(STATUS "minify size of uab header aggressively")

--- a/apps/uab/header/src/main.cpp
+++ b/apps/uab/header/src/main.cpp
@@ -5,6 +5,7 @@
 #include "light_elf.h"
 #include "linglong/api/types/v1/Generators.hpp" // IWYU pragma: keep
 #include "linglong/api/types/v1/UabMetaInfo.hpp"
+#include "linglong/common/uab_signature.h"
 #include "linglong/utils/sha256.h"
 
 #include <gelf.h>
@@ -19,6 +20,8 @@
 #include <filesystem>
 #include <iomanip>
 #include <iostream>
+#include <string>
+#include <string_view>
 
 #include <fcntl.h>
 #include <sys/mman.h>
@@ -29,6 +32,11 @@
 #include <unistd.h>
 
 extern "C" int erofsfuse_main(int argc, char **argv);
+
+// Stable ELF ABI for signing tools. The linker renames this executable input section to
+// .note.uab.sig. Its descriptor stores the 64-byte SHA-256 digest of linglong.meta.
+__attribute__((used, section(".text.uab.sig"), aligned(4))) const auto linglongUabSignature =
+  linglong::common::uab::signatureNote;
 
 namespace {
 
@@ -160,6 +168,10 @@ std::string calculateDigest(int fd, std::size_t bundleOffset, std::size_t bundle
             sha256.update(buffer.get(), bytesRead);
             totalRead += bytesRead;
         }
+        if (totalRead != bundleLength) {
+            std::cerr << "unexpected end of UAB section" << std::endl;
+            return {};
+        }
     }
 
     sha256.final(digest.data());
@@ -171,6 +183,21 @@ std::string calculateDigest(int fd, std::size_t bundleOffset, std::size_t bundle
         stream << std::setw(2) << static_cast<unsigned int>(v);
     }
 
+    return stream.str();
+}
+
+std::string calculateDigest(std::string_view data) noexcept
+{
+    digest::SHA256 sha256;
+    std::array<std::byte, 32> digest{};
+    sha256.update(reinterpret_cast<const std::byte *>(data.data()), data.size());
+    sha256.final(digest.data());
+
+    std::stringstream stream;
+    stream << std::setfill('0') << std::hex;
+    for (auto value : digest) {
+        stream << std::setw(2) << static_cast<unsigned int>(value);
+    }
     return stream.str();
 }
 
@@ -233,6 +260,63 @@ std::optional<std::filesystem::path> find_fusermount() noexcept
     return std::nullopt;
 }
 
+std::optional<linglong::api::types::v1::UabMetaInfo>
+getVerifiedMetaInfo(const lightElf::native_elf &elf) noexcept
+{
+    const auto signatureSh =
+      elf.getSectionHeader(std::string{ linglong::common::uab::signatureSection });
+    if (!signatureSh || signatureSh->sh_size != sizeof(linglong::common::uab::MetaSignatureNote)) {
+        std::cerr << "UAB signature section is missing or invalid" << std::endl;
+        return std::nullopt;
+    }
+
+    std::string noteData(signatureSh->sh_size, '\0');
+    const auto bytesRead =
+      ::pread(elf.underlyingFd(), noteData.data(), signatureSh->sh_size, signatureSh->sh_offset);
+    if (bytesRead != static_cast<ssize_t>(signatureSh->sh_size)) {
+        std::cerr << "failed to read UAB signature section: " << ::strerror(errno) << std::endl;
+        return std::nullopt;
+    }
+
+    const auto expectedMetaDigest = linglong::common::uab::parseSignatureNote(noteData);
+    if (!expectedMetaDigest || !linglong::common::uab::isDigest(*expectedMetaDigest)) {
+        std::cerr << "UAB signature section contains an invalid meta digest" << std::endl;
+        return std::nullopt;
+    }
+
+    const auto metaSh = elf.getSectionHeader(std::string{ linglong::common::uab::metaSection });
+    if (!metaSh || metaSh->sh_type == SHT_NOBITS) {
+        std::cerr << "couldn't find a valid meta section" << std::endl;
+        return std::nullopt;
+    }
+
+    std::string metaData(metaSh->sh_size, '\0');
+    const auto metaBytesRead =
+      ::pread(elf.underlyingFd(), metaData.data(), metaSh->sh_size, metaSh->sh_offset);
+    if (metaBytesRead != static_cast<ssize_t>(metaSh->sh_size)) {
+        std::cerr << "failed to read meta section: " << ::strerror(errno) << std::endl;
+        return std::nullopt;
+    }
+    if (calculateDigest(metaData) != *expectedMetaDigest) {
+        std::cerr << "linglong.meta digest mismatched" << std::endl;
+        return std::nullopt;
+    }
+
+    std::optional<linglong::api::types::v1::UabMetaInfo> meta;
+    try {
+        meta = nlohmann::json::parse(metaData).get<linglong::api::types::v1::UabMetaInfo>();
+    } catch (const std::exception &e) {
+        std::cerr << "failed to parse verified meta section: " << e.what() << std::endl;
+        return std::nullopt;
+    }
+    if (!linglong::common::uab::isDigest(meta->digest)) {
+        std::cerr << "linglong.meta contains an invalid bundle digest" << std::endl;
+        return std::nullopt;
+    }
+
+    return meta;
+}
+
 int mountSelfBundle(const lightElf::native_elf &elf,
                     const linglong::api::types::v1::UabMetaInfo &meta) noexcept
 {
@@ -241,15 +325,20 @@ int mountSelfBundle(const lightElf::native_elf &elf,
         std::cerr << "couldn't get bundle section '" << meta.sections.bundle << "'" << std::endl;
         return -1;
     }
-
-    auto bundleOffset = bundleSh->sh_offset;
-    if (auto digest = calculateDigest(elf.underlyingFd(), bundleOffset, bundleSh->sh_size);
-        digest != meta.digest) {
-        std::cerr << "sha256 mismatched, expected: " << meta.digest << " calculated: " << digest
-                  << std::endl;
+    if (bundleSh->sh_type == SHT_NOBITS) {
+        std::cerr << "bundle section has no file data" << std::endl;
         return -1;
     }
 
+    const auto bundleDigest =
+      calculateDigest(elf.underlyingFd(), bundleSh->sh_offset, bundleSh->sh_size);
+    if (bundleDigest != meta.digest) {
+        std::cerr << "bundle digest mismatched, expected: " << meta.digest
+                  << " calculated: " << bundleDigest << std::endl;
+        return -1;
+    }
+
+    auto bundleOffset = bundleSh->sh_offset;
     auto selfBin = elf.absolutePath();
     auto offsetStr = "--offset=" + std::to_string(bundleOffset);
     std::array<const char *, 4> erofs_argv = { "erofsfuse",
@@ -414,33 +503,6 @@ int createMountPoint(std::string_view uuid) noexcept
     createFlag.store(true, std::memory_order_relaxed);
 
     return 0;
-}
-
-std::optional<linglong::api::types::v1::UabMetaInfo>
-getMetaInfo(const lightElf::native_elf &elf) noexcept
-{
-    auto metaSh = elf.getSectionHeader("linglong.meta");
-    if (!metaSh) {
-        std::cerr << "couldn't find meta section" << std::endl;
-        return std::nullopt;
-    }
-
-    std::string content(metaSh->sh_size, '\0');
-    if (::pread(elf.underlyingFd(), content.data(), metaSh->sh_size, metaSh->sh_offset) == -1) {
-        std::cerr << "read failed:" << ::strerror(errno) << std::endl;
-        return {};
-    }
-
-    std::optional<linglong::api::types::v1::UabMetaInfo> meta;
-    try {
-        auto json = nlohmann::json::parse(content);
-        meta = json.get<linglong::api::types::v1::UabMetaInfo>();
-    } catch (const nlohmann::json::parse_error &e) {
-        std::cerr << "exception: " << e.what() << std::endl;
-        return std::nullopt;
-    }
-
-    return meta;
 }
 
 int extractBundle(std::string_view destination) noexcept
@@ -655,9 +717,9 @@ int main(int argc, char **argv)
     }
 
     lightElf::native_elf elf(selfBin);
-    auto metaInfoRet = getMetaInfo(elf);
+    auto metaInfoRet = getVerifiedMetaInfo(elf);
     if (!metaInfoRet) {
-        std::cerr << "couldn't get metaInfo of this uab file" << std::endl;
+        std::cerr << "couldn't verify metaInfo of this uab file" << std::endl;
         return -1;
     }
     const auto &metaInfo = *metaInfoRet;

--- a/apps/uab/header/uab-header.ld
+++ b/apps/uab/header/uab-header.ld
@@ -1,0 +1,11 @@
+/* SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd. */
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+
+SECTIONS
+{
+    .note.uab.sig : ALIGN(4)
+    {
+        KEEP(*(.text.uab.sig))
+    }
+}
+INSERT AFTER .text;

--- a/libs/common/src/linglong/common/uab_signature.h
+++ b/libs/common/src/linglong/common/uab_signature.h
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string_view>
+
+namespace linglong::common::uab {
+
+inline constexpr std::string_view signatureSection{ ".note.uab.sig" };
+inline constexpr std::string_view metaSection{ "linglong.meta" };
+inline constexpr std::size_t digestSize = 64;
+inline constexpr std::uint32_t signatureNoteType = 1;
+
+constexpr std::size_t noteAlign(std::size_t size) noexcept
+{
+    return (size + 3U) & ~std::size_t{ 3U };
+}
+
+struct NoteHeader
+{
+    std::uint32_t nameSize;
+    std::uint32_t descriptorSize;
+    std::uint32_t type;
+};
+
+template <std::size_t NameSize>
+struct SignatureNote
+{
+    NoteHeader header;
+    std::array<char, noteAlign(NameSize)> name;
+    std::array<char, digestSize> digest;
+};
+
+template <std::size_t NameSize>
+constexpr SignatureNote<NameSize> makeSignatureNote(const char (&name)[NameSize]) noexcept
+{
+    SignatureNote<NameSize> note{};
+    note.header = { NameSize, digestSize, signatureNoteType };
+    for (std::size_t i = 0; i < NameSize; ++i) {
+        note.name[i] = name[i];
+    }
+    note.digest[0] = '!';
+    return note;
+}
+
+using MetaSignatureNote = SignatureNote<sizeof("linglong.meta")>;
+
+inline constexpr MetaSignatureNote signatureNote = makeSignatureNote("linglong.meta");
+inline constexpr std::size_t digestOffset = offsetof(MetaSignatureNote, digest);
+
+inline bool isDigest(std::string_view digest) noexcept
+{
+    return digest.size() == digestSize
+      && std::all_of(digest.cbegin(), digest.cend(), [](char value) noexcept {
+               return (value >= '0' && value <= '9') || (value >= 'a' && value <= 'f');
+           });
+}
+
+inline std::optional<std::string_view> parseSignatureNote(std::string_view data) noexcept
+{
+    if (data.size() != sizeof(MetaSignatureNote)) {
+        return std::nullopt;
+    }
+
+    NoteHeader header{};
+    std::memcpy(&header, data.data(), sizeof(header));
+    if (header.nameSize != metaSection.size() + 1 || header.descriptorSize != digestSize
+        || header.type != signatureNoteType) {
+        return std::nullopt;
+    }
+
+    const auto nameOffset = sizeof(NoteHeader);
+    const auto name = data.substr(nameOffset, header.nameSize);
+    if (name.substr(0, name.size() - 1) != metaSection || name.back() != '\0') {
+        return std::nullopt;
+    }
+
+    const auto alignedNameSize = noteAlign(header.nameSize);
+    const auto padding =
+      data.substr(nameOffset + header.nameSize, alignedNameSize - header.nameSize);
+    if (!std::all_of(padding.cbegin(), padding.cend(), [](char value) {
+            return value == '\0';
+        })) {
+        return std::nullopt;
+    }
+
+    return data.substr(digestOffset, digestSize);
+}
+
+static_assert(sizeof(NoteHeader) == 12);
+static_assert(digestOffset == 28);
+static_assert(sizeof(MetaSignatureNote) == 92);
+
+} // namespace linglong::common::uab

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -62,6 +62,9 @@ std::vector<std::string> Builder::privilegeBuilderCaps = {
 
 namespace {
 
+constexpr auto builderUtilsID = "cn.org.linyaps.builder.utils";
+constexpr auto minimumBuilderUtilsVersion = "0.0.4.0";
+
 utils::error::Result<package::Reference>
 currentReference(const api::types::v1::BuilderProject &project)
 {
@@ -520,6 +523,21 @@ Builder::ensureUtils(const std::string &id, const package::Architecture &arch) n
     auto ref = detail::pullDependency(fuzzyRef->toString(), this->repo, "binary");
     if (!ref) {
         return LINGLONG_ERR("failed to get utils " + id, ref);
+    }
+
+    if (id == builderUtilsID) {
+        auto minimumVersion = package::Version::parse(minimumBuilderUtilsVersion);
+        if (!minimumVersion) {
+            return LINGLONG_ERR(fmt::format("failed to parse minimum builder-utils version {}",
+                                            minimumBuilderUtilsVersion),
+                                minimumVersion);
+        }
+        if (ref->version < *minimumVersion) {
+            return LINGLONG_ERR(
+              fmt::format("builder-utils {} is too old; version {} or newer is required",
+                          ref->version.toString(),
+                          minimumBuilderUtilsVersion));
+        }
     }
 
     auto layerItem = this->repo.getLayerItem(*ref);
@@ -1508,10 +1526,13 @@ utils::error::Result<void> Builder::exportUAB(const ExportOption &option,
         return LINGLONG_ERR(curRef);
     }
 
-    // Retrieves static files from the ll-builder-utils matching the target architecture if
-    // available, including uab-header, uab-loader, ll-box. Fallback to defaults if ll-builder-utils
-    // is not found or fails.
-    auto ref = ensureUtils("cn.org.linyaps.builder.utils", curRef->arch);
+    const auto &arch = package::Architecture::currentCPUArchitecture();
+    const bool crossArchitecture = arch != curRef->arch;
+
+    // Retrieve the static files from ll-builder-utils matching the target architecture, including
+    // uab-header, uab-loader and ll-box. These files are required even for native exports because
+    // the installed defaults may produce an older UAB format.
+    auto ref = ensureUtils(builderUtilsID, curRef->arch);
     if (ref) {
         LogD("using static files from cn.org.linyaps.builder.utils");
         std::vector<std::string> args{
@@ -1527,29 +1548,44 @@ utils::error::Result<void> Builder::exportUAB(const ExportOption &option,
             args.emplace_back("/project/.uabBuild/ll-box");
         }
 
-        auto res = runFromRepo(*ref, args);
-        if (res) {
+        auto utilsResult = runFromRepo(*ref, args);
+        if (utilsResult) {
             std::error_code ec;
-            if (std::filesystem::exists(exportWorkingDir / "uab-header", ec)
-                && std::filesystem::exists(exportWorkingDir / "uab-loader", ec)) {
+            const bool hasHeader = std::filesystem::exists(exportWorkingDir / "uab-header", ec);
+            const bool hasLoader = std::filesystem::exists(exportWorkingDir / "uab-loader", ec);
+            if (hasHeader && hasLoader) {
                 packager.setDefaultHeader(exportWorkingDir / "uab-header");
                 packager.setDefaultLoader(exportWorkingDir / "uab-loader");
+            } else {
+                return LINGLONG_ERR(
+                  "builder utils did not provide uab-header and uab-loader for target architecture "
+                  + curRef->arch.toString());
             }
 
-            if (!distributedOnly && std::filesystem::exists(exportWorkingDir / "ll-box", ec)) {
-                packager.setDefaultBox(exportWorkingDir / "ll-box");
+            if (!distributedOnly) {
+                const bool hasBox = std::filesystem::exists(exportWorkingDir / "ll-box", ec);
+                if (hasBox) {
+                    packager.setDefaultBox(exportWorkingDir / "ll-box");
+                } else {
+                    return LINGLONG_ERR(
+                      "builder utils did not provide ll-box for target architecture "
+                      + curRef->arch.toString());
+                }
             }
         } else {
-            LogW("run builder utils error: {}", res.error());
+            return LINGLONG_ERR("failed to get UAB utilities for target architecture "
+                                  + curRef->arch.toString(),
+                                utilsResult);
         }
     } else {
-        LogW("failed to get builder utils for arch {}: {}", curRef->arch.toString(), ref.error());
+        return LINGLONG_ERR("failed to get builder utils for target architecture "
+                              + curRef->arch.toString(),
+                            ref);
     }
 
     // Using the packdir tools matching current architecture
-    const auto &arch = package::Architecture::currentCPUArchitecture();
-    if (arch != curRef->arch) {
-        ref = ensureUtils("cn.org.linyaps.builder.utils", arch);
+    if (crossArchitecture) {
+        ref = ensureUtils(builderUtilsID, arch);
     }
 
     if (ref) {

--- a/libs/linglong/src/linglong/package/elf_handler.cpp
+++ b/libs/linglong/src/linglong/package/elf_handler.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -113,6 +113,24 @@ bool write_all(int fd, const void *buf, size_t count)
         }
         ptr += written;
         left -= written;
+    }
+    return true;
+}
+
+bool pwrite_all(int fd, const void *buf, size_t count, off_t offset)
+{
+    const char *ptr = static_cast<const char *>(buf);
+    size_t left = count;
+    while (left > 0) {
+        auto written = pwrite(fd, ptr, left, offset);
+        if (written <= 0) {
+            if (errno == EINTR)
+                continue;
+            return false;
+        }
+        ptr += written;
+        left -= written;
+        offset += written;
     }
     return true;
 }
@@ -281,6 +299,62 @@ ElfHandler::ElfHandler(std::filesystem::path file)
 }
 
 ElfHandler::~ElfHandler() { }
+
+utils::error::Result<void> ElfHandler::writeSectionData(const std::string &name,
+                                                        std::size_t offset,
+                                                        const char *data,
+                                                        std::size_t size)
+{
+    LINGLONG_TRACE("write section data:" + name);
+
+    if (elf_version(EV_CURRENT) == EV_NONE) {
+        return LINGLONG_ERR("failed to initialize libelf");
+    }
+
+    int fd = open(file_.c_str(), O_RDWR);
+    if (fd < 0) {
+        return LINGLONG_ERR("failed to open file: " + file_.string());
+    }
+    auto close_fd = utils::finally::finally([fd] {
+        close(fd);
+    });
+
+    Elf *e = elf_begin(fd, ELF_C_READ, nullptr);
+    if (e == nullptr) {
+        return LINGLONG_ERR("failed to get elf");
+    }
+    auto clean_elf = utils::finally::finally([e] {
+        elf_end(e);
+    });
+
+    size_t shstrndx{ 0 };
+    if (elf_getshdrstrndx(e, &shstrndx) != 0) {
+        return LINGLONG_ERR("failed to get elf section header string index");
+    }
+
+    Elf_Scn *scn{ nullptr };
+    while ((scn = elf_nextscn(e, scn)) != nullptr) {
+        GElf_Shdr sectionHeader;
+        if (gelf_getshdr(scn, &sectionHeader) == nullptr) {
+            return LINGLONG_ERR("failed to get section header");
+        }
+
+        const auto *sectionName = elf_strptr(e, shstrndx, sectionHeader.sh_name);
+        if (sectionName == nullptr || name != sectionName) {
+            continue;
+        }
+        if (sectionHeader.sh_type == SHT_NOBITS || offset > sectionHeader.sh_size
+            || size > sectionHeader.sh_size - offset) {
+            return LINGLONG_ERR(fmt::format("data exceeds section {}", name));
+        }
+        if (!pwrite_all(fd, data, size, sectionHeader.sh_offset + offset)) {
+            return LINGLONG_ERR(fmt::format("failed to write section {}", name));
+        }
+        return LINGLONG_OK;
+    }
+
+    return LINGLONG_ERR(fmt::format("couldn't find section {}", name));
+}
 
 utils::error::Result<void> ElfHandler::addSection(const std::string &name,
                                                   const std::filesystem::path &file)

--- a/libs/linglong/src/linglong/package/elf_handler.h
+++ b/libs/linglong/src/linglong/package/elf_handler.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -6,8 +6,10 @@
 
 #include "linglong/utils/error/error.h"
 
+#include <cstddef>
 #include <filesystem>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace linglong::package {
@@ -22,6 +24,10 @@ public:
     utils::error::Result<void> addSection(const std::string &name, const char *data, size_t size);
     utils::error::Result<void> addSection(const std::string &name,
                                           const std::filesystem::path &file);
+    utils::error::Result<void> writeSectionData(const std::string &name,
+                                                std::size_t offset,
+                                                const char *data,
+                                                std::size_t size);
 
 private:
     std::filesystem::path file_;

--- a/libs/linglong/src/linglong/package/uab_file.cpp
+++ b/libs/linglong/src/linglong/package/uab_file.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -7,6 +7,7 @@
 #include "linglong/api/types/v1/Generators.hpp"
 #include "linglong/common/error.h"
 #include "linglong/common/formatter.h"
+#include "linglong/common/uab_signature.h"
 #include "linglong/utils/cmd.h"
 #include "linglong/utils/error/error.h"
 #include "linglong/utils/finally/finally.h"
@@ -20,8 +21,11 @@
 #include <QStandardPaths>
 #include <QUuid>
 
+#include <algorithm>
+#include <array>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <random>
 #include <string_view>
 
@@ -102,6 +106,52 @@ utils::error::Result<GElf_Shdr> UABFile::getSectionHeader(const QString &section
     return LINGLONG_ERR(fmt::format("couldn't found section {}", section));
 }
 
+utils::error::Result<std::string> UABFile::readSectionData(const QString &section,
+                                                           std::size_t offset,
+                                                           std::size_t size) noexcept
+{
+    LINGLONG_TRACE("read uab section data")
+
+    auto sectionHeader = getSectionHeader(section);
+    if (!sectionHeader) {
+        return LINGLONG_ERR(sectionHeader.error());
+    }
+    if (sectionHeader->sh_type == SHT_NOBITS || offset > sectionHeader->sh_size
+        || size > sectionHeader->sh_size - offset) {
+        return LINGLONG_ERR(fmt::format("data exceeds section {}", section));
+    }
+    if (!seek(sectionHeader->sh_offset + offset)) {
+        return LINGLONG_ERR(
+          fmt::format("failed to seek to section {}: {}", section, errorString()));
+    }
+    auto backToHead = utils::finally::finally([this] {
+        seek(0);
+    });
+    auto data = read(size);
+    if (data.size() != static_cast<qint64>(size)) {
+        return LINGLONG_ERR(fmt::format("failed to read section {}: {}", section, errorString()));
+    }
+    return data.toStdString();
+}
+
+utils::error::Result<std::reference_wrapper<const api::types::v1::UabMetaInfo>>
+UABFile::parseMetaInfo(std::string_view metaData) noexcept
+{
+    LINGLONG_TRACE("parse metaInfo")
+
+    try {
+        auto content = nlohmann::json::parse(metaData);
+        this->metaInfo =
+          std::make_unique<api::types::v1::UabMetaInfo>(content.get<api::types::v1::UabMetaInfo>());
+    } catch (nlohmann::json::exception &e) {
+        return LINGLONG_ERR("parsing metaInfo error", e);
+    } catch (...) {
+        return LINGLONG_ERR("unknown exception has been catch");
+    }
+
+    return *(this->metaInfo);
+}
+
 utils::error::Result<std::reference_wrapper<const api::types::v1::UabMetaInfo>>
 UABFile::getMetaInfo() noexcept
 {
@@ -111,85 +161,119 @@ UABFile::getMetaInfo() noexcept
         return { *(this->metaInfo) };
     }
 
-    auto metaSh = getSectionHeader("linglong.meta");
+    const auto metaSection = QString::fromStdString(std::string{ common::uab::metaSection });
+    auto metaSh = getSectionHeader(metaSection);
     if (!metaSh) {
         return LINGLONG_ERR(metaSh.error());
     }
-
-    seek(metaSh->sh_offset);
-    auto backToHead = utils::finally::finally([this] {
-        seek(0);
-    });
-
-    auto metaInfo = read(metaSh->sh_size).toStdString();
-    if (metaInfo.empty()) {
-        return LINGLONG_ERR(fmt::format("couldn't read metaInfo from uab: {}", errorString()));
+    auto metaData = readSectionData(metaSection, 0, metaSh->sh_size);
+    if (!metaData) {
+        return LINGLONG_ERR(metaData.error());
     }
-
-    nlohmann::json content;
-    try {
-        content = nlohmann::json::parse(metaInfo);
-    } catch (nlohmann::json::parse_error &e) {
-        return LINGLONG_ERR("parsing metaInfo error", e);
-    } catch (...) {
-        return LINGLONG_ERR("unknown exception has been catch");
+    if (metaData->empty()) {
+        return LINGLONG_ERR("metaInfo is empty");
     }
-
-    this->metaInfo =
-      std::make_unique<api::types::v1::UabMetaInfo>(content.get<api::types::v1::UabMetaInfo>());
-    return *(this->metaInfo);
+    return parseMetaInfo(*metaData);
 }
 
 utils::error::Result<bool> UABFile::verify() noexcept
 {
     LINGLONG_TRACE("verify uab")
 
-    auto metaInfoRet = getMetaInfo();
+    const auto signatureSection =
+      QString::fromStdString(std::string{ common::uab::signatureSection });
+    auto signatureSh = getSectionHeader(signatureSection);
+    if (!signatureSh) {
+        return LINGLONG_ERR(signatureSh.error());
+    }
+    if (signatureSh->sh_size != sizeof(common::uab::MetaSignatureNote)) {
+        return LINGLONG_ERR(fmt::format("section {} is invalid", signatureSection));
+    }
+
+    auto noteDataRet = readSectionData(signatureSection, 0, signatureSh->sh_size);
+    if (!noteDataRet) {
+        return LINGLONG_ERR(noteDataRet.error());
+    }
+    const auto expectedMetaDigest = common::uab::parseSignatureNote(*noteDataRet);
+    if (!expectedMetaDigest) {
+        return LINGLONG_ERR(fmt::format("section {} has an invalid note layout", signatureSection));
+    }
+    if (!common::uab::isDigest(*expectedMetaDigest)) {
+        return LINGLONG_ERR(fmt::format("section {} has an invalid digest", signatureSection));
+    }
+
+    const auto calculateSectionDigest =
+      [&](const GElf_Shdr &sectionHeader) -> utils::error::Result<std::string> {
+        std::array<char, 4096> buffer{};
+        QCryptographicHash cryptor{ QCryptographicHash::Sha256 };
+        if (!seek(sectionHeader.sh_offset)) {
+            return LINGLONG_ERR(fmt::format("failed to seek to section: {}", errorString()));
+        }
+        auto backToHead = utils::finally::finally([this] {
+            seek(0);
+        });
+
+        std::size_t remaining = sectionHeader.sh_size;
+        while (remaining > 0) {
+            const auto requested = std::min(remaining, buffer.size());
+            const auto bytesRead = read(buffer.data(), static_cast<qint64>(requested));
+            if (bytesRead <= 0) {
+                return LINGLONG_ERR(fmt::format("read error: {}", errorString()));
+            }
+            cryptor.addData(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
+              QByteArrayView{ buffer.data(), bytesRead }
+#else
+              buffer.data(),
+              bytesRead
+#endif
+            );
+            remaining -= static_cast<std::size_t>(bytesRead);
+        }
+        return cryptor.result().toHex().toStdString();
+    };
+
+    const auto metaSection = QString::fromStdString(std::string{ common::uab::metaSection });
+    auto metaSh = getSectionHeader(metaSection);
+    if (!metaSh) {
+        return LINGLONG_ERR(metaSh.error());
+    }
+    auto metaData = readSectionData(metaSection, 0, metaSh->sh_size);
+    if (!metaData) {
+        return LINGLONG_ERR(metaData.error());
+    }
+    if (metaData->size() > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+        return LINGLONG_ERR("linglong.meta is too large");
+    }
+
+    QCryptographicHash metaCryptor{ QCryptographicHash::Sha256 };
+    metaCryptor.addData(metaData->data(), static_cast<int>(metaData->size()));
+    if (metaCryptor.result().toHex().toStdString() != *expectedMetaDigest) {
+        return false;
+    }
+
+    auto metaInfoRet = parseMetaInfo(*metaData);
     if (!metaInfoRet) {
         return LINGLONG_ERR(metaInfoRet.error());
     }
+    const auto &metaInfo = metaInfoRet->get();
+    if (!common::uab::isDigest(metaInfo.digest)) {
+        return LINGLONG_ERR("linglong.meta contains an invalid bundle digest");
+    }
 
-    auto metaInfo = metaInfoRet->get();
-    auto expectedDigest = metaInfo.digest;
-    auto bundleSection = QString::fromStdString(metaInfo.sections.bundle);
-    auto bundleSh = getSectionHeader(bundleSection);
+    auto bundleSh = getSectionHeader(QString::fromStdString(metaInfo.sections.bundle));
     if (!bundleSh) {
-        return LINGLONG_ERR(
-          fmt::format("couldn't find bundle section which named {}", bundleSection));
+        return LINGLONG_ERR(bundleSh.error());
+    }
+    if (bundleSh->sh_type == SHT_NOBITS) {
+        return LINGLONG_ERR("bundle section has no file data");
+    }
+    auto actualBundleDigest = calculateSectionDigest(*bundleSh);
+    if (!actualBundleDigest) {
+        return LINGLONG_ERR(actualBundleDigest.error());
     }
 
-    std::array<char, 4096> buf{};
-    std::string digest;
-    QCryptographicHash cryptor{ QCryptographicHash::Sha256 };
-
-    seek(bundleSh->sh_offset);
-    auto backToHead = utils::finally::finally([this] {
-        seek(0);
-    });
-
-    auto bundleLength = bundleSh->sh_size;
-    auto readBytes = buf.size();
-    int bytesRead{ 0 };
-    while ((bytesRead = read(buf.data(), readBytes)) != 0) {
-        if (bytesRead == -1) {
-            return LINGLONG_ERR(fmt::format("read error: {}", errorString()));
-        }
-        cryptor.addData(
-#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
-          QByteArrayView{ buf.data(), bytesRead }
-#else
-          buf.data(),
-          bytesRead
-#endif
-        );
-        bundleLength -= bytesRead;
-        if (bundleLength <= 0) {
-            digest = cryptor.result().toHex().toStdString();
-            break;
-        }
-    }
-
-    return (expectedDigest == digest);
+    return *actualBundleDigest == metaInfo.digest;
 }
 
 utils::error::Result<std::filesystem::path> UABFile::unpack() noexcept

--- a/libs/linglong/src/linglong/package/uab_file.h
+++ b/libs/linglong/src/linglong/package/uab_file.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -13,8 +13,10 @@
 #include <QDir>
 #include <QString>
 
+#include <cstddef>
 #include <filesystem>
 #include <string>
+#include <string_view>
 
 namespace linglong::package {
 
@@ -40,6 +42,11 @@ public:
 private:
     [[nodiscard]] utils::error::Result<GElf_Shdr>
     getSectionHeader(const QString &section) const noexcept;
+    [[nodiscard]] utils::error::Result<std::string> readSectionData(const QString &section,
+                                                                    std::size_t offset,
+                                                                    std::size_t size) noexcept;
+    [[nodiscard]] utils::error::Result<std::reference_wrapper<const api::types::v1::UabMetaInfo>>
+    parseMetaInfo(std::string_view content) noexcept;
     UABFile() = default;
 
     Elf *e{ nullptr };

--- a/libs/linglong/src/linglong/package/uab_packager.cpp
+++ b/libs/linglong/src/linglong/package/uab_packager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -8,6 +8,7 @@
 #include "linglong/api/types/v1/Generators.hpp"
 #include "linglong/api/types/v1/UabLayer.hpp"
 #include "linglong/api/types/v1/Version.hpp"
+#include "linglong/common/uab_signature.h"
 #include "linglong/package/architecture.h"
 #include "linglong/utils/cmd.h"
 #include "linglong/utils/error/error.h"
@@ -841,6 +842,29 @@ utils::error::Result<void> UABPackager::packMetaInfo() noexcept
     const auto *metaSection = "linglong.meta";
     if (auto ret = this->uab->addSection(metaSection, metaFilePath); !ret) {
         return LINGLONG_ERR(ret);
+    }
+
+    QFile metaFile{ QString::fromStdString(metaFilePath.string()) };
+    if (!metaFile.open(QIODevice::ReadOnly | QIODevice::ExistingOnly)) {
+        return LINGLONG_ERR(fmt::format("failed to open meta file {}", metaFilePath));
+    }
+    QCryptographicHash cryptor{ QCryptographicHash::Sha256 };
+    if (!cryptor.addData(&metaFile)) {
+        return LINGLONG_ERR(fmt::format("failed to calculate digest from {}: {}",
+                                        metaFilePath,
+                                        metaFile.errorString().toStdString()));
+    }
+    const auto metaDigest = cryptor.result().toHex().toStdString();
+
+    const auto signatureSection = std::string{ common::uab::signatureSection };
+    if (auto ret = this->uab->writeSectionData(signatureSection,
+                                               common::uab::digestOffset,
+                                               metaDigest.data(),
+                                               metaDigest.size());
+        !ret) {
+        return LINGLONG_ERR(
+          fmt::format("failed to write digest for section {}", common::uab::metaSection),
+          ret);
     }
 
     return LINGLONG_OK;

--- a/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -8,20 +8,28 @@
 #include "common/tempdir.h"
 #include "linglong/api/types/v1/Generators.hpp"
 #include "linglong/common/strings.h"
+#include "linglong/common/uab_signature.h"
+#include "linglong/package/elf_handler.h"
 #include "linglong/package/uab_file.h"
 #include "linglong/package/uab_packager.h"
 #include "linglong/utils/cmd.h"
 
 #include <QCryptographicHash>
+#include <QFile>
 #include <QFileInfo>
 
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <memory>
 #include <string>
+#include <string_view>
 
 #include <fcntl.h>
 #include <unistd.h>
+
+__attribute__((used, section(".note.uab.sig"), aligned(4))) const auto linglongUabSignature =
+  linglong::common::uab::signatureNote;
 
 using namespace linglong;
 
@@ -35,6 +43,7 @@ protected:
         testDir = std::make_unique<TempDir>("linglong-uab-file-test-");
         ASSERT_TRUE(testDir->isValid()) << "Failed to create temporary directory";
         uabFile = (testDir->path() / "test.uab").string();
+        ASSERT_EQ(linglongUabSignature.digest[0], '!');
         std::filesystem::copy_file("/proc/self/exe", uabFile);
         auto uab = ElfHandler::create(uabFile);
         ASSERT_TRUE(uab.has_value()) << "Failed to create uab file";
@@ -79,13 +88,27 @@ protected:
                 ASSERT_TRUE(false) << "Failed to add data to cryptor";
             }
             bundle.close();
-            meta.digest = cryptor.result().toHex().toStdString();
+            const auto digest = cryptor.result().toHex().toStdString();
+
+            meta.digest = digest;
 
             std::ofstream jsonFile(testDir->path() / "info.json");
             jsonFile << nlohmann::json(meta).dump();
             jsonFile.close();
             auto ret = (*uab)->addSection("linglong.meta", testDir->path() / "info.json");
             ASSERT_TRUE(ret.has_value()) << "Failed to add meta section";
+
+            QFile metaFile{ (testDir->path() / "info.json").c_str() };
+            ASSERT_TRUE(metaFile.open(QIODevice::ReadOnly | QIODevice::ExistingOnly));
+            QCryptographicHash metaCryptor{ QCryptographicHash::Sha256 };
+            ASSERT_TRUE(metaCryptor.addData(&metaFile));
+            const auto metaDigest = metaCryptor.result().toHex().toStdString();
+            auto writeMetaDigest =
+              (*uab)->writeSectionData(std::string{ common::uab::signatureSection },
+                                       common::uab::digestOffset,
+                                       metaDigest.data(),
+                                       metaDigest.size());
+            ASSERT_TRUE(writeMetaDigest.has_value()) << writeMetaDigest.error().message();
         }
         // 再添加sign section
         {
@@ -107,16 +130,25 @@ protected:
 
     static void TearDownTestCase() { testDir.reset(); }
 
-    void SetUp() override { }
-
-    void TearDown() override { }
-
     static std::string uabFile;
     static std::unique_ptr<TempDir> testDir;
 };
 
 std::string UabFileTest::uabFile;
 std::unique_ptr<TempDir> UabFileTest::testDir;
+
+std::string calculateDigest(std::string_view data)
+{
+    QCryptographicHash cryptor{ QCryptographicHash::Sha256 };
+    cryptor.addData(data.data(), static_cast<int>(data.size()));
+    return cryptor.result().toHex().toStdString();
+}
+
+std::string readFile(const std::filesystem::path &path)
+{
+    std::ifstream stream{ path };
+    return { std::istreambuf_iterator<char>{ stream }, std::istreambuf_iterator<char>{} };
+}
 
 TEST_F(UabFileTest, UnpackFuseOffset)
 {
@@ -188,6 +220,235 @@ TEST_F(UabFileTest, Verify)
     auto verifyRet = uab.verify();
     ASSERT_TRUE(verifyRet.has_value()) << "Failed to verify uab file";
     ASSERT_TRUE(*verifyRet) << "Verify failed";
+}
+
+TEST_F(UabFileTest, VerifyRejectsMismatchedMetaSignature)
+{
+    TempDir modifiedDir{ "linglong-uab-modified-" };
+    ASSERT_TRUE(modifiedDir.isValid());
+    const auto modifiedUab = modifiedDir.path() / "mismatched-meta.uab";
+    std::filesystem::copy_file(uabFile,
+                               modifiedUab,
+                               std::filesystem::copy_options::overwrite_existing);
+    {
+        auto elf = ElfHandler::create(modifiedUab);
+        ASSERT_TRUE(elf.has_value()) << elf.error().message();
+        const std::string mismatchedDigest(common::uab::digestSize, '0');
+        auto writeRet = (*elf)->writeSectionData(std::string{ common::uab::signatureSection },
+                                                 common::uab::digestOffset,
+                                                 mismatchedDigest.data(),
+                                                 mismatchedDigest.size());
+        ASSERT_TRUE(writeRet.has_value()) << writeRet.error().message();
+    }
+
+    const auto fd = open(modifiedUab.c_str(), O_RDONLY);
+    ASSERT_NE(fd, -1);
+    auto uab = UABFile::loadFromFile(fd);
+    ASSERT_TRUE(uab.has_value()) << uab.error().message();
+    auto verifyRet = (*uab)->verify();
+    ASSERT_TRUE(verifyRet.has_value()) << verifyRet.error().message();
+    EXPECT_FALSE(*verifyRet);
+}
+
+TEST_F(UabFileTest, VerifyRejectsTamperedMetaSection)
+{
+    TempDir modifiedDir{ "linglong-uab-modified-" };
+    ASSERT_TRUE(modifiedDir.isValid());
+    const auto modifiedUab = modifiedDir.path() / "tampered-meta.uab";
+    std::filesystem::copy_file(uabFile,
+                               modifiedUab,
+                               std::filesystem::copy_options::overwrite_existing);
+    {
+        auto elf = ElfHandler::create(modifiedUab);
+        ASSERT_TRUE(elf.has_value()) << elf.error().message();
+        constexpr char tamperedByte{ '!' };
+        auto writeRet =
+          (*elf)->writeSectionData("linglong.meta", 0, &tamperedByte, sizeof(tamperedByte));
+        ASSERT_TRUE(writeRet.has_value()) << writeRet.error().message();
+    }
+
+    const auto fd = open(modifiedUab.c_str(), O_RDONLY);
+    ASSERT_NE(fd, -1);
+    auto uab = UABFile::loadFromFile(fd);
+    ASSERT_TRUE(uab.has_value()) << uab.error().message();
+    auto verifyRet = (*uab)->verify();
+    ASSERT_TRUE(verifyRet.has_value()) << verifyRet.error().message();
+    EXPECT_FALSE(*verifyRet);
+}
+
+TEST_F(UabFileTest, VerifyRejectsAuthenticatedInvalidBundleDigest)
+{
+    TempDir modifiedDir{ "linglong-uab-modified-" };
+    ASSERT_TRUE(modifiedDir.isValid());
+    const auto modifiedUab = modifiedDir.path() / "invalid-bundle-digest.uab";
+    std::filesystem::copy_file(uabFile,
+                               modifiedUab,
+                               std::filesystem::copy_options::overwrite_existing);
+
+    auto metaData = readFile(testDir->path() / "info.json");
+    auto meta = nlohmann::json::parse(metaData).get<api::types::v1::UabMetaInfo>();
+    const auto digestOffset = metaData.find(meta.digest);
+    ASSERT_NE(digestOffset, std::string::npos);
+    const std::string invalidDigest(common::uab::digestSize, 'g');
+    metaData.replace(digestOffset, meta.digest.size(), invalidDigest);
+    const auto metaDigest = calculateDigest(metaData);
+
+    {
+        auto elf = ElfHandler::create(modifiedUab);
+        ASSERT_TRUE(elf.has_value()) << elf.error().message();
+        auto writeMetaRet =
+          (*elf)->writeSectionData("linglong.meta", 0, metaData.data(), metaData.size());
+        ASSERT_TRUE(writeMetaRet.has_value()) << writeMetaRet.error().message();
+        auto writeSignatureRet =
+          (*elf)->writeSectionData(std::string{ common::uab::signatureSection },
+                                   common::uab::digestOffset,
+                                   metaDigest.data(),
+                                   metaDigest.size());
+        ASSERT_TRUE(writeSignatureRet.has_value()) << writeSignatureRet.error().message();
+    }
+
+    const auto fd = open(modifiedUab.c_str(), O_RDONLY);
+    ASSERT_NE(fd, -1);
+    auto uab = UABFile::loadFromFile(fd);
+    ASSERT_TRUE(uab.has_value()) << uab.error().message();
+    auto verifyRet = (*uab)->verify();
+    EXPECT_FALSE(verifyRet.has_value());
+}
+
+TEST_F(UabFileTest, VerifyRejectsAuthenticatedMissingBundleSection)
+{
+    TempDir modifiedDir{ "linglong-uab-modified-" };
+    ASSERT_TRUE(modifiedDir.isValid());
+    const auto modifiedUab = modifiedDir.path() / "missing-bundle-section.uab";
+    std::filesystem::copy_file(uabFile,
+                               modifiedUab,
+                               std::filesystem::copy_options::overwrite_existing);
+
+    auto metaData = readFile(testDir->path() / "info.json");
+    constexpr std::string_view bundleSection{ "linglong.bundle" };
+    constexpr std::string_view missingSection{ "missing.section" };
+    static_assert(bundleSection.size() == missingSection.size());
+    const auto sectionOffset = metaData.find(bundleSection);
+    ASSERT_NE(sectionOffset, std::string::npos);
+    metaData.replace(sectionOffset, bundleSection.size(), missingSection);
+    const auto metaDigest = calculateDigest(metaData);
+
+    {
+        auto elf = ElfHandler::create(modifiedUab);
+        ASSERT_TRUE(elf.has_value()) << elf.error().message();
+        auto writeMetaRet =
+          (*elf)->writeSectionData("linglong.meta", 0, metaData.data(), metaData.size());
+        ASSERT_TRUE(writeMetaRet.has_value()) << writeMetaRet.error().message();
+        auto writeSignatureRet =
+          (*elf)->writeSectionData(std::string{ common::uab::signatureSection },
+                                   common::uab::digestOffset,
+                                   metaDigest.data(),
+                                   metaDigest.size());
+        ASSERT_TRUE(writeSignatureRet.has_value()) << writeSignatureRet.error().message();
+    }
+
+    const auto fd = open(modifiedUab.c_str(), O_RDONLY);
+    ASSERT_NE(fd, -1);
+    auto uab = UABFile::loadFromFile(fd);
+    ASSERT_TRUE(uab.has_value()) << uab.error().message();
+    auto verifyRet = (*uab)->verify();
+    EXPECT_FALSE(verifyRet.has_value());
+}
+
+TEST_F(UabFileTest, VerifyRejectsMismatchedBundleDigest)
+{
+    TempDir modifiedDir{ "linglong-uab-modified-" };
+    ASSERT_TRUE(modifiedDir.isValid());
+    const auto modifiedUab = modifiedDir.path() / "mismatched-bundle.uab";
+    std::filesystem::copy_file(uabFile,
+                               modifiedUab,
+                               std::filesystem::copy_options::overwrite_existing);
+    {
+        auto elf = ElfHandler::create(modifiedUab);
+        ASSERT_TRUE(elf.has_value()) << elf.error().message();
+        constexpr char tamperedByte{ '!' };
+        auto writeRet =
+          (*elf)->writeSectionData("linglong.bundle", 0, &tamperedByte, sizeof(tamperedByte));
+        ASSERT_TRUE(writeRet.has_value()) << writeRet.error().message();
+    }
+
+    const auto fd = open(modifiedUab.c_str(), O_RDONLY);
+    ASSERT_NE(fd, -1);
+    auto uab = UABFile::loadFromFile(fd);
+    ASSERT_TRUE(uab.has_value()) << uab.error().message();
+    auto verifyRet = (*uab)->verify();
+    ASSERT_TRUE(verifyRet.has_value()) << verifyRet.error().message();
+    EXPECT_FALSE(*verifyRet);
+}
+
+TEST_F(UabFileTest, VerifyWithoutBundleSignSection)
+{
+    TempDir unsignedDir{ "linglong-uab-unsigned-" };
+    ASSERT_TRUE(unsignedDir.isValid());
+    const auto unsignedUab = unsignedDir.path() / "unsigned.uab";
+    std::filesystem::copy_file("/proc/self/exe",
+                               unsignedUab,
+                               std::filesystem::copy_options::overwrite_existing);
+
+    auto calculateDigest = [](const std::filesystem::path &path) {
+        QFile file{ path.c_str() };
+        EXPECT_TRUE(file.open(QIODevice::ReadOnly | QIODevice::ExistingOnly));
+        QCryptographicHash cryptor{ QCryptographicHash::Sha256 };
+        EXPECT_TRUE(cryptor.addData(&file));
+        return cryptor.result().toHex().toStdString();
+    };
+
+    {
+        auto elf = ElfHandler::create(unsignedUab);
+        ASSERT_TRUE(elf.has_value()) << elf.error().message();
+        const auto bundleFile = testDir->path() / "bundle.erofs";
+        const auto metaFile = testDir->path() / "info.json";
+        ASSERT_TRUE((*elf)->addSection("linglong.bundle", bundleFile));
+        ASSERT_TRUE((*elf)->addSection(std::string{ common::uab::metaSection }, metaFile));
+
+        const auto digest = calculateDigest(metaFile);
+        auto writeRet = (*elf)->writeSectionData(std::string{ common::uab::signatureSection },
+                                                 common::uab::digestOffset,
+                                                 digest.data(),
+                                                 digest.size());
+        ASSERT_TRUE(writeRet.has_value()) << writeRet.error().message();
+    }
+
+    const auto fd = open(unsignedUab.c_str(), O_RDONLY);
+    ASSERT_NE(fd, -1);
+    auto uab = UABFile::loadFromFile(fd);
+    ASSERT_TRUE(uab.has_value()) << uab.error().message();
+    auto verifyRet = (*uab)->verify();
+    ASSERT_TRUE(verifyRet.has_value()) << verifyRet.error().message();
+    EXPECT_TRUE(*verifyRet);
+}
+
+TEST(UabSignatureTest, ParseMetaSignatureNote)
+{
+    const auto bytes = std::string_view{
+        reinterpret_cast<const char *>(&common::uab::signatureNote),
+        sizeof(common::uab::signatureNote),
+    };
+    auto digest = common::uab::parseSignatureNote(bytes);
+    ASSERT_TRUE(digest.has_value());
+    EXPECT_EQ(digest->size(), common::uab::digestSize);
+}
+
+TEST(UabSignatureTest, ParseRejectsExtraNote)
+{
+    std::string bytes{ reinterpret_cast<const char *>(&common::uab::signatureNote),
+                       sizeof(common::uab::signatureNote) };
+    bytes.append(reinterpret_cast<const char *>(&common::uab::signatureNote),
+                 sizeof(common::uab::signatureNote));
+    EXPECT_FALSE(common::uab::parseSignatureNote(bytes).has_value());
+}
+
+TEST(UabSignatureTest, ParseRejectsWrongName)
+{
+    auto note = common::uab::signatureNote;
+    note.name[0] = 'x';
+    const auto bytes = std::string_view{ reinterpret_cast<const char *>(&note), sizeof(note) };
+    EXPECT_FALSE(common::uab::parseSignatureNote(bytes).has_value());
 }
 
 TEST_F(UabFileTest, ExtractSignData)

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -5,7 +5,7 @@ version: '1'
 package:
   id: cn.org.linyaps.builder.utils
   name: ll-builder-utils
-  version: 0.0.3.0
+  version: 0.0.4.0
   kind: app
   description: |
     Utils for ll-builder
@@ -33,13 +33,13 @@ build: |
   mkdir build || true
   cd build
   meson setup ../
-  meson configure --default-library static -D utils=false -D examples=false -D tests=false -D disable-libc-symbol-version=false
+  meson configure --buildtype release --default-library static -D utils=false -D examples=false -D tests=false -D disable-libc-symbol-version=false
   ninja && ninja install
 
   # build erofsfuse static library
   cd /project/linglong/sources/erofs-utils/erofs-utils-1.8.6
   ./autogen.sh
-  ./configure -with-libzstd --enable-fuse --enable-static-fuse --with-libdeflate --without-xxhash libdeflate_LIBS=-ldeflate libdeflate_CFLAGS=-ldeflate
+  CFLAGS="-O2 -g0" ./configure -with-libzstd --enable-fuse --enable-static-fuse --with-libdeflate --without-xxhash libdeflate_LIBS=-ldeflate libdeflate_CFLAGS=-ldeflate
   make -j$(nproc)
   make install
 
@@ -50,10 +50,10 @@ build: |
   cmake --install build-static --prefix=$PREFIX
 
   cd /project
-  cmake -B build-linglong -DENABLE_CPM=false -DENABLE_TESTING=false -DBUILD_LINGLONG_BUILDER_UTILS_IN_BOX=true -DAGGRESSIVE_UAB_SIZE=ON
+  cmake -B build-linglong -DCMAKE_BUILD_TYPE=MinSizeRel -DENABLE_CPM=false -DENABLE_TESTING=false -DBUILD_LINGLONG_BUILDER_UTILS_IN_BOX=true -DAGGRESSIVE_UAB_SIZE=ON
   cmake --build build-linglong -j$(nproc)
   cmake --install build-linglong --prefix=$PREFIX
-  install /usr/local/bin/mkfs.erofs $PREFIX/bin/
+  install -s -m 0755 /usr/local/bin/mkfs.erofs $PREFIX/bin/
 buildext:
   apt:
     build_depends:


### PR DESCRIPTION
Replace JSON-based digest verification at runtime with a stable ELF section .note.uab.sig. holds SHA-256(linglong.meta)

bump ll-builder-utils to 0.0.4.0.