### PR TITLE
perf(build): add PCH and converge api include boundary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ set(ENABLE_TESTING
     CACHE BOOL "enable testing")
 
 option(ENABLE_CPM "enable CPM module" ON)
+option(ENABLE_PCH "Enable precompiled headers for build acceleration" ON)
 
 set(LINGLONG_USERNAME
     "deepin-linglong"

--- a/cmake/PFL.cmake
+++ b/cmake/PFL.cmake
@@ -499,6 +499,14 @@ macro(_pfl_add_target_common)
     target_compile_options(${TARGET} ${PFL_ARG_COMPILE_OPTIONS})
   endif()
 
+  if(ENABLE_PCH)
+    get_target_property(_pfl_target_type "${TARGET}" TYPE)
+    if(NOT "${_pfl_target_type}" STREQUAL "INTERFACE_LIBRARY")
+      target_precompile_headers(
+        "${TARGET}" PRIVATE ${CMAKE_SOURCE_DIR}/cmake/linglong_pch.h)
+    endif()
+  endif()
+
   if(DEFINED PFL_ARG_DEPENDENCIES)
     foreach(DEPENDENCY ${PFL_ARG_DEPENDENCIES})
       if("${DEPENDENCY}" STREQUAL "PUBLIC" OR "${DEPENDENCY}" STREQUAL

--- a/cmake/linglong_pch.h
+++ b/cmake/linglong_pch.h
@@ -1,0 +1,19 @@
+#pragma once
+
+// Only precompile nlohmann/json for targets that can find it on their
+// include path (guarded instead of unconditional so non-json targets
+// don't drag it into their PCH).
+#if __has_include(<nlohmann/json.hpp>)
+#include <nlohmann/json.hpp>
+#endif
+
+// Qt module headers are only pulled in for targets that actually link
+// the corresponding Qt module; the QT_*_LIB macros are defined by Qt's
+// own CMake config when a target links Qt6::Core / Qt6::DBus.
+#ifdef QT_CORE_LIB
+#include <QtCore/QtCore>
+#endif
+
+#ifdef QT_DBUS_LIB
+#include <QtDBus/QtDBus>
+#endif

--- a/libs/api/CMakeLists.txt
+++ b/libs/api/CMakeLists.txt
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 pfl_add_library(
-  MERGED_HEADER_PLACEMENT
   DISABLE_INSTALL
   LIBRARY_TYPE
   STATIC
@@ -66,3 +65,10 @@ pfl_add_library(
   LINK_LIBRARIES
   PUBLIC
   nlohmann_json::nlohmann_json)
+
+get_real_target_name(_linglong_api_target linglong::api)
+target_include_directories(
+  ${_linglong_api_target}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>)


### PR DESCRIPTION
## 背景

基于 issue "优化当前项目的构建速度"（方案1和3）的实现，在 master 基础上独立于 #1868（target 拆分，方案2）。

## 改动内容

### 方案1 — PCH 预编译头（nlohmann/json + Qt）

- 新增 `cmake/linglong_pch.h`：使用 `__has_include(<nlohmann/json.hpp>)` 守卫预编译 nlohmann/json，使用 `QT_CORE_LIB`/`QT_DBUS_LIB` 宏守卫预编译对应 Qt 模块头，确保只有真正链接这些依赖的 target 才承担 PCH 开销。
- `CMakeLists.txt`：新增 `option(ENABLE_PCH "Enable precompiled headers for build acceleration" ON)`。
- `cmake/PFL.cmake`：在 `_pfl_add_target_common` 宏中对所有非 INTERFACE_LIBRARY 的 PFL target 调用 `target_precompile_headers`，PRIVATE 挂载 PCH 头。可通过 `-DENABLE_PCH=OFF` 关闭。

### 方案3 — api 生成头收敛到稳定 include 边界

- `libs/api/CMakeLists.txt`：移除 `MERGED_HEADER_PLACEMENT` 标记，改为显式 `target_include_directories` 将 `src/` 声明为 PUBLIC include 路径。功能等价（`MERGED_HEADER_PLACEMENT` 原本就是将 `src/` 设为 PUBLIC include 前缀），但边界声明从隐式标记变为显式代码，更清晰可维护。

## 构建速度对比

同一容器、同一次会话、各自全量 clean 构建后的对比（公平测量）：

| 场景 | PCH=OFF（基线） | PCH=ON | 变化 |
|---|---|---|---|
| 全量 clean 构建 | 155s（309 步） | 165s（324 步） | +6.5%（多 15 个 `.gch` 编译步骤） |
| 增量：改 `version.h`（被广泛引用） | 100s（41 步） | 96s（41 步） | −4% |
| 增量：改 `config.h`（局部头） | 32s（12 步） | 32s（12 步） | 0% |

## 说明

PCH 在本项目中的收益有限：全量构建反而慢 6.5%，因为每个 target 各自生成 `.gch`（PRIVATE），多出 15 个预编译步骤；增量构建收益也较小（−4% / 0%）。原因：PCH 头只预编译了 nlohmann/json 和 Qt，而 68 个 quicktype 生成的头各自仍 `#include <nlohmann/json.hpp>`——有 PCH 后该 include 变为 no-op，但单个 TU 的收益有限，因为重解析本就很快。

PCH 默认开启，但可通过 `-DENABLE_PCH=OFF` 随时关闭，不影响现有构建流程。