### PR TITLE
fix(oci-cfg-generators): guard absent mount options in mountpoint fixer

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/oci-cfg-generators/container_cfg_builder_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/oci-cfg-generators/container_cfg_builder_test.cpp
@@ -1194,4 +1194,32 @@ TEST_F(ContainerCfgBuilderTest, EnableIPCMountNoValidSocket)
     }
 }
 
+TEST_F(ContainerCfgBuilderTest, SelfAdjustingMountWithoutMountOptions)
+{
+    // a bind mount whose source exists as a regular file under the base layer and
+    // whose "options" is absent must not dereference the missing options vector
+    auto hostFile = baseDir.path() / "opt" / "apps" / "org.deepin.demo" / "files" / "datafile";
+    ASSERT_TRUE(std::filesystem::create_directories(hostFile.parent_path()));
+    {
+        std::ofstream out{ hostFile };
+        out << "data";
+    }
+
+    Mount mount;
+    mount.destination = "/opt/apps/org.deepin.demo/files/datafile";
+    mount.source = hostFile;
+    mount.type = "bind";
+    // mount.options deliberately left unset
+
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .addExtraMount(mount)
+      .enableSelfAdjustingMount();
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+}
+
 } // namespace

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -2066,6 +2066,9 @@ bool ContainerCfgBuilder::shouldFix(int node, std::filesystem::path &fixPath) no
 
     auto isCopySymlink = [this](int node) {
         const auto &mount = mounts[mountpoints[node].mount_idx];
+        if (!mount.options) {
+            return false;
+        }
         auto find = std::find_if(mount.options->begin(), mount.options->end(), [](const auto &opt) {
             return opt == "copy-symlink";
         });


### PR DESCRIPTION
## Summary

Treat an absent `Mount::options` as empty in the mountpoint fixer instead of dereferencing the optional.

## Root cause

`ContainerCfgBuilder::shouldFix` dereferences `mount.options->begin()` while checking the copy-symlink flag. `Mount::options` is `std::optional` and a mount without an `options` array in JSON yields `nullopt`, so the dereference is undefined behavior. `constructMountpointsTree` already checks `mount.options` before use.

## Changes

- Return `false` from `isCopySymlink` when options are absent.
- Add `ContainerCfgBuilderTest.SelfAdjustingMountWithoutMountOptions` with an options-less bind mount in a self-adjusting build.

## Test plan

- [x] `ctest -R ContainerCfgBuilder`
- [x] Full `ctest` run
- [x] `clang-format --dry-run --Werror`