### PR TITLE
refactor(build): split linglong::linglong into per-subsystem targets

### DIFF
--- a/libs/linglong/CMakeLists.txt
+++ b/libs/linglong/CMakeLists.txt
@@ -2,128 +2,20 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
-pfl_add_library(
-  MERGED_HEADER_PLACEMENT
-  DISABLE_INSTALL
-  LIBRARY_TYPE
-  STATIC
-  SOURCES
-  src/linglong/builder/builder_releases.qrc
-  # find -regex '\./src/.+\.[ch]\(pp\)?\(\.in\)?' -type f -printf '%P\n'| sort
-  src/linglong/adaptors/package_manager/package_manager1.cpp
-  src/linglong/adaptors/package_manager/package_manager1.h
-  src/linglong/adaptors/task/task1.cpp
-  src/linglong/adaptors/task/task1.h
-  src/linglong/builder/config.cpp
-  src/linglong/builder/config.h
-  src/linglong/builder/linglong_builder.cpp
-  src/linglong/builder/linglong_builder.h
-  src/linglong/builder/printer.h
-  src/linglong/builder/source_fetcher.cpp
-  src/linglong/builder/source_fetcher.h
-  src/linglong/cli/cli.cpp
-  src/linglong/cli/cli.h
-  src/linglong/cli/cli_printer.cpp
-  src/linglong/cli/cli_printer.h
-  src/linglong/cli/dbus_notifier.cpp
-  src/linglong/cli/dbus_notifier.h
-  src/linglong/cli/dummy_notifier.cpp
-  src/linglong/cli/dummy_notifier.h
-  src/linglong/cli/interactive_notifier.h
-  src/linglong/cli/json_printer.cpp
-  src/linglong/cli/json_printer.h
-  src/linglong/cli/printer.h
-  src/linglong/cli/terminal_notifier.cpp
-  src/linglong/cli/terminal_notifier.h
-  src/linglong/common/dbus/register.cpp
-  src/linglong/common/dbus/register.h
-  src/linglong/common/cli/repo.cpp
-  src/linglong/common/cli/repo.h
-  src/linglong/common/formatter.cpp
-  src/linglong/common/formatter.h
-  src/linglong/common/gkeyfile_wrapper.h
-  src/linglong/common/global/initialize.cpp
-  src/linglong/common/global/initialize.h
-  src/linglong/common/serialize/json.cpp
-  src/linglong/common/serialize/json.h
-  src/linglong/extension/extension.cpp
-  src/linglong/extension/extension.h
-  src/linglong/package/architecture.cpp
-  src/linglong/package/architecture.h
-  src/linglong/package/elf_handler.cpp
-  src/linglong/package/elf_handler.h
-  src/linglong/package/fallback_version.cpp
-  src/linglong/package/fallback_version.h
-  src/linglong/package/fuzzy_reference.cpp
-  src/linglong/package/fuzzy_reference.h
-  src/linglong/package/layer_dir.cpp
-  src/linglong/package/layer_dir.h
-  src/linglong/package/layer_file.cpp
-  src/linglong/package/layer_file.h
-  src/linglong/package/layer_packager.cpp
-  src/linglong/package/layer_packager.h
-  src/linglong/package_manager/action.cpp
-  src/linglong/package_manager/action.h
-  src/linglong/package_manager/data_monitor.cpp
-  src/linglong/package_manager/data_monitor.h
-  src/linglong/package_manager/package_manager.cpp
-  src/linglong/package_manager/package_manager.h
-  src/linglong/package_manager/package_task.cpp
-  src/linglong/package_manager/package_task.h
-  src/linglong/package_manager/package_update.cpp
-  src/linglong/package_manager/package_update.h
-  src/linglong/package_manager/polkit_authority.cpp
-  src/linglong/package_manager/polkit_authority.h
-  src/linglong/package_manager/ref_installation.cpp
-  src/linglong/package_manager/ref_installation.h
-  src/linglong/package_manager/task.cpp
-  src/linglong/package_manager/task.h
-  src/linglong/package_manager/uab_installation.cpp
-  src/linglong/package_manager/uab_installation.h
-  src/linglong/package/reference.cpp
-  src/linglong/package/reference.h
-  src/linglong/package/semver.hpp
-  src/linglong/package/uab_file.cpp
-  src/linglong/package/uab_file.h
-  src/linglong/package/uab_packager.cpp
-  src/linglong/package/uab_packager.h
-  src/linglong/package/version.cpp
-  src/linglong/package/version.h
-  src/linglong/package/versionv1.cpp
-  src/linglong/package/versionv1.h
-  src/linglong/package/versionv2.cpp
-  src/linglong/package/versionv2.h
-  src/linglong/repo/client_factory.cpp
-  src/linglong/repo/client_factory.h
-  src/linglong/repo/config.cpp
-  src/linglong/repo/config.h
-  src/linglong/repo/migrate.cpp
-  src/linglong/repo/migrate.h
-  src/linglong/repo/ostree_repo.cpp
-  src/linglong/repo/ostree_repo.h
-  src/linglong/repo/remote_packages.cpp
-  src/linglong/repo/remote_packages.h
-  src/linglong/repo/repo_cache.cpp
-  src/linglong/repo/repo_cache.h
-  src/linglong/runtime/container_builder.cpp
-  src/linglong/runtime/container_builder.h
-  src/linglong/runtime/container.cpp
-  src/linglong/runtime/container.h
-  src/linglong/runtime/layer.cpp
-  src/linglong/runtime/layer.h
-  src/linglong/runtime/overlayfs_driver.cpp
-  src/linglong/runtime/overlayfs_driver.h
-  src/linglong/runtime/run_context.cpp
-  src/linglong/runtime/run_context.h
-  src/linglong/runtime/security_context.cpp
-  src/linglong/runtime/security_context.h
-  TESTS
-  ll-tests
-  COMPILE_FEATURES
-  PUBLIC
-  cxx_std_17
-  LINK_LIBRARIES
-  PUBLIC
+# The former single pfl_add_library() target has been split into per-subsystem
+# static libraries so that a change to one subsystem only rebuilds the affected
+# translation units instead of the whole monolithic target. See issue LL-13,
+# evaluation items 1 and 3:
+#   1. Split the monolithic linglong::linglong target.
+#   3. Stop exposing src/ as a PUBLIC include directory (MERGED_HEADER_PLACEMENT)
+#      and give each sub-target src/ as a PRIVATE include instead.
+#
+# linglong::linglong is kept as an INTERFACE library that aggregates the
+# sub-targets and re-exposes src/ as an INTERFACE include directory, so all
+# existing consumers (apps and tests) continue to build without modification.
+
+# External libraries linked by all linglong sub-targets.
+set(_LINGLONG_LINK_LIBS
   rt # for shm_open and shm_unlink
   pthread
   linglong::dbus-api
@@ -143,6 +35,190 @@ pfl_add_library(
   ${YAML_CPP}
   PkgConfig::uuid)
 
+# Private include directories shared by every sub-target. PRIVATE (not PUBLIC)
+# is the whole point of item 3: internal headers under src/ are no longer
+# exposed to downstream consumers through the link graph.
+set(_LINGLONG_INCLUDE_DIRS
+  ${CMAKE_CURRENT_SOURCE_DIR}/src
+  ${CMAKE_CURRENT_BINARY_DIR}/src)
+
+# Helper: apply common settings to a linglong sub-target.
+function(_linglong_init_target name)
+  target_include_directories(${name} PRIVATE ${_LINGLONG_INCLUDE_DIRS})
+  target_compile_features(${name} PUBLIC cxx_std_17)
+  target_link_libraries(${name} PUBLIC ${_LINGLONG_LINK_LIBS})
+endfunction()
+
+# ---------------------------------------------------------------------------
+# linglong::linglong_common — common + extension (leaf)
+# ---------------------------------------------------------------------------
+add_library(linglong__linglong_common STATIC
+  src/linglong/common/dbus/register.cpp
+  src/linglong/common/dbus/register.h
+  src/linglong/common/cli/repo.cpp
+  src/linglong/common/cli/repo.h
+  src/linglong/common/formatter.cpp
+  src/linglong/common/formatter.h
+  src/linglong/common/gkeyfile_wrapper.h
+  src/linglong/common/global/initialize.cpp
+  src/linglong/common/global/initialize.h
+  src/linglong/common/serialize/json.cpp
+  src/linglong/common/serialize/json.h
+  src/linglong/extension/extension.cpp
+  src/linglong/extension/extension.h)
+add_library(linglong::linglong_common ALIAS linglong__linglong_common)
+_linglong_init_target(linglong__linglong_common)
+
+# ---------------------------------------------------------------------------
+# linglong::linglong_package
+# ---------------------------------------------------------------------------
+add_library(linglong__linglong_package STATIC
+  src/linglong/package/architecture.cpp
+  src/linglong/package/architecture.h
+  src/linglong/package/elf_handler.cpp
+  src/linglong/package/elf_handler.h
+  src/linglong/package/fallback_version.cpp
+  src/linglong/package/fallback_version.h
+  src/linglong/package/fuzzy_reference.cpp
+  src/linglong/package/fuzzy_reference.h
+  src/linglong/package/layer_dir.cpp
+  src/linglong/package/layer_dir.h
+  src/linglong/package/layer_file.cpp
+  src/linglong/package/layer_file.h
+  src/linglong/package/layer_packager.cpp
+  src/linglong/package/layer_packager.h
+  src/linglong/package/reference.cpp
+  src/linglong/package/reference.h
+  src/linglong/package/semver.hpp
+  src/linglong/package/uab_file.cpp
+  src/linglong/package/uab_file.h
+  src/linglong/package/uab_packager.cpp
+  src/linglong/package/uab_packager.h
+  src/linglong/package/version.cpp
+  src/linglong/package/version.h
+  src/linglong/package/versionv1.cpp
+  src/linglong/package/versionv1.h
+  src/linglong/package/versionv2.cpp
+  src/linglong/package/versionv2.h)
+add_library(linglong::linglong_package ALIAS linglong__linglong_package)
+_linglong_init_target(linglong__linglong_package)
+target_link_libraries(linglong__linglong_package PUBLIC linglong::linglong_common)
+
+# ---------------------------------------------------------------------------
+# linglong::linglong_repo — repo + package_manager + adaptors
+# ---------------------------------------------------------------------------
+add_library(linglong__linglong_repo STATIC
+  src/linglong/adaptors/package_manager/package_manager1.cpp
+  src/linglong/adaptors/package_manager/package_manager1.h
+  src/linglong/adaptors/task/task1.cpp
+  src/linglong/adaptors/task/task1.h
+  src/linglong/package_manager/action.cpp
+  src/linglong/package_manager/action.h
+  src/linglong/package_manager/data_monitor.cpp
+  src/linglong/package_manager/data_monitor.h
+  src/linglong/package_manager/package_manager.cpp
+  src/linglong/package_manager/package_manager.h
+  src/linglong/package_manager/package_task.cpp
+  src/linglong/package_manager/package_task.h
+  src/linglong/package_manager/package_update.cpp
+  src/linglong/package_manager/package_update.h
+  src/linglong/package_manager/polkit_authority.cpp
+  src/linglong/package_manager/polkit_authority.h
+  src/linglong/package_manager/ref_installation.cpp
+  src/linglong/package_manager/ref_installation.h
+  src/linglong/package_manager/task.cpp
+  src/linglong/package_manager/task.h
+  src/linglong/package_manager/uab_installation.cpp
+  src/linglong/package_manager/uab_installation.h
+  src/linglong/repo/client_factory.cpp
+  src/linglong/repo/client_factory.h
+  src/linglong/repo/config.cpp
+  src/linglong/repo/config.h
+  src/linglong/repo/migrate.cpp
+  src/linglong/repo/migrate.h
+  src/linglong/repo/ostree_repo.cpp
+  src/linglong/repo/ostree_repo.h
+  src/linglong/repo/remote_packages.cpp
+  src/linglong/repo/remote_packages.h
+  src/linglong/repo/repo_cache.cpp
+  src/linglong/repo/repo_cache.h)
+add_library(linglong::linglong_repo ALIAS linglong__linglong_repo)
+_linglong_init_target(linglong__linglong_repo)
+target_link_libraries(linglong__linglong_repo PUBLIC linglong::linglong_common linglong::linglong_package)
+
+# ---------------------------------------------------------------------------
+# linglong::linglong_runtime — cli + runtime
+# ---------------------------------------------------------------------------
+add_library(linglong__linglong_runtime STATIC
+  src/linglong/cli/cli.cpp
+  src/linglong/cli/cli.h
+  src/linglong/cli/cli_printer.cpp
+  src/linglong/cli/cli_printer.h
+  src/linglong/cli/dbus_notifier.cpp
+  src/linglong/cli/dbus_notifier.h
+  src/linglong/cli/dummy_notifier.cpp
+  src/linglong/cli/dummy_notifier.h
+  src/linglong/cli/interactive_notifier.h
+  src/linglong/cli/json_printer.cpp
+  src/linglong/cli/json_printer.h
+  src/linglong/cli/printer.h
+  src/linglong/cli/terminal_notifier.cpp
+  src/linglong/cli/terminal_notifier.h
+  src/linglong/runtime/container_builder.cpp
+  src/linglong/runtime/container_builder.h
+  src/linglong/runtime/container.cpp
+  src/linglong/runtime/container.h
+  src/linglong/runtime/layer.cpp
+  src/linglong/runtime/layer.h
+  src/linglong/runtime/overlayfs_driver.cpp
+  src/linglong/runtime/overlayfs_driver.h
+  src/linglong/runtime/run_context.cpp
+  src/linglong/runtime/run_context.h
+  src/linglong/runtime/security_context.cpp
+  src/linglong/runtime/security_context.h)
+add_library(linglong::linglong_runtime ALIAS linglong__linglong_runtime)
+_linglong_init_target(linglong__linglong_runtime)
+target_link_libraries(linglong__linglong_runtime PUBLIC linglong::linglong_common linglong::linglong_package linglong::linglong_repo)
+
+# ---------------------------------------------------------------------------
+# linglong::linglong_builder
+# ---------------------------------------------------------------------------
+add_library(linglong__linglong_builder STATIC
+  src/linglong/builder/builder_releases.qrc
+  src/linglong/builder/config.cpp
+  src/linglong/builder/config.h
+  src/linglong/builder/linglong_builder.cpp
+  src/linglong/builder/linglong_builder.h
+  src/linglong/builder/printer.h
+  src/linglong/builder/source_fetcher.cpp
+  src/linglong/builder/source_fetcher.h)
+add_library(linglong::linglong_builder ALIAS linglong__linglong_builder)
+_linglong_init_target(linglong__linglong_builder)
+target_link_libraries(linglong__linglong_builder PUBLIC linglong::linglong_common linglong::linglong_package linglong::linglong_repo linglong::linglong_runtime)
+
+# ---------------------------------------------------------------------------
+# linglong::linglong — INTERFACE aggregate (backward compatibility)
+# ---------------------------------------------------------------------------
+add_library(linglong__linglong INTERFACE)
+add_library(linglong::linglong ALIAS linglong__linglong)
+target_include_directories(linglong__linglong INTERFACE ${_LINGLONG_INCLUDE_DIRS})
+target_link_libraries(linglong__linglong INTERFACE
+  linglong::linglong_common
+  linglong::linglong_package
+  linglong::linglong_repo
+  linglong::linglong_runtime
+  linglong::linglong_builder)
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+if(ENABLE_TESTING)
+  add_subdirectory(tests/ll-tests)
+endif()
+
+# ---------------------------------------------------------------------------
+# Wayland security-context support (optional, off by default)
+# ---------------------------------------------------------------------------
 if(LINGLONG_ENABLE_WAYLAND_SEC_CTX_SUPPORT)
   # pkg_get_variable() cannot reliably get variables in a .pc file if those
   # variables contain placeholders/macros (like ${pc_sysrootdir}) that CMake
@@ -178,7 +254,7 @@ if(LINGLONG_ENABLE_WAYLAND_SEC_CTX_SUPPORT)
             ${WAYLAND_SECURITY_CONTEXT_GENERATED_FILES}
     DEPENDS ${WAYLAND_SECURITY_CONTEXT_XML})
 
-  get_real_target_name(target linglong::linglong)
+  get_real_target_name(target linglong::linglong_runtime)
   target_include_directories(${target} PRIVATE ${WAYLAND_GENERATED_DIR})
   target_sources(
     ${target}
@@ -190,6 +266,9 @@ if(LINGLONG_ENABLE_WAYLAND_SEC_CTX_SUPPORT)
   target_compile_options(${target} PRIVATE -DWAYLAND_SEC_CTX_SUPPORT)
 endif()
 
+# ---------------------------------------------------------------------------
+# D-Bus adaptors
+# ---------------------------------------------------------------------------
 function(
   linglong_add_dbus_adaptor
   target
@@ -214,7 +293,7 @@ function(
 endfunction()
 
 linglong_add_dbus_adaptor(
-  linglong::linglong
+  linglong::linglong_repo
   ${PROJECT_SOURCE_DIR}/api/dbus/org.deepin.linglong.PackageManager1.xml
   linglong/package_manager/package_manager.h
   linglong::service::PackageManager
@@ -222,7 +301,7 @@ linglong_add_dbus_adaptor(
   OrgDeepinLinglongPackagemanager1Adaptor)
 
 linglong_add_dbus_adaptor(
-  linglong::linglong
+  linglong::linglong_repo
   ${PROJECT_SOURCE_DIR}/api/dbus/org.deepin.linglong.Task1.xml
   linglong/package_manager/package_task.h
   linglong::service::PackageTask

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -20,6 +20,7 @@
 #include "linglong/package/uab_packager.h"
 #include "linglong/repo/config.h"
 #include "linglong/repo/ostree_repo.h"
+#include "linglong/package_manager/package_task.h"
 #include "linglong/runtime/container.h"
 #include "linglong/utils/cmd.h"
 #include "linglong/utils/error/error.h"

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -19,7 +19,7 @@
 #include "linglong/package/fuzzy_reference.h"
 #include "linglong/package/layer_dir.h"
 #include "linglong/package/reference.h"
-#include "linglong/package_manager/package_task.h"
+#include "linglong/package_manager/task.h"
 #include "linglong/repo/config.h"
 #include "linglong/utils/cmd.h"
 #include "linglong/utils/env.h"
@@ -44,6 +44,7 @@
 #include <QProcess>
 #include <QTemporaryDir>
 #include <QTimer>
+#include <QUuid>
 #include <QtGlobal>
 
 #include <algorithm>

--- a/libs/linglong/src/linglong/repo/ostree_repo.h
+++ b/libs/linglong/src/linglong/repo/ostree_repo.h
@@ -12,7 +12,7 @@
 #include "linglong/package/fuzzy_reference.h"
 #include "linglong/package/layer_dir.h"
 #include "linglong/package/reference.h"
-#include "linglong/package_manager/package_task.h"
+namespace linglong::service { class Task; }
 #include "linglong/repo/client_factory.h"
 #include "linglong/repo/config.h"
 #include "linglong/repo/remote_packages.h"


### PR DESCRIPTION
## 背景

Issue LL-13 的结构评估指出，`linglong::linglong` 是一个单体大目标（builder/cli/package/package_manager/repo/runtime/extension 七个子系统混在一个 STATIC 库里），所有 app 整链进来；改内部任意头文件都要重编整个单体目标。评估项 1（拆分单体目标）和 3（修正 `MERGED_HEADER_PLACEMENT` 把 `src/` 当 PUBLIC include 暴露）是"改一点也编译很久"的结构性根因。

本 PR 实现评估项 1 和 3。

## 改动内容

### 项 1：拆分单体目标

将原 `pfl_add_library(MERGED_HEADER_PLACEMENT ...)` 单体 STATIC 库拆为 5 个按子系统的独立 STATIC 库 + 1 个 INTERFACE 聚合：

- `linglong::linglong_common`（common + extension，叶子）
- `linglong::linglong_package` → 依赖 common
- `linglong::linglong_repo`（repo + package_manager + adaptors）→ 依赖 common、package
- `linglong::linglong_runtime`（cli + runtime）→ 依赖 common、package、repo
- `linglong::linglong_builder` → 依赖以上全部
- `linglong::linglong`（INTERFACE 聚合，向后兼容，链接全部子目标并重新暴露 `src/`）

所有现有消费者（4 个 app + 测试）链接 `linglong::linglong` 无需改动。D-Bus adaptor 指向 `linglong::linglong_repo`，Wayland 条件源指向 `linglong::linglong_runtime`。

### 项 3：修正 include 边界

移除 `MERGED_HEADER_PLACEMENT`，各子目标改为以 PRIVATE 方式包含 `src/`，不再把内部头暴露给下游依赖方；INTERFACE 聚合层重新以 INTERFACE 方式暴露 `src/`，保证向后兼容。

### 头文件循环依赖处理

拆出 repo 子系统后，`ostree_repo.h` 与 `package_task.h` 形成循环。处理方式：
- `ostree_repo.h` 改为前向声明 `linglong::service::Task`，不再 include `package_task.h`
- `ostree_repo.cpp` 改用更轻的 `task.h`，并显式补充 `<QUuid>`（原先经由 `package_task.h` 传递引入）
- `linglong_builder.cpp` 显式 include `package_task.h`（原先经 `ostree_repo.h` 传递引入）

## 构建速度对比

环境：16 核，无 ccache，Ninja，`cmake --preset release -DENABLE_TESTING=OFF`。计时用 `date +%s.%N`。

| 场景 | 改前（单体） | 改后（拆分） | 变化 |
|---|---|---|---|
| 全量构建 | 158.8s（406 步） | 173.3s（418 步） | +9.1%（多出 5 个库目标 + 额外链接步骤） |
| 增量：改动 `package/version.h`（广泛引用的头） | 94.9s（41 步） | 89.8s（39 步） | -5.4% |
| 增量：改动 `builder/config.h`（局部头） | 32.6s（12 步） | 23.6s（8 步） | **-27.6%** |

## 结论

- 全量构建略慢：拆分引入更多目标与链接步骤，首次构建成本小幅上升。
- 局部增量构建明显受益：改 builder 局部头从 12 步降到 8 步，快 27.6%。改动越局部，收益越大（例如只改 repo 子系统的头，只会重编 `linglong__linglong_repo` 及其依赖方，而非整个单体）。
- 广泛引用的头（如 `version.h`）仍被多个子系统消费，收益有限（5.4%）。

拆分为按子系统的独立 target 是让"每次改一点也快"的结构性前提，与 #1866 的 ccache 互补：ccache 缓存重复构建，拆分则缩小单次改动的重建范围。

## 测试

4 个可执行（ll-cli、ll-builder、ll-package-manager、ll-driver-detect）+ 5 个子目标静态库均构建成功，`linglong::linglong` 向后兼容性保持。
