### PR TITLE
fix: reject package info without architecture array

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -655,6 +655,11 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
 
     const auto &packageInfo = *packageInfoRet;
 
+    if (packageInfo.arch.empty()) {
+        return toDBusReply(utils::error::ErrorCode::Failed,
+                           "no architecture in layer package info");
+    }
+
     auto architectureRet = package::Architecture::parse(packageInfo.arch[0]);
     if (!architectureRet) {
         return toDBusReply(architectureRet);

--- a/libs/linglong/src/linglong/package_manager/uab_installation.cpp
+++ b/libs/linglong/src/linglong/package_manager/uab_installation.cpp
@@ -71,6 +71,10 @@ utils::error::Result<void> UabInstallationAction::checkUABLayersConstrain(
 
     const auto &front = layers.front().info;
     for (const auto &layer : layers) {
+        if (layer.info.arch.empty()) {
+            return LINGLONG_ERR("no architecture in uab layer info");
+        }
+
         auto arch = package::Architecture::parse(layer.info.arch[0]);
         if (!arch) {
             return LINGLONG_ERR(arch);

--- a/libs/linglong/src/linglong/repo/ostree_repo.cpp
+++ b/libs/linglong/src/linglong/repo/ostree_repo.cpp
@@ -130,8 +130,9 @@ void progress_changed(OstreeAsyncProgress *progress, gpointer user_data)
 
 std::string ostreeRefFromLayerItem(const api::types::v1::RepositoryCacheLayersItem &layer)
 {
+    const auto arch = layer.info.arch.empty() ? std::string{} : layer.info.arch.front();
     std::string refspec = layer.info.channel + "/" + layer.info.id + "/" + layer.info.version + "/"
-      + layer.info.arch.front() + "/" + layer.info.packageInfoV2Module;
+      + arch + "/" + layer.info.packageInfoV2Module;
 
     return refspec;
 }
@@ -365,6 +366,10 @@ utils::error::Result<bool> semanticMatch(const package::FuzzyReference &fuzzy,
     auto version = package::Version::parse(record.version);
     if (!version) {
         return LINGLONG_ERR(version);
+    }
+
+    if (record.arch.empty()) {
+        return LINGLONG_ERR("no architecture in package info");
     }
 
     auto arch = package::Architecture::parse(record.arch[0]);

--- a/libs/linglong/src/linglong/repo/remote_packages.cpp
+++ b/libs/linglong/src/linglong/repo/remote_packages.cpp
@@ -52,7 +52,7 @@ std::vector<std::string> RemotePackages::getReferenceModules(const package::Refe
     for (const auto &packages : repoPackages) {
         for (const auto &package : packages.second) {
             if (package.id == ref.id && package.channel == ref.channel
-                && package.version == ref.version.toString()
+                && package.version == ref.version.toString() && !package.arch.empty()
                 && package.arch[0] == ref.arch.toString()) {
                 modules.emplace_back(package.packageInfoV2Module);
             }

--- a/libs/linglong/src/linglong/repo/repo_cache.cpp
+++ b/libs/linglong/src/linglong/repo/repo_cache.cpp
@@ -153,10 +153,11 @@ RepoCache::findMatchingItem(const api::types::v1::RepositoryCacheLayersItem &ite
       cache.layers.begin(),
       cache.layers.end(),
       [&item](const api::types::v1::RepositoryCacheLayersItem &val) {
+          const auto itemArch = item.info.arch.empty() ? std::string{} : item.info.arch.front();
+          const auto valArch = val.info.arch.empty() ? std::string{} : val.info.arch.front();
           return !(item.commit != val.commit || item.repo != val.repo
                    || item.info.channel != val.info.channel || item.info.id != val.info.id
-                   || item.info.version != val.info.version
-                   || item.info.arch.front() != val.info.arch.front()
+                   || item.info.version != val.info.version || itemArch != valArch
                    || item.info.packageInfoV2Module != val.info.packageInfoV2Module);
       });
 
@@ -226,7 +227,8 @@ RepoCache::queryLayerItem(const repoCacheQuery &query) const noexcept
             continue;
         }
 
-        if (query.architecture && query.architecture.value() != layer.info.arch.front()) {
+        if (query.architecture
+            && (layer.info.arch.empty() || query.architecture.value() != layer.info.arch.front())) {
             continue;
         }
 

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/repo_cache_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/repo_cache_test.cpp
@@ -280,6 +280,42 @@ TEST_F(RepoCacheTest, QueryUsesRemainingFilters)
     ASSERT_EQ(byId.size(), 1);
 }
 
+TEST_F(RepoCacheTest, queryLayerItemSkipsItemsWithoutArchitectureWhenFiltering)
+{
+    auto cacheFile = tempDir.path() / "states.json";
+    RepoCache cache(cacheFile);
+
+    auto noArch = createLayerItem("c-noarch", "app.noarch", "1.0.0");
+    noArch.info.arch.clear();
+    ASSERT_TRUE(cache.addLayerItem(noArch).has_value());
+    ASSERT_TRUE(cache.addLayerItem(createLayerItem("c-arch", "app.noarch", "2.0.0")).has_value());
+
+    // filtering by architecture must skip entries without architecture instead of
+    // reading past the end of the empty arch vector
+    auto byArch = cache.queryLayerItem(repoCacheQuery{ .architecture = "x86_64" });
+    ASSERT_EQ(byArch.size(), 1);
+    EXPECT_EQ(byArch.front().commit, "c-arch");
+
+    // without the filter, the entry without architecture is still returned
+    auto all = cache.queryLayerItem(repoCacheQuery{ .id = "app.noarch" });
+    ASSERT_EQ(all.size(), 2);
+}
+
+TEST_F(RepoCacheTest, deleteLayerItemMatchesItemsWithoutArchitecture)
+{
+    auto cacheFile = tempDir.path() / "states.json";
+    RepoCache cache(cacheFile);
+
+    auto item = createLayerItem("c-del", "app.del", "1.0.0");
+    item.info.arch.clear();
+    ASSERT_TRUE(cache.addLayerItem(item).has_value());
+
+    // findMatchingItem must compare entries without architecture without
+    // dereferencing the empty arch vector
+    EXPECT_TRUE(cache.deleteLayerItem(item).has_value());
+    EXPECT_TRUE(cache.queryLayerItem(repoCacheQuery{ .id = "app.del" }).empty());
+}
+
 } // namespace
 
 } // namespace linglong::repo::test


### PR DESCRIPTION
## Summary

Return a validation error or skip consistently when package metadata has an empty architecture array instead of indexing past the end.

## Root cause

The JSON schema does not set `minItems` for `arch`, so an empty array passes deserialization. Several call sites still access `arch[0]` / `arch.front()` unguarded, which is undefined behavior for malformed layer, uab or remote repository data:

- `OSTreeRepo::semanticMatch` and `ostreeRefFromLayerItem`
- `RemotePackages::getReferenceModules`
- `RepoCache::findMatchingItem` and `queryLayerItem`
- `UabInstallationAction::checkUABLayersConstrain`
- `PackageManager::installFromLayer`

The merged-items grouping code already handles empty arrays, so the remaining sites look like oversights. Follow-up to #1794.

## Changes

- Guard each call site: return a clear error where a `Result` is available, otherwise skip like the existing grouping code.
- Add regression tests to `RepoCacheTest`.

## Test plan

- [x] `ctest -R RepoCache`
- [x] Full `ctest` run
- [x] `clang-format --dry-run --Werror`