### PR TITLE
fix(builder): reject project identifiers that are not usable as path components

### DIFF
--- a/apps/ll-builder/src/main.cpp
+++ b/apps/ll-builder/src/main.cpp
@@ -65,7 +65,24 @@ parseProjectConfig(const std::filesystem::path &filename)
                             "'MAJOR.MINOR.PATCH.TWEAK'");
     }
 
+    // package.id becomes path components on the host and inside the package
+    // (/opt/apps/<id>/files, export file names), module names become build
+    // output directories, so neither may escape their intended directory
+    auto isUsableDirName = [](const std::string &name) {
+        return !name.empty() && name != "." && name != ".." && name.find('/') == std::string::npos
+          && name.find('\\') == std::string::npos && name.find('\0') == std::string::npos;
+    };
+    if (!isUsableDirName(project->package.id)) {
+        return LINGLONG_ERR(fmt::format("invalid package.id: {}", project->package.id));
+    }
+
     if (project->modules.has_value()) {
+        for (const auto &module : project->modules.value()) {
+            if (!isUsableDirName(module.name)) {
+                return LINGLONG_ERR(fmt::format("invalid module name: {}", module.name));
+            }
+        }
+
         if (std::any_of(project->modules->begin(), project->modules->end(), [](const auto &module) {
                 return module.name == "binary";
             })) {


### PR DESCRIPTION
## Summary

Reject `linglong.yaml` `package.id` and `modules[].name` values that are not usable as path components.

## Root cause

`package.id` feeds `/opt/apps/<id>/files` and the export file names (the app id only triggered a non-blocking warning), and each module name becomes `<project>/linglong/output/<name>`. Values like `../evil` therefore write build artifacts, exported layers/uabs and whole module outputs outside the project directory. Project files are often taken from third parties, so building an untrusted project triggers this.

## Changes

- Validate both fields in `parseProjectConfig`: reject empty names, "."/"..", path separators and null bytes with a clear error before anything is written.

## Reproduction

```
id: "../evil"                     -> invalid package.id: ../evil
modules: [{ name: "../../tmp/x" }] -> invalid module name: ../../tmp/x
```

## Test plan

- [x] Verified with the real CLI (both rejections and a normal project)
- [x] Full `ctest` run
- [x] `clang-format --dry-run --Werror`