### PR TITLE
fix(builder): keep fetched sources inside destination

### DIFF
--- a/libs/linglong/src/linglong/builder/source_fetcher.cpp
+++ b/libs/linglong/src/linglong/builder/source_fetcher.cpp
@@ -59,12 +59,19 @@ auto SourceFetcher::fetch(QDir destination) noexcept -> utils::error::Result<voi
     if (source.kind == "git") {
         m_cmd->setEnv("GIT_SUBMODULES", source.submodules.value_or(true) ? "true" : "");
     }
-    auto output = m_cmd->exec(
-      std::vector<std::string>{ scriptFile.toStdString(),
-                                destination.absoluteFilePath(getSourceName()).toStdString(),
-                                *source.url,
-                                source.kind == "git" ? *source.commit : *source.digest,
-                                this->cacheDir.absolutePath().toStdString() });
+
+    auto sourceName = getSourceName();
+    if (sourceName.isEmpty() || sourceName == "." || sourceName == ".."
+        || QDir::isAbsolutePath(sourceName) || QFileInfo(sourceName).fileName() != sourceName) {
+        return LINGLONG_ERR("source name must be a non-empty file name");
+    }
+
+    auto output =
+      m_cmd->exec(std::vector<std::string>{ scriptFile.toStdString(),
+                                            destination.absoluteFilePath(sourceName).toStdString(),
+                                            *source.url,
+                                            source.kind == "git" ? *source.commit : *source.digest,
+                                            this->cacheDir.absolutePath().toStdString() });
     if (!output.has_value()) {
         LogE("output error: {}", output.error());
         return LINGLONG_ERR("stderr:", output);

--- a/libs/linglong/tests/ll-tests/src/linglong/builder/source_fetcher_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/builder/source_fetcher_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include <gmock/gmock.h>
@@ -247,6 +247,46 @@ TEST_F(SourceFetcherTest, FetchNoSetName)
     fetcher.setCommand(mockCmd);
     auto ret = fetcher.fetch(QDir("/tmp/dest"));
     EXPECT_TRUE(ret.has_value());
+}
+
+TEST_F(SourceFetcherTest, RejectSourceNamesOutsideDestination)
+{
+    const std::vector<std::string> invalidNames = { "",           ".",           "..",
+                                                    "../outside", "nested/repo", "/tmp/outside" };
+
+    for (const auto &name : invalidNames) {
+        api::types::v1::BuilderProjectSource source;
+        source.kind = "file";
+        source.url = "https://example.com/repo.tar.gz";
+        source.digest = "digest";
+        source.name = name;
+
+        QDir cacheDir("/tmp/cache");
+        auto mockCmd = std::make_shared<MockCommand>("mock");
+        EXPECT_CALL(*mockCmd, exec(_)).Times(0);
+
+        SourceFetcher fetcher(source, cacheDir);
+        fetcher.setCommand(mockCmd);
+        auto ret = fetcher.fetch(QDir("/tmp/dest"));
+        EXPECT_FALSE(ret.has_value()) << "accepted source name: " << name;
+    }
+}
+
+TEST_F(SourceFetcherTest, RejectEmptyNameDerivedFromUrl)
+{
+    api::types::v1::BuilderProjectSource source;
+    source.kind = "file";
+    source.url = "https://example.com/downloads/";
+    source.digest = "digest";
+
+    QDir cacheDir("/tmp/cache");
+    auto mockCmd = std::make_shared<MockCommand>("mock");
+    EXPECT_CALL(*mockCmd, exec(_)).Times(0);
+
+    SourceFetcher fetcher(source, cacheDir);
+    fetcher.setCommand(mockCmd);
+    auto ret = fetcher.fetch(QDir("/tmp/dest"));
+    EXPECT_FALSE(ret.has_value());
 }
 
 } // namespace linglong::builder


### PR DESCRIPTION
## Summary

- require fetched source names to be non-empty single filenames
- reject absolute paths, parent-directory references, nested paths, and URLs without a filename before invoking the command
- add coverage for invalid configured and URL-derived names

## Verification

- `python -m pre_commit run --files libs/linglong/src/linglong/builder/source_fetcher.cpp libs/linglong/tests/ll-tests/src/linglong/builder/source_fetcher_test.cpp`
- Full C++ tests were not run locally because this checkout is on Windows and the project test environment requires Linux dependencies.

Fixes #1873