### PR TITLE
fix(repo): make layer cache query sort well-defined for unparsable versions

### DIFF
--- a/libs/linglong/src/linglong/repo/repo_cache.cpp
+++ b/libs/linglong/src/linglong/repo/repo_cache.cpp
@@ -242,14 +242,16 @@ RepoCache::queryLayerItem(const repoCacheQuery &query) const noexcept
 
     std::sort(layers_view.begin(), layers_view.end(), [](itemRef lhs, itemRef rhs) {
         auto lhsVersion = linglong::package::Version::parse(lhs.get().info.version.c_str());
+        auto rhsVersion = linglong::package::Version::parse(rhs.get().info.version.c_str());
         if (!lhsVersion) {
-            LogE("Failed to parse lhs version: {}", lhs.get().info.version);
+            // the list is sorted in descending version order, so treat an
+            // unparsable version as the smallest value: it never comes before a
+            // valid version and is equivalent to other unparsable versions,
+            // keeping the sort well-defined
             return false;
         }
-        auto rhsVersion = linglong::package::Version::parse(rhs.get().info.version.c_str());
         if (!rhsVersion) {
-            LogE("Failed to parse rhs version: {}", rhs.get().info.version);
-            return false;
+            return true;
         }
         return *lhsVersion > *rhsVersion;
     });

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/repo_cache_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/repo_cache_test.cpp
@@ -280,6 +280,35 @@ TEST_F(RepoCacheTest, QueryUsesRemainingFilters)
     ASSERT_EQ(byId.size(), 1);
 }
 
+TEST_F(RepoCacheTest, queryLayerItemSortsUnparsableVersionsLast)
+{
+    auto cacheFile = tempDir.path() / "states.json";
+    RepoCache cache(cacheFile);
+
+    ASSERT_TRUE(cache.addLayerItem(createLayerItem("c-low", "app.sort", "1.0.0")).has_value());
+    ASSERT_TRUE(cache.addLayerItem(createLayerItem("c-high", "app.sort", "2.0.0")).has_value());
+
+    // entries whose version cannot be parsed must not introduce a comparator
+    // that violates strict weak ordering while std::sort runs
+    for (int i = 0; i < 20; ++i) {
+        auto invalid = createLayerItem("c-invalid-" + std::to_string(i), "app.bad", ".");
+        ASSERT_TRUE(cache.addLayerItem(invalid).has_value());
+    }
+
+    ASSERT_TRUE(cache.addLayerItem(createLayerItem("c-mid", "app.sort", "1.5.0")).has_value());
+
+    auto items = cache.queryLayerItem(repoCacheQuery{});
+    ASSERT_EQ(items.size(), 23);
+
+    // valid entries keep descending version order, unparsable ones sort last
+    EXPECT_EQ(items.front().commit, "c-high");
+    EXPECT_EQ(items[1].commit, "c-mid");
+    EXPECT_EQ(items[2].commit, "c-low");
+    for (std::size_t i = 3; i < items.size(); ++i) {
+        EXPECT_EQ(items[i].commit.rfind("c-invalid-", 0), 0) << "commit: " << items[i].commit;
+    }
+}
+
 } // namespace
 
 } // namespace linglong::repo::test


### PR DESCRIPTION
## Summary

Make `RepoCache::queryLayerItem` sorting well-defined when a cache entry has an unparsable version.

## Root cause

The sort comparator returned `false` whenever either version failed to parse, so an unparsable entry compared equivalent to every entry while valid entries still strictly ordered among themselves. That intransitive equivalence violates the strict weak ordering required by `std::sort` and is undefined behavior (libstdc++ introsort runs out of bounds once enough elements are mixed).

## Changes

- Treat an unparsable version as the smallest value in the descending order, so unparsable entries only compare equivalent to each other and always sort last.
- Add `RepoCacheTest.queryLayerItemSortsUnparsableVersionsLast` with 20 unparsable entries mixed into valid ones.

## Test plan

- [x] `ctest -R RepoCache`
- [x] Full `ctest` run
- [x] `clang-format --dry-run --Werror`