### PR TITLE
fix(common): make case-insensitive string equality safe

### DIFF
--- a/libs/common/src/linglong/common/strings.cpp
+++ b/libs/common/src/linglong/common/strings.cpp
@@ -8,6 +8,7 @@
 
 #include <fmt/format.h>
 
+#include <cctype>
 #include <random>
 #include <sstream>
 
@@ -38,9 +39,16 @@ bool stringEqual(std::string_view str1, std::string_view str2, bool caseSensitiv
         return str1 == str2;
     }
 
-    return std::equal(str1.begin(), str1.end(), str2.begin(), str2.end(), [](char ch1, char ch2) {
-        return tolower(ch1) == tolower(ch2);
-    });
+    if (str1.size() != str2.size()) {
+        return false;
+    }
+
+    return std::equal(str1.begin(),
+                      str1.end(),
+                      str2.begin(),
+                      [](unsigned char ch1, unsigned char ch2) {
+                          return std::tolower(ch1) == std::tolower(ch2);
+                      });
 }
 
 std::string_view trim_left(std::string_view str, std::string_view chars) noexcept

--- a/libs/linglong/tests/ll-tests/src/linglong/common/strings_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/common/strings_test.cpp
@@ -19,8 +19,13 @@ TEST(StringsTest, StringEqual)
     EXPECT_TRUE(stringEqual("", "", true));
     EXPECT_TRUE(stringEqual("", "", false));
     EXPECT_FALSE(stringEqual("hello", "", true));
+    EXPECT_FALSE(stringEqual("hello", "", false));
     EXPECT_FALSE(stringEqual("", "hello", false));
     EXPECT_FALSE(stringEqual("hello", "hello world", true));
+    EXPECT_FALSE(stringEqual("hello world", "hello", false));
+
+    const std::string nonAscii{ static_cast<char>(0xFF) };
+    EXPECT_TRUE(stringEqual(nonAscii, nonAscii, false));
 }
 
 TEST(StringsTest, Trim)


### PR DESCRIPTION
## Summary

- return false before comparing case-insensitive ranges of different sizes
- pass unsigned byte values to `std::tolower`
- cover reversed unequal ranges and high-bit bytes

## Verification

- `python -m pre_commit run --files libs/common/src/linglong/common/strings.cpp libs/linglong/tests/ll-tests/src/linglong/common/strings_test.cpp`
- Full C++ tests were not run locally because this checkout is on Windows and the project test environment requires Linux dependencies.

Fixes #1872