### PR TITLE
fix(package): compare large fallback versions numerically

### DIFF
--- a/libs/linglong/src/linglong/package/fallback_version.cpp
+++ b/libs/linglong/src/linglong/package/fallback_version.cpp
@@ -12,7 +12,8 @@
 
 #include <fmt/format.h>
 
-#include <charconv>
+#include <algorithm>
+#include <cctype>
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 namespace Qt {
@@ -21,10 +22,20 @@ static auto SkipEmptyParts = QString::SkipEmptyParts;
 #endif
 
 namespace {
-bool parse_int_strict(const std::string &s, int &out)
+std::optional<std::string_view> normalizeUnsignedInteger(std::string_view value) noexcept
 {
-    auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), out);
-    return ec == std::errc() && ptr == s.data() + s.size();
+    if (value.empty() || !std::all_of(value.begin(), value.end(), [](unsigned char ch) {
+            return std::isdigit(ch);
+        })) {
+        return std::nullopt;
+    }
+
+    auto firstNonZero = value.find_first_not_of('0');
+    if (firstNonZero == std::string_view::npos) {
+        return value.substr(value.size() - 1);
+    }
+
+    return value.substr(firstNonZero);
 }
 
 } // namespace
@@ -59,7 +70,7 @@ bool FallbackVersion::semanticMatch(const std::string &versionStr) const noexcep
 
 bool FallbackVersion::operator==(const FallbackVersion &that) const
 {
-    return this->list == that.list;
+    return compare(that) == 0;
 }
 
 bool FallbackVersion::operator!=(const FallbackVersion &that) const
@@ -93,15 +104,16 @@ int FallbackVersion::compare(const FallbackVersion &other) const noexcept
     auto otherPart = other.list.cbegin();
 
     while (thisPart != this->list.cend() && otherPart != other.list.cend()) {
-        int thisNumber{ -1 };
-        int otherNumber{ -1 };
-        const bool thisIsNum = parse_int_strict(*thisPart, thisNumber);
-        const bool otherIsNum = parse_int_strict(*otherPart, otherNumber);
+        auto thisNumber = normalizeUnsignedInteger(*thisPart);
+        auto otherNumber = normalizeUnsignedInteger(*otherPart);
 
         // all numbers
-        if (thisIsNum && otherIsNum) {
-            if (thisNumber != otherNumber) {
-                return (thisNumber < otherNumber) ? -1 : 1;
+        if (thisNumber && otherNumber) {
+            if (thisNumber->size() != otherNumber->size()) {
+                return thisNumber->size() < otherNumber->size() ? -1 : 1;
+            }
+            if (*thisNumber != *otherNumber) {
+                return thisNumber->compare(*otherNumber);
             }
         } else {
             // if the one of them is not a number

--- a/libs/linglong/tests/ll-tests/src/linglong/package/fallback_version_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/fallback_version_test.cpp
@@ -181,6 +181,11 @@ TEST(FallbackVersionTest, compare)
     EXPECT_GT(FallbackVersion::parse("1.2.3-🚀").value(),
               FallbackVersion::parse("1.2.3-😊").value());
 
+    EXPECT_EQ(FallbackVersion::parse("1.02.0003").value(), FallbackVersion::parse("1.2.3").value());
+    EXPECT_LT(FallbackVersion::parse("3").value(), FallbackVersion::parse("2147483648").value());
+    EXPECT_LT(FallbackVersion::parse("18446744073709551616").value(),
+              FallbackVersion::parse("18446744073709551617").value());
+
     // 空字符串和只有分隔符的版本号
     EXPECT_FALSE(FallbackVersion::parse("").has_value());
     EXPECT_FALSE(FallbackVersion::parse("...").has_value());


### PR DESCRIPTION
## Summary

- normalize unsigned numeric components without converting them to fixed-width integers
- compare arbitrary-length components by significant length and digits
- make equality consistent with ordering for leading-zero variants
- add coverage above both `int` and `uint64_t` ranges

## Verification

- `python -m pre_commit run --files libs/linglong/src/linglong/package/fallback_version.cpp libs/linglong/tests/ll-tests/src/linglong/package/fallback_version_test.cpp`
- Full C++ tests were not run locally because this checkout is on Windows and the project test environment requires Linux dependencies.

Fixes #1875