### PR TITLE
docs: 修复乌班图 24.04 安装的存储库链接

### DIFF
--- a/docs/pages/guide/start/install.md
+++ b/docs/pages/guide/start/install.md
@@ -87,7 +87,7 @@ sudo dnf install linglong-bin linyaps-web-store-installer
 ### Ubuntu 24.04
 
 ```sh
-echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/xUbuntu_24.04/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
+echo "deb [trusted=yes] https://ci.deepin.com/repo/obs/linglong:/CI:/release/Ubuntu_24.04/ ./" | sudo tee /etc/apt/sources.list.d/linglong.list
 sudo apt update
 sudo apt install linglong-bin linglong-installer
 ```


### PR DESCRIPTION
网页路径 Xubuntu 是打不开的啊