### PR TITLE
feat(cli): add --region option to repo enable-mirror

### DIFF
--- a/api/schema/v1.json
+++ b/api/schema/v1.json
@@ -621,6 +621,10 @@
         "mirror_enabled": {
           "type": "boolean",
           "description": "whether mirror is enabled for this repo"
+        },
+        "region": {
+          "type": "string",
+          "description": "region code for mirror selection, e.g. CN, US"
         }
       }
     },

--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -493,6 +493,9 @@ $defs:
       mirror_enabled:
         type: boolean
         description: whether mirror is enabled for this repo
+      region:
+        type: string
+        description: region code for mirror selection, e.g. CN, US
   LayerInfo:
     description: Meta information on the head of layer file.
     type: object

--- a/docs/pages/en/guide/reference/commands/ll-cli/repo.md
+++ b/docs/pages/en/guide/reference/commands/ll-cli/repo.md
@@ -119,11 +119,13 @@ Enable mirror for repository.
 **Parameters**:
 
 - **ALIAS** _TEXT_ _REQUIRED_: Repository name alias
+- **--region** _REGION_: Region code for mirror selection, e.g. CN, US. When set, it is appended to the mirrorlist URL as a query parameter
 
 **Examples**:
 
 ```bash
 ll-cli repo enable-mirror myrepo
+ll-cli repo enable-mirror myrepo --region CN
 ```
 
 ### disable-mirror

--- a/docs/pages/guide/reference/commands/ll-cli/repo.md
+++ b/docs/pages/guide/reference/commands/ll-cli/repo.md
@@ -119,11 +119,13 @@ ll-cli repo set-priority myrepo 100
 **参数**:
 
 - **ALIAS** _TEXT_ _REQUIRED_: 仓库名称的别名
+- **--region** _REGION_: 镜像区域代码，例如 CN、US。设置后会将该参数作为查询参数追加到 mirrorlist URL
 
 **示例**:
 
 ```bash
 ll-cli repo enable-mirror myrepo
+ll-cli repo enable-mirror myrepo --region CN
 ```
 
 ### disable-mirror

--- a/libs/api/src/linglong/api/types/helper.h
+++ b/libs/api/src/linglong/api/types/helper.h
@@ -14,7 +14,7 @@ namespace linglong::api::types::v1 {
 // I added this size assertion because these structs overload == operator.
 // Adding new fields will make this fail, reminding me to update the == implementation.
 #ifndef __i386__
-static_assert(sizeof(struct Repo) == 120);
+static_assert(sizeof(struct Repo) == 160);
 static_assert(sizeof(struct RepoConfig) == 88);
 static_assert(sizeof(struct RepoConfigV2) == 64);
 static_assert(sizeof(struct UpgradeListResult) == 96);
@@ -23,7 +23,8 @@ static_assert(sizeof(struct UpgradeListResult) == 96);
 inline bool operator==(const Repo &cfg1, const Repo &cfg2) noexcept
 {
     return cfg1.alias == cfg2.alias && cfg1.name == cfg2.name && cfg1.url == cfg2.url
-      && cfg1.priority == cfg2.priority && cfg1.mirrorEnabled == cfg2.mirrorEnabled;
+      && cfg1.priority == cfg2.priority && cfg1.mirrorEnabled == cfg2.mirrorEnabled
+      && cfg1.region == cfg2.region;
 }
 
 inline bool operator!=(const Repo &cfg1, const Repo &cfg2) noexcept

--- a/libs/api/src/linglong/api/types/v1/Generators.hpp
+++ b/libs/api/src/linglong/api/types/v1/Generators.hpp
@@ -1177,6 +1177,7 @@ x.alias = get_stack_optional<std::string>(j, "alias");
 x.mirrorEnabled = get_stack_optional<bool>(j, "mirror_enabled");
 x.name = j.at("name").get<std::string>();
 x.priority = j.at("priority").get<int64_t>();
+x.region = get_stack_optional<std::string>(j, "region");
 x.url = j.at("url").get<std::string>();
 }
 
@@ -1190,6 +1191,9 @@ j["mirror_enabled"] = x.mirrorEnabled;
 }
 j["name"] = x.name;
 j["priority"] = x.priority;
+if (x.region) {
+j["region"] = x.region;
+}
 j["url"] = x.url;
 }
 
@@ -1656,7 +1660,7 @@ j["XDGDirectoryPermissions"] = x.xdgDirectoryPermissions;
 
 inline void from_json(const json & j, DeviceOption & x) {
 if (j == "passthru") x = DeviceOption::Passthru;
-else { throw std::runtime_error("Input JSON does not conform to schema!"); }
+else { throw std::runtime_error("Cannot deserialize to enumeration \"DeviceOption\""); }
 }
 
 inline void to_json(json & j, const DeviceOption & x) {
@@ -1672,7 +1676,7 @@ else if (j == "Install") x = InteractionMessageType::Install;
 else if (j == "Uninstall") x = InteractionMessageType::Uninstall;
 else if (j == "Unknown") x = InteractionMessageType::Unknown;
 else if (j == "Upgrade") x = InteractionMessageType::Upgrade;
-else { throw std::runtime_error("Input JSON does not conform to schema!"); }
+else { throw std::runtime_error("Cannot deserialize to enumeration \"InteractionMessageType\""); }
 }
 
 inline void to_json(json & j, const InteractionMessageType & x) {
@@ -1694,7 +1698,7 @@ else if (j == "Processing") x = State::Processing;
 else if (j == "Queued") x = State::Queued;
 else if (j == "Succeed") x = State::Succeed;
 else if (j == "Unknown") x = State::Unknown;
-else { throw std::runtime_error("Input JSON does not conform to schema!"); }
+else { throw std::runtime_error("Cannot deserialize to enumeration \"State\""); }
 }
 
 inline void to_json(json & j, const State & x) {
@@ -1712,7 +1716,7 @@ default: throw std::runtime_error("Unexpected value in enumeration \"State\": " 
 
 inline void from_json(const json & j, Version & x) {
 if (j == "1") x = Version::The1;
-else { throw std::runtime_error("Input JSON does not conform to schema!"); }
+else { throw std::runtime_error("Cannot deserialize to enumeration \"Version\""); }
 }
 
 inline void to_json(json & j, const Version & x) {

--- a/libs/api/src/linglong/api/types/v1/Repo.hpp
+++ b/libs/api/src/linglong/api/types/v1/Repo.hpp
@@ -48,6 +48,10 @@ std::string name;
 */
 int64_t priority;
 /**
+* region code for mirror selection, e.g. CN, US
+*/
+std::optional<std::string> region;
+/**
 * repo url
 */
 std::string url;

--- a/libs/linglong/src/linglong/common/cli/repo.cpp
+++ b/libs/linglong/src/linglong/common/cli/repo.cpp
@@ -113,6 +113,12 @@ CLI::App *addRepoCommand(CLI::App &commandParser,
     repoEnableMirror->add_option("ALIAS", repoOptions.repoAlias, _("Alias of the repo name"))
       ->required()
       ->check(validatorString);
+    repoEnableMirror
+      ->add_option("--region",
+                   repoOptions.repoRegion,
+                   _("Region code for mirror selection, e.g. CN, US"))
+      ->type_name("REGION")
+      ->check(validatorString);
 
     auto *repoDisableMirror =
       cliRepo->add_subcommand("disable-mirror", _("Disable mirror for the repo"));
@@ -248,6 +254,7 @@ utils::error::Result<void> handleRepoCommand(CLI::App *app,
 
     if (argsParsed("enable-mirror")) {
         existingRepo->mirrorEnabled = true;
+        existingRepo->region = options.repoRegion;
         auto ret = backend.setConfig(cfgRef);
         if (!ret) {
             return LINGLONG_ERR(ret);

--- a/libs/linglong/src/linglong/common/cli/repo.h
+++ b/libs/linglong/src/linglong/common/cli/repo.h
@@ -24,6 +24,7 @@ struct RepoOptions
     std::string repoUrl;
     std::optional<std::string> repoAlias;
     std::int64_t repoPriority{ 0 };
+    std::optional<std::string> repoRegion;
 };
 
 struct RepoConfigBackend

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -288,6 +288,9 @@ updateOstreeRepoConfig(OstreeRepo *repo,
         // add contenturl to use mirrorlist
         if (repoCfg.mirrorEnabled.value_or(false)) {
             auto mirrorlist = std::string("mirrorlist=") + repoCfg.url + "/api/v2/mirrors/stable";
+            if (repoCfg.region.has_value() && !repoCfg.region->empty()) {
+                mirrorlist += "?region=" + *repoCfg.region;
+            }
             g_variant_builder_add(&builder,
                                   "{sv}",
                                   "contenturl",

--- a/libs/linglong/tests/ll-tests/src/linglong/common/cli/repo_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/common/cli/repo_test.cpp
@@ -155,6 +155,19 @@ TEST_F(RepoCommandTest, EnableMirror)
     ASSERT_TRUE(ret.has_value()) << ret.error().message();
     ASSERT_TRUE(config.repos[0].mirrorEnabled.has_value());
     EXPECT_TRUE(*config.repos[0].mirrorEnabled);
+    EXPECT_FALSE(config.repos[0].region.has_value());
+}
+
+TEST_F(RepoCommandTest, EnableMirrorWithRegion)
+{
+    parse("repo enable-mirror stable --region CN");
+    auto ret = handle();
+
+    ASSERT_TRUE(ret.has_value()) << ret.error().message();
+    ASSERT_TRUE(config.repos[0].mirrorEnabled.has_value());
+    EXPECT_TRUE(*config.repos[0].mirrorEnabled);
+    ASSERT_TRUE(config.repos[0].region.has_value());
+    EXPECT_EQ(*config.repos[0].region, "CN");
 }
 
 TEST_F(RepoCommandTest, DisableMirror)


### PR DESCRIPTION
## 变更内容

为 `ll-cli repo enable-mirror` 命令添加 `--region` 参数，用户可手动输入区域代码（如 CN、US）。设置后，region 会持久化到 repo 配置中，并作为查询参数追加到 mirrorlist URL（`?region=CN`）。

## 修改文件

- `api/schema/v1.yaml` / `v1.json`：Repo schema 新增 `region` 字段
- `libs/api/src/linglong/api/types/v1/Repo.hpp`：新增 `std::optional<std::string> region` 字段
- `libs/api/src/linglong/api/types/v1/Generators.hpp`：`region` 的 JSON 序列化/反序列化
- `libs/api/src/linglong/api/types/helper.h`：更新 `sizeof(Repo)` 断言与 `operator==`
- `libs/linglong/src/linglong/common/cli/repo.h` / `repo.cpp`：`enable-mirror` 子命令添加 `--region` 选项
- `libs/linglong/src/linglong/repo/ostree_repo.cpp`：mirrorlist 构造时追加 `?region=` 查询参数
- `docs/`：中英文文档补充 `--region` 参数说明与示例
- `libs/linglong/tests/.../repo_test.cpp`：新增 `EnableMirrorWithRegion` 测试

## 测试

本地构建通过，`RepoCommandTest` 全部 11 项用例通过（含新增 `EnableMirrorWithRegion`）。