### PR TITLE
fix(common): preserve non-socket paths when creating Unix sockets

### DIFF
--- a/libs/common/src/linglong/common/socket.cpp
+++ b/libs/common/src/linglong/common/socket.cpp
@@ -168,7 +168,23 @@ tl::expected<int, std::string> createUnixSocket(std::string_view path)
             return tl::make_unexpected("Path too long");
         }
 
-        std::filesystem::remove(path);
+        std::error_code ec;
+        auto status = std::filesystem::symlink_status(path, ec);
+        if (ec && ec != std::errc::no_such_file_or_directory) {
+            return tl::make_unexpected("Failed to inspect existing socket path: " + ec.message());
+        }
+
+        if (std::filesystem::exists(status)) {
+            if (status.type() != std::filesystem::file_type::socket) {
+                return tl::make_unexpected("Existing socket path is not a socket");
+            }
+
+            std::filesystem::remove(path, ec);
+            if (ec) {
+                return tl::make_unexpected("Failed to remove stale socket: " + ec.message());
+            }
+        }
+
         std::copy(path.cbegin(), path.cend(), addr.sun_path);
         addr.sun_path[path.size()] = '\0';
 

--- a/libs/linglong/tests/ll-tests/src/linglong/common/socket_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/common/socket_test.cpp
@@ -6,7 +6,13 @@
 
 #include "linglong/common/socket.h"
 
+#include <common/tempdir.h>
+
+#include <filesystem>
+#include <fstream>
+
 #include <sys/socket.h>
+#include <sys/un.h>
 
 class SocketFdTest : public ::testing::Test
 {
@@ -192,4 +198,48 @@ TEST_F(SocketFdTest, LargePayloadHandling)
     }
 
     waitpid(child, nullptr, 0);
+}
+
+TEST(SocketPathTest, PreserveExistingRegularFile)
+{
+    TempDir tempDir("linglong-socket-test-");
+    ASSERT_TRUE(tempDir.isValid());
+    auto path = tempDir.path() / "service.sock";
+
+    {
+        std::ofstream file(path);
+        ASSERT_TRUE(file.is_open());
+        file << "keep me";
+    }
+
+    auto result = createUnixSocket(path.string());
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), "Existing socket path is not a socket");
+
+    std::ifstream file(path);
+    std::string content;
+    std::getline(file, content);
+    EXPECT_EQ(content, "keep me");
+}
+
+TEST(SocketPathTest, ReplaceStaleSocket)
+{
+    TempDir tempDir("linglong-socket-test-");
+    ASSERT_TRUE(tempDir.isValid());
+    auto path = tempDir.path() / "service.sock";
+
+    auto staleFd = ::socket(AF_UNIX, SOCK_SEQPACKET | SOCK_CLOEXEC, 0);
+    ASSERT_GE(staleFd, 0);
+
+    struct sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    auto pathString = path.string();
+    ASSERT_LT(pathString.size(), sizeof(addr.sun_path));
+    std::copy(pathString.begin(), pathString.end(), addr.sun_path);
+    ASSERT_EQ(::bind(staleFd, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)), 0);
+    ::close(staleFd);
+
+    auto result = createUnixSocket(path.string());
+    ASSERT_TRUE(result.has_value()) << result.error();
+    ::close(*result);
 }


### PR DESCRIPTION
## Summary

- inspect an existing Unix socket path before removing it
- replace stale sockets while refusing to delete regular files or other non-socket entries
- test both preservation of a regular file and replacement of a stale socket

## Verification

- `python -m pre_commit run --files libs/common/src/linglong/common/socket.cpp libs/linglong/tests/ll-tests/src/linglong/common/socket_test.cpp`
- Full C++ tests were not run locally because this checkout is on Windows and the project test environment requires Linux dependencies.

Fixes #1874