### PR TITLE
fix: enforce shared permissions for files regardless of umask

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,8 +35,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Update apt metadata
+        run: sudo apt-get update
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: >-
             cmake ninja-build debhelper-compat erofs-utils erofsfuse intltool libcap-dev
@@ -62,8 +64,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Update apt metadata
+        run: sudo apt-get update
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: >-
             cmake ninja-build debhelper-compat erofs-utils erofsfuse intltool libcap-dev
@@ -89,8 +93,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Update apt metadata
+        run: sudo apt-get update
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: >-
             cmake ninja-build debhelper-compat erofs-utils erofsfuse intltool libcap-dev
@@ -114,8 +120,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Update apt metadata
+        run: sudo apt-get update
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: >-
             cmake ninja-build debhelper-compat erofs-utils erofsfuse intltool libcap-dev

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -34,8 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - name: Update apt metadata
+        run: sudo apt-get update
+      - name: Install dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: >-
             gcovr cmake debhelper-compat erofs-utils erofsfuse intltool libcap-dev libcli11-dev

--- a/apps/ll-package-manager/src/main.cpp
+++ b/apps/ll-package-manager/src/main.cpp
@@ -28,7 +28,11 @@
 #include <memory>
 #include <string>
 
+#include <sys/stat.h>
+
 namespace {
+
+constexpr mode_t packageManagerUmask = 0022;
 
 struct CommandLineOptions
 {
@@ -258,6 +262,8 @@ auto runInitRunMode(ocppi::cli::CLI &cli, const CommandLineOptions &options) -> 
 
 auto main(int argc, char *argv[]) -> int
 {
+    ::umask(packageManagerUmask);
+
     QCoreApplication app(argc, argv);
 
     linglong::common::global::applicationInitialize();

--- a/libs/common/src/linglong/common/constants.h
+++ b/libs/common/src/linglong/common/constants.h
@@ -1,7 +1,21 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 
+#include <filesystem>
+
+namespace linglong::common {
+
 constexpr auto default_file_mode = 0644;
+
+constexpr auto shared_directory_permissions = std::filesystem::perms::owner_all
+  | std::filesystem::perms::group_read | std::filesystem::perms::group_exec
+  | std::filesystem::perms::others_read | std::filesystem::perms::others_exec;
+
+constexpr auto shared_file_permissions = std::filesystem::perms::owner_read
+  | std::filesystem::perms::owner_write | std::filesystem::perms::group_read
+  | std::filesystem::perms::others_read;
+
+} // namespace linglong::common

--- a/libs/linglong/src/linglong/cli/cli.cpp
+++ b/libs/linglong/src/linglong/cli/cli.cpp
@@ -24,6 +24,7 @@
 #include "linglong/api/types/v1/PackageManager1UninstallParameters.hpp"
 #include "linglong/api/types/v1/State.hpp"
 #include "linglong/cli/printer.h"
+#include "linglong/common/constants.h"
 #include "linglong/common/dir.h"
 #include "linglong/common/error.h"
 #include "linglong/common/socket.h"
@@ -1646,7 +1647,8 @@ int Cli::run(const RunOptions &options)
     LINGLONG_TRACE("command run");
 
     auto userContainerDir = std::filesystem::path{ "/run/linglong" } / std::to_string(getuid());
-    if (auto ret = utils::ensureDirectory(userContainerDir); !ret) {
+    if (auto ret = utils::ensureDirectory(userContainerDir, common::shared_directory_permissions);
+        !ret) {
         this->printer.printErr(ret.error());
         return -1;
     }
@@ -1809,14 +1811,13 @@ int Cli::run(const RunOptions &options)
         }
 
         auto pidFile = userContainerDir / std::to_string(getpid());
-        std::ofstream stream{ pidFile };
-        if (!stream.is_open()) {
-            this->printer.printErr(
-              LINGLONG_ERRV(fmt::format("failed to open {}", pidFile.c_str())));
+        auto result = utils::writeFile(pidFile,
+                                       nlohmann::json(runContext->stateInfo()).dump(),
+                                       common::shared_file_permissions);
+        if (!result) {
+            this->printer.printErr(result.error());
             return false;
         }
-        stream << nlohmann::json(runContext->stateInfo());
-        stream.close();
 
         return true;
     };

--- a/libs/linglong/src/linglong/repo/config.cpp
+++ b/libs/linglong/src/linglong/repo/config.cpp
@@ -89,6 +89,10 @@ utils::error::Result<void> saveConfig(const api::types::v1::RepoConfigV2 &cfg,
 
         auto node = ytj::to_yaml(cfg);
         ofs << node;
+        ofs.close();
+        if (!ofs) {
+            return LINGLONG_ERR("write failed");
+        }
 
         return LINGLONG_OK;
     } catch (const std::exception &e) {

--- a/libs/linglong/src/linglong/repo/repo_cache.cpp
+++ b/libs/linglong/src/linglong/repo/repo_cache.cpp
@@ -9,6 +9,7 @@
 #include "configure.h"
 #include "linglong/common/formatter.h"
 #include "linglong/package/version.h"
+#include "linglong/utils/file.h"
 #include "linglong/utils/log/log.h"
 #include "linglong/utils/serialize/json.h"
 #include "linglong/utils/serialize/packageinfo_handler.h"
@@ -319,6 +320,10 @@ utils::error::Result<void> RepoCache::writeToDisk()
     auto data = nlohmann::json(this->cache).dump();
     ofs << data;
     ofs.close();
+    if (!ofs) {
+        std::filesystem::remove(tmpFile, ec);
+        return LINGLONG_ERR("failed to write cache");
+    }
 
     std::filesystem::rename(tmpFile, this->cacheFile, ec);
     if (ec) {
@@ -348,14 +353,11 @@ utils::error::Result<void> RepoCache::writeToDisk()
     }
 
     auto versionTag = parent_path / ".version";
-    ofs.open(parent_path / ".version", std::ios::out | std::ios::trunc);
-    if (ofs.fail()) {
-        LogE("failed to open file {}", versionTag.string());
+    auto versionWritten = utils::writeFile(versionTag, LINGLONG_VERSION);
+    if (!versionWritten) {
+        LogE("failed to write file {}: {}", versionTag.string(), versionWritten.error());
         return LINGLONG_OK;
     }
-
-    ofs << LINGLONG_VERSION;
-    ofs.close();
 
     return LINGLONG_OK;
 }

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -12,6 +12,7 @@ pfl_add_executable(
   DISABLE_INSTALL
   SOURCES
   # find -regex '\./src/.+\.[ch]\(pp\)?' -type f -printf '%P\n'| sort
+  src/common/scoped_umask.h
   src/common/tempdir.h
   src/linglong/builder/config_test.cpp
   src/linglong/builder/linglong_builder_test.cpp
@@ -20,6 +21,7 @@ pfl_add_executable(
   src/linglong/cli/cli_test.cpp
   src/linglong/common/gkeyfile_wrapper_test.cpp
   src/linglong/common/cli/repo_test.cpp
+  src/linglong/common/dir_test.cpp
   src/linglong/common/strings_test.cpp
   src/linglong/common/display_test.cpp
   src/linglong/common/socket_test.cpp

--- a/libs/linglong/tests/ll-tests/src/common/scoped_umask.h
+++ b/libs/linglong/tests/ll-tests/src/common/scoped_umask.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <sys/stat.h>
+
+class ScopedUmask
+{
+public:
+    explicit ScopedUmask(mode_t mask)
+        : previousMask(::umask(mask))
+    {
+    }
+
+    ~ScopedUmask() { ::umask(this->previousMask); }
+
+    ScopedUmask(const ScopedUmask &) = delete;
+    ScopedUmask &operator=(const ScopedUmask &) = delete;
+
+private:
+    mode_t previousMask;
+};

--- a/libs/linglong/tests/ll-tests/src/linglong/common/dir_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/common/dir_test.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "common/scoped_umask.h"
+#include "common/tempdir.h"
+#include "linglong/common/constants.h"
+#include "linglong/utils/file.h"
+
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+TEST(DirTest, ContainerCacheDirectoryUsesPackageManagerUmask)
+{
+    TempDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    const auto cacheDir = tempDir.path() / "cache";
+    const auto commitDir = cacheDir / "commit";
+    const auto containerDir = commitDir / "container";
+
+    ScopedUmask scopedUmask{ 0022 };
+    auto result = linglong::utils::ensureDirectory(containerDir);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(fs::status(cacheDir).permissions() & fs::perms::mask,
+              linglong::common::shared_directory_permissions);
+    EXPECT_EQ(fs::status(commitDir).permissions() & fs::perms::mask,
+              linglong::common::shared_directory_permissions);
+    EXPECT_EQ(fs::status(containerDir).permissions() & fs::perms::mask,
+              linglong::common::shared_directory_permissions);
+}

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/ostree_repo_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/ostree_repo_test.cpp
@@ -7,9 +7,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "../../common/scoped_umask.h"
 #include "../../common/tempdir.h"
 #include "../mocks/ostree_repo_mock.h"
 #include "linglong/api/types/v1/Generators.hpp"
+#include "linglong/common/constants.h"
 #include "linglong/package/reference.h"
 #include "linglong/repo/client_factory.h"
 #include "linglong/repo/config.h"
@@ -112,12 +114,28 @@ TEST_F(RepoTest, createPersistsConfigAndBootstrapsRepoArtifacts)
     ASSERT_TRUE(fs::create_directories(repoRoot));
 
     auto config = createRepoConfig();
+    ScopedUmask scopedUmask{ 0022 };
     auto repo = OSTreeRepo::create(repoRoot, config);
     ASSERT_TRUE(repo.has_value()) << repo.error().message();
 
     EXPECT_TRUE(fs::exists(repoRoot / "config.yaml"));
     EXPECT_TRUE(fs::exists(repoRoot / "repo"));
     EXPECT_TRUE(fs::exists(repoRoot / "states.json"));
+    EXPECT_EQ(fs::status(repoRoot / "config.yaml").permissions() & fs::perms::mask,
+              common::shared_file_permissions);
+    EXPECT_EQ(fs::status(repoRoot / "repo").permissions() & fs::perms::mask,
+              common::shared_directory_permissions);
+    EXPECT_EQ(fs::status(repoRoot / "states.json").permissions() & fs::perms::mask,
+              common::shared_file_permissions);
+    EXPECT_EQ(fs::status(repoRoot / ".version").permissions() & fs::perms::mask,
+              common::shared_file_permissions);
+
+    auto entriesResult = repo->get()->fixExportAllEntries();
+    ASSERT_TRUE(entriesResult.has_value()) << entriesResult.error().message();
+    EXPECT_EQ(fs::status(repoRoot / "entries").permissions() & fs::perms::mask,
+              common::shared_directory_permissions);
+    EXPECT_EQ(fs::status(repoRoot / "entries/.version").permissions() & fs::perms::mask,
+              common::shared_file_permissions);
 
     auto loaded = OSTreeRepo::loadFromPath(repoRoot);
     EXPECT_TRUE(loaded.has_value()) << loaded.error().message();
@@ -138,6 +156,7 @@ TEST_F(RepoTest, exportLayerSignDataExportsWhitelistedPathForEveryLayerKindAndMo
         std::pair{ "custom", "custom-module" },
     };
 
+    ScopedUmask scopedUmask{ 0022 };
     for (std::size_t i = 0; i < layerTypes.size(); ++i) {
         const auto commit = "commit-" + std::to_string(i);
         const auto source = tempDir.path() / "layers" / commit / "entries";
@@ -163,6 +182,13 @@ TEST_F(RepoTest, exportLayerSignDataExportsWhitelistedPathForEveryLayerKindAndMo
     }
 
     EXPECT_FALSE(fs::exists(tempDir.path() / "entries/share/applications"));
+    for (const auto &entry : fs::recursive_directory_iterator(tempDir.path() / "entries")) {
+        if (entry.is_directory()) {
+            EXPECT_EQ(entry.status().permissions() & fs::perms::mask,
+                      common::shared_directory_permissions)
+              << entry.path();
+        }
+    }
 }
 
 TEST_F(RepoTest, exportLayerSignDataSkipsPathNotInWhitelist)

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/repo_cache_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/repo_cache_test.cpp
@@ -6,12 +6,14 @@
 
 #include <gtest/gtest.h>
 
+#include "../../common/scoped_umask.h"
 #include "../../common/tempdir.h"
 #include "linglong/api/types/v1/Generators.hpp"
 #include "linglong/api/types/v1/PackageInfoV2.hpp"
 #include "linglong/api/types/v1/Repo.hpp"
 #include "linglong/api/types/v1/RepoConfigV2.hpp"
 #include "linglong/api/types/v1/RepositoryCache.hpp"
+#include "linglong/common/constants.h"
 #include "linglong/repo/repo_cache.h"
 
 #include <filesystem>
@@ -147,6 +149,23 @@ TEST_F(RepoCacheTest, addAndDeleteLayerItemPersistAcrossReload)
     RepoCache afterDelete(cacheFile);
     ASSERT_TRUE(afterDelete.load().has_value());
     EXPECT_TRUE(afterDelete.queryLayerItem(repoCacheQuery{ .id = "app.test" }).empty());
+}
+
+TEST_F(RepoCacheTest, PersistedFilesUsePackageManagerUmask)
+{
+    ASSERT_TRUE(tempDir.isValid());
+
+    auto cacheFile = tempDir.path() / "states.json";
+    RepoCache cache(cacheFile);
+
+    ScopedUmask scopedUmask{ 0022 };
+    auto result = cache.addLayerItem(createLayerItem("commit-1", "app.test", "1.0.0"));
+
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+    EXPECT_EQ(fs::status(cacheFile).permissions() & fs::perms::mask,
+              common::shared_file_permissions);
+    EXPECT_EQ(fs::status(tempDir.path() / ".version").permissions() & fs::perms::mask,
+              common::shared_file_permissions);
 }
 
 } // namespace

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/file_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/file_test.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include "common/scoped_umask.h"
 #include "common/tempdir.h"
 #include "linglong/utils/file.h"
 
@@ -277,6 +278,34 @@ TEST_F(FileTest, EnsureDirectory)
     result = linglong::utils::ensureDirectory(multiple_dir);
     ASSERT_TRUE(result.has_value());
     EXPECT_TRUE(fs::is_directory(multiple_dir));
+}
+
+TEST_F(FileTest, EnsureDirectoryWithPermissionsIgnoresUmask)
+{
+    constexpr auto permissions = fs::perms::owner_all | fs::perms::group_read
+      | fs::perms::group_exec | fs::perms::others_read | fs::perms::others_exec;
+    const auto parentDirectory = dest_dir / "public-directory";
+    const auto directory = parentDirectory / "nested-directory";
+
+    ScopedUmask scopedUmask{ 0077 };
+    auto result = linglong::utils::ensureDirectory(directory, permissions);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(fs::status(parentDirectory).permissions() & fs::perms::mask, permissions);
+    EXPECT_EQ(fs::status(directory).permissions() & fs::perms::mask, permissions);
+}
+
+TEST_F(FileTest, WriteFileWithPermissionsIgnoresUmask)
+{
+    constexpr auto permissions = fs::perms::owner_read | fs::perms::owner_write
+      | fs::perms::group_read | fs::perms::others_read;
+    const auto file = dest_dir / "public-file";
+
+    ScopedUmask scopedUmask{ 0077 };
+    auto result = linglong::utils::writeFile(file, "content", permissions);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(fs::status(file).permissions() & fs::perms::mask, permissions);
 }
 
 TEST_F(FileTest, MakeDirectoryTreeRemovable)

--- a/libs/utils/src/linglong/utils/file.cpp
+++ b/libs/utils/src/linglong/utils/file.cpp
@@ -79,10 +79,31 @@ linglong::utils::error::Result<void> writeFile(const std::filesystem::path &file
           fmt::format("failed to open file {}: {}", filepath, common::error::errorString(errno)));
     }
     out << content;
-    if (out.bad()) {
+    out.close();
+    if (!out) {
         return LINGLONG_ERR(
           fmt::format("failed to write file {}", common::error::errorString(errno)));
     }
+    return LINGLONG_OK;
+}
+
+linglong::utils::error::Result<void> writeFile(const std::filesystem::path &filepath,
+                                               const std::string &content,
+                                               std::filesystem::perms permissions)
+{
+    LINGLONG_TRACE(fmt::format("write file {} with permissions", filepath));
+
+    auto result = writeFile(filepath, content);
+    if (!result) {
+        return LINGLONG_ERR(result);
+    }
+
+    std::error_code ec;
+    std::filesystem::permissions(filepath, permissions, std::filesystem::perm_options::replace, ec);
+    if (ec) {
+        return LINGLONG_ERR(fmt::format("failed to set permissions for {}", filepath), ec);
+    }
+
     return LINGLONG_OK;
 }
 
@@ -295,6 +316,51 @@ linglong::utils::error::Result<void> ensureDirectory(const std::filesystem::path
 
     if (!std::filesystem::create_directories(dir, ec) && ec) {
         return LINGLONG_ERR("failed to create directory", ec);
+    }
+
+    return LINGLONG_OK;
+}
+
+linglong::utils::error::Result<void> ensureDirectory(const std::filesystem::path &dir,
+                                                     std::filesystem::perms permissions)
+{
+    LINGLONG_TRACE(fmt::format("ensure directory {} with permissions", dir));
+
+    std::vector<std::filesystem::path> missingDirectories;
+    for (auto current = dir; !current.empty();) {
+        std::error_code ec;
+        if (std::filesystem::exists(current, ec)) {
+            break;
+        }
+        if (ec) {
+            return LINGLONG_ERR(fmt::format("failed to check directory {}", current), ec);
+        }
+
+        missingDirectories.push_back(current);
+        auto parent = current.parent_path();
+        if (parent == current) {
+            break;
+        }
+        current = std::move(parent);
+    }
+
+    auto result = ensureDirectory(dir);
+    if (!result) {
+        return LINGLONG_ERR(result);
+    }
+
+    if (missingDirectories.empty()) {
+        missingDirectories.push_back(dir);
+    }
+    for (const auto &directory : missingDirectories) {
+        std::error_code ec;
+        std::filesystem::permissions(directory,
+                                     permissions,
+                                     std::filesystem::perm_options::replace,
+                                     ec);
+        if (ec) {
+            return LINGLONG_ERR(fmt::format("failed to set permissions for {}", directory), ec);
+        }
     }
 
     return LINGLONG_OK;

--- a/libs/utils/src/linglong/utils/file.h
+++ b/libs/utils/src/linglong/utils/file.h
@@ -14,6 +14,9 @@ linglong::utils::error::Result<std::string> readFile(const std::filesystem::path
 
 linglong::utils::error::Result<void> writeFile(const std::filesystem::path &filepath,
                                                const std::string &content);
+linglong::utils::error::Result<void> writeFile(const std::filesystem::path &filepath,
+                                               const std::string &content,
+                                               std::filesystem::perms permissions);
 
 linglong::utils::error::Result<void> concatFile(const std::filesystem::path &source,
                                                 const std::filesystem::path &target);
@@ -37,6 +40,8 @@ linglong::utils::error::Result<std::vector<std::filesystem::path>>
 getFiles(const std::filesystem::path &dir);
 
 linglong::utils::error::Result<void> ensureDirectory(const std::filesystem::path &dir);
+linglong::utils::error::Result<void> ensureDirectory(const std::filesystem::path &dir,
+                                                     std::filesystem::perms permissions);
 
 linglong::utils::error::Result<void>
 makeDirectoryTreeRemovable(const std::filesystem::path &root) noexcept;

--- a/libs/utils/src/linglong/utils/filelock.cpp
+++ b/libs/utils/src/linglong/utils/filelock.cpp
@@ -64,7 +64,7 @@ utils::error::Result<FileLock> FileLock::create(std::filesystem::path path,
         flags |= O_CREAT;
     }
 
-    auto fd = ::open(abs_path.c_str(), flags, default_file_mode);
+    auto fd = ::open(abs_path.c_str(), flags, common::default_file_mode);
     if (fd < 0) {
         return LINGLONG_ERR(fmt::format("failed to open lock file {} :{}",
                                         abs_path,


### PR DESCRIPTION
Repo artifacts created by the package manager, and the /run/linglong/<uid> container dir previously inherited the process umask, so a restrictive umask produced files/directories unreadable by other users.

- Set umask 0022 in ll-package-manager at startup.
- Add writeFile/ensureDirectory overloads that explicitly replace perms, bypassing the inherited umask.
- Apply the shared perms in RepoCache::writeToDisk, saveConfig, and the ll-cli container dump path.