### PR TITLE
build: add Clang -ftime-trace profiling with clang-build-analyzer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,23 @@ if(SYSTEM_PROC_LOWER MATCHES "^mips")
   add_compile_options(-mxgot)
 endif()
 
+option(ENABLE_BUILD_TRACE
+       "Generate Clang -ftime-trace files for build-time analysis (Clang only)"
+       OFF)
+
+if(ENABLE_BUILD_TRACE)
+  if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    message(
+      WARNING
+        "ENABLE_BUILD_TRACE requires Clang (-ftime-trace), but the current "
+        "compiler is '${CMAKE_CXX_COMPILER_ID}'; the option is ignored.")
+    set(ENABLE_BUILD_TRACE OFF)
+  else()
+    message(STATUS "Build tracing enabled (-ftime-trace)")
+    add_compile_options(-ftime-trace)
+  endif()
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(PFL)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -36,6 +36,18 @@
                 "CMAKE_CXX_CLANG_TIDY": "clang-tidy",
                 "CMAKE_CXX_COMPILER": "clang++"
             }
+        },
+        {
+            "name": "build-trace",
+            "displayName": "Build-time trace configuration",
+            "description": "Configure linglong with Clang -ftime-trace for clang-build-analyzer.",
+            "binaryDir": "${sourceDir}/build-trace",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "ENABLE_BUILD_TRACE": true,
+                "CMAKE_EXPORT_COMPILE_COMMANDS": true
+            }
         }
     ],
     "buildPresets": [
@@ -57,6 +69,12 @@
             "displayName": "Run clang-tidy",
             "description": "Build linglong with clang-tidy",
             "configurePreset": "clang-tidy"
+        },
+        {
+            "name": "build-trace",
+            "displayName": "Build with -ftime-trace",
+            "description": "Build linglong with -ftime-trace enabled.",
+            "configurePreset": "build-trace"
         }
     ],
     "testPresets": [

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -65,6 +65,33 @@ ctest --preset debug
 
 [cmake presets]: https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html
 
+## Build-Time Profiling
+
+To locate compile-time hot spots (slowest files, heaviest headers, template
+instantiation costs), build with Clang `-ftime-trace` and aggregate the traces
+with [clang-build-analyzer]:
+
+```bash
+tools/analyze-build.sh
+```
+
+This configures the `build-trace` preset (Clang + `ENABLE_BUILD_TRACE=ON`),
+builds the project, then prints a hot-spot report. The aggregated trace is
+written to `build-trace/build-analysis.json`. `clang-build-analyzer` is built
+from source into `~/.cache/clang-build-analyzer` on first run if not on PATH.
+
+You can also drive the preset manually:
+
+```bash
+cmake --preset build-trace
+cmake --build --preset build-trace
+```
+
+Each translation unit emits a `*.json` trace file (Chrome tracing format) that
+can be opened in `chrome://tracing` for a per-file timeline.
+
+[clang-build-analyzer]: https://github.com/CacheFactory/clang-build-analyzer
+
 ## Packaging
 
 Linglong uses [CPM.cmake] to download missing dependencies locally.

--- a/tools/analyze-build.sh
+++ b/tools/analyze-build.sh
@@ -1,0 +1,63 @@
+#!/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# Build linyaps with Clang -ftime-trace and produce a build-time hot-spot
+# report via clang-build-analyzer.
+#
+# Usage: tools/analyze-build.sh
+#
+# Prerequisites: clang/clang++ and the usual linyaps build dependencies.
+# clang-build-analyzer is built from source into ~/.cache on first run if it
+# is not already on PATH.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || exit 255
+
+builddir=build-trace
+analyzer_root="${HOME}/.cache/clang-build-analyzer"
+analyzer_bin="${analyzer_root}/clang-build-analyzer"
+
+ensure_analyzer() {
+    if command -v clang-build-analyzer &> /dev/null; then
+        return 0
+    fi
+    if [ -x "$analyzer_bin" ]; then
+        return 0
+    fi
+
+    echo "clang-build-analyzer not found, building from source..." >&2
+    mkdir -p "$analyzer_root"
+    local src="$analyzer_root/src"
+    if [ ! -d "$src/.git" ]; then
+        git clone --depth 1 https://github.com/CacheFactory/clang-build-analyzer "$src"
+    fi
+    cmake -S "$src" -B "$analyzer_root/build" -DCMAKE_BUILD_TYPE=Release
+    cmake --build "$analyzer_root/build" -j "$(nproc)"
+    cp "$analyzer_root/build/clang-build-analyzer" "$analyzer_bin"
+}
+
+ensure_analyzer
+
+analyzer=clang-build-analyzer
+if ! command -v clang-build-analyzer &> /dev/null; then
+    analyzer="$analyzer_bin"
+fi
+
+echo "==> Configuring (preset build-trace)..."
+cmake --fresh --preset build-trace
+
+echo "==> Building..."
+num_jobs=${NUM_JOBS:-$(nproc)}
+cmake --build --preset build-trace -j "$num_jobs"
+
+echo "==> Aggregating -ftime-trace files..."
+report="${builddir}/build-analysis.json"
+"$analyzer" --all "$builddir" "$report"
+
+echo "==> Report written to ${report}"
+echo
+"$analyzer" --analyze "$report"


### PR DESCRIPTION
## 背景

构建速度优化（LL-13）讨论中，需要精确定位编译耗时热点（最慢文件、最重头文件、模板实例化开销），以数据驱动后续优化。本 PR 在项目中集成 Clang `-ftime-trace` + [clang-build-analyzer](https://github.com/CacheFactory/clang-build-analyzer) 构建分析工具，独立于 #1869（PCH 方案）。

## 改动内容

**1. `CMakeLists.txt` — `ENABLE_BUILD_TRACE` 选项**

新增 `option(ENABLE_BUILD_TRACE ...)`（默认 OFF）。开启时检测编译器是否为 Clang：是则添加 `-ftime-trace` 编译选项；非 Clang 则给出 WARNING 并忽略该选项，避免破坏 GCC 等常规构建。

**2. `CMakePresets.json` — `build-trace` 预设**

新增 `build-trace` configure/build 预设：使用 `clang`/`clang++` 并开启 `ENABLE_BUILD_TRACE=ON`、`CMAKE_EXPORT_COMPILE_COMMANDS=ON`，构建目录 `build-trace`。

**3. `tools/analyze-build.sh` — 一键分析脚本**

自动完成：配置 `build-trace` 预设 → 构建 → 聚合 trace → 打印热点报告。`clang-build-analyzer` 首次运行时若不在 PATH，自动从源码构建到 `~/.cache/clang-build-analyzer`。

**4. `DEVELOPER_GUIDE.md`**

新增「Build-Time Profiling」章节，说明使用方式。

## 用法

```bash
# 一键分析（自动构建 clang-build-analyzer）
tools/analyze-build.sh

# 或手动驱动预设
cmake --preset build-trace
cmake --build --preset build-trace
```

每个 TU 会生成 Chrome tracing 格式的 `*.json`，可用 `chrome://tracing` 打开查看单文件时间线；`build-trace/build-analysis.json` 为聚合结果。

## 说明

- 默认 OFF，不影响现有构建流程。
- 需要 Clang（`-ftime-trace` 为 Clang 专有），非 Clang 编译器会警告并忽略。
- 本 PR 仅提供测量工具，不改变构建产物。
