### PR TITLE
fix(builder): reject push/export-layer commands without a project file

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -887,6 +887,10 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     }
 
     if (buildPush->parsed()) {
+        if (!project) {
+            LogE("the project file is not found");
+            return -1;
+        }
         if (!pushModule.empty()) {
             pushOpts.pushModules = { pushModule };
         } else {

--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -1673,6 +1673,9 @@ utils::error::Result<void> Builder::exportLayer(const ExportOption &option)
 {
     LINGLONG_TRACE("export layer file");
 
+    if (!this->project) {
+        return LINGLONG_ERR("not under project");
+    }
     auto &project = *this->project;
     auto ref = currentReference(project);
     if (!ref) {


### PR DESCRIPTION
## Summary

Report a clean error for `ll-builder push` and `ll-builder export --layer` when no project file exists instead of dereferencing an empty optional.

## Root cause

The push branch dereferences `*project` via `getProjectModule(*project)` before the missing-project guard runs, and `Builder::exportLayer` dereferences `*this->project` without any guard. In a directory without a project file both are undefined behavior and typically crash.

## Changes

- Check `project` in the push branch before `getProjectModule`.
- Add the same "not under project" guard used by `Builder::push` to `exportLayer`.
- `exportUAB` keeps working without a project file via `--ref`, so the guards are local to the two unchecked call sites.

## Reproduction

```
cd $(mktemp -d)
ll-builder push          # segfault before, "the project file is not found" after
ll-builder export --layer # segfault before, "not under project" after
```

## Test plan

- [x] Verified with the real CLI (both commands and `export --ref`)
- [x] Full `ctest` run
- [x] `clang-format --dry-run --Werror`