### PR TITLE
fix(builder): escape build output path interpolated into module rules

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -313,13 +313,23 @@ installModule(const std::filesystem::path &buildOutput,
                   }
               } else {
                   // rule is a regex
+                  // the build output directory is an arbitrary path, escape it so
+                  // regex metacharacters in the project path cannot break the rule
+                  auto escapedOutput =
+                    QRegularExpression::escape(QString::fromStdString(buildOutput.string()));
                   if (rule.rfind("^/", 0) != 0) {
-                      rule.insert(1, buildOutput.string() + "/");
+                      rule.insert(1, (escapedOutput + "/").toStdString());
                   } else {
-                      rule.insert(1, buildOutput);
+                      rule.insert(1, escapedOutput.toStdString());
                   }
 
                   QRegularExpression regexp(rule.c_str());
+                  if (!regexp.isValid()) {
+                      LogW("skip invalid module rule {}: {}",
+                           rule,
+                           regexp.errorString().toStdString());
+                      continue;
+                  }
                   if (regexp.match((buildOutput / path).c_str()).hasMatch()) {
                       return true;
                   }

--- a/libs/linglong/tests/ll-tests/src/linglong/builder/linglong_builder_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/builder/linglong_builder_test.cpp
@@ -117,6 +117,7 @@ TEST(LinglongBuilder, installModuleWithRegexMetacharactersInPath)
     std::unordered_set<std::string> rules = {
         "^/include/.+",  // regex rule
         "^/lib/.+\\.a$", // regex rule
+        "^[/lib/[.+",    // invalid regex rule, skipped with a warning
     };
 
     auto result = linglong::builder::installModule(buildOutput.path(), moduleOutput.path(), rules);

--- a/libs/linglong/tests/ll-tests/src/linglong/builder/linglong_builder_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/builder/linglong_builder_test.cpp
@@ -98,6 +98,34 @@ TEST(LinglongBuilder, installModule)
     EXPECT_EQ(installedFiles, expectedFiles);
 }
 
+TEST(LinglongBuilder, installModuleWithRegexMetacharactersInPath)
+{
+    // the project path may contain regex metacharacters; the directory is
+    // interpolated into "^"-rules and must not break or invalidate them
+    TempDir buildOutput{ "ll-build-+([x])" };
+    ASSERT_TRUE(buildOutput.isValid());
+    TempDir moduleOutput;
+    ASSERT_TRUE(moduleOutput.isValid());
+    ASSERT_NE(buildOutput.path().string().find('+'), std::string::npos);
+
+    std::filesystem::create_directories(buildOutput.path() / "include");
+    std::filesystem::create_directories(buildOutput.path() / "lib");
+
+    std::ofstream(buildOutput.path() / "include/header.h");
+    std::ofstream(buildOutput.path() / "lib/libfoo.a");
+
+    std::unordered_set<std::string> rules = {
+        "^/include/.+",  // regex rule
+        "^/lib/.+\\.a$", // regex rule
+    };
+
+    auto result = linglong::builder::installModule(buildOutput.path(), moduleOutput.path(), rules);
+    ASSERT_TRUE(result.has_value());
+
+    EXPECT_TRUE(std::filesystem::exists(moduleOutput.path() / "include/header.h"));
+    EXPECT_TRUE(std::filesystem::exists(moduleOutput.path() / "lib/libfoo.a"));
+}
+
 TEST(LinglongBuilder, mergeOutput)
 {
     TempDir srcDir1;


### PR DESCRIPTION
## Summary

Escape the build output path interpolated into "^"-prefixed module install rules and skip rules that do not compile.

## Root cause

`installModule` interpolated the project path verbatim into rules before compiling them as regular expressions and never checked `isValid()`. A project in a directory such as `/tmp/c++proj` made the default develop rules invalid, so the develop module silently ended up empty; `/tmp/a[1]` silently changed what matched.

## Changes

- Escape the interpolated path with `QRegularExpression::escape`.
- Warn and skip rules that still fail to compile instead of silently matching nothing.
- Add `LinglongBuilder.installModuleWithRegexMetacharactersInPath` (path contains `, (`, `[`; regex rules must still move files).

## Test plan

- [x] `ctest -R LinglongBuilder`
- [x] Full `ctest` run
- [x] `clang-format --dry-run --Werror`