### PR TITLE
chore: update Chinese translation files

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2,39 +2,143 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gary Wang <wzc782970009@gmail.com>, 2025
 # chang Gao, 2025
 # deepiner, 2026
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-23 19:04+0800\n"
+"POT-Creation-Date: 2026-08-28 16:24+0800\n"
 "PO-Revision-Date: 2025-04-11 01:38+0000\n"
 "Last-Translator: deepiner, 2026\n"
-"Language-Team: Chinese (China) (https://app.transifex.com/linuxdeepin/teams/3976/zh_CN/)\n"
+"Language-Team: Chinese (China) (https://app.transifex.com/linuxdeepin/teams/"
+"3976/zh_CN/)\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1238
+#: ../libs/linglong/src/linglong/cli/cli.cpp:448
+msgid "Debug mode is enabled. Attach from another terminal with gdb:"
+msgstr "调试模式已启用。请在另一个终端中使用 gdb 进行附加："
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:468
+msgid "Debug mode is enabled. Attach from another terminal with:"
+msgstr "调试模式已启用。请在另一个终端中使用以下命令附加："
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:471
+msgid "Generated gdb attach script:"
+msgstr "已生成 gdb 附加脚本："
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1949
+#, c++-format
+msgid "Base {} has no develop module installed, installing it now."
+msgstr "基础环境 {} 未安装开发模块，正在安装。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2361
+#, c++-format
+msgid "{} is not a regular file; expected a .layer or .uab file."
+msgstr "{} 不是普通文件；应为 .layer 或 .uab 文件。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2372
+#, c++-format
+msgid "Unsupported file format {}; expected a .layer or .uab file."
+msgstr "不支持的文件格式 {}；应为 .layer 或 .uab 文件。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2385
+#, c++-format
+msgid "Package file {} does not exist."
+msgstr "软件包文件 {} 不存在。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2452
 #, c++-format
 msgid "Application {} is not installed."
 msgstr "应用程序 {} 未安装。"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1248
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2462
 #, c++-format
 msgid "{} is not an application."
 msgstr "{} 不是一个应用程序。"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1353
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2343
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3631
+msgid "To install the module, one must first install the app."
+msgstr "要安装该模块，必须先安装此应用程序。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3634
+msgid "Module is already installed."
+msgstr "模块已经安装"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3637
+msgid "The module could not be found remotely."
+msgstr "远程无法找到该模块"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3640
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3676
+msgid "Application already installed"
+msgstr "应用程序已经安装"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3644
+#, c++-format
+msgid "Application {} is not found in remote repo."
+msgstr "远程仓库中未找到应用 {}"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3647
+msgid "Cannot specify a version when installing a module."
+msgstr "安装模块时不允许指定版本。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3651
+#, c++-format
+msgid ""
+"The latest version has been installed. If you want to replace it, try using "
+"'ll-cli install {} --force'"
+msgstr ""
+"已安装最新版本。如需覆盖安装，请尝试使用命令：'ll-cli install {} --force'"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3657
+msgid "Install failed"
+msgstr "安装失败"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3698
+msgid ""
+"The application is currently running and cannot be uninstalled. Please turn "
+"off the application and try again."
+msgstr "应用程序当前正在运行，无法卸载。请关闭应用程序后重试。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3706
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3739
+msgid "Application is not installed."
+msgstr "应用未安装。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3710
+#, c++-format
+msgid ""
+"Multiple versions of the package are installed. Please specify a single "
+"version to uninstall:\n"
+"{}"
+msgstr ""
+"已安装该软件包的多个版本。请指定要卸载的具体版本：\n"
+"{}"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3716
+msgid "Base or runtime cannot be uninstalled, please use 'll-cli prune'."
+msgstr ""
+"基础环境(base)或运行时(runtime)无法直接卸载，请使用命令'll-cli prune'。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3720
+msgid "Uninstall failed"
+msgstr "卸载失败"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3743
+msgid "Upgrade failed"
+msgstr "升级失败"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3762
 msgid ""
 "Network connection failed. Please:\n"
 "1. Check your internet connection\n"
@@ -44,103 +148,32 @@ msgstr ""
 "1. 检查您的互联网连接\n"
 "2. 如使用代理，请确认网络代理设置"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2228
-msgid "To install the module, one must first install the app."
-msgstr "要安装该模块，必须先安装此应用程序。"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2231
-msgid "Module is already installed."
-msgstr "模块已经安装"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2234
-msgid "The module could not be found remotely."
-msgstr "远程无法找到该模块"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2238
-#, c++-format
-msgid ""
-"Application already installed, If you want to replace it, try using 'll-cli "
-"install {} --force'"
-msgstr "应用已安装。如需覆盖安装，请尝试使用命令：ll-cli install {} --force"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2244
-#, c++-format
-msgid "Application {} is not found in remote repo."
-msgstr "远程仓库中未找到应用 {}"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2247
-msgid "Cannot specify a version when installing a module."
-msgstr "安装模块时不允许指定版本。"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2251
-#, c++-format
-msgid ""
-"The latest version has been installed. If you want to replace it, try using "
-"'ll-cli install {} --force'"
-msgstr "已安装最新版本。如需覆盖安装，请尝试使用命令：'ll-cli install {} --force'"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2257
-msgid "Install failed"
-msgstr "安装失败"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2279
-msgid ""
-"The application is currently running and cannot be uninstalled. Please turn "
-"off the application and try again."
-msgstr "应用程序当前正在运行，无法卸载。请关闭应用程序后重试。"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2287
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2320
-msgid "Application is not installed."
-msgstr "应用未安装。"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2291
-#, c++-format
-msgid ""
-"Multiple versions of the package are installed. Please specify a single version to uninstall:\n"
-"{}"
-msgstr ""
-"已安装该软件包的多个版本。请指定要卸载的具体版本：\n"
-"{}"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2297
-msgid "Base or runtime cannot be uninstalled, please use 'll-cli prune'."
-msgstr "基础环境(base)或运行时(runtime)无法直接卸载，请使用命令'll-cli prune'。"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2301
-msgid "Uninstall failed"
-msgstr "卸载失败"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2324
-msgid "Upgrade failed"
-msgstr "升级失败"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2348
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3767
 msgid "Package not found"
 msgstr "未找到软件包"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2351
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3770
 msgid "Operation canceled"
 msgstr "操作已取消"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2354
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3773
 msgid "Permission denied, authentication is required"
 msgstr "权限被拒绝，需要进行身份验证"
 
-#: ../apps/ll-cli/src/main.cpp:105 ../apps/ll-builder/src/main.cpp:46
+#: ../apps/ll-cli/src/main.cpp:70 ../apps/ll-builder/src/main.cpp:47
 msgid "Input parameter is empty, please input valid parameter instead"
 msgstr "输入参数为空，请输入有效参数"
 
-#: ../apps/ll-cli/src/main.cpp:116
+#: ../apps/ll-cli/src/main.cpp:81
 msgid "Run an application"
 msgstr "运行应用程序"
 
 #. add sub command run options
-#: ../apps/ll-cli/src/main.cpp:119
+#: ../apps/ll-cli/src/main.cpp:84
 msgid "Specify the application ID"
 msgstr "指定应用程序名"
 
-#: ../apps/ll-cli/src/main.cpp:122
+#: ../apps/ll-cli/src/main.cpp:87
 msgid ""
 "Usage: ll-cli run [OPTIONS] APP [COMMAND...]\n"
 "\n"
@@ -162,78 +195,106 @@ msgstr ""
 "ll-cli run org.deepin.demo -- bash\n"
 "ll-cli run org.deepin.demo -- bash -x /path/to/bash/script"
 
-#: ../apps/ll-cli/src/main.cpp:134
+#: ../apps/ll-cli/src/main.cpp:99
 msgid "Pass file to applications running in a sandbox"
 msgstr "将文件传递到沙盒中运行的应用程序"
 
-#: ../apps/ll-cli/src/main.cpp:138
+#: ../apps/ll-cli/src/main.cpp:103
 msgid "Pass url to applications running in a sandbox"
 msgstr "将URL传递到沙盒中运行的应用程序"
 
-#: ../apps/ll-cli/src/main.cpp:141
+#: ../apps/ll-cli/src/main.cpp:106
 msgid "Set environment variables for the application"
 msgstr "为应用程序设置环境变量"
 
-#: ../apps/ll-cli/src/main.cpp:148
+#: ../apps/ll-cli/src/main.cpp:113
 msgid "Input parameter is invalid, please input valid parameter instead"
 msgstr "输入参数无效，请输入有效参数"
 
-#: ../apps/ll-cli/src/main.cpp:154
+#: ../apps/ll-cli/src/main.cpp:119
 msgid "Specify the base used by the application to run"
 msgstr "指定应用程序运行所需的基础环境(base)"
 
-#: ../apps/ll-cli/src/main.cpp:160
+#: ../apps/ll-cli/src/main.cpp:125
 msgid "Specify the runtime used by the application to run"
 msgstr "指定应用程序运行所需的运行时(runtime)"
 
-#: ../apps/ll-cli/src/main.cpp:166 ../apps/ll-builder/src/main.cpp:544
+#: ../apps/ll-cli/src/main.cpp:131 ../apps/ll-builder/src/main.cpp:574
 msgid "Specify the working directory where the application runs"
 msgstr "指定应用程序运行的工作目录"
 
-#: ../apps/ll-cli/src/main.cpp:171
+#: ../apps/ll-cli/src/main.cpp:136
 msgid "Specify extension(s) used by the application to run"
 msgstr "指定应用程序运行所需的扩展"
 
-#: ../apps/ll-cli/src/main.cpp:179
+#: ../apps/ll-cli/src/main.cpp:144
 msgid ""
 "Enable or disable xdg-desktop-portal related integration inside the sandbox"
 msgstr "在沙盒内启用或禁用 xdg-desktop-portal"
 
-#: ../apps/ll-cli/src/main.cpp:181
+#: ../apps/ll-cli/src/main.cpp:149
+msgid "Enable PipeWire socket mount inside the sandbox"
+msgstr "在沙盒内启用 PipeWire socket 挂载"
+
+#: ../apps/ll-cli/src/main.cpp:154
+msgid "Enable AT SPI socket mount inside the sandbox"
+msgstr "在沙盒内启用 AT SPI socket 挂载"
+
+#: ../apps/ll-cli/src/main.cpp:156
 msgid "Run context json string"
 msgstr "运行上下文 json 字符串"
 
-#: ../apps/ll-cli/src/main.cpp:184
+#: ../apps/ll-cli/src/main.cpp:159
 msgid "Run the application in privileged mode"
 msgstr "以特权模式运行应用程序"
 
-#: ../apps/ll-cli/src/main.cpp:186
+#: ../apps/ll-cli/src/main.cpp:161
 msgid "Add capabilities to the application"
 msgstr "为应用程序添加特权能力"
 
-#: ../apps/ll-cli/src/main.cpp:190
+#: ../apps/ll-cli/src/main.cpp:165
 msgid "CDI spec directory"
 msgstr "CDI 规范目录"
 
-#: ../apps/ll-cli/src/main.cpp:194
+#: ../apps/ll-cli/src/main.cpp:169
 msgid "Add CDI devices"
 msgstr "添加 CDI 设备"
 
-#: ../apps/ll-cli/src/main.cpp:200
+#: ../apps/ll-cli/src/main.cpp:175
 msgid "Add device options"
 msgstr "添加设备选项"
 
-#: ../apps/ll-cli/src/main.cpp:207
+#: ../apps/ll-cli/src/main.cpp:182
 msgid "Specify the container instance name for reuse or identification"
 msgstr "指定容器实例名称，用于复用或标识"
 
-#: ../apps/ll-cli/src/main.cpp:210 ../apps/ll-cli/src/main.cpp:241
+#: ../apps/ll-cli/src/main.cpp:186
+msgid "Run the application under gdbserver"
+msgstr "在 gdbserver 下运行应用程序"
+
+#: ../apps/ll-cli/src/main.cpp:190
+msgid "Specify the gdbserver listen address"
+msgstr "指定 gdbserver 监听地址"
+
+#: ../apps/ll-cli/src/main.cpp:198
+msgid "Specify debuginfod urls for debugging"
+msgstr "指定用于调试的 debuginfod URL 地址"
+
+#: ../apps/ll-cli/src/main.cpp:205
+msgid "Specify the directory used by gdb to load debug symbols"
+msgstr "指定 gdb 用于加载调试符号的目录"
+
+#: ../apps/ll-cli/src/main.cpp:209 ../apps/ll-cli/src/main.cpp:241
 msgid "Run commands in a running sandbox"
 msgstr "在正在运行的沙盒中运行命令"
 
-#: ../apps/ll-cli/src/main.cpp:216
+#: ../apps/ll-cli/src/main.cpp:215
 msgid "List running applications"
 msgstr "列出正在运行的应用程序"
+
+#: ../apps/ll-cli/src/main.cpp:218
+msgid "Do not truncate container IDs"
+msgstr "不截断容器 ID"
 
 #: ../apps/ll-cli/src/main.cpp:219
 msgid "Usage: ll-cli ps [OPTIONS]"
@@ -279,9 +340,9 @@ msgid ""
 "# install application by appid\n"
 "ll-cli install org.deepin.demo\n"
 "# install application by linyaps layer\n"
-"ll-cli install demo_0.0.0.1_x86_64_binary.layer\n"
+"ll-cli install ./demo_0.0.0.1_x86_64_binary.layer\n"
 "# install application by linyaps uab\n"
-"ll-cli install demo_x86_64_0.0.0.1_main.uab\n"
+"ll-cli install ./demo_x86_64_0.0.0.1_main.uab\n"
 "# install specified module of the appid\n"
 "ll-cli install org.deepin.demo --module=binary\n"
 "# install specified version of the appid\n"
@@ -290,20 +351,20 @@ msgid ""
 "ll-cli install stable:org.deepin.demo/0.0.0.1/x86_64\n"
 "    "
 msgstr ""
-"用法: ll-cli install [选项] 应用程序\n"
+"用法: ll-cli install [选项] 应用\n"
 "\n"
 "示例:\n"
 "# 通过应用名安装应用程序\n"
 "ll-cli install org.deepin.demo\n"
-"# 通过如意玲珑.layer文件安装应用程序\n"
-"ll-cli install demo_0.0.0.1_x86_64_binary.layer\n"
-"# 通过通过如意玲珑.uab文件安装应用程序\n"
-"ll-cli install demo_x86_64_0.0.0.1_main.uab\n"
-"# 安装应用的指定模块\n"
+"# 通过如意玲珑 layer 文件安装应用程序\n"
+"ll-cli install ./demo_0.0.0.1_x86_64_binary.layer\n"
+"# 通过如意玲珑 uab 文件安装应用程序\n"
+"ll-cli install ./demo_x86_64_0.0.0.1_main.uab\n"
+"# 安装指定应用名的指定模块\n"
 "ll-cli install org.deepin.demo --module=binary\n"
-"# 安装应用的指定版本\n"
+"# 安装指定应用名的指定版本\n"
 "ll-cli install org.deepin.demo/0.0.0.1\n"
-"# 通过特定标识安装应用程序\n"
+"# 通过详细引用标识安装应用程序\n"
 "ll-cli install stable:org.deepin.demo/0.0.0.1/x86_64\n"
 "    "
 
@@ -327,64 +388,65 @@ msgstr "强制安装指定版本的应用程序"
 msgid "Automatically answer yes to all questions"
 msgstr "自动对所有问题回答是"
 
-#: ../apps/ll-cli/src/main.cpp:310
+#: ../apps/ll-cli/src/main.cpp:304 ../apps/ll-cli/src/main.cpp:328
+#: ../apps/ll-cli/src/main.cpp:360
+msgid "Do not automatically remove unused dependencies"
+msgstr "不自动清理未使用的依赖项"
+
+#: ../apps/ll-cli/src/main.cpp:313
 msgid "Uninstall the application or runtimes"
 msgstr "卸载应用程序或运行时"
 
-#: ../apps/ll-cli/src/main.cpp:313
+#: ../apps/ll-cli/src/main.cpp:316
 msgid "Usage: ll-cli uninstall [OPTIONS] APP"
 msgstr "用法: ll-cli uninstall [选项] 应用"
 
-#: ../apps/ll-cli/src/main.cpp:314
+#: ../apps/ll-cli/src/main.cpp:317
 msgid "Specify the applications ID"
 msgstr "指定应用程序名"
 
-#: ../apps/ll-cli/src/main.cpp:317
+#: ../apps/ll-cli/src/main.cpp:320
 msgid "Uninstall a specify module"
 msgstr "卸载指定模块"
 
-#: ../apps/ll-cli/src/main.cpp:322
+#: ../apps/ll-cli/src/main.cpp:325
 msgid "Force uninstall base or runtime"
 msgstr "强制卸载基础环境(base)或运行时(runtime)"
 
 #. below options are used for compatibility with old ll-cli
-#: ../apps/ll-cli/src/main.cpp:325
+#: ../apps/ll-cli/src/main.cpp:331
 msgid "Remove all unused modules"
 msgstr "移除所有不使用的模块"
 
-#: ../apps/ll-cli/src/main.cpp:329
+#: ../apps/ll-cli/src/main.cpp:335
 msgid "Uninstall all modules"
 msgstr "卸载所有模块"
 
-#: ../apps/ll-cli/src/main.cpp:339
+#: ../apps/ll-cli/src/main.cpp:345
 msgid "Upgrade the application or runtimes"
 msgstr "升级应用程序或运行时"
 
-#: ../apps/ll-cli/src/main.cpp:342
+#: ../apps/ll-cli/src/main.cpp:348
 msgid "Usage: ll-cli upgrade [OPTIONS] [APP]"
 msgstr "用法: ll-cli upgrade [选项] [应用]"
 
-#: ../apps/ll-cli/src/main.cpp:346
+#: ../apps/ll-cli/src/main.cpp:352
 msgid ""
-"Specify the application ID. If it not be specified, all applications will be"
-" upgraded"
+"Specify the application ID. If it not be specified, all applications will be "
+"upgraded"
 msgstr "指定应用程序名。如果未指定，将升级所有可升级的应用程序"
 
-#: ../apps/ll-cli/src/main.cpp:351
+#: ../apps/ll-cli/src/main.cpp:357
 msgid "Only upgrade dependencies of application"
 msgstr "仅升级应用程序的依赖项"
 
-#: ../apps/ll-cli/src/main.cpp:352
-msgid "Only upgrade application"
-msgstr "仅升级应用程序"
-
-#: ../apps/ll-cli/src/main.cpp:363
+#: ../apps/ll-cli/src/main.cpp:370
 msgid ""
 "Search the applications/runtimes containing the specified text from the "
 "remote repository"
 msgstr "从远程仓库中搜索包含指定关键词的应用程序/运行时"
 
-#: ../apps/ll-cli/src/main.cpp:367
+#: ../apps/ll-cli/src/main.cpp:374
 msgid ""
 "Usage: ll-cli search [OPTIONS] KEYWORDS\n"
 "\n"
@@ -412,31 +474,34 @@ msgstr ""
 "# 搜索远程所有的runtime\n"
 "ll-cli search . --type=runtime"
 
-#: ../apps/ll-cli/src/main.cpp:378
+#: ../apps/ll-cli/src/main.cpp:385
 msgid "Specify the Keywords"
 msgstr "指定搜索关键词"
 
-#: ../apps/ll-cli/src/main.cpp:385 ../apps/ll-cli/src/main.cpp:424
-msgid "Filter result with specify type. One of \"runtime\", \"base\", \"app\" or \"all\""
-msgstr "按指定类型过滤结果。可选类型：\"runtime\"、\"base\"、\"app\"或 \"all\"。"
+#: ../apps/ll-cli/src/main.cpp:392 ../apps/ll-cli/src/main.cpp:431
+msgid ""
+"Filter result with specify type. One of \"runtime\", \"base\", \"app\" or "
+"\"all\""
+msgstr ""
+"按指定类型过滤结果。可选类型：\"runtime\"、\"base\"、\"app\"或 \"all\"。"
 
-#: ../apps/ll-cli/src/main.cpp:389
+#: ../apps/ll-cli/src/main.cpp:396
 msgid "Specify the repo"
 msgstr "指定仓库"
 
-#: ../apps/ll-cli/src/main.cpp:394
+#: ../apps/ll-cli/src/main.cpp:401
 msgid "Include develop application in result"
 msgstr "结果包括应用调试包"
 
-#: ../apps/ll-cli/src/main.cpp:397
+#: ../apps/ll-cli/src/main.cpp:404
 msgid "Show all versions of an application(s), base(s) or runtime(s)"
 msgstr "显示应用，base或runtime的所有版本"
 
-#: ../apps/ll-cli/src/main.cpp:405
+#: ../apps/ll-cli/src/main.cpp:412
 msgid "List installed application(s), base(s) or runtime(s)"
 msgstr "列出已安装的 应用, base或runtime"
 
-#: ../apps/ll-cli/src/main.cpp:408
+#: ../apps/ll-cli/src/main.cpp:415
 msgid ""
 "Usage: ll-cli list [OPTIONS]\n"
 "\n"
@@ -462,75 +527,136 @@ msgstr ""
 "# 显示当前已安装应用的最新版本列表\n"
 "ll-cli list --upgradable\n"
 
-#: ../apps/ll-cli/src/main.cpp:430
+#: ../apps/ll-cli/src/main.cpp:437
 msgid ""
 "Show the list of latest version of the currently installed application(s), "
 "base(s) or runtime(s)"
-msgstr "显示当前已安装的应用（application）、基础环境（base）或运行时（runtime）的最新版本"
+msgstr ""
+"显示当前已安装的应用（application）、基础环境（base）或运行时（runtime）的最"
+"新版本"
 
-#: ../apps/ll-cli/src/main.cpp:439
-msgid "Display information about installed apps or runtimes"
-msgstr "显示已安装的应用程序或运行时的信息"
+#: ../apps/ll-cli/src/main.cpp:445
+msgid "Show installed module sizes and repository real size"
+msgstr "显示已安装模块的大小以及仓库的实际占用空间"
 
-#: ../apps/ll-cli/src/main.cpp:442
-msgid "Usage: ll-cli info [OPTIONS] APP"
-msgstr "用法: ll-cli info [选项] 应用"
+#: ../apps/ll-cli/src/main.cpp:447
+msgid ""
+"Usage: ll-cli analyze size [OPTIONS]\n"
+"\n"
+"Example:\n"
+"# show installed module sizes\n"
+"ll-cli analyze size\n"
+msgstr ""
+"用法: ll-cli analyze size [选项]\n"
+"\n"
+"示例:\n"
+"# 显示已安装模块的大小\n"
+"ll-cli analyze size\n"
 
-#: ../apps/ll-cli/src/main.cpp:446
-msgid "Specify the application ID, and it can also be a .layer file"
-msgstr "指定应用程序名，也可以是如意玲珑.layer文件"
-
-#: ../apps/ll-cli/src/main.cpp:458
-msgid "Display the exported files of installed application"
-msgstr "显示已安装应用导出的文件"
+#: ../apps/ll-cli/src/main.cpp:457
+msgid ""
+"Sort result by specify field. One of \"actual\", \"logical\", \"exclusive\", "
+"\"shared\" or \"id\""
+msgstr ""
+"按指定字段对结果排序。可选字段：\"实际大小\"、\"逻辑大小\"、\"独占大小\"、\"共享大小\" 或 \"应用ID\""
 
 #: ../apps/ll-cli/src/main.cpp:461
-msgid "Usage: ll-cli content [OPTIONS] APP"
-msgstr "用法: ll-cli content [选项] 应用"
+msgid "Sort in ascending order"
+msgstr "按升序排序"
 
-#: ../apps/ll-cli/src/main.cpp:462
+#: ../apps/ll-cli/src/main.cpp:470
+msgid "Analyze installed applications"
+msgstr "分析已安装的应用程序"
+
+#: ../apps/ll-cli/src/main.cpp:472
+msgid "Usage: ll-cli analyze SUBCOMMAND [OPTIONS]"
+msgstr "用法: ll-cli analyze 子命令 [选项]"
+
+#: ../apps/ll-cli/src/main.cpp:478
+msgid "Display installed application dependency tree"
+msgstr "显示已安装应用程序的依赖树"
+
+#: ../apps/ll-cli/src/main.cpp:480
+msgid ""
+"Usage: ll-cli analyze depends [APP]\n"
+"\n"
+"Example:\n"
+"# show dependency tree for all installed application(s)\n"
+"ll-cli analyze depends\n"
+"# show dependency tree for an installed application\n"
+"ll-cli analyze depends org.deepin.demo\n"
+msgstr ""
+"用法: ll-cli analyze depends [应用]\n"
+"\n"
+"示例:\n"
+"# 显示所有已安装应用程序的依赖树\n"
+"ll-cli analyze depends\n"
+"# 显示指定已安装应用程序的依赖树\n"
+"ll-cli analyze depends org.deepin.demo\n"
+
+#: ../apps/ll-cli/src/main.cpp:488 ../apps/ll-cli/src/main.cpp:520
 msgid "Specify the installed application ID"
 msgstr "指定已安装应用程序名"
 
-#: ../apps/ll-cli/src/main.cpp:470
+#: ../apps/ll-cli/src/main.cpp:497
+msgid "Display information about installed apps or runtimes"
+msgstr "显示已安装的应用程序或运行时的信息"
+
+#: ../apps/ll-cli/src/main.cpp:500
+msgid "Usage: ll-cli info [OPTIONS] APP"
+msgstr "用法: ll-cli info [选项] 应用"
+
+#: ../apps/ll-cli/src/main.cpp:504
+msgid "Specify the application ID, and it can also be a .layer file"
+msgstr "指定应用程序名，也可以是如意玲珑.layer文件"
+
+#: ../apps/ll-cli/src/main.cpp:516
+msgid "Display the exported files of installed application"
+msgstr "显示已安装应用导出的文件"
+
+#: ../apps/ll-cli/src/main.cpp:519
+msgid "Usage: ll-cli content [OPTIONS] APP"
+msgstr "用法: ll-cli content [选项] 应用"
+
+#: ../apps/ll-cli/src/main.cpp:528
 msgid "Remove the unused base or runtime"
 msgstr "移除未使用的最小系统或运行时"
 
-#: ../apps/ll-cli/src/main.cpp:472
+#: ../apps/ll-cli/src/main.cpp:530
 msgid "Usage: ll-cli prune [OPTIONS]"
 msgstr "用法: ll-cli prune [选项]"
 
-#: ../apps/ll-cli/src/main.cpp:483
+#: ../apps/ll-cli/src/main.cpp:541
 msgid "Display the inspect information of the installed application"
 msgstr "显示已安装应用程序的检查信息"
 
-#: ../apps/ll-cli/src/main.cpp:485
+#: ../apps/ll-cli/src/main.cpp:543
 msgid "Usage: ll-cli inspect SUBCOMMAND [OPTIONS]"
 msgstr "用法: ll-cli inspect 子命令 [选项]"
 
-#: ../apps/ll-cli/src/main.cpp:492
+#: ../apps/ll-cli/src/main.cpp:550
 msgid ""
 "Display the data(bundle) directory of the installed(running) application"
 msgstr "显示已安装（运行中）应用程序的数据目录(bundle)"
 
-#: ../apps/ll-cli/src/main.cpp:493
+#: ../apps/ll-cli/src/main.cpp:551
 msgid "Usage: ll-cli inspect dir [OPTIONS] APP"
 msgstr "用法: ll-cli inspect dir [选项] 应用程序"
 
-#: ../apps/ll-cli/src/main.cpp:497
+#: ../apps/ll-cli/src/main.cpp:555
 msgid "Specify the application ID, and it can also be reference"
 msgstr "指定应用程序 ID，也可以是引用标识"
 
-#: ../apps/ll-cli/src/main.cpp:503
+#: ../apps/ll-cli/src/main.cpp:561
 msgid "Specify the directory type (layer or bundle),the default is layer"
 msgstr "指定目录类型 (layer 或 bundle)，默认为 layer"
 
-#: ../apps/ll-cli/src/main.cpp:510
+#: ../apps/ll-cli/src/main.cpp:568
 msgid ""
 "Specify the module type (binary or develop). Only works when type is layer"
 msgstr "指定模块类型 (binary 或 develop)。仅在类型为 layer 时生效"
 
-#: ../apps/ll-cli/src/main.cpp:519
+#: ../apps/ll-cli/src/main.cpp:577
 msgid ""
 "linyaps CLI\n"
 "A CLI program to run application and manage application and runtime\n"
@@ -538,152 +664,194 @@ msgstr ""
 "如意玲珑 CLI\n"
 "一个用于运行应用程序和管理应用程序和运行时的命令行工具\n"
 
-#: ../apps/ll-cli/src/main.cpp:527 ../apps/ll-builder/src/main.cpp:449
+#: ../apps/ll-cli/src/main.cpp:585 ../apps/ll-builder/src/main.cpp:478
 msgid "Print this help message and exit"
 msgstr "打印帮助信息并退出"
 
-#: ../apps/ll-cli/src/main.cpp:528 ../apps/ll-builder/src/main.cpp:450
+#: ../apps/ll-cli/src/main.cpp:586 ../apps/ll-builder/src/main.cpp:479
 msgid "Expand all help"
 msgstr "展开所有帮助"
 
-#: ../apps/ll-cli/src/main.cpp:529
+#: ../apps/ll-cli/src/main.cpp:587
 msgid "Usage: ll-cli [OPTIONS] [SUBCOMMAND]"
 msgstr "用法: ll-cli [选项] [子命令]"
 
-#: ../apps/ll-cli/src/main.cpp:530
+#: ../apps/ll-cli/src/main.cpp:588
 msgid ""
 "If you found any problems during use,\n"
-"You can report bugs to the linyaps team under this project: https://github.com/OpenAtom-Linyaps/linyaps/issues"
+"You can report bugs to the linyaps team under this project: https://"
+"github.com/OpenAtom-Linyaps/linyaps/issues"
 msgstr ""
 "如果在使用过程中遇到任何问题，\n"
-"您可以通过此项目向如意玲珑项目团队报告错误：https://github.com/OpenAtom-Linyaps/linyaps/issues"
+"您可以通过此项目向如意玲珑项目团队报告错误：https://github.com/OpenAtom-"
+"Linyaps/linyaps/issues"
 
 #. version flag
-#: ../apps/ll-cli/src/main.cpp:537 ../apps/ll-builder/src/main.cpp:474
+#: ../apps/ll-cli/src/main.cpp:595 ../apps/ll-builder/src/main.cpp:504
 msgid "Show version"
 msgstr "显示版本"
 
-#: ../apps/ll-cli/src/main.cpp:542
+#: ../apps/ll-cli/src/main.cpp:600
 msgid ""
 "Use peer to peer DBus, this is used only in case that DBus daemon is not "
 "available"
 msgstr "使用点对点 DBus，仅在 DBus 守护程序不可用时使用"
 
 #. json flag
-#: ../apps/ll-cli/src/main.cpp:547
+#: ../apps/ll-cli/src/main.cpp:605
 msgid "Use json format to output result"
 msgstr "使用json格式输出结果"
 
-#: ../apps/ll-cli/src/main.cpp:554
-msgid "Show debug info (verbose logs)"
-msgstr "显示调试信息（详细日志）"
+#: ../apps/ll-cli/src/main.cpp:612
+msgid "Show debug info; repeat to enable backtrace"
+msgstr "显示调试信息；重复该参数可启用调用栈回溯"
 
-#: ../apps/ll-cli/src/main.cpp:557
+#: ../apps/ll-cli/src/main.cpp:615
 msgid "Don't output progress information"
 msgstr "不输出进度信息"
 
 #. groups for subcommands
-#: ../apps/ll-cli/src/main.cpp:574
+#: ../apps/ll-cli/src/main.cpp:635
 msgid "Managing installed applications and runtimes"
 msgstr "管理已安装的应用程序和运行时"
 
-#: ../apps/ll-cli/src/main.cpp:575
+#: ../apps/ll-cli/src/main.cpp:636
 msgid "Managing running applications"
 msgstr "管理正在运行的应用程序"
 
-#: ../apps/ll-cli/src/main.cpp:576
+#: ../apps/ll-cli/src/main.cpp:637
 msgid "Finding applications and runtimes"
 msgstr "查找应用程序和运行时"
 
-#: ../apps/ll-cli/src/main.cpp:577 ../apps/ll-builder/src/main.cpp:662
+#: ../apps/ll-cli/src/main.cpp:638 ../apps/ll-builder/src/main.cpp:703
 msgid "Managing remote repositories"
 msgstr "管理仓库"
 
-#: ../apps/ll-cli/src/main.cpp:607
+#: ../apps/ll-cli/src/main.cpp:669
 msgid "linyaps CLI version "
 msgstr "如意玲珑CLI版本 "
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:71
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:134
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:314
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:73
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:136
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:316
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:364
 msgid "ID"
 msgstr "ID"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:72
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:135
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:247
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:74
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:137
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:249
 msgid "Name"
 msgstr "名称"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:73
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:136
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:75
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:138
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:365
 msgid "Version"
 msgstr "版本"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:74
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:137
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:76
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:139
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:367
 msgid "Channel"
 msgstr "渠道"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:75
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:138
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:77
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:140
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:367
 msgid "Module"
 msgstr "模块"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:76
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:140
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:78
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:142
 msgid "Description"
 msgstr "描述"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:107
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:109
 msgid "No packages found in the remote repo."
 msgstr "远程仓库中未找到软件包"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:139
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:141
 msgid "Repo"
 msgstr "仓库"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:174
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:176
 msgid "No containers are running."
 msgstr "没有正在运行的容器"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:178
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:180
 msgid "App"
 msgstr "应用"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:179
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:181
 msgid "ContainerID"
 msgstr "容器ID"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:180
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:182
 msgid "Pid"
 msgstr "进程ID"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:248
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:250
 msgid "Url"
 msgstr "地址"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:249
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:251
 msgid "Alias"
 msgstr "别名"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:250
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:252
 msgid "Priority"
 msgstr "优先级"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:302
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:304
 msgid "No apps available for update."
 msgstr "没有可更新的应用"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:315
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:317
 msgid "Installed"
 msgstr "已安装"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:316
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:318
 msgid "New"
 msgstr "新版本"
 
-#: ../apps/ll-builder/src/main.cpp:447
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:368
+msgid "Exclusive"
+msgstr "独占"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:369
+msgid "Shared"
+msgstr "共享"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:370
+msgid "Logical"
+msgstr "逻辑"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:370
+msgid "Actual"
+msgstr "实际"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:385
+msgid "Calculated logical total size: "
+msgstr "计算出的逻辑总大小："
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:386
+msgid "Exclusive: "
+msgstr "独占："
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:386
+msgid "Shared: "
+msgstr "共享："
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:388
+msgid "Calculated actual total size: "
+msgstr "计算出的实际总大小："
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:389
+msgid "Repository real size: "
+msgstr "仓库实际大小："
+
+#: ../apps/ll-builder/src/main.cpp:476
 msgid ""
 "linyaps builder CLI \n"
 "A CLI program to build linyaps application\n"
@@ -691,250 +859,243 @@ msgstr ""
 "如意玲珑构建工具 CLI\n"
 "一个用于构建如意玲珑应用的命令行工具\n"
 
-#: ../apps/ll-builder/src/main.cpp:452
+#: ../apps/ll-builder/src/main.cpp:481
 msgid "Usage: ll-builder [OPTIONS] [SUBCOMMAND]"
 msgstr "用法: ll-builder [选项] [子命令]"
 
-#: ../apps/ll-builder/src/main.cpp:454
+#: ../apps/ll-builder/src/main.cpp:483
 msgid ""
 "If you found any problems during use\n"
-"You can report bugs to the linyaps team under this project: https://github.com/OpenAtom-Linyaps/linyaps/issues"
+"You can report bugs to the linyaps team under this project: https://"
+"github.com/OpenAtom-Linyaps/linyaps/issues"
 msgstr ""
 "如果在使用过程中遇到任何问题，\n"
-"您可以通过此项目向如意玲珑项目团队报告错误：https://github.com/OpenAtom-Linyaps/linyaps/issues"
+"您可以通过此项目向如意玲珑项目团队报告错误：https://github.com/OpenAtom-"
+"Linyaps/linyaps/issues"
 
-#: ../apps/ll-builder/src/main.cpp:478
+#: ../apps/ll-builder/src/main.cpp:508
 msgid "Create linyaps build template project"
 msgstr "创建如意玲珑构建模板"
 
-#: ../apps/ll-builder/src/main.cpp:479
+#: ../apps/ll-builder/src/main.cpp:509
 msgid "Usage: ll-builder create [OPTIONS] NAME"
 msgstr "用法: ll-builder create [选项] 名称"
 
-#: ../apps/ll-builder/src/main.cpp:480
+#: ../apps/ll-builder/src/main.cpp:510
 msgid "Project name"
 msgstr "项目名称"
 
-#: ../apps/ll-builder/src/main.cpp:488
+#: ../apps/ll-builder/src/main.cpp:518
 msgid "Build a linyaps project"
 msgstr "构建如意玲珑项目"
 
-#: ../apps/ll-builder/src/main.cpp:489
+#: ../apps/ll-builder/src/main.cpp:519
 msgid "Usage: ll-builder build [OPTIONS] [COMMAND...]"
 msgstr "用法: ll-builder build [选项] [命令...]"
 
-#: ../apps/ll-builder/src/main.cpp:490 ../apps/ll-builder/src/main.cpp:531
-#: ../apps/ll-builder/src/main.cpp:575 ../apps/ll-builder/src/main.cpp:621
+#: ../apps/ll-builder/src/main.cpp:520 ../apps/ll-builder/src/main.cpp:561
+#: ../apps/ll-builder/src/main.cpp:605 ../apps/ll-builder/src/main.cpp:656
+#: ../apps/ll-builder/src/main.cpp:697
 msgid "File path of the linglong.yaml"
 msgstr "linglong.yaml的文件路径"
 
-#: ../apps/ll-builder/src/main.cpp:496
-msgid ""
-"Enter the container to execute command instead of building applications"
+#: ../apps/ll-builder/src/main.cpp:526
+msgid "Enter the container to execute command instead of building applications"
 msgstr "进入容器执行命令而不是构建应用"
 
-#: ../apps/ll-builder/src/main.cpp:499
+#: ../apps/ll-builder/src/main.cpp:529
 msgid ""
 "Only use local files. This implies --skip-fetch-source and --skip-pull-"
 "depend will be set"
 msgstr "仅使用本地文件。这意味着将设置--skip-fetch-source和--skip-pull-depend"
 
-#: ../apps/ll-builder/src/main.cpp:504
+#: ../apps/ll-builder/src/main.cpp:534
 msgid "Build full develop packages, runtime requires"
 msgstr "构建完整的开发包，binary是必须的"
 
-#: ../apps/ll-builder/src/main.cpp:508
+#: ../apps/ll-builder/src/main.cpp:538
 msgid "Skip fetch sources"
 msgstr "跳过获取源代码"
 
-#: ../apps/ll-builder/src/main.cpp:511
+#: ../apps/ll-builder/src/main.cpp:541
 msgid "Skip pull dependency"
 msgstr "跳过拉取依赖项"
 
-#: ../apps/ll-builder/src/main.cpp:514
+#: ../apps/ll-builder/src/main.cpp:544
 msgid "Skip run container"
 msgstr "跳过运行容器"
 
-#: ../apps/ll-builder/src/main.cpp:517
+#: ../apps/ll-builder/src/main.cpp:547
 msgid "Skip commit build output"
 msgstr "跳过提交构建输出"
 
-#: ../apps/ll-builder/src/main.cpp:520
+#: ../apps/ll-builder/src/main.cpp:550
 msgid "Skip output check"
 msgstr "跳过输出检查"
 
-#: ../apps/ll-builder/src/main.cpp:523
+#: ../apps/ll-builder/src/main.cpp:553
 msgid "Skip strip debug symbols"
 msgstr "跳过剥离调试符号"
 
-#: ../apps/ll-builder/src/main.cpp:526
+#: ../apps/ll-builder/src/main.cpp:556
 msgid "Build in an isolated network environment"
 msgstr "在隔离网络的环境中构建"
 
 #. add builder run
-#: ../apps/ll-builder/src/main.cpp:529
+#: ../apps/ll-builder/src/main.cpp:559
 msgid "Run built linyaps app"
 msgstr "运行构建好的应用程序"
 
-#: ../apps/ll-builder/src/main.cpp:530
+#: ../apps/ll-builder/src/main.cpp:560
 msgid "Usage: ll-builder run [OPTIONS] [COMMAND...]"
 msgstr "用法: ll-builder run [选项] [命令...]"
 
-#: ../apps/ll-builder/src/main.cpp:537
+#: ../apps/ll-builder/src/main.cpp:567
 msgid "Run specified module. eg: --modules binary,develop"
 msgstr "运行指定模块。例如: --modules binary,develop"
 
-#: ../apps/ll-builder/src/main.cpp:549
+#: ../apps/ll-builder/src/main.cpp:579
 msgid "Enter the container to execute command instead of running application"
 msgstr "进入容器执行命令而不是运行应用"
 
-#: ../apps/ll-builder/src/main.cpp:552
+#: ../apps/ll-builder/src/main.cpp:582
 msgid "Run in debug mode (enable develop module)"
 msgstr "在调试模式下运行（启用开发模块）"
 
-#: ../apps/ll-builder/src/main.cpp:556
+#: ../apps/ll-builder/src/main.cpp:586
 msgid "Specify extension(s) used by the app to run"
 msgstr "指定应用运行所需的扩展"
 
-#: ../apps/ll-builder/src/main.cpp:562
+#: ../apps/ll-builder/src/main.cpp:592
 msgid "List built linyaps app"
 msgstr "列出已构建的应用程序"
 
-#: ../apps/ll-builder/src/main.cpp:563
+#: ../apps/ll-builder/src/main.cpp:593
 msgid "Usage: ll-builder list [OPTIONS]"
 msgstr "用法: ll-builder list [选项]"
 
-#: ../apps/ll-builder/src/main.cpp:564
+#: ../apps/ll-builder/src/main.cpp:594
 msgid "Remove built linyaps app"
 msgstr "删除已构建的应用程序"
 
-#: ../apps/ll-builder/src/main.cpp:565
+#: ../apps/ll-builder/src/main.cpp:595
 msgid "Usage: ll-builder remove [OPTIONS] [APP...]"
 msgstr "用法: ll-builder remove [OPTIONS] [APP...]"
 
-#: ../apps/ll-builder/src/main.cpp:568
+#: ../apps/ll-builder/src/main.cpp:598
 msgid "Do not clean objects files before remove apps"
 msgstr "移除应用前不清理对象文件"
 
 #. build export
-#: ../apps/ll-builder/src/main.cpp:572
-msgid "Export to linyaps layer or uab"
-msgstr "导出如意玲珑layer或uab"
+#: ../apps/ll-builder/src/main.cpp:602
+msgid "Export to linyaps layer or UAB"
+msgstr "导出为如意玲珑 layer 或 UAB 文件"
 
-#: ../apps/ll-builder/src/main.cpp:573
+#: ../apps/ll-builder/src/main.cpp:603
 msgid "Usage: ll-builder export [OPTIONS]"
 msgstr "用法: ll-builder export [选项]"
 
-#: ../apps/ll-builder/src/main.cpp:585
+#: ../apps/ll-builder/src/main.cpp:615
 msgid "Uab icon (optional)"
 msgstr "Uab图标（可选）"
 
-#: ../apps/ll-builder/src/main.cpp:590
+#: ../apps/ll-builder/src/main.cpp:620
 msgid "Export to linyaps layer file (deprecated)"
 msgstr "导出如意玲珑layer文件（已弃用）"
 
-#: ../apps/ll-builder/src/main.cpp:593
+#: ../apps/ll-builder/src/main.cpp:623
+msgid "Export an executable UABX file"
+msgstr "导出可执行的 UABX 文件"
+
+#: ../apps/ll-builder/src/main.cpp:627
 msgid "Use custom loader"
 msgstr "使用自定义的loader"
 
-#: ../apps/ll-builder/src/main.cpp:600
+#: ../apps/ll-builder/src/main.cpp:635
 msgid "Don't export the develop module"
 msgstr "不导出develop模块"
 
-#: ../apps/ll-builder/src/main.cpp:602
+#: ../apps/ll-builder/src/main.cpp:637
 msgid "Output file"
 msgstr "输出文件"
 
-#: ../apps/ll-builder/src/main.cpp:606
+#: ../apps/ll-builder/src/main.cpp:641
 msgid "Reference of the package"
 msgstr "软件包的引用标识"
 
-#: ../apps/ll-builder/src/main.cpp:611
+#: ../apps/ll-builder/src/main.cpp:646
 msgid "Modules to export"
 msgstr "要导出的模块"
 
-#: ../apps/ll-builder/src/main.cpp:619
+#: ../apps/ll-builder/src/main.cpp:654
 msgid "Push linyaps app to remote repo"
 msgstr "推送如意玲珑应用到远程仓库"
 
-#: ../apps/ll-builder/src/main.cpp:620
+#: ../apps/ll-builder/src/main.cpp:655
 msgid "Usage: ll-builder push [OPTIONS]"
 msgstr "用法: ll-builder push [选项]"
 
-#: ../apps/ll-builder/src/main.cpp:624
+#: ../apps/ll-builder/src/main.cpp:659
 msgid "Remote repo url"
 msgstr "远程仓库URL"
 
-#: ../apps/ll-builder/src/main.cpp:627
+#: ../apps/ll-builder/src/main.cpp:662
 msgid "Remote repo name"
 msgstr "远程仓库名"
 
-#: ../apps/ll-builder/src/main.cpp:630
+#: ../apps/ll-builder/src/main.cpp:665
 msgid "Push single module"
 msgstr "推送单个模块"
 
-#: ../apps/ll-builder/src/main.cpp:634
+#: ../apps/ll-builder/src/main.cpp:669
 msgid "Import linyaps layer to build repo"
 msgstr "导入如意玲珑layer文件到构建仓库"
 
-#: ../apps/ll-builder/src/main.cpp:635
+#: ../apps/ll-builder/src/main.cpp:670
 msgid "Usage: ll-builder import [OPTIONS] LAYER"
 msgstr "用法: ll-builder import [选项] LAYER文件"
 
-#: ../apps/ll-builder/src/main.cpp:636 ../apps/ll-builder/src/main.cpp:653
+#: ../apps/ll-builder/src/main.cpp:671 ../apps/ll-builder/src/main.cpp:688
 msgid "Layer file path"
 msgstr "layer文件路径"
 
-#: ../apps/ll-builder/src/main.cpp:643
+#: ../apps/ll-builder/src/main.cpp:678
 msgid "Import linyaps layer dir to build repo"
 msgstr "导入如意玲珑layer目录到构建仓库"
 
-#: ../apps/ll-builder/src/main.cpp:645
+#: ../apps/ll-builder/src/main.cpp:680
 msgid "Usage: ll-builder import-dir PATH"
 msgstr "用法: ll-builder import-dir PATH"
 
-#: ../apps/ll-builder/src/main.cpp:646
+#: ../apps/ll-builder/src/main.cpp:681
 msgid "Layer dir path"
 msgstr "layer目录路径"
 
 #. add build extract
-#: ../apps/ll-builder/src/main.cpp:651
+#: ../apps/ll-builder/src/main.cpp:686
 msgid "Extract linyaps layer to dir"
 msgstr "将如意玲珑layer文件解压到目录"
 
-#: ../apps/ll-builder/src/main.cpp:652
+#: ../apps/ll-builder/src/main.cpp:687
 msgid "Usage: ll-builder extract [OPTIONS] LAYER DIR"
 msgstr "用法: ll-builder extract [选项] LAYER文件 目录"
 
-#: ../apps/ll-builder/src/main.cpp:656
+#: ../apps/ll-builder/src/main.cpp:691
 msgid "Destination directory"
 msgstr "目标目录"
 
-#: ../apps/ll-builder/src/main.cpp:669
+#. add builder clean
+#: ../apps/ll-builder/src/main.cpp:695
+msgid "Clean build artifacts"
+msgstr "清理构建产物"
+
+#: ../apps/ll-builder/src/main.cpp:696
+msgid "Usage: ll-builder clean"
+msgstr "用法: ll-builder clean"
+
+#: ../apps/ll-builder/src/main.cpp:710
 msgid "linyaps build tool version "
 msgstr "如意玲珑构建工具版本"
-
-#: ../apps/ll-dialog/src/permissionDialog.cpp:34
-msgid "Whether to allow %1 to access %2?"
-msgstr "是否允许%1访问目录%2?"
-
-#. button
-#: ../apps/ll-dialog/src/permissionDialog.cpp:43
-msgid "Allow"
-msgstr "允许"
-
-#: ../apps/ll-dialog/src/permissionDialog.cpp:48
-#, c-format
-msgid "Deny (%1s)"
-msgstr "不允许 (%1s)"
-
-#: ../apps/ll-dialog/src/cache_dialog.cpp:53
-msgid "Linglong Package Manager"
-msgstr "玲珑软件包管理器"
-
-#: ../apps/ll-dialog/src/cache_dialog.cpp:54
-msgid "is starting"
-msgstr "正在启动"
 
 #. Define command line options
 #: ../apps/ll-driver-detect/src/main.cpp:104
@@ -955,7 +1116,8 @@ msgstr "有可用的显卡驱动"
 
 #: ../apps/ll-driver-detect/src/main.cpp:217
 msgid ""
-"Graphics driver package is available that can improve performance for some Linyaps applications.\n"
+"Graphics driver package is available that can improve performance for some "
+"Linyaps applications.\n"
 "Would you like to install it?"
 msgstr ""
 "检测到有可安装的显卡驱动包，安装后可提高部分玲珑应用运行性能\n"
@@ -1010,7 +1172,7 @@ msgstr "仓库URL"
 #: ../libs/linglong/src/linglong/common/cli/repo.cpp:93
 #: ../libs/linglong/src/linglong/common/cli/repo.cpp:103
 #: ../libs/linglong/src/linglong/common/cli/repo.cpp:113
-#: ../libs/linglong/src/linglong/common/cli/repo.cpp:120
+#: ../libs/linglong/src/linglong/common/cli/repo.cpp:126
 msgid "Alias of the repo name"
 msgstr "仓库别名"
 
@@ -1046,6 +1208,10 @@ msgstr "仓库优先级"
 msgid "Enable mirror for the repo"
 msgstr "启用仓库镜像"
 
-#: ../libs/linglong/src/linglong/common/cli/repo.cpp:118
+#: ../libs/linglong/src/linglong/common/cli/repo.cpp:119
+msgid "Region code for mirror selection, e.g. CN, US"
+msgstr "用于镜像选择的国家/地区代码，例如 CN、US"
+
+#: ../libs/linglong/src/linglong/common/cli/repo.cpp:124
 msgid "Disable mirror for the repo"
 msgstr "禁用仓库镜像"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -2,143 +2,175 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # deepiner, 2026
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-23 19:04+0800\n"
+"POT-Creation-Date: 2026-08-28 16:24+0800\n"
 "PO-Revision-Date: 2025-04-11 01:38+0000\n"
 "Last-Translator: deepiner, 2026\n"
-"Language-Team: Chinese (Hong Kong) (https://app.transifex.com/linuxdeepin/teams/3976/zh_HK/)\n"
+"Language-Team: Chinese (Hong Kong) (https://app.transifex.com/linuxdeepin/"
+"teams/3976/zh_HK/)\n"
+"Language: zh_HK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_HK\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1238
+#: ../libs/linglong/src/linglong/cli/cli.cpp:448
+msgid "Debug mode is enabled. Attach from another terminal with gdb:"
+msgstr "已啟用除錯模式。請在另一個終端機使用 gdb 連接："
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:468
+msgid "Debug mode is enabled. Attach from another terminal with:"
+msgstr "已啟用除錯模式。請在另一個終端機使用以下命令連接："
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:471
+msgid "Generated gdb attach script:"
+msgstr "已生成的 gdb 連接指令稿："
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1949
+#, c++-format
+msgid "Base {} has no develop module installed, installing it now."
+msgstr "基礎環境 {} 未安裝開發（develop）模組，正在進行安裝。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2361
+#, c++-format
+msgid "{} is not a regular file; expected a .layer or .uab file."
+msgstr "{} 不是一般檔案；應為 .layer 或 .uab 檔案。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2372
+#, c++-format
+msgid "Unsupported file format {}; expected a .layer or .uab file."
+msgstr "不支援的檔案格式 {}；應為 .layer 或 .uab 檔案。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2385
+#, c++-format
+msgid "Package file {} does not exist."
+msgstr "套件檔案 {} 不存在。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2452
 #, c++-format
 msgid "Application {} is not installed."
 msgstr "應用程式 {} 未安裝。"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1248
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2462
 #, c++-format
 msgid "{} is not an application."
 msgstr "{} 不是一個應用程式。"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1353
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2343
-msgid ""
-"Network connection failed. Please:\n"
-"1. Check your internet connection\n"
-"2. Verify network proxy settings if used"
-msgstr ""
-"網絡連接失敗。請：\n"
-"1. 檢查您的互聯網連接\n"
-"2. 檢查網絡代理設置（如有使用）"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2228
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3631
 msgid "To install the module, one must first install the app."
 msgstr "要安裝該模組，必須先安裝對應的應用程式。"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2231
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3634
 msgid "Module is already installed."
 msgstr "模組已安裝。"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2234
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3637
 msgid "The module could not be found remotely."
 msgstr "在遠端找不到該模組。"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2238
-#, c++-format
-msgid ""
-"Application already installed, If you want to replace it, try using 'll-cli "
-"install {} --force'"
-msgstr "應用程式已安裝。如果您想替換它，請嘗試使用 'll-cli install {} --force'"
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3640
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3676
+msgid "Application already installed"
+msgstr "應用程式已安裝"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2244
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3644
 #, c++-format
 msgid "Application {} is not found in remote repo."
 msgstr "在遠端倉庫中找不到應用程式 {}。"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2247
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3647
 msgid "Cannot specify a version when installing a module."
 msgstr "安裝模組時無法指定版本。"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2251
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3651
 #, c++-format
 msgid ""
 "The latest version has been installed. If you want to replace it, try using "
 "'ll-cli install {} --force'"
 msgstr "已安裝最新版本。如果您想替換它，請嘗試使用 'll-cli install {} --force'"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2257
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3657
 msgid "Install failed"
 msgstr "安裝失敗"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2279
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3698
 msgid ""
 "The application is currently running and cannot be uninstalled. Please turn "
 "off the application and try again."
-msgstr "該應用程式目前正在運行，無法解除安裝。請先關閉應用程式後再試。"
+msgstr "該應用程式目前正在執行，無法解除安裝。請先關閉應用程式後再試。"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2287
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2320
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3706
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3739
 msgid "Application is not installed."
 msgstr "應用程式未安裝。"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2291
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3710
 #, c++-format
 msgid ""
-"Multiple versions of the package are installed. Please specify a single version to uninstall:\n"
+"Multiple versions of the package are installed. Please specify a single "
+"version to uninstall:\n"
 "{}"
 msgstr ""
 "已安裝該套件的多個版本。請指定單一版本進行解除安裝：\n"
 "{}"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2297
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3716
 msgid "Base or runtime cannot be uninstalled, please use 'll-cli prune'."
-msgstr "無法解除安裝基礎環境（Base）或運行時（Runtime），請使用 'll-cli prune'。"
+msgstr ""
+"無法解除安裝基礎環境（Base）或執行時（Runtime），請使用 'll-cli prune'。"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2301
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3720
 msgid "Uninstall failed"
 msgstr "解除安裝失敗"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2324
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3743
 msgid "Upgrade failed"
 msgstr "升級失敗"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2348
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3762
+msgid ""
+"Network connection failed. Please:\n"
+"1. Check your internet connection\n"
+"2. Verify network proxy settings if used"
+msgstr ""
+"網絡連線失敗。請：\n"
+"1. 檢查您的網際網路連線\n"
+"2. 檢查網絡代理設定（如有使用）"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3767
 msgid "Package not found"
 msgstr "找不到套件"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2351
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3770
 msgid "Operation canceled"
 msgstr "操作已取消"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2354
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3773
 msgid "Permission denied, authentication is required"
 msgstr "權限被拒絕，需要進行身份驗證"
 
-#: ../apps/ll-cli/src/main.cpp:105 ../apps/ll-builder/src/main.cpp:46
+#: ../apps/ll-cli/src/main.cpp:70 ../apps/ll-builder/src/main.cpp:47
 msgid "Input parameter is empty, please input valid parameter instead"
 msgstr "輸入參數為空，請輸入有效的參數"
 
-#: ../apps/ll-cli/src/main.cpp:116
+#: ../apps/ll-cli/src/main.cpp:81
 msgid "Run an application"
-msgstr "運行應用程式"
+msgstr "執行應用程式"
 
 #. add sub command run options
-#: ../apps/ll-cli/src/main.cpp:119
+#: ../apps/ll-cli/src/main.cpp:84
 msgid "Specify the application ID"
 msgstr "指定應用程式 ID"
 
-#: ../apps/ll-cli/src/main.cpp:122
+#: ../apps/ll-cli/src/main.cpp:87
 msgid ""
 "Usage: ll-cli run [OPTIONS] APP [COMMAND...]\n"
 "\n"
@@ -152,86 +184,114 @@ msgid ""
 msgstr ""
 "用法：ll-cli run [選項] 應用程式 [命令...]\n"
 "\n"
-"示例：\n"
-"# 通過 appid 運行應用程式\n"
+"範例：\n"
+"# 透過 appid 執行應用程式\n"
 "ll-cli run org.deepin.demo\n"
-"# 在容器內執行命令，而不是運行應用程式\n"
+"# 在容器內執行命令，而不是執行應用程式\n"
 "ll-cli run org.deepin.demo bash\n"
 "ll-cli run org.deepin.demo -- bash\n"
 "ll-cli run org.deepin.demo -- bash -x /path/to/bash/script"
 
-#: ../apps/ll-cli/src/main.cpp:134
+#: ../apps/ll-cli/src/main.cpp:99
 msgid "Pass file to applications running in a sandbox"
-msgstr "將檔案傳遞給在沙盒中運行的應用程式"
+msgstr "將檔案傳遞給在沙盒中執行的應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:138
+#: ../apps/ll-cli/src/main.cpp:103
 msgid "Pass url to applications running in a sandbox"
-msgstr "將 URL 傳遞給在沙盒中運行的應用程式"
+msgstr "將 URL 傳遞給在沙盒中執行的應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:141
+#: ../apps/ll-cli/src/main.cpp:106
 msgid "Set environment variables for the application"
-msgstr "為應用程式設置環境變量"
+msgstr "為應用程式設定環境變數"
 
-#: ../apps/ll-cli/src/main.cpp:148
+#: ../apps/ll-cli/src/main.cpp:113
 msgid "Input parameter is invalid, please input valid parameter instead"
 msgstr "輸入參數無效，請輸入有效的參數"
 
-#: ../apps/ll-cli/src/main.cpp:154
+#: ../apps/ll-cli/src/main.cpp:119
 msgid "Specify the base used by the application to run"
-msgstr "指定應用程式運行所需的基礎環境（Base）"
+msgstr "指定應用程式執行所需的基礎環境（Base）"
 
-#: ../apps/ll-cli/src/main.cpp:160
+#: ../apps/ll-cli/src/main.cpp:125
 msgid "Specify the runtime used by the application to run"
-msgstr "指定應用程式運行所需的運行時（Runtime）"
+msgstr "指定應用程式執行所需的執行時（Runtime）"
 
-#: ../apps/ll-cli/src/main.cpp:166 ../apps/ll-builder/src/main.cpp:544
+#: ../apps/ll-cli/src/main.cpp:131 ../apps/ll-builder/src/main.cpp:574
 msgid "Specify the working directory where the application runs"
-msgstr "指定應用程式運行的工作目錄"
+msgstr "指定應用程式執行的工作目錄"
 
-#: ../apps/ll-cli/src/main.cpp:171
+#: ../apps/ll-cli/src/main.cpp:136
 msgid "Specify extension(s) used by the application to run"
-msgstr "指定應用程式運行所需的擴充模組"
+msgstr "指定應用程式執行所需的擴充模組"
 
-#: ../apps/ll-cli/src/main.cpp:179
+#: ../apps/ll-cli/src/main.cpp:144
 msgid ""
 "Enable or disable xdg-desktop-portal related integration inside the sandbox"
 msgstr "啟用或停用沙盒內與 xdg-desktop-portal 相關的整合"
 
-#: ../apps/ll-cli/src/main.cpp:181
+#: ../apps/ll-cli/src/main.cpp:149
+msgid "Enable PipeWire socket mount inside the sandbox"
+msgstr "啟用沙盒內的 PipeWire socket 掛載"
+
+#: ../apps/ll-cli/src/main.cpp:154
+msgid "Enable AT SPI socket mount inside the sandbox"
+msgstr "啟用沙盒內的 AT SPI socket 掛載"
+
+#: ../apps/ll-cli/src/main.cpp:156
 msgid "Run context json string"
-msgstr "運行上下文的 JSON 字串"
+msgstr "執行上下文的 JSON 字串"
 
-#: ../apps/ll-cli/src/main.cpp:184
+#: ../apps/ll-cli/src/main.cpp:159
 msgid "Run the application in privileged mode"
-msgstr "以特權模式運行應用程式"
+msgstr "以特權模式執行應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:186
+#: ../apps/ll-cli/src/main.cpp:161
 msgid "Add capabilities to the application"
 msgstr "為應用程式增加 Linux Capabilities 權限"
 
-#: ../apps/ll-cli/src/main.cpp:190
+#: ../apps/ll-cli/src/main.cpp:165
 msgid "CDI spec directory"
 msgstr "CDI 規格（spec）目錄"
 
-#: ../apps/ll-cli/src/main.cpp:194
+#: ../apps/ll-cli/src/main.cpp:169
 msgid "Add CDI devices"
 msgstr "新增 CDI 裝置"
 
-#: ../apps/ll-cli/src/main.cpp:200
+#: ../apps/ll-cli/src/main.cpp:175
 msgid "Add device options"
 msgstr "新增裝置選項"
 
-#: ../apps/ll-cli/src/main.cpp:207
+#: ../apps/ll-cli/src/main.cpp:182
 msgid "Specify the container instance name for reuse or identification"
 msgstr "指定容器實例名稱以用於重複使用或識別"
 
-#: ../apps/ll-cli/src/main.cpp:210 ../apps/ll-cli/src/main.cpp:241
-msgid "Run commands in a running sandbox"
-msgstr "在執行中的沙盒內運行命令"
+#: ../apps/ll-cli/src/main.cpp:186
+msgid "Run the application under gdbserver"
+msgstr "在 gdbserver 下執行應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:216
+#: ../apps/ll-cli/src/main.cpp:190
+msgid "Specify the gdbserver listen address"
+msgstr "指定 gdbserver 監聽地址"
+
+#: ../apps/ll-cli/src/main.cpp:198
+msgid "Specify debuginfod urls for debugging"
+msgstr "指定用於除錯的 debuginfod URL"
+
+#: ../apps/ll-cli/src/main.cpp:205
+msgid "Specify the directory used by gdb to load debug symbols"
+msgstr "指定 gdb 載入除錯符號的目錄"
+
+#: ../apps/ll-cli/src/main.cpp:209 ../apps/ll-cli/src/main.cpp:241
+msgid "Run commands in a running sandbox"
+msgstr "在執行中的沙盒內執行命令"
+
+#: ../apps/ll-cli/src/main.cpp:215
 msgid "List running applications"
-msgstr "列出正在運行的應用程式"
+msgstr "列出正在執行的應用程式"
+
+#: ../apps/ll-cli/src/main.cpp:218
+msgid "Do not truncate container IDs"
+msgstr "不截斷容器 ID"
 
 #: ../apps/ll-cli/src/main.cpp:219
 msgid "Usage: ll-cli ps [OPTIONS]"
@@ -243,7 +303,7 @@ msgstr "進入應用程式執行中的命名空間（Namespace）"
 
 #: ../apps/ll-cli/src/main.cpp:234
 msgid "Specify the application running instance(you can get it by ps command)"
-msgstr "指定應用程式的運行實例（可透過 ps 命令獲取）"
+msgstr "指定應用程式的執行實例（可透過 ps 命令獲取）"
 
 #: ../apps/ll-cli/src/main.cpp:238
 msgid "Specify working directory"
@@ -251,7 +311,7 @@ msgstr "指定工作目錄"
 
 #: ../apps/ll-cli/src/main.cpp:247
 msgid "Stop running applications"
-msgstr "停止運行的應用程式"
+msgstr "停止執行的應用程式"
 
 #: ../apps/ll-cli/src/main.cpp:250
 msgid "Usage: ll-cli kill [OPTIONS] APP"
@@ -267,7 +327,7 @@ msgstr "指定執行中的應用程式"
 
 #: ../apps/ll-cli/src/main.cpp:267
 msgid "Installing an application or runtime"
-msgstr "安裝應用程式或運行時（Runtime）"
+msgstr "安裝應用程式或執行時（Runtime）"
 
 #: ../apps/ll-cli/src/main.cpp:270
 msgid ""
@@ -277,9 +337,9 @@ msgid ""
 "# install application by appid\n"
 "ll-cli install org.deepin.demo\n"
 "# install application by linyaps layer\n"
-"ll-cli install demo_0.0.0.1_x86_64_binary.layer\n"
+"ll-cli install ./demo_0.0.0.1_x86_64_binary.layer\n"
 "# install application by linyaps uab\n"
-"ll-cli install demo_x86_64_0.0.0.1_main.uab\n"
+"ll-cli install ./demo_x86_64_0.0.0.1_main.uab\n"
 "# install specified module of the appid\n"
 "ll-cli install org.deepin.demo --module=binary\n"
 "# install specified version of the appid\n"
@@ -290,18 +350,18 @@ msgid ""
 msgstr ""
 "用法：ll-cli install [選項] 應用程式\n"
 "\n"
-"示例：\n"
-"# 通過 appid 安裝應用程式\n"
+"範例：\n"
+"# 透過 appid 安裝應用程式\n"
 "ll-cli install org.deepin.demo\n"
-"# 通過 linyaps layer 檔案安裝應用程式\n"
-"ll-cli install demo_0.0.0.1_x86_64_binary.layer\n"
-"# 通過 linyaps uab 檔案安裝應用程式\n"
-"ll-cli install demo_x86_64_0.0.0.1_main.uab\n"
-"# 安裝指定 appid 的指定模組\n"
+"# 透過 linyaps layer 安裝應用程式\n"
+"ll-cli install ./demo_0.0.0.1_x86_64_binary.layer\n"
+"# 透過 linyaps uab 安裝應用程式\n"
+"ll-cli install ./demo_x86_64_0.0.0.1_main.uab\n"
+"# 安裝 appid 指定的模組\n"
 "ll-cli install org.deepin.demo --module=binary\n"
-"# 安裝指定 appid 的指定版本\n"
+"# 安裝 appid 指定的版本\n"
 "ll-cli install org.deepin.demo/0.0.0.1\n"
-"# 通過詳細引用資訊安裝應用程式\n"
+"# 透過詳細引用資訊安裝應用程式\n"
 "ll-cli install stable:org.deepin.demo/0.0.0.1/x86_64\n"
 "    "
 
@@ -325,64 +385,65 @@ msgstr "強制安裝應用程式"
 msgid "Automatically answer yes to all questions"
 msgstr "對所有提問自動回答 yes"
 
-#: ../apps/ll-cli/src/main.cpp:310
-msgid "Uninstall the application or runtimes"
-msgstr "解除安裝應用程式或運行時（Runtime）"
+#: ../apps/ll-cli/src/main.cpp:304 ../apps/ll-cli/src/main.cpp:328
+#: ../apps/ll-cli/src/main.cpp:360
+msgid "Do not automatically remove unused dependencies"
+msgstr "不自動移除未使用的依賴項"
 
 #: ../apps/ll-cli/src/main.cpp:313
+msgid "Uninstall the application or runtimes"
+msgstr "解除安裝應用程式或執行時（Runtime）"
+
+#: ../apps/ll-cli/src/main.cpp:316
 msgid "Usage: ll-cli uninstall [OPTIONS] APP"
 msgstr "用法：ll-cli uninstall [選項] 應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:314
+#: ../apps/ll-cli/src/main.cpp:317
 msgid "Specify the applications ID"
 msgstr "指定應用程式 ID"
 
-#: ../apps/ll-cli/src/main.cpp:317
+#: ../apps/ll-cli/src/main.cpp:320
 msgid "Uninstall a specify module"
 msgstr "解除安裝指定模組"
 
-#: ../apps/ll-cli/src/main.cpp:322
+#: ../apps/ll-cli/src/main.cpp:325
 msgid "Force uninstall base or runtime"
-msgstr "強制解除安裝基礎環境（Base）或運行時（Runtime）"
+msgstr "強制解除安裝基礎環境（Base）或執行時（Runtime）"
 
 #. below options are used for compatibility with old ll-cli
-#: ../apps/ll-cli/src/main.cpp:325
+#: ../apps/ll-cli/src/main.cpp:331
 msgid "Remove all unused modules"
 msgstr "移除所有未使用的模組"
 
-#: ../apps/ll-cli/src/main.cpp:329
+#: ../apps/ll-cli/src/main.cpp:335
 msgid "Uninstall all modules"
 msgstr "解除安裝所有模組"
 
-#: ../apps/ll-cli/src/main.cpp:339
+#: ../apps/ll-cli/src/main.cpp:345
 msgid "Upgrade the application or runtimes"
-msgstr "升級應用程式或運行時（Runtime）"
+msgstr "升級應用程式或執行時（Runtime）"
 
-#: ../apps/ll-cli/src/main.cpp:342
+#: ../apps/ll-cli/src/main.cpp:348
 msgid "Usage: ll-cli upgrade [OPTIONS] [APP]"
 msgstr "用法：ll-cli upgrade [選項] [應用程式]"
 
-#: ../apps/ll-cli/src/main.cpp:346
+#: ../apps/ll-cli/src/main.cpp:352
 msgid ""
-"Specify the application ID. If it not be specified, all applications will be"
-" upgraded"
+"Specify the application ID. If it not be specified, all applications will be "
+"upgraded"
 msgstr "指定應用程式 ID。如果未指定，將升級所有應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:351
+#: ../apps/ll-cli/src/main.cpp:357
 msgid "Only upgrade dependencies of application"
-msgstr ""
+msgstr "僅升級應用程式的依賴項"
 
-#: ../apps/ll-cli/src/main.cpp:352
-msgid "Only upgrade application"
-msgstr ""
-
-#: ../apps/ll-cli/src/main.cpp:363
+#: ../apps/ll-cli/src/main.cpp:370
 msgid ""
 "Search the applications/runtimes containing the specified text from the "
 "remote repository"
-msgstr ""
+msgstr "從遠端倉庫搜尋包含指定文字的應用程式/執行時"
 
-#: ../apps/ll-cli/src/main.cpp:367
+#: ../apps/ll-cli/src/main.cpp:374
 msgid ""
 "Usage: ll-cli search [OPTIONS] KEYWORDS\n"
 "\n"
@@ -396,32 +457,45 @@ msgid ""
 "# find all of runtime(s) of remote\n"
 "ll-cli search . --type=runtime"
 msgstr ""
+"用法：ll-cli search [選項] 關鍵字\n"
+"\n"
+"範例：\n"
+"# 透過關鍵字在遠端尋找應用程式、基礎環境或執行時\n"
+"ll-cli search org.deepin.demo\n"
+"# 尋找遠端的所有應用程式\n"
+"ll-cli search .\n"
+"# 尋找遠端的所有基礎環境\n"
+"ll-cli search . --type=base\n"
+"# 尋找遠端的所有執行時\n"
+"ll-cli search . --type=runtime"
 
-#: ../apps/ll-cli/src/main.cpp:378
+#: ../apps/ll-cli/src/main.cpp:385
 msgid "Specify the Keywords"
-msgstr ""
+msgstr "指定關鍵字"
 
-#: ../apps/ll-cli/src/main.cpp:385 ../apps/ll-cli/src/main.cpp:424
-msgid "Filter result with specify type. One of \"runtime\", \"base\", \"app\" or \"all\""
-msgstr ""
+#: ../apps/ll-cli/src/main.cpp:392 ../apps/ll-cli/src/main.cpp:431
+msgid ""
+"Filter result with specify type. One of \"runtime\", \"base\", \"app\" or "
+"\"all\""
+msgstr "使用指定類型篩選結果。可選 \"runtime\"、\"base\"、\"app\" 或 \"all\""
 
-#: ../apps/ll-cli/src/main.cpp:389
+#: ../apps/ll-cli/src/main.cpp:396
 msgid "Specify the repo"
-msgstr ""
+msgstr "指定倉庫"
 
-#: ../apps/ll-cli/src/main.cpp:394
+#: ../apps/ll-cli/src/main.cpp:401
 msgid "Include develop application in result"
-msgstr ""
+msgstr "結果中包含開發（develop）應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:397
+#: ../apps/ll-cli/src/main.cpp:404
 msgid "Show all versions of an application(s), base(s) or runtime(s)"
-msgstr ""
+msgstr "顯示應用程式、基礎環境或執行時的所有版本"
 
-#: ../apps/ll-cli/src/main.cpp:405
+#: ../apps/ll-cli/src/main.cpp:412
 msgid "List installed application(s), base(s) or runtime(s)"
-msgstr ""
+msgstr "列出已安裝的應用程式、基礎環境或執行時"
 
-#: ../apps/ll-cli/src/main.cpp:408
+#: ../apps/ll-cli/src/main.cpp:415
 msgid ""
 "Usage: ll-cli list [OPTIONS]\n"
 "\n"
@@ -435,472 +509,587 @@ msgid ""
 "# show the latest version list of the currently installed application(s)\n"
 "ll-cli list --upgradable\n"
 msgstr ""
+"用法：ll-cli list [選項]\n"
+"\n"
+"範例：\n"
+"# 顯示已安裝的應用程式、基礎環境或執行時\n"
+"ll-cli list\n"
+"# 顯示已安裝的基礎環境\n"
+"ll-cli list --type=base\n"
+"# 顯示已安裝的執行時\n"
+"ll-cli list --type=runtime\n"
+"# 顯示目前已安裝應用程式的最新版本列表\n"
+"ll-cli list --upgradable\n"
 
-#: ../apps/ll-cli/src/main.cpp:430
+#: ../apps/ll-cli/src/main.cpp:437
 msgid ""
 "Show the list of latest version of the currently installed application(s), "
 "base(s) or runtime(s)"
-msgstr ""
+msgstr "顯示目前已安裝的應用程式、基礎環境或執行時的最新版本列表"
 
-#: ../apps/ll-cli/src/main.cpp:439
-msgid "Display information about installed apps or runtimes"
-msgstr ""
+#: ../apps/ll-cli/src/main.cpp:445
+msgid "Show installed module sizes and repository real size"
+msgstr "顯示已安裝模組的大小與倉庫實際大小"
 
-#: ../apps/ll-cli/src/main.cpp:442
-msgid "Usage: ll-cli info [OPTIONS] APP"
+#: ../apps/ll-cli/src/main.cpp:447
+msgid ""
+"Usage: ll-cli analyze size [OPTIONS]\n"
+"\n"
+"Example:\n"
+"# show installed module sizes\n"
+"ll-cli analyze size\n"
 msgstr ""
+"用法：ll-cli analyze size [選項]\n"
+"\n"
+"範例：\n"
+"# 顯示已安裝模組的大小\n"
+"ll-cli analyze size\n"
 
-#: ../apps/ll-cli/src/main.cpp:446
-msgid "Specify the application ID, and it can also be a .layer file"
+#: ../apps/ll-cli/src/main.cpp:457
+msgid ""
+"Sort result by specify field. One of \"actual\", \"logical\", \"exclusive\", "
+"\"shared\" or \"id\""
 msgstr ""
-
-#: ../apps/ll-cli/src/main.cpp:458
-msgid "Display the exported files of installed application"
-msgstr ""
+"按指定欄位排序結果。可選 \"實際大小\"、\"邏輯大小\"、\"獨佔大小\"、\"共享大小\" "
+"或 \"應用 ID\""
 
 #: ../apps/ll-cli/src/main.cpp:461
-msgid "Usage: ll-cli content [OPTIONS] APP"
-msgstr ""
-
-#: ../apps/ll-cli/src/main.cpp:462
-msgid "Specify the installed application ID"
-msgstr ""
+msgid "Sort in ascending order"
+msgstr "按升序排序"
 
 #: ../apps/ll-cli/src/main.cpp:470
-msgid "Remove the unused base or runtime"
-msgstr ""
+msgid "Analyze installed applications"
+msgstr "分析已安裝的應用程式"
 
 #: ../apps/ll-cli/src/main.cpp:472
-msgid "Usage: ll-cli prune [OPTIONS]"
-msgstr ""
+msgid "Usage: ll-cli analyze SUBCOMMAND [OPTIONS]"
+msgstr "用法：ll-cli analyze 子命令 [選項]"
 
-#: ../apps/ll-cli/src/main.cpp:483
-msgid "Display the inspect information of the installed application"
-msgstr ""
+#: ../apps/ll-cli/src/main.cpp:478
+msgid "Display installed application dependency tree"
+msgstr "顯示已安裝應用程式的依賴關係樹"
 
-#: ../apps/ll-cli/src/main.cpp:485
-msgid "Usage: ll-cli inspect SUBCOMMAND [OPTIONS]"
-msgstr ""
-
-#: ../apps/ll-cli/src/main.cpp:492
+#: ../apps/ll-cli/src/main.cpp:480
 msgid ""
-"Display the data(bundle) directory of the installed(running) application"
+"Usage: ll-cli analyze depends [APP]\n"
+"\n"
+"Example:\n"
+"# show dependency tree for all installed application(s)\n"
+"ll-cli analyze depends\n"
+"# show dependency tree for an installed application\n"
+"ll-cli analyze depends org.deepin.demo\n"
 msgstr ""
+"用法：ll-cli analyze depends [應用程式]\n"
+"\n"
+"範例：\n"
+"# 顯示所有已安裝應用程式的依賴關係樹\n"
+"ll-cli analyze depends\n"
+"# 顯示特定已安裝應用程式的依賴關係樹\n"
+"ll-cli analyze depends org.deepin.demo\n"
 
-#: ../apps/ll-cli/src/main.cpp:493
-msgid "Usage: ll-cli inspect dir [OPTIONS] APP"
-msgstr ""
+#: ../apps/ll-cli/src/main.cpp:488 ../apps/ll-cli/src/main.cpp:520
+msgid "Specify the installed application ID"
+msgstr "指定已安裝的應用程式 ID"
 
 #: ../apps/ll-cli/src/main.cpp:497
-msgid "Specify the application ID, and it can also be reference"
-msgstr ""
+msgid "Display information about installed apps or runtimes"
+msgstr "顯示已安裝應用程式或執行時的資訊"
 
-#: ../apps/ll-cli/src/main.cpp:503
-msgid "Specify the directory type (layer or bundle),the default is layer"
-msgstr ""
+#: ../apps/ll-cli/src/main.cpp:500
+msgid "Usage: ll-cli info [OPTIONS] APP"
+msgstr "用法：ll-cli info [選項] 應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:510
-msgid ""
-"Specify the module type (binary or develop). Only works when type is layer"
-msgstr ""
+#: ../apps/ll-cli/src/main.cpp:504
+msgid "Specify the application ID, and it can also be a .layer file"
+msgstr "指定應用程式 ID，也可以是 .layer 檔案"
+
+#: ../apps/ll-cli/src/main.cpp:516
+msgid "Display the exported files of installed application"
+msgstr "顯示已安裝應用程式的匯出檔案"
 
 #: ../apps/ll-cli/src/main.cpp:519
+msgid "Usage: ll-cli content [OPTIONS] APP"
+msgstr "用法：ll-cli content [選項] 應用程式"
+
+#: ../apps/ll-cli/src/main.cpp:528
+msgid "Remove the unused base or runtime"
+msgstr "移除未使用的基礎環境或執行時"
+
+#: ../apps/ll-cli/src/main.cpp:530
+msgid "Usage: ll-cli prune [OPTIONS]"
+msgstr "用法：ll-cli prune [選項]"
+
+#: ../apps/ll-cli/src/main.cpp:541
+msgid "Display the inspect information of the installed application"
+msgstr "顯示已安裝應用程式的詳細檢查資訊"
+
+#: ../apps/ll-cli/src/main.cpp:543
+msgid "Usage: ll-cli inspect SUBCOMMAND [OPTIONS]"
+msgstr "用法：ll-cli inspect 子命令 [選項]"
+
+#: ../apps/ll-cli/src/main.cpp:550
+msgid ""
+"Display the data(bundle) directory of the installed(running) application"
+msgstr "顯示已安裝（執行中）應用程式的資料（bundle）目錄"
+
+#: ../apps/ll-cli/src/main.cpp:551
+msgid "Usage: ll-cli inspect dir [OPTIONS] APP"
+msgstr "用法：ll-cli inspect dir [選項] 應用程式"
+
+#: ../apps/ll-cli/src/main.cpp:555
+msgid "Specify the application ID, and it can also be reference"
+msgstr "指定應用程式 ID，也可以是引用資訊"
+
+#: ../apps/ll-cli/src/main.cpp:561
+msgid "Specify the directory type (layer or bundle),the default is layer"
+msgstr "指定目錄類型（layer 或 bundle），預設為 layer"
+
+#: ../apps/ll-cli/src/main.cpp:568
+msgid ""
+"Specify the module type (binary or develop). Only works when type is layer"
+msgstr "指定模組類型（binary 或 develop）。僅在類型為 layer 時生效"
+
+#: ../apps/ll-cli/src/main.cpp:577
 msgid ""
 "linyaps CLI\n"
 "A CLI program to run application and manage application and runtime\n"
 msgstr ""
+"linyaps CLI\n"
+"用於執行應用程式以及管理應用程式和執行時的命令列程式\n"
 
-#: ../apps/ll-cli/src/main.cpp:527 ../apps/ll-builder/src/main.cpp:449
+#: ../apps/ll-cli/src/main.cpp:585 ../apps/ll-builder/src/main.cpp:478
 msgid "Print this help message and exit"
-msgstr ""
+msgstr "顯示此說明訊息並退出"
 
-#: ../apps/ll-cli/src/main.cpp:528 ../apps/ll-builder/src/main.cpp:450
+#: ../apps/ll-cli/src/main.cpp:586 ../apps/ll-builder/src/main.cpp:479
 msgid "Expand all help"
-msgstr ""
+msgstr "展開所有說明"
 
-#: ../apps/ll-cli/src/main.cpp:529
+#: ../apps/ll-cli/src/main.cpp:587
 msgid "Usage: ll-cli [OPTIONS] [SUBCOMMAND]"
-msgstr ""
+msgstr "用法：ll-cli [選項] [子命令]"
 
-#: ../apps/ll-cli/src/main.cpp:530
+#: ../apps/ll-cli/src/main.cpp:588
 msgid ""
 "If you found any problems during use,\n"
-"You can report bugs to the linyaps team under this project: https://github.com/OpenAtom-Linyaps/linyaps/issues"
+"You can report bugs to the linyaps team under this project: https://"
+"github.com/OpenAtom-Linyaps/linyaps/issues"
 msgstr ""
+"如果您在使用過程中遇到任何問題，\n"
+"可以在此專案下向 linyaps 團隊回報 Bug：https://"
+"github.com/OpenAtom-Linyaps/linyaps/issues"
 
 #. version flag
-#: ../apps/ll-cli/src/main.cpp:537 ../apps/ll-builder/src/main.cpp:474
+#: ../apps/ll-cli/src/main.cpp:595 ../apps/ll-builder/src/main.cpp:504
 msgid "Show version"
-msgstr ""
+msgstr "顯示版本"
 
-#: ../apps/ll-cli/src/main.cpp:542
+#: ../apps/ll-cli/src/main.cpp:600
 msgid ""
 "Use peer to peer DBus, this is used only in case that DBus daemon is not "
 "available"
-msgstr ""
+msgstr "使用點對點 DBus，僅在 DBus 守護程序不可用時使用"
 
 #. json flag
-#: ../apps/ll-cli/src/main.cpp:547
+#: ../apps/ll-cli/src/main.cpp:605
 msgid "Use json format to output result"
-msgstr ""
+msgstr "使用 JSON 格式輸出結果"
 
-#: ../apps/ll-cli/src/main.cpp:554
-msgid "Show debug info (verbose logs)"
-msgstr ""
+#: ../apps/ll-cli/src/main.cpp:612
+msgid "Show debug info; repeat to enable backtrace"
+msgstr "顯示除錯資訊；重複傳入可啟用堆疊追蹤（backtrace）"
 
-#: ../apps/ll-cli/src/main.cpp:557
+#: ../apps/ll-cli/src/main.cpp:615
 msgid "Don't output progress information"
-msgstr ""
+msgstr "不輸出進度資訊"
 
 #. groups for subcommands
-#: ../apps/ll-cli/src/main.cpp:574
+#: ../apps/ll-cli/src/main.cpp:635
 msgid "Managing installed applications and runtimes"
-msgstr ""
+msgstr "管理已安裝的應用程式和執行時"
 
-#: ../apps/ll-cli/src/main.cpp:575
+#: ../apps/ll-cli/src/main.cpp:636
 msgid "Managing running applications"
-msgstr ""
+msgstr "管理執行中的應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:576
+#: ../apps/ll-cli/src/main.cpp:637
 msgid "Finding applications and runtimes"
-msgstr ""
+msgstr "尋找應用程式和執行時"
 
-#: ../apps/ll-cli/src/main.cpp:577 ../apps/ll-builder/src/main.cpp:662
+#: ../apps/ll-cli/src/main.cpp:638 ../apps/ll-builder/src/main.cpp:703
 msgid "Managing remote repositories"
-msgstr ""
+msgstr "管理遠端倉庫"
 
-#: ../apps/ll-cli/src/main.cpp:607
+#: ../apps/ll-cli/src/main.cpp:669
 msgid "linyaps CLI version "
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:71
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:134
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:314
-msgid "ID"
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:72
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:135
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:247
-msgid "Name"
-msgstr ""
+msgstr "linyaps CLI 版本 "
 
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:73
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:136
-msgid "Version"
-msgstr ""
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:316
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:364
+msgid "ID"
+msgstr "ID"
 
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:74
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:137
-msgid "Channel"
-msgstr ""
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:249
+msgid "Name"
+msgstr "名稱"
 
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:75
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:138
-msgid "Module"
-msgstr ""
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:365
+msgid "Version"
+msgstr "版本"
 
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:76
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:140
-msgid "Description"
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:107
-msgid "No packages found in the remote repo."
-msgstr ""
-
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:139
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:366
+msgid "Channel"
+msgstr "渠道"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:77
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:140
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:367
+msgid "Module"
+msgstr "模組"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:78
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:142
+msgid "Description"
+msgstr "描述"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:109
+msgid "No packages found in the remote repo."
+msgstr "在遠端倉庫中找不到套件。"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:141
 msgid "Repo"
-msgstr ""
+msgstr "倉庫"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:174
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:176
 msgid "No containers are running."
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:178
-msgid "App"
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:179
-msgid "ContainerID"
-msgstr ""
+msgstr "沒有正在執行的容器。"
 
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:180
+msgid "App"
+msgstr "應用程式"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:181
+msgid "ContainerID"
+msgstr "容器 ID"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:182
 msgid "Pid"
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:248
-msgid "Url"
-msgstr ""
-
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:249
-msgid "Alias"
-msgstr ""
+msgstr "Pid"
 
 #: ../libs/linglong/src/linglong/cli/cli_printer.cpp:250
+msgid "Url"
+msgstr "Url"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:251
+msgid "Alias"
+msgstr "別名"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:252
 msgid "Priority"
-msgstr ""
+msgstr "優先級"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:302
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:304
 msgid "No apps available for update."
-msgstr ""
+msgstr "沒有可供更新的應用程式。"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:315
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:317
 msgid "Installed"
-msgstr ""
+msgstr "已安裝"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:316
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:318
 msgid "New"
-msgstr ""
+msgstr "最新"
 
-#: ../apps/ll-builder/src/main.cpp:447
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:368
+msgid "Exclusive"
+msgstr "獨佔"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:369
+msgid "Shared"
+msgstr "共享"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:370
+msgid "Logical"
+msgstr "邏輯"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:370
+msgid "Actual"
+msgstr "實際"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:385
+msgid "Calculated logical total size: "
+msgstr "計算出的邏輯總大小： "
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:386
+msgid "Exclusive: "
+msgstr "獨佔： "
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:386
+msgid "Shared: "
+msgstr "共享： "
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:388
+msgid "Calculated actual total size: "
+msgstr "計算出的實際總大小： "
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:389
+msgid "Repository real size: "
+msgstr "倉庫真實大小： "
+
+#: ../apps/ll-builder/src/main.cpp:476
 msgid ""
 "linyaps builder CLI \n"
 "A CLI program to build linyaps application\n"
 msgstr ""
+"linyaps builder CLI \n"
+"用於建置 linyaps 應用程式的命令列程式\n"
 
-#: ../apps/ll-builder/src/main.cpp:452
+#: ../apps/ll-builder/src/main.cpp:481
 msgid "Usage: ll-builder [OPTIONS] [SUBCOMMAND]"
-msgstr ""
+msgstr "用法：ll-builder [選項] [子命令]"
 
-#: ../apps/ll-builder/src/main.cpp:454
+#: ../apps/ll-builder/src/main.cpp:483
 msgid ""
 "If you found any problems during use\n"
-"You can report bugs to the linyaps team under this project: https://github.com/OpenAtom-Linyaps/linyaps/issues"
+"You can report bugs to the linyaps team under this project: https://"
+"github.com/OpenAtom-Linyaps/linyaps/issues"
 msgstr ""
+"如果您在使用過程中遇到任何問題\n"
+"可以在此專案下向 linyaps 團隊回報 Bug：https://"
+"github.com/OpenAtom-Linyaps/linyaps/issues"
 
-#: ../apps/ll-builder/src/main.cpp:478
+#: ../apps/ll-builder/src/main.cpp:508
 msgid "Create linyaps build template project"
-msgstr ""
+msgstr "建立 linyaps 建置範本專案"
 
-#: ../apps/ll-builder/src/main.cpp:479
+#: ../apps/ll-builder/src/main.cpp:509
 msgid "Usage: ll-builder create [OPTIONS] NAME"
-msgstr ""
+msgstr "用法：ll-builder create [選項] 名稱"
 
-#: ../apps/ll-builder/src/main.cpp:480
+#: ../apps/ll-builder/src/main.cpp:510
 msgid "Project name"
-msgstr ""
+msgstr "專案名稱"
 
-#: ../apps/ll-builder/src/main.cpp:488
+#: ../apps/ll-builder/src/main.cpp:518
 msgid "Build a linyaps project"
-msgstr ""
+msgstr "建置 linyaps 專案"
 
-#: ../apps/ll-builder/src/main.cpp:489
+#: ../apps/ll-builder/src/main.cpp:519
 msgid "Usage: ll-builder build [OPTIONS] [COMMAND...]"
-msgstr ""
+msgstr "用法：ll-builder build [選項] [命令...]"
 
-#: ../apps/ll-builder/src/main.cpp:490 ../apps/ll-builder/src/main.cpp:531
-#: ../apps/ll-builder/src/main.cpp:575 ../apps/ll-builder/src/main.cpp:621
+#: ../apps/ll-builder/src/main.cpp:520 ../apps/ll-builder/src/main.cpp:561
+#: ../apps/ll-builder/src/main.cpp:605 ../apps/ll-builder/src/main.cpp:656
+#: ../apps/ll-builder/src/main.cpp:697
 msgid "File path of the linglong.yaml"
-msgstr ""
+msgstr "linglong.yaml 的檔案路徑"
 
-#: ../apps/ll-builder/src/main.cpp:496
-msgid ""
-"Enter the container to execute command instead of building applications"
-msgstr ""
+#: ../apps/ll-builder/src/main.cpp:526
+msgid "Enter the container to execute command instead of building applications"
+msgstr "進入容器以執行命令，而不是建置應用程式"
 
-#: ../apps/ll-builder/src/main.cpp:499
+#: ../apps/ll-builder/src/main.cpp:529
 msgid ""
 "Only use local files. This implies --skip-fetch-source and --skip-pull-"
 "depend will be set"
 msgstr ""
+"僅使用本機檔案。這意味著將自動設定 --skip-fetch-source 與 --skip-pull-depend"
 
-#: ../apps/ll-builder/src/main.cpp:504
+#: ../apps/ll-builder/src/main.cpp:534
 msgid "Build full develop packages, runtime requires"
-msgstr ""
+msgstr "建置完整的開發（develop）套件，執行時需要"
 
-#: ../apps/ll-builder/src/main.cpp:508
+#: ../apps/ll-builder/src/main.cpp:538
 msgid "Skip fetch sources"
-msgstr ""
+msgstr "跳過獲取原始碼"
 
-#: ../apps/ll-builder/src/main.cpp:511
+#: ../apps/ll-builder/src/main.cpp:541
 msgid "Skip pull dependency"
 msgstr "跳過拉取依賴項"
 
-#: ../apps/ll-builder/src/main.cpp:514
+#: ../apps/ll-builder/src/main.cpp:544
 msgid "Skip run container"
-msgstr "跳過運行容器"
+msgstr "跳過執行容器"
 
-#: ../apps/ll-builder/src/main.cpp:517
+#: ../apps/ll-builder/src/main.cpp:547
 msgid "Skip commit build output"
-msgstr "跳過提交構建輸出"
+msgstr "跳過提交建置輸出"
 
-#: ../apps/ll-builder/src/main.cpp:520
+#: ../apps/ll-builder/src/main.cpp:550
 msgid "Skip output check"
 msgstr "跳過輸出檢查"
 
-#: ../apps/ll-builder/src/main.cpp:523
+#: ../apps/ll-builder/src/main.cpp:553
 msgid "Skip strip debug symbols"
 msgstr "跳過清除除錯符號（strip）"
 
-#: ../apps/ll-builder/src/main.cpp:526
+#: ../apps/ll-builder/src/main.cpp:556
 msgid "Build in an isolated network environment"
-msgstr "在隔離的網絡環境中進行構建"
+msgstr "在隔離的網絡環境中進行建置"
 
 #. add builder run
-#: ../apps/ll-builder/src/main.cpp:529
+#: ../apps/ll-builder/src/main.cpp:559
 msgid "Run built linyaps app"
-msgstr "運行已構建的 linyaps 應用程式"
+msgstr "執行已建置的 linyaps 應用程式"
 
-#: ../apps/ll-builder/src/main.cpp:530
+#: ../apps/ll-builder/src/main.cpp:560
 msgid "Usage: ll-builder run [OPTIONS] [COMMAND...]"
 msgstr "用法：ll-builder run [選項] [命令...]"
 
-#: ../apps/ll-builder/src/main.cpp:537
+#: ../apps/ll-builder/src/main.cpp:567
 msgid "Run specified module. eg: --modules binary,develop"
-msgstr "運行指定模組。例如：--modules binary,develop"
+msgstr "執行指定模組。例如：--modules binary,develop"
 
-#: ../apps/ll-builder/src/main.cpp:549
+#: ../apps/ll-builder/src/main.cpp:579
 msgid "Enter the container to execute command instead of running application"
-msgstr "進入容器以執行命令，而不是運行應用程式"
+msgstr "進入容器以執行命令，而不是執行應用程式"
 
-#: ../apps/ll-builder/src/main.cpp:552
+#: ../apps/ll-builder/src/main.cpp:582
 msgid "Run in debug mode (enable develop module)"
-msgstr "以除錯模式運行（啟用開發開發模組）"
+msgstr "以除錯模式執行（啟用開發模組）"
 
-#: ../apps/ll-builder/src/main.cpp:556
+#: ../apps/ll-builder/src/main.cpp:586
 msgid "Specify extension(s) used by the app to run"
-msgstr "指定應用程式運行所需的擴充模組"
+msgstr "指定應用程式執行所需的擴充模組"
 
-#: ../apps/ll-builder/src/main.cpp:562
+#: ../apps/ll-builder/src/main.cpp:592
 msgid "List built linyaps app"
-msgstr "列出已構建的 linyaps 應用程式"
+msgstr "列出已建置的 linyaps 應用程式"
 
-#: ../apps/ll-builder/src/main.cpp:563
+#: ../apps/ll-builder/src/main.cpp:593
 msgid "Usage: ll-builder list [OPTIONS]"
 msgstr "用法：ll-builder list [選項]"
 
-#: ../apps/ll-builder/src/main.cpp:564
+#: ../apps/ll-builder/src/main.cpp:594
 msgid "Remove built linyaps app"
-msgstr "移除已構建的 linyaps 應用程式"
+msgstr "移除已建置的 linyaps 應用程式"
 
-#: ../apps/ll-builder/src/main.cpp:565
+#: ../apps/ll-builder/src/main.cpp:595
 msgid "Usage: ll-builder remove [OPTIONS] [APP...]"
 msgstr "用法：ll-builder remove [選項] [應用程式...]"
 
-#: ../apps/ll-builder/src/main.cpp:568
+#: ../apps/ll-builder/src/main.cpp:598
 msgid "Do not clean objects files before remove apps"
 msgstr "移除應用程式前不清除中間目的檔案（object files）"
 
 #. build export
-#: ../apps/ll-builder/src/main.cpp:572
-msgid "Export to linyaps layer or uab"
-msgstr "匯出為 linyaps layer 或 uab 檔案"
+#: ../apps/ll-builder/src/main.cpp:602
+msgid "Export to linyaps layer or UAB"
+msgstr "匯出為 linyaps layer 或 UAB"
 
-#: ../apps/ll-builder/src/main.cpp:573
+#: ../apps/ll-builder/src/main.cpp:603
 msgid "Usage: ll-builder export [OPTIONS]"
 msgstr "用法：ll-builder export [選項]"
 
-#: ../apps/ll-builder/src/main.cpp:585
+#: ../apps/ll-builder/src/main.cpp:615
 msgid "Uab icon (optional)"
 msgstr "Uab 圖示（選填）"
 
-#: ../apps/ll-builder/src/main.cpp:590
+#: ../apps/ll-builder/src/main.cpp:620
 msgid "Export to linyaps layer file (deprecated)"
 msgstr "匯出為 linyaps layer 檔案（已棄用）"
 
-#: ../apps/ll-builder/src/main.cpp:593
+#: ../apps/ll-builder/src/main.cpp:623
+msgid "Export an executable UABX file"
+msgstr "匯出可執行的 UABX 檔案"
+
+#: ../apps/ll-builder/src/main.cpp:627
 msgid "Use custom loader"
 msgstr "使用自訂載入器"
 
-#: ../apps/ll-builder/src/main.cpp:600
+#: ../apps/ll-builder/src/main.cpp:635
 msgid "Don't export the develop module"
 msgstr "不匯出開發（develop）模組"
 
-#: ../apps/ll-builder/src/main.cpp:602
+#: ../apps/ll-builder/src/main.cpp:637
 msgid "Output file"
 msgstr "輸出檔案"
 
-#: ../apps/ll-builder/src/main.cpp:606
+#: ../apps/ll-builder/src/main.cpp:641
 msgid "Reference of the package"
 msgstr "套件的引用資訊（Reference）"
 
-#: ../apps/ll-builder/src/main.cpp:611
+#: ../apps/ll-builder/src/main.cpp:646
 msgid "Modules to export"
 msgstr "要匯出的模組"
 
-#: ../apps/ll-builder/src/main.cpp:619
+#: ../apps/ll-builder/src/main.cpp:654
 msgid "Push linyaps app to remote repo"
 msgstr "將 linyaps 應用程式推送到遠端倉庫"
 
-#: ../apps/ll-builder/src/main.cpp:620
+#: ../apps/ll-builder/src/main.cpp:655
 msgid "Usage: ll-builder push [OPTIONS]"
 msgstr "用法：ll-builder push [選項]"
 
-#: ../apps/ll-builder/src/main.cpp:624
+#: ../apps/ll-builder/src/main.cpp:659
 msgid "Remote repo url"
 msgstr "遠端倉庫 URL"
 
-#: ../apps/ll-builder/src/main.cpp:627
+#: ../apps/ll-builder/src/main.cpp:662
 msgid "Remote repo name"
 msgstr "遠端倉庫名稱"
 
-#: ../apps/ll-builder/src/main.cpp:630
+#: ../apps/ll-builder/src/main.cpp:665
 msgid "Push single module"
 msgstr "推送單一模組"
 
-#: ../apps/ll-builder/src/main.cpp:634
+#: ../apps/ll-builder/src/main.cpp:669
 msgid "Import linyaps layer to build repo"
-msgstr "匯入 linyaps layer 到構建倉庫"
+msgstr "匯入 linyaps layer 到建置倉庫"
 
-#: ../apps/ll-builder/src/main.cpp:635
+#: ../apps/ll-builder/src/main.cpp:670
 msgid "Usage: ll-builder import [OPTIONS] LAYER"
 msgstr "用法：ll-builder import [選項] LAYER"
 
-#: ../apps/ll-builder/src/main.cpp:636 ../apps/ll-builder/src/main.cpp:653
+#: ../apps/ll-builder/src/main.cpp:671 ../apps/ll-builder/src/main.cpp:688
 msgid "Layer file path"
 msgstr "Layer 檔案路徑"
 
-#: ../apps/ll-builder/src/main.cpp:643
+#: ../apps/ll-builder/src/main.cpp:678
 msgid "Import linyaps layer dir to build repo"
-msgstr "匯入 linyaps layer 目錄到構建倉庫"
+msgstr "匯入 linyaps layer 目錄到建置倉庫"
 
-#: ../apps/ll-builder/src/main.cpp:645
+#: ../apps/ll-builder/src/main.cpp:680
 msgid "Usage: ll-builder import-dir PATH"
 msgstr "用法：ll-builder import-dir 路徑"
 
-#: ../apps/ll-builder/src/main.cpp:646
+#: ../apps/ll-builder/src/main.cpp:681
 msgid "Layer dir path"
 msgstr "Layer 目錄路徑"
 
 #. add build extract
-#: ../apps/ll-builder/src/main.cpp:651
+#: ../apps/ll-builder/src/main.cpp:686
 msgid "Extract linyaps layer to dir"
 msgstr "解壓 linyaps layer 到目錄"
 
-#: ../apps/ll-builder/src/main.cpp:652
+#: ../apps/ll-builder/src/main.cpp:687
 msgid "Usage: ll-builder extract [OPTIONS] LAYER DIR"
 msgstr "用法：ll-builder extract [選項] LAYER 目錄"
 
-#: ../apps/ll-builder/src/main.cpp:656
+#: ../apps/ll-builder/src/main.cpp:691
 msgid "Destination directory"
 msgstr "目標目錄"
 
-#: ../apps/ll-builder/src/main.cpp:669
+#. add builder clean
+#: ../apps/ll-builder/src/main.cpp:695
+msgid "Clean build artifacts"
+msgstr "清除建置產物"
+
+#: ../apps/ll-builder/src/main.cpp:696
+msgid "Usage: ll-builder clean"
+msgstr "用法：ll-builder clean"
+
+#: ../apps/ll-builder/src/main.cpp:710
 msgid "linyaps build tool version "
-msgstr "linyaps 構建工具版本 "
-
-#: ../apps/ll-dialog/src/permissionDialog.cpp:34
-msgid "Whether to allow %1 to access %2?"
-msgstr "是否允許 %1 存取 %2？"
-
-#. button
-#: ../apps/ll-dialog/src/permissionDialog.cpp:43
-msgid "Allow"
-msgstr "允許"
-
-#: ../apps/ll-dialog/src/permissionDialog.cpp:48
-#, c-format
-msgid "Deny (%1s)"
-msgstr "拒絕 (%1秒)"
-
-#: ../apps/ll-dialog/src/cache_dialog.cpp:53
-msgid "Linglong Package Manager"
-msgstr "玲瓏套件管理器"
-
-#: ../apps/ll-dialog/src/cache_dialog.cpp:54
-msgid "is starting"
-msgstr "正在啟動"
+msgstr "linyaps 建置工具版本 "
 
 #. Define command line options
 #: ../apps/ll-driver-detect/src/main.cpp:104
@@ -921,7 +1110,8 @@ msgstr "有可用的顯示卡驅動程式"
 
 #: ../apps/ll-driver-detect/src/main.cpp:217
 msgid ""
-"Graphics driver package is available that can improve performance for some Linyaps applications.\n"
+"Graphics driver package is available that can improve performance for some "
+"Linyaps applications.\n"
 "Would you like to install it?"
 msgstr ""
 "有可用的顯示卡驅動程式套件，可提升部分 Linyaps 應用程式的效能。\n"
@@ -953,7 +1143,7 @@ msgstr "用法："
 
 #: ../libs/linglong/src/linglong/common/cli/repo.cpp:50
 msgid "Display or modify information of the repository currently using"
-msgstr "顯示或修改當前正在使用的倉庫資訊"
+msgstr "顯示或修改目前正在使用的倉庫資訊"
 
 #: ../libs/linglong/src/linglong/common/cli/repo.cpp:55
 msgid "Add a new repository"
@@ -976,7 +1166,7 @@ msgstr "倉庫的 URL"
 #: ../libs/linglong/src/linglong/common/cli/repo.cpp:93
 #: ../libs/linglong/src/linglong/common/cli/repo.cpp:103
 #: ../libs/linglong/src/linglong/common/cli/repo.cpp:113
-#: ../libs/linglong/src/linglong/common/cli/repo.cpp:120
+#: ../libs/linglong/src/linglong/common/cli/repo.cpp:126
 msgid "Alias of the repo name"
 msgstr "倉庫名稱的別名"
 
@@ -994,7 +1184,7 @@ msgstr "更新倉庫 URL"
 
 #: ../libs/linglong/src/linglong/common/cli/repo.cpp:91
 msgid "Set a default repository name"
-msgstr "設置預設倉庫名稱"
+msgstr "設定預設倉庫名稱"
 
 #: ../libs/linglong/src/linglong/common/cli/repo.cpp:97
 msgid "Show repository information"
@@ -1002,7 +1192,7 @@ msgstr "顯示倉庫資訊"
 
 #: ../libs/linglong/src/linglong/common/cli/repo.cpp:101
 msgid "Set the priority of the repo"
-msgstr "設置倉庫的優先級"
+msgstr "設定倉庫的優先級"
 
 #: ../libs/linglong/src/linglong/common/cli/repo.cpp:106
 msgid "Priority of the repo"
@@ -1012,6 +1202,10 @@ msgstr "倉庫的優先級"
 msgid "Enable mirror for the repo"
 msgstr "啟用該倉庫的鏡像（Mirror）"
 
-#: ../libs/linglong/src/linglong/common/cli/repo.cpp:118
+#: ../libs/linglong/src/linglong/common/cli/repo.cpp:119
+msgid "Region code for mirror selection, e.g. CN, US"
+msgstr "用於選擇鏡像的地區代碼，例如 CN、US"
+
+#: ../libs/linglong/src/linglong/common/cli/repo.cpp:124
 msgid "Disable mirror for the repo"
 msgstr "停用該倉庫的鏡像（Mirror）"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -2,37 +2,140 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # deepiner, 2026
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-23 19:04+0800\n"
+"POT-Creation-Date: 2026-08-28 16:24+0800\n"
 "PO-Revision-Date: 2025-04-11 01:38+0000\n"
 "Last-Translator: deepiner, 2026\n"
-"Language-Team: Chinese (Taiwan) (https://app.transifex.com/linuxdeepin/teams/3976/zh_TW/)\n"
+"Language-Team: Chinese (Taiwan) (https://app.transifex.com/linuxdeepin/teams/"
+"3976/zh_TW/)\n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1238
+#: ../libs/linglong/src/linglong/cli/cli.cpp:448
+msgid "Debug mode is enabled. Attach from another terminal with gdb:"
+msgstr "除錯模式已啟用。請從另一個終端機使用 gdb 連線："
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:468
+msgid "Debug mode is enabled. Attach from another terminal with:"
+msgstr "除錯模式已啟用。請從另一個終端機使用以下命令連線："
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:471
+msgid "Generated gdb attach script:"
+msgstr "已產生的 gdb 連線指令稿："
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:1949
+#, c++-format
+msgid "Base {} has no develop module installed, installing it now."
+msgstr "基礎環境 {} 未安裝開發模組，正在進行安裝。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2361
+#, c++-format
+msgid "{} is not a regular file; expected a .layer or .uab file."
+msgstr "{} 不是一般檔案；應為 .layer 或 .uab 檔案。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2372
+#, c++-format
+msgid "Unsupported file format {}; expected a .layer or .uab file."
+msgstr "不支援的檔案格式 {}；應為 .layer 或 .uab 檔案。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2385
+#, c++-format
+msgid "Package file {} does not exist."
+msgstr "套件檔案 {} 不存在。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2452
 #, c++-format
 msgid "Application {} is not installed."
 msgstr "應用程式 {} 未安裝。"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1248
+#: ../libs/linglong/src/linglong/cli/cli.cpp:2462
 #, c++-format
 msgid "{} is not an application."
 msgstr "{} 不是一個應用程式。"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:1353
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2343
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3631
+msgid "To install the module, one must first install the app."
+msgstr "若要安裝該模組，必須先安裝對應的應用程式。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3634
+msgid "Module is already installed."
+msgstr "模組已安裝。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3637
+msgid "The module could not be found remotely."
+msgstr "在遠端找不到該模組。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3640
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3676
+msgid "Application already installed"
+msgstr "應用程式已安裝"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3644
+#, c++-format
+msgid "Application {} is not found in remote repo."
+msgstr "在遠端軟體庫中找不到應用程式 {}。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3647
+msgid "Cannot specify a version when installing a module."
+msgstr "安裝模組時無法指定版本。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3651
+#, c++-format
+msgid ""
+"The latest version has been installed. If you want to replace it, try using "
+"'ll-cli install {} --force'"
+msgstr "已安裝最新版本。如果您想替換它，請嘗試使用 'll-cli install {} --force'"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3657
+msgid "Install failed"
+msgstr "安裝失敗"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3698
+msgid ""
+"The application is currently running and cannot be uninstalled. Please turn "
+"off the application and try again."
+msgstr "該應用程式目前正在執行，無法解除安裝。請先關閉應用程式後再試一次。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3706
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3739
+msgid "Application is not installed."
+msgstr "應用程式未安裝。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3710
+#, c++-format
+msgid ""
+"Multiple versions of the package are installed. Please specify a single "
+"version to uninstall:\n"
+"{}"
+msgstr ""
+"已安裝該套件的多個版本。請指定單一版本進行解除安裝：\n"
+"{}"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3716
+msgid "Base or runtime cannot be uninstalled, please use 'll-cli prune'."
+msgstr ""
+"無法解除安裝基礎環境（Base）或執行時環境（Runtime），請使用 'll-cli prune'。"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3720
+msgid "Uninstall failed"
+msgstr "解除安裝失敗"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3743
+msgid "Upgrade failed"
+msgstr "升級失敗"
+
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3762
 msgid ""
 "Network connection failed. Please:\n"
 "1. Check your internet connection\n"
@@ -42,103 +145,32 @@ msgstr ""
 "1. 檢查您的網際網路連線\n"
 "2. 若有使用網路代理，請驗證其設定"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2228
-msgid "To install the module, one must first install the app."
-msgstr "若要安裝該模組，必須先安裝對應的應用程式。"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2231
-msgid "Module is already installed."
-msgstr "模組已安裝。"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2234
-msgid "The module could not be found remotely."
-msgstr "在遠端找不到該模組。"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2238
-#, c++-format
-msgid ""
-"Application already installed, If you want to replace it, try using 'll-cli "
-"install {} --force'"
-msgstr "應用程式已安裝。如果您想替換它，請嘗試使用 'll-cli install {} --force'"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2244
-#, c++-format
-msgid "Application {} is not found in remote repo."
-msgstr "在遠端軟體庫中找不到應用程式 {}。"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2247
-msgid "Cannot specify a version when installing a module."
-msgstr "安裝模組時無法指定版本。"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2251
-#, c++-format
-msgid ""
-"The latest version has been installed. If you want to replace it, try using "
-"'ll-cli install {} --force'"
-msgstr "已安裝最新版本。如果您想替換它，請嘗試使用 'll-cli install {} --force'"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2257
-msgid "Install failed"
-msgstr "安裝失敗"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2279
-msgid ""
-"The application is currently running and cannot be uninstalled. Please turn "
-"off the application and try again."
-msgstr "該應用程式目前正在執行，無法解除安裝。請先關閉應用程式後再試一次。"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2287
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2320
-msgid "Application is not installed."
-msgstr "應用程式未安裝。"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2291
-#, c++-format
-msgid ""
-"Multiple versions of the package are installed. Please specify a single version to uninstall:\n"
-"{}"
-msgstr ""
-"已安裝該套件的多個版本。請指定單一版本進行解除安裝：\n"
-"{}"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2297
-msgid "Base or runtime cannot be uninstalled, please use 'll-cli prune'."
-msgstr "無法解除安裝基礎環境（Base）或執行時環境（Runtime），請使用 'll-cli prune'。"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2301
-msgid "Uninstall failed"
-msgstr "解除安裝失敗"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2324
-msgid "Upgrade failed"
-msgstr "升級失敗"
-
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2348
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3767
 msgid "Package not found"
 msgstr "找不到套件"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2351
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3770
 msgid "Operation canceled"
 msgstr "操作已取消"
 
-#: ../libs/linglong/src/linglong/cli/cli.cpp:2354
+#: ../libs/linglong/src/linglong/cli/cli.cpp:3773
 msgid "Permission denied, authentication is required"
 msgstr "權限被拒絕，需要進行身分驗證"
 
-#: ../apps/ll-cli/src/main.cpp:105 ../apps/ll-builder/src/main.cpp:46
+#: ../apps/ll-cli/src/main.cpp:70 ../apps/ll-builder/src/main.cpp:47
 msgid "Input parameter is empty, please input valid parameter instead"
 msgstr "輸入參數為空，請改輸入有效的參數"
 
-#: ../apps/ll-cli/src/main.cpp:116
+#: ../apps/ll-cli/src/main.cpp:81
 msgid "Run an application"
 msgstr "執行應用程式"
 
 #. add sub command run options
-#: ../apps/ll-cli/src/main.cpp:119
+#: ../apps/ll-cli/src/main.cpp:84
 msgid "Specify the application ID"
 msgstr "指定應用程式 ID"
 
-#: ../apps/ll-cli/src/main.cpp:122
+#: ../apps/ll-cli/src/main.cpp:87
 msgid ""
 "Usage: ll-cli run [OPTIONS] APP [COMMAND...]\n"
 "\n"
@@ -160,78 +192,106 @@ msgstr ""
 "ll-cli run org.deepin.demo -- bash\n"
 "ll-cli run org.deepin.demo -- bash -x /path/to/bash/script"
 
-#: ../apps/ll-cli/src/main.cpp:134
+#: ../apps/ll-cli/src/main.cpp:99
 msgid "Pass file to applications running in a sandbox"
 msgstr "將檔案傳遞給在沙盒中執行的應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:138
+#: ../apps/ll-cli/src/main.cpp:103
 msgid "Pass url to applications running in a sandbox"
 msgstr "將 URL 傳遞給在沙盒中執行的應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:141
+#: ../apps/ll-cli/src/main.cpp:106
 msgid "Set environment variables for the application"
 msgstr "為應用程式設定環境變數"
 
-#: ../apps/ll-cli/src/main.cpp:148
+#: ../apps/ll-cli/src/main.cpp:113
 msgid "Input parameter is invalid, please input valid parameter instead"
 msgstr "輸入參數無效，請改輸入有效的參數"
 
-#: ../apps/ll-cli/src/main.cpp:154
+#: ../apps/ll-cli/src/main.cpp:119
 msgid "Specify the base used by the application to run"
 msgstr "指定應用程式執行所需的基礎環境（Base）"
 
-#: ../apps/ll-cli/src/main.cpp:160
+#: ../apps/ll-cli/src/main.cpp:125
 msgid "Specify the runtime used by the application to run"
 msgstr "指定應用程式執行所需的執行時環境（Runtime）"
 
-#: ../apps/ll-cli/src/main.cpp:166 ../apps/ll-builder/src/main.cpp:544
+#: ../apps/ll-cli/src/main.cpp:131 ../apps/ll-builder/src/main.cpp:574
 msgid "Specify the working directory where the application runs"
 msgstr "指定應用程式執行的工作目錄"
 
-#: ../apps/ll-cli/src/main.cpp:171
+#: ../apps/ll-cli/src/main.cpp:136
 msgid "Specify extension(s) used by the application to run"
 msgstr "指定應用程式執行所需的擴充功能"
 
-#: ../apps/ll-cli/src/main.cpp:179
+#: ../apps/ll-cli/src/main.cpp:144
 msgid ""
 "Enable or disable xdg-desktop-portal related integration inside the sandbox"
 msgstr "啟用或停用沙盒內與 xdg-desktop-portal 相關的整合"
 
-#: ../apps/ll-cli/src/main.cpp:181
+#: ../apps/ll-cli/src/main.cpp:149
+msgid "Enable PipeWire socket mount inside the sandbox"
+msgstr "在沙盒內啟用 PipeWire socket 掛載"
+
+#: ../apps/ll-cli/src/main.cpp:154
+msgid "Enable AT SPI socket mount inside the sandbox"
+msgstr "在沙盒內啟用 AT SPI socket 掛載"
+
+#: ../apps/ll-cli/src/main.cpp:156
 msgid "Run context json string"
 msgstr "執行上下文的 JSON 字串"
 
-#: ../apps/ll-cli/src/main.cpp:184
+#: ../apps/ll-cli/src/main.cpp:159
 msgid "Run the application in privileged mode"
 msgstr "以特權模式執行應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:186
+#: ../apps/ll-cli/src/main.cpp:161
 msgid "Add capabilities to the application"
 msgstr "為應用程式增加 Linux Capabilities 權限"
 
-#: ../apps/ll-cli/src/main.cpp:190
+#: ../apps/ll-cli/src/main.cpp:165
 msgid "CDI spec directory"
 msgstr "CDI 規格（spec）目錄"
 
-#: ../apps/ll-cli/src/main.cpp:194
+#: ../apps/ll-cli/src/main.cpp:169
 msgid "Add CDI devices"
 msgstr "新增 CDI 裝置"
 
-#: ../apps/ll-cli/src/main.cpp:200
+#: ../apps/ll-cli/src/main.cpp:175
 msgid "Add device options"
 msgstr "新增裝置選項"
 
-#: ../apps/ll-cli/src/main.cpp:207
+#: ../apps/ll-cli/src/main.cpp:182
 msgid "Specify the container instance name for reuse or identification"
 msgstr "指定容器實例名稱以用於重複使用或識別"
 
-#: ../apps/ll-cli/src/main.cpp:210 ../apps/ll-cli/src/main.cpp:241
+#: ../apps/ll-cli/src/main.cpp:186
+msgid "Run the application under gdbserver"
+msgstr "在 gdbserver 下執行應用程式"
+
+#: ../apps/ll-cli/src/main.cpp:190
+msgid "Specify the gdbserver listen address"
+msgstr "指定 gdbserver 的接聽位址"
+
+#: ../apps/ll-cli/src/main.cpp:198
+msgid "Specify debuginfod urls for debugging"
+msgstr "指定用於除錯的 debuginfod URL"
+
+#: ../apps/ll-cli/src/main.cpp:205
+msgid "Specify the directory used by gdb to load debug symbols"
+msgstr "指定 gdb 用於載入除錯符號的目錄"
+
+#: ../apps/ll-cli/src/main.cpp:209 ../apps/ll-cli/src/main.cpp:241
 msgid "Run commands in a running sandbox"
 msgstr "在執行中的沙盒內執行命令"
 
-#: ../apps/ll-cli/src/main.cpp:216
+#: ../apps/ll-cli/src/main.cpp:215
 msgid "List running applications"
 msgstr "列出正在執行的應用程式"
+
+#: ../apps/ll-cli/src/main.cpp:218
+msgid "Do not truncate container IDs"
+msgstr "不截斷容器 ID"
 
 #: ../apps/ll-cli/src/main.cpp:219
 msgid "Usage: ll-cli ps [OPTIONS]"
@@ -277,9 +337,9 @@ msgid ""
 "# install application by appid\n"
 "ll-cli install org.deepin.demo\n"
 "# install application by linyaps layer\n"
-"ll-cli install demo_0.0.0.1_x86_64_binary.layer\n"
+"ll-cli install ./demo_0.0.0.1_x86_64_binary.layer\n"
 "# install application by linyaps uab\n"
-"ll-cli install demo_x86_64_0.0.0.1_main.uab\n"
+"ll-cli install ./demo_x86_64_0.0.0.1_main.uab\n"
 "# install specified module of the appid\n"
 "ll-cli install org.deepin.demo --module=binary\n"
 "# install specified version of the appid\n"
@@ -293,15 +353,15 @@ msgstr ""
 "範例：\n"
 "# 透過 appid 安裝應用程式\n"
 "ll-cli install org.deepin.demo\n"
-"# 透過 linyaps layer 檔案安裝應用程式\n"
-"ll-cli install demo_0.0.0.1_x86_64_binary.layer\n"
-"# 透過 linyaps uab 檔案安裝應用程式\n"
-"ll-cli install demo_x86_64_0.0.0.1_main.uab\n"
-"# 安裝指定 appid 的特定模組\n"
+"# 透過 linyaps layer 安裝應用程式\n"
+"ll-cli install ./demo_0.0.0.1_x86_64_binary.layer\n"
+"# 透過 linyaps uab 安裝應用程式\n"
+"ll-cli install ./demo_x86_64_0.0.0.1_main.uab\n"
+"# 安裝 appid 的指定模組\n"
 "ll-cli install org.deepin.demo --module=binary\n"
-"# 安裝指定 appid 的指定版本\n"
+"# 安裝 appid 的指定版本\n"
 "ll-cli install org.deepin.demo/0.0.0.1\n"
-"# 透過詳細引用資訊安裝應用程式\n"
+"# 透過詳細參考資訊安裝應用程式\n"
 "ll-cli install stable:org.deepin.demo/0.0.0.1/x86_64\n"
 "    "
 
@@ -325,64 +385,65 @@ msgstr "強制安裝應用程式"
 msgid "Automatically answer yes to all questions"
 msgstr "對所有提問自動回答 yes"
 
-#: ../apps/ll-cli/src/main.cpp:310
+#: ../apps/ll-cli/src/main.cpp:304 ../apps/ll-cli/src/main.cpp:328
+#: ../apps/ll-cli/src/main.cpp:360
+msgid "Do not automatically remove unused dependencies"
+msgstr "不自動移除未使用的相依項目"
+
+#: ../apps/ll-cli/src/main.cpp:313
 msgid "Uninstall the application or runtimes"
 msgstr "解除安裝應用程式或執行時環境（Runtime）"
 
-#: ../apps/ll-cli/src/main.cpp:313
+#: ../apps/ll-cli/src/main.cpp:316
 msgid "Usage: ll-cli uninstall [OPTIONS] APP"
 msgstr "用法：ll-cli uninstall [選項] 應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:314
+#: ../apps/ll-cli/src/main.cpp:317
 msgid "Specify the applications ID"
 msgstr "指定應用程式 ID"
 
-#: ../apps/ll-cli/src/main.cpp:317
+#: ../apps/ll-cli/src/main.cpp:320
 msgid "Uninstall a specify module"
 msgstr "解除安裝指定模組"
 
-#: ../apps/ll-cli/src/main.cpp:322
+#: ../apps/ll-cli/src/main.cpp:325
 msgid "Force uninstall base or runtime"
 msgstr "強制解除安裝基礎環境（Base）或執行時環境（Runtime）"
 
 #. below options are used for compatibility with old ll-cli
-#: ../apps/ll-cli/src/main.cpp:325
+#: ../apps/ll-cli/src/main.cpp:331
 msgid "Remove all unused modules"
 msgstr "移除所有未使用的模組"
 
-#: ../apps/ll-cli/src/main.cpp:329
+#: ../apps/ll-cli/src/main.cpp:335
 msgid "Uninstall all modules"
 msgstr "解除安裝所有模組"
 
-#: ../apps/ll-cli/src/main.cpp:339
+#: ../apps/ll-cli/src/main.cpp:345
 msgid "Upgrade the application or runtimes"
 msgstr "升級應用程式或執行時環境（Runtime）"
 
-#: ../apps/ll-cli/src/main.cpp:342
+#: ../apps/ll-cli/src/main.cpp:348
 msgid "Usage: ll-cli upgrade [OPTIONS] [APP]"
 msgstr "用法：ll-cli upgrade [選項] [應用程式]"
 
-#: ../apps/ll-cli/src/main.cpp:346
+#: ../apps/ll-cli/src/main.cpp:352
 msgid ""
-"Specify the application ID. If it not be specified, all applications will be"
-" upgraded"
+"Specify the application ID. If it not be specified, all applications will be "
+"upgraded"
 msgstr "指定應用程式 ID。如果未指定，將升級所有應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:351
+#: ../apps/ll-cli/src/main.cpp:357
 msgid "Only upgrade dependencies of application"
 msgstr "僅升級應用程式的相依項目"
 
-#: ../apps/ll-cli/src/main.cpp:352
-msgid "Only upgrade application"
-msgstr "僅升級應用程式"
-
-#: ../apps/ll-cli/src/main.cpp:363
+#: ../apps/ll-cli/src/main.cpp:370
 msgid ""
 "Search the applications/runtimes containing the specified text from the "
 "remote repository"
 msgstr "從遠端軟體庫中搜尋包含指定文字的應用程式/執行時環境"
 
-#: ../apps/ll-cli/src/main.cpp:367
+#: ../apps/ll-cli/src/main.cpp:374
 msgid ""
 "Usage: ll-cli search [OPTIONS] KEYWORDS\n"
 "\n"
@@ -408,31 +469,34 @@ msgstr ""
 "# 尋找遠端所有的執行時環境\n"
 "ll-cli search . --type=runtime"
 
-#: ../apps/ll-cli/src/main.cpp:378
+#: ../apps/ll-cli/src/main.cpp:385
 msgid "Specify the Keywords"
 msgstr "指定關鍵字"
 
-#: ../apps/ll-cli/src/main.cpp:385 ../apps/ll-cli/src/main.cpp:424
-msgid "Filter result with specify type. One of \"runtime\", \"base\", \"app\" or \"all\""
-msgstr "使用指定類型過濾結果。可為 \"runtime\"、\"base\"、\"app\" 或 \"all\" 其中之一"
+#: ../apps/ll-cli/src/main.cpp:392 ../apps/ll-cli/src/main.cpp:431
+msgid ""
+"Filter result with specify type. One of \"runtime\", \"base\", \"app\" or "
+"\"all\""
+msgstr ""
+"使用指定類型過濾結果。可為 \"runtime\"、\"base\"、\"app\" 或 \"all\" 其中之一"
 
-#: ../apps/ll-cli/src/main.cpp:389
+#: ../apps/ll-cli/src/main.cpp:396
 msgid "Specify the repo"
 msgstr "指定軟體庫"
 
-#: ../apps/ll-cli/src/main.cpp:394
+#: ../apps/ll-cli/src/main.cpp:401
 msgid "Include develop application in result"
 msgstr "結果中包含開發版（develop）應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:397
+#: ../apps/ll-cli/src/main.cpp:404
 msgid "Show all versions of an application(s), base(s) or runtime(s)"
 msgstr "顯示應用程式、基礎環境或執行時環境的所有版本"
 
-#: ../apps/ll-cli/src/main.cpp:405
+#: ../apps/ll-cli/src/main.cpp:412
 msgid "List installed application(s), base(s) or runtime(s)"
 msgstr "列出已安裝的應用程式、基礎環境或執行時環境"
 
-#: ../apps/ll-cli/src/main.cpp:408
+#: ../apps/ll-cli/src/main.cpp:415
 msgid ""
 "Usage: ll-cli list [OPTIONS]\n"
 "\n"
@@ -458,75 +522,135 @@ msgstr ""
 "# 顯示目前已安裝應用程式的可升級最新版本列表\n"
 "ll-cli list --upgradable\n"
 
-#: ../apps/ll-cli/src/main.cpp:430
+#: ../apps/ll-cli/src/main.cpp:437
 msgid ""
 "Show the list of latest version of the currently installed application(s), "
 "base(s) or runtime(s)"
 msgstr "顯示目前已安裝的應用程式、基礎環境或執行時環境的最新版本列表"
 
-#: ../apps/ll-cli/src/main.cpp:439
-msgid "Display information about installed apps or runtimes"
-msgstr "顯示已安裝應用程式或執行時環境的資訊"
+#: ../apps/ll-cli/src/main.cpp:445
+msgid "Show installed module sizes and repository real size"
+msgstr "顯示已安裝模組的大小與軟體庫實際大小"
 
-#: ../apps/ll-cli/src/main.cpp:442
-msgid "Usage: ll-cli info [OPTIONS] APP"
-msgstr "用法：ll-cli info [選項] 應用程式"
+#: ../apps/ll-cli/src/main.cpp:447
+msgid ""
+"Usage: ll-cli analyze size [OPTIONS]\n"
+"\n"
+"Example:\n"
+"# show installed module sizes\n"
+"ll-cli analyze size\n"
+msgstr ""
+"用法：ll-cli analyze size [選項]\n"
+"\n"
+"範例：\n"
+"# 顯示已安裝模組的大小\n"
+"ll-cli analyze size\n"
 
-#: ../apps/ll-cli/src/main.cpp:446
-msgid "Specify the application ID, and it can also be a .layer file"
-msgstr "指定應用程式 ID，也可以是 .layer 檔案"
-
-#: ../apps/ll-cli/src/main.cpp:458
-msgid "Display the exported files of installed application"
-msgstr "顯示已安裝應用程式的匯出檔案"
+#: ../apps/ll-cli/src/main.cpp:457
+msgid ""
+"Sort result by specify field. One of \"actual\", \"logical\", \"exclusive\", "
+"\"shared\" or \"id\""
+msgstr ""
+"依指定欄位排序結果。可為 \"實際大小\"、\"邏輯大小\"、\"獨佔大小\"、"
+"\"共享大小\" 或 \"應用程式 ID\" 其中之一"
 
 #: ../apps/ll-cli/src/main.cpp:461
-msgid "Usage: ll-cli content [OPTIONS] APP"
-msgstr "用法：ll-cli content [選項] 應用程式"
+msgid "Sort in ascending order"
+msgstr "升冪排序"
 
-#: ../apps/ll-cli/src/main.cpp:462
+#: ../apps/ll-cli/src/main.cpp:470
+msgid "Analyze installed applications"
+msgstr "分析已安裝的應用程式"
+
+#: ../apps/ll-cli/src/main.cpp:472
+msgid "Usage: ll-cli analyze SUBCOMMAND [OPTIONS]"
+msgstr "用法：ll-cli analyze 子命令 [選項]"
+
+#: ../apps/ll-cli/src/main.cpp:478
+msgid "Display installed application dependency tree"
+msgstr "顯示已安裝應用程式的相依性樹狀圖"
+
+#: ../apps/ll-cli/src/main.cpp:480
+msgid ""
+"Usage: ll-cli analyze depends [APP]\n"
+"\n"
+"Example:\n"
+"# show dependency tree for all installed application(s)\n"
+"ll-cli analyze depends\n"
+"# show dependency tree for an installed application\n"
+"ll-cli analyze depends org.deepin.demo\n"
+msgstr ""
+"用法：ll-cli analyze depends [應用程式]\n"
+"\n"
+"範例：\n"
+"# 顯示所有已安裝應用程式的相依性樹狀圖\n"
+"ll-cli analyze depends\n"
+"# 顯示特定已安裝應用程式的相依性樹狀圖\n"
+"ll-cli analyze depends org.deepin.demo\n"
+
+#: ../apps/ll-cli/src/main.cpp:488 ../apps/ll-cli/src/main.cpp:520
 msgid "Specify the installed application ID"
 msgstr "指定已安裝的應用程式 ID"
 
-#: ../apps/ll-cli/src/main.cpp:470
+#: ../apps/ll-cli/src/main.cpp:497
+msgid "Display information about installed apps or runtimes"
+msgstr "顯示已安裝應用程式或執行時環境的資訊"
+
+#: ../apps/ll-cli/src/main.cpp:500
+msgid "Usage: ll-cli info [OPTIONS] APP"
+msgstr "用法：ll-cli info [選項] 應用程式"
+
+#: ../apps/ll-cli/src/main.cpp:504
+msgid "Specify the application ID, and it can also be a .layer file"
+msgstr "指定應用程式 ID，也可以是 .layer 檔案"
+
+#: ../apps/ll-cli/src/main.cpp:516
+msgid "Display the exported files of installed application"
+msgstr "顯示已安裝應用程式的匯出檔案"
+
+#: ../apps/ll-cli/src/main.cpp:519
+msgid "Usage: ll-cli content [OPTIONS] APP"
+msgstr "用法：ll-cli content [選項] 應用程式"
+
+#: ../apps/ll-cli/src/main.cpp:528
 msgid "Remove the unused base or runtime"
 msgstr "移除未使用的基礎環境或執行時環境"
 
-#: ../apps/ll-cli/src/main.cpp:472
+#: ../apps/ll-cli/src/main.cpp:530
 msgid "Usage: ll-cli prune [OPTIONS]"
 msgstr "用法：ll-cli prune [選項]"
 
-#: ../apps/ll-cli/src/main.cpp:483
+#: ../apps/ll-cli/src/main.cpp:541
 msgid "Display the inspect information of the installed application"
 msgstr "顯示已安裝應用程式的詳細檢查（inspect）資訊"
 
-#: ../apps/ll-cli/src/main.cpp:485
+#: ../apps/ll-cli/src/main.cpp:543
 msgid "Usage: ll-cli inspect SUBCOMMAND [OPTIONS]"
 msgstr "用法：ll-cli inspect 子命令 [選項]"
 
-#: ../apps/ll-cli/src/main.cpp:492
+#: ../apps/ll-cli/src/main.cpp:550
 msgid ""
 "Display the data(bundle) directory of the installed(running) application"
 msgstr "顯示已安裝（執行中）應用程式的資料（bundle）目錄"
 
-#: ../apps/ll-cli/src/main.cpp:493
+#: ../apps/ll-cli/src/main.cpp:551
 msgid "Usage: ll-cli inspect dir [OPTIONS] APP"
 msgstr "用法：ll-cli inspect dir [選項] 應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:497
+#: ../apps/ll-cli/src/main.cpp:555
 msgid "Specify the application ID, and it can also be reference"
 msgstr "指定應用程式 ID，也可以是參考資訊（reference）"
 
-#: ../apps/ll-cli/src/main.cpp:503
+#: ../apps/ll-cli/src/main.cpp:561
 msgid "Specify the directory type (layer or bundle),the default is layer"
 msgstr "指定目錄類型（layer 或 bundle），預設為 layer"
 
-#: ../apps/ll-cli/src/main.cpp:510
+#: ../apps/ll-cli/src/main.cpp:568
 msgid ""
 "Specify the module type (binary or develop). Only works when type is layer"
 msgstr "指定模組類型（binary 或 develop）。僅在類型為 layer 時有效"
 
-#: ../apps/ll-cli/src/main.cpp:519
+#: ../apps/ll-cli/src/main.cpp:577
 msgid ""
 "linyaps CLI\n"
 "A CLI program to run application and manage application and runtime\n"
@@ -534,152 +658,194 @@ msgstr ""
 "linyaps 命令列介面\n"
 "一個用來執行應用程式並管理應用程式與執行時環境的命令列工具\n"
 
-#: ../apps/ll-cli/src/main.cpp:527 ../apps/ll-builder/src/main.cpp:449
+#: ../apps/ll-cli/src/main.cpp:585 ../apps/ll-builder/src/main.cpp:478
 msgid "Print this help message and exit"
 msgstr "顯示此說明訊息並離開"
 
-#: ../apps/ll-cli/src/main.cpp:528 ../apps/ll-builder/src/main.cpp:450
+#: ../apps/ll-cli/src/main.cpp:586 ../apps/ll-builder/src/main.cpp:479
 msgid "Expand all help"
 msgstr "展開所有說明"
 
-#: ../apps/ll-cli/src/main.cpp:529
+#: ../apps/ll-cli/src/main.cpp:587
 msgid "Usage: ll-cli [OPTIONS] [SUBCOMMAND]"
 msgstr "用法：ll-cli [選項] [子命令]"
 
-#: ../apps/ll-cli/src/main.cpp:530
+#: ../apps/ll-cli/src/main.cpp:588
 msgid ""
 "If you found any problems during use,\n"
-"You can report bugs to the linyaps team under this project: https://github.com/OpenAtom-Linyaps/linyaps/issues"
+"You can report bugs to the linyaps team under this project: https://"
+"github.com/OpenAtom-Linyaps/linyaps/issues"
 msgstr ""
 "如果您在使用過程中遇到任何問題，\n"
-"可以在此專案下向 linyaps 團隊回報錯誤：https://github.com/OpenAtom-Linyaps/linyaps/issues"
+"可以在此專案下向 linyaps 團隊回報錯誤：https://github.com/OpenAtom-Linyaps/"
+"linyaps/issues"
 
 #. version flag
-#: ../apps/ll-cli/src/main.cpp:537 ../apps/ll-builder/src/main.cpp:474
+#: ../apps/ll-cli/src/main.cpp:595 ../apps/ll-builder/src/main.cpp:504
 msgid "Show version"
 msgstr "顯示版本"
 
-#: ../apps/ll-cli/src/main.cpp:542
+#: ../apps/ll-cli/src/main.cpp:600
 msgid ""
 "Use peer to peer DBus, this is used only in case that DBus daemon is not "
 "available"
 msgstr "使用點對點（P2P）DBus，僅在 DBus 背景程式無法使用時啟用"
 
 #. json flag
-#: ../apps/ll-cli/src/main.cpp:547
+#: ../apps/ll-cli/src/main.cpp:605
 msgid "Use json format to output result"
 msgstr "使用 JSON 格式輸出結果"
 
-#: ../apps/ll-cli/src/main.cpp:554
-msgid "Show debug info (verbose logs)"
-msgstr "顯示除錯資訊（詳細日誌）"
+#: ../apps/ll-cli/src/main.cpp:612
+msgid "Show debug info; repeat to enable backtrace"
+msgstr "顯示除錯資訊；重複輸入可啟用回溯（backtrace）"
 
-#: ../apps/ll-cli/src/main.cpp:557
+#: ../apps/ll-cli/src/main.cpp:615
 msgid "Don't output progress information"
 msgstr "不輸出進度資訊"
 
 #. groups for subcommands
-#: ../apps/ll-cli/src/main.cpp:574
+#: ../apps/ll-cli/src/main.cpp:635
 msgid "Managing installed applications and runtimes"
 msgstr "管理已安裝的應用程式與執行時環境"
 
-#: ../apps/ll-cli/src/main.cpp:575
+#: ../apps/ll-cli/src/main.cpp:636
 msgid "Managing running applications"
 msgstr "管理執行中的應用程式"
 
-#: ../apps/ll-cli/src/main.cpp:576
+#: ../apps/ll-cli/src/main.cpp:637
 msgid "Finding applications and runtimes"
 msgstr "尋找應用程式與執行時環境"
 
-#: ../apps/ll-cli/src/main.cpp:577 ../apps/ll-builder/src/main.cpp:662
+#: ../apps/ll-cli/src/main.cpp:638 ../apps/ll-builder/src/main.cpp:703
 msgid "Managing remote repositories"
 msgstr "管理遠端軟體庫"
 
-#: ../apps/ll-cli/src/main.cpp:607
+#: ../apps/ll-cli/src/main.cpp:669
 msgid "linyaps CLI version "
 msgstr "linyaps 命令列工具版本 "
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:71
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:134
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:314
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:73
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:136
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:316
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:364
 msgid "ID"
 msgstr "ID"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:72
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:135
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:247
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:74
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:137
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:249
 msgid "Name"
 msgstr "名稱"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:73
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:136
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:75
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:138
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:365
 msgid "Version"
 msgstr "版本"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:74
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:137
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:76
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:139
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:366
 msgid "Channel"
 msgstr "渠道"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:75
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:138
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:77
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:140
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:367
 msgid "Module"
 msgstr "模組"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:76
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:140
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:78
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:142
 msgid "Description"
 msgstr "描述"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:107
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:109
 msgid "No packages found in the remote repo."
 msgstr "在遠端軟體庫中找不到任何套件。"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:139
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:141
 msgid "Repo"
 msgstr "軟體庫"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:174
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:176
 msgid "No containers are running."
 msgstr "沒有正在執行的容器。"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:178
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:180
 msgid "App"
 msgstr "應用程式"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:179
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:181
 msgid "ContainerID"
 msgstr "容器 ID"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:180
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:182
 msgid "Pid"
 msgstr "Pid"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:248
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:250
 msgid "Url"
 msgstr "Url"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:249
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:251
 msgid "Alias"
 msgstr "別名"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:250
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:252
 msgid "Priority"
 msgstr "優先級"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:302
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:304
 msgid "No apps available for update."
 msgstr "沒有可更新的應用程式。"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:315
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:317
 msgid "Installed"
 msgstr "已安裝"
 
-#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:316
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:318
 msgid "New"
 msgstr "全新"
 
-#: ../apps/ll-builder/src/main.cpp:447
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:368
+msgid "Exclusive"
+msgstr "獨佔"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:369
+msgid "Shared"
+msgstr "共享"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:370
+msgid "Logical"
+msgstr "邏輯"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:370
+msgid "Actual"
+msgstr "實際"
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:385
+msgid "Calculated logical total size: "
+msgstr "計算出的邏輯總大小："
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:386
+msgid "Exclusive: "
+msgstr "獨佔："
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:386
+msgid "Shared: "
+msgstr "共享："
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:388
+msgid "Calculated actual total size: "
+msgstr "計算出的實際總大小："
+
+#: ../libs/linglong/src/linglong/cli/cli_printer.cpp:389
+msgid "Repository real size: "
+msgstr "軟體庫真實大小："
+
+#: ../apps/ll-builder/src/main.cpp:476
 msgid ""
 "linyaps builder CLI \n"
 "A CLI program to build linyaps application\n"
@@ -687,250 +853,244 @@ msgstr ""
 "linyaps 構建器命令列工具 \n"
 "一個用來構建 linyaps 應用程式的命令列程式\n"
 
-#: ../apps/ll-builder/src/main.cpp:452
+#: ../apps/ll-builder/src/main.cpp:481
 msgid "Usage: ll-builder [OPTIONS] [SUBCOMMAND]"
 msgstr "用法：ll-builder [選項] [子命令]"
 
-#: ../apps/ll-builder/src/main.cpp:454
+#: ../apps/ll-builder/src/main.cpp:483
 msgid ""
 "If you found any problems during use\n"
-"You can report bugs to the linyaps team under this project: https://github.com/OpenAtom-Linyaps/linyaps/issues"
+"You can report bugs to the linyaps team under this project: https://"
+"github.com/OpenAtom-Linyaps/linyaps/issues"
 msgstr ""
 "如果您在使用過程中遇到任何問題\n"
-"可以在此專案下向 linyaps 團隊回報錯誤：https://github.com/OpenAtom-Linyaps/linyaps/issues"
+"可以在此專案下向 linyaps 團隊回報錯誤：https://github.com/OpenAtom-Linyaps/"
+"linyaps/issues"
 
-#: ../apps/ll-builder/src/main.cpp:478
+#: ../apps/ll-builder/src/main.cpp:508
 msgid "Create linyaps build template project"
 msgstr "建立 linyaps 構建範本專案"
 
-#: ../apps/ll-builder/src/main.cpp:479
+#: ../apps/ll-builder/src/main.cpp:509
 msgid "Usage: ll-builder create [OPTIONS] NAME"
 msgstr "用法：ll-builder create [選項] 名稱"
 
-#: ../apps/ll-builder/src/main.cpp:480
+#: ../apps/ll-builder/src/main.cpp:510
 msgid "Project name"
 msgstr "專案名稱"
 
-#: ../apps/ll-builder/src/main.cpp:488
+#: ../apps/ll-builder/src/main.cpp:518
 msgid "Build a linyaps project"
 msgstr "構建 linyaps 專案"
 
-#: ../apps/ll-builder/src/main.cpp:489
+#: ../apps/ll-builder/src/main.cpp:519
 msgid "Usage: ll-builder build [OPTIONS] [COMMAND...]"
 msgstr "用法：ll-builder build [選項] [命令...]"
 
-#: ../apps/ll-builder/src/main.cpp:490 ../apps/ll-builder/src/main.cpp:531
-#: ../apps/ll-builder/src/main.cpp:575 ../apps/ll-builder/src/main.cpp:621
+#: ../apps/ll-builder/src/main.cpp:520 ../apps/ll-builder/src/main.cpp:561
+#: ../apps/ll-builder/src/main.cpp:605 ../apps/ll-builder/src/main.cpp:656
+#: ../apps/ll-builder/src/main.cpp:697
 msgid "File path of the linglong.yaml"
 msgstr "linglong.yaml 的檔案路徑"
 
-#: ../apps/ll-builder/src/main.cpp:496
-msgid ""
-"Enter the container to execute command instead of building applications"
+#: ../apps/ll-builder/src/main.cpp:526
+msgid "Enter the container to execute command instead of building applications"
 msgstr "進入容器以執行命令，而不是構建應用程式"
 
-#: ../apps/ll-builder/src/main.cpp:499
+#: ../apps/ll-builder/src/main.cpp:529
 msgid ""
 "Only use local files. This implies --skip-fetch-source and --skip-pull-"
 "depend will be set"
-msgstr "僅使用本機檔案。這意味著會同時設定 --skip-fetch-source 與 --skip-pull-depend"
+msgstr ""
+"僅使用本機檔案。這意味著會同時設定 --skip-fetch-source 與 --skip-pull-depend"
 
-#: ../apps/ll-builder/src/main.cpp:504
+#: ../apps/ll-builder/src/main.cpp:534
 msgid "Build full develop packages, runtime requires"
 msgstr "構建完整的開發套件，為執行時環境所需"
 
-#: ../apps/ll-builder/src/main.cpp:508
+#: ../apps/ll-builder/src/main.cpp:538
 msgid "Skip fetch sources"
 msgstr "跳過獲取原始碼"
 
-#: ../apps/ll-builder/src/main.cpp:511
+#: ../apps/ll-builder/src/main.cpp:541
 msgid "Skip pull dependency"
 msgstr "跳過拉取相依項目"
 
-#: ../apps/ll-builder/src/main.cpp:514
+#: ../apps/ll-builder/src/main.cpp:544
 msgid "Skip run container"
 msgstr "跳過執行容器"
 
-#: ../apps/ll-builder/src/main.cpp:517
+#: ../apps/ll-builder/src/main.cpp:547
 msgid "Skip commit build output"
 msgstr "跳過提交構建輸出"
 
-#: ../apps/ll-builder/src/main.cpp:520
+#: ../apps/ll-builder/src/main.cpp:550
 msgid "Skip output check"
 msgstr "跳過輸出檢查"
 
-#: ../apps/ll-builder/src/main.cpp:523
+#: ../apps/ll-builder/src/main.cpp:553
 msgid "Skip strip debug symbols"
 msgstr "跳過清除除錯符號（strip）"
 
-#: ../apps/ll-builder/src/main.cpp:526
+#: ../apps/ll-builder/src/main.cpp:556
 msgid "Build in an isolated network environment"
 msgstr "在隔離的網路環境中進行構建"
 
 #. add builder run
-#: ../apps/ll-builder/src/main.cpp:529
+#: ../apps/ll-builder/src/main.cpp:559
 msgid "Run built linyaps app"
 msgstr "執行已構建的 linyaps 應用程式"
 
-#: ../apps/ll-builder/src/main.cpp:530
+#: ../apps/ll-builder/src/main.cpp:560
 msgid "Usage: ll-builder run [OPTIONS] [COMMAND...]"
 msgstr "用法：ll-builder run [選項] [命令...]"
 
-#: ../apps/ll-builder/src/main.cpp:537
+#: ../apps/ll-builder/src/main.cpp:567
 msgid "Run specified module. eg: --modules binary,develop"
 msgstr "執行指定模組。例如：--modules binary,develop"
 
-#: ../apps/ll-builder/src/main.cpp:549
+#: ../apps/ll-builder/src/main.cpp:579
 msgid "Enter the container to execute command instead of running application"
 msgstr "進入容器以執行命令，而不是執行應用程式主體"
 
-#: ../apps/ll-builder/src/main.cpp:552
+#: ../apps/ll-builder/src/main.cpp:582
 msgid "Run in debug mode (enable develop module)"
 msgstr "以除錯模式執行（啟用開發模組）"
 
-#: ../apps/ll-builder/src/main.cpp:556
+#: ../apps/ll-builder/src/main.cpp:586
 msgid "Specify extension(s) used by the app to run"
 msgstr "指定應用程式執行所需的擴充功能"
 
-#: ../apps/ll-builder/src/main.cpp:562
+#: ../apps/ll-builder/src/main.cpp:592
 msgid "List built linyaps app"
 msgstr "列出已構建的 linyaps 應用程式"
 
-#: ../apps/ll-builder/src/main.cpp:563
+#: ../apps/ll-builder/src/main.cpp:593
 msgid "Usage: ll-builder list [OPTIONS]"
 msgstr "用法：ll-builder list [選項]"
 
-#: ../apps/ll-builder/src/main.cpp:564
+#: ../apps/ll-builder/src/main.cpp:594
 msgid "Remove built linyaps app"
 msgstr "移除已構建的 linyaps 應用程式"
 
-#: ../apps/ll-builder/src/main.cpp:565
+#: ../apps/ll-builder/src/main.cpp:595
 msgid "Usage: ll-builder remove [OPTIONS] [APP...]"
 msgstr "用法：ll-builder remove [選項] [應用程式...]"
 
-#: ../apps/ll-builder/src/main.cpp:568
+#: ../apps/ll-builder/src/main.cpp:598
 msgid "Do not clean objects files before remove apps"
 msgstr "移除應用程式前不清除中介目的檔案（object files）"
 
 #. build export
-#: ../apps/ll-builder/src/main.cpp:572
-msgid "Export to linyaps layer or uab"
-msgstr "匯出為 linyaps layer 或 uab 檔案"
+#: ../apps/ll-builder/src/main.cpp:602
+msgid "Export to linyaps layer or UAB"
+msgstr "匯出為 linyaps layer 或 UAB"
 
-#: ../apps/ll-builder/src/main.cpp:573
+#: ../apps/ll-builder/src/main.cpp:603
 msgid "Usage: ll-builder export [OPTIONS]"
 msgstr "用法：ll-builder export [選項]"
 
-#: ../apps/ll-builder/src/main.cpp:585
+#: ../apps/ll-builder/src/main.cpp:615
 msgid "Uab icon (optional)"
 msgstr "Uab 圖示（選填）"
 
-#: ../apps/ll-builder/src/main.cpp:590
+#: ../apps/ll-builder/src/main.cpp:620
 msgid "Export to linyaps layer file (deprecated)"
 msgstr "匯出為 linyaps layer 檔案（已棄用）"
 
-#: ../apps/ll-builder/src/main.cpp:593
+#: ../apps/ll-builder/src/main.cpp:623
+msgid "Export an executable UABX file"
+msgstr "匯出可執行的 UABX 檔案"
+
+#: ../apps/ll-builder/src/main.cpp:627
 msgid "Use custom loader"
 msgstr "使用自訂載入器"
 
-#: ../apps/ll-builder/src/main.cpp:600
+#: ../apps/ll-builder/src/main.cpp:635
 msgid "Don't export the develop module"
 msgstr "不匯出開發（develop）模組"
 
-#: ../apps/ll-builder/src/main.cpp:602
+#: ../apps/ll-builder/src/main.cpp:637
 msgid "Output file"
 msgstr "輸出檔案"
 
-#: ../apps/ll-builder/src/main.cpp:606
+#: ../apps/ll-builder/src/main.cpp:641
 msgid "Reference of the package"
 msgstr "套件的參考資訊（Reference）"
 
-#: ../apps/ll-builder/src/main.cpp:611
+#: ../apps/ll-builder/src/main.cpp:646
 msgid "Modules to export"
 msgstr "要匯出的模組"
 
-#: ../apps/ll-builder/src/main.cpp:619
+#: ../apps/ll-builder/src/main.cpp:654
 msgid "Push linyaps app to remote repo"
 msgstr "將 linyaps 應用程式推送到遠端軟體庫"
 
-#: ../apps/ll-builder/src/main.cpp:620
+#: ../apps/ll-builder/src/main.cpp:655
 msgid "Usage: ll-builder push [OPTIONS]"
 msgstr "用法：ll-builder push [選項]"
 
-#: ../apps/ll-builder/src/main.cpp:624
+#: ../apps/ll-builder/src/main.cpp:659
 msgid "Remote repo url"
 msgstr "遠端軟體庫 URL"
 
-#: ../apps/ll-builder/src/main.cpp:627
+#: ../apps/ll-builder/src/main.cpp:662
 msgid "Remote repo name"
 msgstr "遠端軟體庫名稱"
 
-#: ../apps/ll-builder/src/main.cpp:630
+#: ../apps/ll-builder/src/main.cpp:665
 msgid "Push single module"
 msgstr "推送單一模組"
 
-#: ../apps/ll-builder/src/main.cpp:634
+#: ../apps/ll-builder/src/main.cpp:669
 msgid "Import linyaps layer to build repo"
 msgstr "匯入 linyaps layer 到構建軟體庫"
 
-#: ../apps/ll-builder/src/main.cpp:635
+#: ../apps/ll-builder/src/main.cpp:670
 msgid "Usage: ll-builder import [OPTIONS] LAYER"
 msgstr "用法：ll-builder import [選項] LAYER"
 
-#: ../apps/ll-builder/src/main.cpp:636 ../apps/ll-builder/src/main.cpp:653
+#: ../apps/ll-builder/src/main.cpp:671 ../apps/ll-builder/src/main.cpp:688
 msgid "Layer file path"
 msgstr "Layer 檔案路徑"
 
-#: ../apps/ll-builder/src/main.cpp:643
+#: ../apps/ll-builder/src/main.cpp:678
 msgid "Import linyaps layer dir to build repo"
 msgstr "匯入 linyaps layer 目錄到構建軟體庫"
 
-#: ../apps/ll-builder/src/main.cpp:645
+#: ../apps/ll-builder/src/main.cpp:680
 msgid "Usage: ll-builder import-dir PATH"
 msgstr "用法：ll-builder import-dir 路徑"
 
-#: ../apps/ll-builder/src/main.cpp:646
+#: ../apps/ll-builder/src/main.cpp:681
 msgid "Layer dir path"
 msgstr "Layer 目錄路徑"
 
 #. add build extract
-#: ../apps/ll-builder/src/main.cpp:651
+#: ../apps/ll-builder/src/main.cpp:686
 msgid "Extract linyaps layer to dir"
 msgstr "解壓縮 linyaps layer 到目錄"
 
-#: ../apps/ll-builder/src/main.cpp:652
+#: ../apps/ll-builder/src/main.cpp:687
 msgid "Usage: ll-builder extract [OPTIONS] LAYER DIR"
 msgstr "用法：ll-builder extract [選項] LAYER 目錄"
 
-#: ../apps/ll-builder/src/main.cpp:656
+#: ../apps/ll-builder/src/main.cpp:691
 msgid "Destination directory"
 msgstr "目標目錄"
 
-#: ../apps/ll-builder/src/main.cpp:669
+#. add builder clean
+#: ../apps/ll-builder/src/main.cpp:695
+msgid "Clean build artifacts"
+msgstr "清除構建產物"
+
+#: ../apps/ll-builder/src/main.cpp:696
+msgid "Usage: ll-builder clean"
+msgstr "用法：ll-builder clean"
+
+#: ../apps/ll-builder/src/main.cpp:710
 msgid "linyaps build tool version "
 msgstr "linyaps 構建工具版本 "
-
-#: ../apps/ll-dialog/src/permissionDialog.cpp:34
-msgid "Whether to allow %1 to access %2?"
-msgstr "是否允許 %1 存取 %2？"
-
-#. button
-#: ../apps/ll-dialog/src/permissionDialog.cpp:43
-msgid "Allow"
-msgstr "允許"
-
-#: ../apps/ll-dialog/src/permissionDialog.cpp:48
-#, c-format
-msgid "Deny (%1s)"
-msgstr "拒絕 (%1秒)"
-
-#: ../apps/ll-dialog/src/cache_dialog.cpp:53
-msgid "Linglong Package Manager"
-msgstr "玲瓏套件管理器"
-
-#: ../apps/ll-dialog/src/cache_dialog.cpp:54
-msgid "is starting"
-msgstr "正在啟動"
 
 #. Define command line options
 #: ../apps/ll-driver-detect/src/main.cpp:104
@@ -951,7 +1111,8 @@ msgstr "有可用的顯示卡驅動程式"
 
 #: ../apps/ll-driver-detect/src/main.cpp:217
 msgid ""
-"Graphics driver package is available that can improve performance for some Linyaps applications.\n"
+"Graphics driver package is available that can improve performance for some "
+"Linyaps applications.\n"
 "Would you like to install it?"
 msgstr ""
 "有可用的顯示卡驅動程式套件，可提升部分 Linyaps 應用程式的效能。\n"
@@ -1006,7 +1167,7 @@ msgstr "軟體庫的 URL"
 #: ../libs/linglong/src/linglong/common/cli/repo.cpp:93
 #: ../libs/linglong/src/linglong/common/cli/repo.cpp:103
 #: ../libs/linglong/src/linglong/common/cli/repo.cpp:113
-#: ../libs/linglong/src/linglong/common/cli/repo.cpp:120
+#: ../libs/linglong/src/linglong/common/cli/repo.cpp:126
 msgid "Alias of the repo name"
 msgstr "軟體庫名稱的別名"
 
@@ -1042,6 +1203,10 @@ msgstr "軟體庫的優先級"
 msgid "Enable mirror for the repo"
 msgstr "啟用該軟體庫的鏡像（Mirror）"
 
-#: ../libs/linglong/src/linglong/common/cli/repo.cpp:118
+#: ../libs/linglong/src/linglong/common/cli/repo.cpp:119
+msgid "Region code for mirror selection, e.g. CN, US"
+msgstr "鏡像選擇的地區代碼，例如：CN, US"
+
+#: ../libs/linglong/src/linglong/common/cli/repo.cpp:124
 msgid "Disable mirror for the repo"
 msgstr "停用該軟體庫的鏡像（Mirror）"


### PR DESCRIPTION
1. Sync Simplified Chinese (zh_CN), Traditional Chinese (zh_HK) and Traditional Chinese (zh_TW) PO files with the latest source strings
2. Add translations for newly introduced CLI features: debug mode/ gdbserver, PipeWire and AT SPI socket mount options, `analyze size` and `analyze depends` subcommands, UABX export, `ll-builder clean`, and repo region code for mirror selection
3. Reword existing usage examples and error messages for consistency, including adding `./` prefix to layer/uab install examples
4. Clean up obsolete strings from ll-dialog and realign header metadata such as Language field placement

Influence:
1. Run `ll-cli` and `ll-builder` with `LANG=zh_CN.UTF-8`, `zh_HK`, and `zh_TW` to verify translated output displays correctly without garbled characters
2. Test newly added translations by executing `ll-cli analyze size`, `ll-cli analyze depends`, `ll-cli run --gdbserver`, `ll-builder export --uabx`, and `ll-builder clean` in Chinese locales
3. Check help texts and usage examples for install/list/search commands to ensure proper formatting and correct display of `./demo_*.layer` and `./demo_*.uab`
4. Verify no missing translations or formatting errors by compiling the MO files and running the tools under the three Chinese locales