### PR TITLE
fix(oci-cfg-generators): treat invalid XDG overrides as unset in home mounts

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/oci-cfg-generators/container_cfg_builder_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/oci-cfg-generators/container_cfg_builder_test.cpp
@@ -44,6 +44,39 @@ protected:
     TempDir runtimeDir{ "ll-cfg-runtime-" };
 };
 
+// set an environment variable for the duration of the test and restore it afterwards
+class ScopedEnvVar
+{
+public:
+    ScopedEnvVar(std::string name, const char *value)
+        : name(std::move(name))
+    {
+        const char *previous = ::getenv(this->name.c_str());
+        existed = previous != nullptr;
+        if (existed) {
+            oldValue = previous;
+        }
+        ::setenv(this->name.c_str(), value, 1);
+    }
+
+    ~ScopedEnvVar()
+    {
+        if (existed) {
+            ::setenv(this->name.c_str(), oldValue.c_str(), 1);
+        } else {
+            ::unsetenv(this->name.c_str());
+        }
+    }
+
+    ScopedEnvVar(const ScopedEnvVar &) = delete;
+    ScopedEnvVar &operator=(const ScopedEnvVar &) = delete;
+
+private:
+    std::string name;
+    bool existed{ false };
+    std::string oldValue;
+};
+
 TEST_F(ContainerCfgBuilderTest, BuildWithRequiredFields)
 {
     ContainerCfgBuilder builder;
@@ -1191,6 +1224,52 @@ TEST_F(ContainerCfgBuilderTest, EnableIPCMountNoValidSocket)
     ASSERT_TRUE(builder.getConfig().mounts.has_value());
     for (const auto &m : *builder.getConfig().mounts) {
         EXPECT_NE(m.destination, (runtime / "bus").string());
+    }
+}
+
+TEST_F(ContainerCfgBuilderTest, BindHomeTreatsEmptyXDGOverridesAsUnset)
+{
+    auto home = baseDir.path() / "home";
+    ASSERT_TRUE(std::filesystem::create_directories(home));
+
+    // XDG base directory spec: empty overrides are invalid and must fall back to
+    // the defaults instead of producing a mount that cannot be created
+    ScopedEnvVar dataGuard{ "XDG_DATA_HOME", "" };
+    ScopedEnvVar configGuard{ "XDG_CONFIG_HOME", "" };
+    ScopedEnvVar cacheGuard{ "XDG_CACHE_HOME", "" };
+    ScopedEnvVar stateGuard{ "XDG_STATE_HOME", "" };
+
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindHome(home);
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+}
+
+TEST_F(ContainerCfgBuilderTest, BindHomeIgnoresRelativeXDGConfigOverride)
+{
+    auto home = baseDir.path() / "home";
+    ASSERT_TRUE(std::filesystem::create_directories(home));
+
+    ScopedEnvVar configGuard{ "XDG_CONFIG_HOME", "relative-config" };
+
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .bindHome(home);
+
+    auto result = builder.build();
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    // a relative XDG override must never become a mount source
+    ASSERT_TRUE(builder.getConfig().mounts.has_value());
+    for (const auto &m : *builder.getConfig().mounts) {
+        EXPECT_FALSE(m.source.has_value() && *m.source == "relative-config")
+          << "relative XDG_CONFIG_HOME leaked into a mount source";
     }
 }
 

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -992,9 +992,23 @@ utils::error::Result<void> ContainerCfgBuilder::buildMountHome() noexcept
         return true;
     };
 
-    auto *value = getenv("XDG_DATA_HOME");
-    std::filesystem::path XDG_DATA_HOME =
-      value ? std::filesystem::path{ value } : *homePath / ".local" / "share";
+    // XDG base directory spec: empty or relative overrides are invalid, fall back
+    // to the default location instead of mounting a broken host path
+    auto xdgHomeDir = [](const char *name,
+                         const std::filesystem::path &fallback) -> std::filesystem::path {
+        const auto *value = getenv(name);
+        if (value == nullptr || *value == '\0') {
+            return fallback;
+        }
+        std::filesystem::path dir{ value };
+        if (!dir.is_absolute()) {
+            LogW("ignoring non-absolute {} value: {}", name, value);
+            return fallback;
+        }
+        return dir;
+    };
+
+    auto XDG_DATA_HOME = xdgHomeDir("XDG_DATA_HOME", *homePath / ".local" / "share");
     std::string containerDataHome = containerHome + "/.local/share";
     if (XDG_DATA_HOME != containerDataHome) {
         if (!mountDir(XDG_DATA_HOME, containerDataHome)) {
@@ -1016,9 +1030,7 @@ utils::error::Result<void> ContainerCfgBuilder::buildMountHome() noexcept
         return std::filesystem::path{};
     };
 
-    value = getenv("XDG_CONFIG_HOME");
-    std::filesystem::path XDG_CONFIG_HOME =
-      value ? std::filesystem::path{ value } : *homePath / ".config";
+    auto XDG_CONFIG_HOME = xdgHomeDir("XDG_CONFIG_HOME", *homePath / ".config");
     std::filesystem::path XDGConfigHome = XDG_CONFIG_HOME;
     auto privateConfigPath = checkPrivatePath("config");
     if (!privateConfigPath.empty()) {
@@ -1032,9 +1044,7 @@ utils::error::Result<void> ContainerCfgBuilder::buildMountHome() noexcept
     }
     environment["XDG_CONFIG_HOME"] = containerConfigHome;
 
-    value = getenv("XDG_CACHE_HOME");
-    std::filesystem::path XDG_CACHE_HOME =
-      value ? std::filesystem::path{ value } : *homePath / ".cache";
+    auto XDG_CACHE_HOME = xdgHomeDir("XDG_CACHE_HOME", *homePath / ".cache");
     std::filesystem::path XDGCacheHome = XDG_CACHE_HOME;
     auto privateCachePath = checkPrivatePath("cache");
     if (!privateCachePath.empty()) {
@@ -1048,9 +1058,7 @@ utils::error::Result<void> ContainerCfgBuilder::buildMountHome() noexcept
     }
     environment["XDG_CACHE_HOME"] = containerCacheHome;
 
-    value = getenv("XDG_STATE_HOME");
-    std::filesystem::path XDG_STATE_HOME =
-      value ? std::filesystem::path{ value } : *homePath / ".local" / "state";
+    auto XDG_STATE_HOME = xdgHomeDir("XDG_STATE_HOME", *homePath / ".local" / "state");
     auto privateStatePath = checkPrivatePath("state");
     if (!privateStatePath.empty()) {
         XDG_STATE_HOME = privateStatePath;


### PR DESCRIPTION
## Summary

Fall back to the default location when an XDG override is empty or relative, as required by the XDG base directory specification.

## Root cause

`buildMountHome` only checked the `getenv` pointer, so an exported-but-empty variable (`export XDG_DATA_HOME=`) passed the check and failed `mountDir("")`, aborting the container build with "can't be mount". A relative value was created relative to the daemon working directory.

## Changes

- Resolve the four variables (`XDG_DATA_HOME`, `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, `XDG_STATE_HOME`) through one helper that treats unset, empty and relative values as unset.
- Add a `ScopedEnvVar` test helper and two regression tests.

## Test plan

- [x] `ctest -R ContainerCfgBuilder`
- [x] Full `ctest` run
- [x] `clang-format --dry-run --Werror`