### PR TITLE
fix: reject package ids that are not usable as path components

### DIFF
--- a/libs/linglong/src/linglong/package_manager/uab_installation.cpp
+++ b/libs/linglong/src/linglong/package_manager/uab_installation.cpp
@@ -6,6 +6,7 @@
 
 #include "linglong/utils/finally/finally.h"
 #include "linglong/utils/log/log.h"
+#include "linglong/utils/serialize/packageinfo_handler.h"
 
 #include <unistd.h>
 
@@ -71,6 +72,10 @@ utils::error::Result<void> UabInstallationAction::checkUABLayersConstrain(
 
     const auto &front = layers.front().info;
     for (const auto &layer : layers) {
+        if (auto idValid = utils::serialize::validatePackageId(layer.info.id); !idValid) {
+            return LINGLONG_ERR(idValid);
+        }
+
         auto arch = package::Architecture::parse(layer.info.arch[0]);
         if (!arch) {
             return LINGLONG_ERR(arch);

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/packageinfo_handler_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/packageinfo_handler_test.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "common/tempdir.h"
@@ -294,4 +295,86 @@ TEST_F(PackageInfoHandlerTest, parsePackageInfo_FromJSONInvalid)
 
     // 验证解析失败
     EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(PackageInfoHandlerTest, parsePackageInfo_RejectsPathLikeIds)
+{
+    // the id becomes a host path component (app runtime dir, private dir), so a
+    // malformed id from a layer or uab must not escape its intended directory
+    for (const auto *id : { "../evil", "a/b", ".", "..", "com.example.App\\id" }) {
+        nlohmann::json jsonData = { { "arch", { "x86_64" } },
+                                    { "base", "org.deepin.base" },
+                                    { "channel", "main" },
+                                    { "description", "Test application" },
+                                    { "id", id },
+                                    { "kind", "app" },
+                                    { "module", "runtime" },
+                                    { "name", "TestApp" },
+                                    { "schema_version", "1.0" },
+                                    { "size", 1024 },
+                                    { "version", "1.0.0" } };
+
+        auto result = linglong::utils::serialize::parsePackageInfo(jsonData);
+        EXPECT_FALSE(result.has_value()) << "id was accepted: " << id;
+        if (!result.has_value()) {
+            EXPECT_THAT(result.error().message(), ::testing::HasSubstr("package id"))
+              << "id: " << id;
+        }
+    }
+}
+
+TEST_F(PackageInfoHandlerTest, parsePackageInfoFile_RejectsPathLikeIds)
+{
+    for (const auto *id : { "../evil", "a/b" }) {
+        nlohmann::json jsonData = { { "arch", { "x86_64" } },
+                                    { "base", "org.deepin.base" },
+                                    { "channel", "main" },
+                                    { "description", "Test application" },
+                                    { "id", id },
+                                    { "kind", "app" },
+                                    { "module", "runtime" },
+                                    { "name", "TestApp" },
+                                    { "schema_version", "1.0" },
+                                    { "size", 1024 },
+                                    { "version", "1.0.0" } };
+
+        auto filePath = tempDir->path() / "info.json";
+        std::ofstream file{ filePath };
+        file << jsonData.dump();
+        file.close();
+
+        auto result = linglong::utils::serialize::parsePackageInfoFile(filePath);
+        EXPECT_FALSE(result.has_value()) << "id was accepted: " << id;
+    }
+}
+
+TEST_F(PackageInfoHandlerTest, parsePackageInfo_RejectsPathLikeLegacyIds)
+{
+    // the legacy PackageInfo conversion goes through the same validation
+    nlohmann::json jsonData = { { "arch", { "x86_64" } },
+                                { "appid", "../evil" },
+                                { "base", "org.deepin.base" },
+                                { "description", "Test application" },
+                                { "kind", "app" },
+                                { "module", "runtime" },
+                                { "name", "TestApp" },
+                                { "size", 1024 },
+                                { "version", "1.0.0" } };
+
+    auto result = linglong::utils::serialize::parsePackageInfo(jsonData);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(PackageInfoHandlerTest, validatePackageId_AcceptsRegularIds)
+{
+    for (const auto *id : { "com.example.testapp", "org.deepin.something", "a", "a1" }) {
+        auto result = linglong::utils::serialize::validatePackageId(id);
+        ASSERT_TRUE(result.has_value())
+          << "id was rejected: " << id << " " << result.error().message();
+    }
+}
+
+TEST_F(PackageInfoHandlerTest, validatePackageId_RejectsEmptyId)
+{
+    EXPECT_FALSE(linglong::utils::serialize::validatePackageId("").has_value());
 }

--- a/libs/utils/src/linglong/utils/serialize/packageinfo_handler.cpp
+++ b/libs/utils/src/linglong/utils/serialize/packageinfo_handler.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 

--- a/libs/utils/src/linglong/utils/serialize/packageinfo_handler.cpp
+++ b/libs/utils/src/linglong/utils/serialize/packageinfo_handler.cpp
@@ -4,6 +4,8 @@
 
 #include "packageinfo_handler.h"
 
+#include <fmt/format.h>
+
 namespace linglong::utils::serialize {
 
 api::types::v1::PackageInfoV2 toPackageInfoV2(const api::types::v1::PackageInfo &oldInfo)
@@ -28,12 +30,40 @@ api::types::v1::PackageInfoV2 toPackageInfoV2(const api::types::v1::PackageInfo 
     };
 }
 
+error::Result<void> validatePackageId(const std::string &id)
+{
+    LINGLONG_TRACE("validate package id");
+
+    if (id.empty()) {
+        return LINGLONG_ERR("package id is empty");
+    }
+
+    // the id is used as a single path component when building host directories
+    // such as the app runtime dir and the private dir, so a malformed id from a
+    // layer or uab must not be able to escape its intended directory
+    if (id.find('/') != std::string::npos || id.find('\\') != std::string::npos) {
+        return LINGLONG_ERR(fmt::format("package id {} contains path separators", id));
+    }
+    if (id == "." || id == "..") {
+        return LINGLONG_ERR(fmt::format("package id {} is not a usable directory name", id));
+    }
+    if (id.find('\0') != std::string::npos) {
+        return LINGLONG_ERR("package id contains a null byte");
+    }
+
+    return LINGLONG_OK;
+}
+
 error::Result<api::types::v1::PackageInfoV2> parsePackageInfoFile(const std::filesystem::path &path)
 {
     LINGLONG_TRACE("parse package info from file: " + path.string());
 
     auto pkgInfo = serialize::LoadJSONFile<api::types::v1::PackageInfoV2>(path);
     if (pkgInfo) {
+        auto idValid = validatePackageId(pkgInfo->id);
+        if (!idValid) {
+            return LINGLONG_ERR(idValid);
+        }
         return pkgInfo;
     }
 
@@ -43,7 +73,12 @@ error::Result<api::types::v1::PackageInfoV2> parsePackageInfoFile(const std::fil
         return LINGLONG_ERR(oldPkgInfo.error());
     }
 
-    return toPackageInfoV2(*oldPkgInfo);
+    auto convertedInfo = toPackageInfoV2(*oldPkgInfo);
+    auto idValid = validatePackageId(convertedInfo.id);
+    if (!idValid) {
+        return LINGLONG_ERR(idValid);
+    }
+    return convertedInfo;
 }
 
 } // namespace linglong::utils::serialize

--- a/libs/utils/src/linglong/utils/serialize/packageinfo_handler.h
+++ b/libs/utils/src/linglong/utils/serialize/packageinfo_handler.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 

--- a/libs/utils/src/linglong/utils/serialize/packageinfo_handler.h
+++ b/libs/utils/src/linglong/utils/serialize/packageinfo_handler.h
@@ -17,6 +17,7 @@
 namespace linglong::utils::serialize {
 
 api::types::v1::PackageInfoV2 toPackageInfoV2(const api::types::v1::PackageInfo &oldInfo);
+error::Result<void> validatePackageId(const std::string &id);
 error::Result<api::types::v1::PackageInfoV2>
 parsePackageInfoFile(const std::filesystem::path &path);
 
@@ -27,6 +28,10 @@ error::Result<api::types::v1::PackageInfoV2> parsePackageInfo(const T &contents)
 
     auto pkgInfo = serialize::LoadJSON<api::types::v1::PackageInfoV2>(contents);
     if (pkgInfo) {
+        auto idValid = validatePackageId(pkgInfo->id);
+        if (!idValid) {
+            return LINGLONG_ERR(idValid);
+        }
         return pkgInfo;
     }
 
@@ -36,7 +41,12 @@ error::Result<api::types::v1::PackageInfoV2> parsePackageInfo(const T &contents)
         return LINGLONG_ERR(oldPkgInfo.error());
     }
 
-    return toPackageInfoV2(*oldPkgInfo);
+    auto convertedInfo = toPackageInfoV2(*oldPkgInfo);
+    auto idValid = validatePackageId(convertedInfo.id);
+    if (!idValid) {
+        return LINGLONG_ERR(idValid);
+    }
+    return convertedInfo;
 }
 
 } // namespace linglong::utils::serialize


### PR DESCRIPTION
## Summary

Validate the package id at deserialization so a crafted layer or uab cannot escape its intended directories.

## Root cause

The id from `info.json` builds host paths when a package is used (`common::dir::getAppRuntimeDir(id)`, the private dir `~/.linglong/<id>`, `/opt/apps/<id>/files`), but deserialization only rejected an empty id. A package with id like `../evil` passed install and made the runtime create and bind-mount directories outside the intended prefixes.

## Changes

- Add `validatePackageId`: reject path separators, `."/"..` and null bytes.
- Apply it in `parsePackageInfo` / `parsePackageInfoFile` (install, cache, checkout and the run-time `LayerDir::info()` path) and in `checkUABLayersConstrain` for uab metadata.
- Add regression tests for V2 JSON, file parsing, the legacy V1 conversion and regular ids.

## Test plan

- [x] `ctest -R PackageInfoHandler`
- [x] Full `ctest` run
- [x] `clang-format --dry-run --Werror`