### PR TITLE
fix(oci-cfg-generators): reject environment variable names that break 00env.sh

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/oci-cfg-generators/container_cfg_builder_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/oci-cfg-generators/container_cfg_builder_test.cpp
@@ -1194,4 +1194,20 @@ TEST_F(ContainerCfgBuilderTest, EnableIPCMountNoValidSocket)
     }
 }
 
+TEST_F(ContainerCfgBuilderTest, AppendEnvRejectsInvalidVariableNames)
+{
+    ContainerCfgBuilder builder;
+    builder.setAppId("org.deepin.demo")
+      .setBasePath(baseDir.path())
+      .setBundlePath(bundleDir.path())
+      .appendEnv("BAD;KEY", "value");
+
+    // 00env.sh exports entries unquoted, so a key that is not a plain POSIX
+    // identifier would corrupt or inject into the generated profile script
+    auto result = builder.build();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error().message(),
+                ::testing::HasSubstr("invalid environment variable name"));
+}
+
 } // namespace

--- a/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
+++ b/libs/oci-cfg-generators/src/linglong/oci-cfg-generators/container_cfg_builder.cpp
@@ -25,6 +25,7 @@
 #include <sys/mount.h>
 
 #include <algorithm>
+#include <cctype>
 #include <climits>
 #include <fstream>
 #include <iomanip>
@@ -1545,6 +1546,17 @@ utils::error::Result<void> ContainerCfgBuilder::buildEnv() noexcept
 
     auto env = std::vector<std::string>{};
     for (const auto &[key, value] : environment) {
+        // the profile script exports entries unquoted, so only plain POSIX
+        // identifiers are safe; anything else would corrupt or inject into 00env.sh
+        auto validKey = !key.empty()
+          && (std::isalpha(static_cast<unsigned char>(key[0])) != 0 || key[0] == '_')
+          && std::all_of(key.begin() + 1, key.end(), [](char ch) {
+                 return std::isalnum(static_cast<unsigned char>(ch)) != 0 || ch == '_';
+             });
+        if (!validKey) {
+            return LINGLONG_ERR(fmt::format("invalid environment variable name: {}", key));
+        }
+
         env.emplace_back(key + "=" + value);
 
         // here we process environment variables with single quotes.


### PR DESCRIPTION
## Summary

Reject environment variable names that are not POSIX identifiers before writing the generated profile script.

## Root cause

`buildEnv` escapes the *value* but writes the *key* raw into `export KEY='value'` in `/etc/profile.d/00env.sh`, and keys come from user-supplied JSON (`RuntimeConfigure.env`, config.d, `--env`). A key such as `A;id` produces `export A;id='v'`, which executes `id` every time a shell inside the container sources the script.

## Changes

- Validate keys in `buildEnv` and return an error naming the offending key.
- Add `ContainerCfgBuilderTest.AppendEnvRejectsInvalidVariableNames`.

## Test plan

- [x] `ctest -R ContainerCfgBuilder`
- [x] Full `ctest` run
- [x] `clang-format --dry-run --Werror`