### PR TITLE
fix(package-manager): require polkit authorization for InitRunContext

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -1902,6 +1902,36 @@ auto PackageManager::InitRunContext(const QString &runContextCfg,
         return toDBusReply(utils::error::ErrorCode::Failed, "daemon mode not initialized");
     }
 
+    if (!m_peerMode) {
+        auto msg = message();
+        auto conn = connection();
+        setDelayedReply(true);
+
+        CallerContext ctx{ conn, msg };
+
+        checkPolkitAuthorizationAsync(
+          "org.deepin.linglong.PackageManager1.init-run-context",
+          msg.service().toStdString(),
+          [this, runContextCfg, containerID, ctx](utils::error::Result<void> authResult) {
+              if (!authResult) {
+                  ctx.connection.send(ctx.message.createErrorReply(
+                    QDBusError::AccessDenied,
+                    QString::fromStdString(authResult.error().message())));
+                  return;
+              }
+
+              auto reply = queueInitRunContext(runContextCfg, containerID);
+              ctx.connection.send(ctx.message.createReply(reply));
+          });
+        return {};
+    }
+
+    return queueInitRunContext(runContextCfg, containerID);
+}
+
+QVariantMap PackageManager::queueInitRunContext(const QString &runContextCfg,
+                                                const QString &containerID)
+{
     auto task = m_init_run_context_queue.addPackageTask(
       [this, runContextCfg = runContextCfg.toStdString(), containerID = containerID.toStdString()](
         Task &task) {

--- a/libs/linglong/src/linglong/package_manager/package_manager.h
+++ b/libs/linglong/src/linglong/package_manager/package_manager.h
@@ -151,6 +151,7 @@ private:
       std::vector<api::types::v1::ContainerProcessStateInfo>>
     getAllRunningContainers() noexcept;
     utils::error::Result<bool> isRefBusy(const package::Reference &ref) noexcept;
+    QVariantMap queueInitRunContext(const QString &runContextCfg, const QString &containerID);
     void deferredUninstall() noexcept;
     utils::error::Result<void>
     Prune(std::vector<api::types::v1::PackageInfoV2> &removedInfo) noexcept;

--- a/misc/share/polkit-1/actions/org.deepin.linglong.PackageManager1.policy
+++ b/misc/share/polkit-1/actions/org.deepin.linglong.PackageManager1.policy
@@ -94,6 +94,16 @@
 		<description xml:lang="zh_TW">解除安裝套件</description>
 		<message xml:lang="zh_TW">解除安裝套件需要進行身分驗證</message>
 	</action>
+	<action id="org.deepin.linglong.PackageManager1.init-run-context">
+		<description>Initialize a container run context</description>
+		<message>Authentication is required to initialize a container run context</message>
+		<defaults>
+			<allow_any>auth_admin</allow_any>
+			<allow_inactive>auth_admin</allow_inactive>
+			<allow_active>yes</allow_active>
+		</defaults>
+		<annotate key="org.freedesktop.policykit.owner">unix-user:@LINGLONG_USERNAME@</annotate>
+	</action>
 	<action id="org.deepin.linglong.PackageManager1.install-from-file">
 		<description>Install packages from local files</description>
 		<message>Authentication is required to install packages from local files</message>


### PR DESCRIPTION
## Summary

Require polkit authorization for the `InitRunContext` DBus method, consistent with every other mutating method of the system service.

## Root cause

The DBus policy allows any local user to call the service and states that permission control is handled by polkit. All mutating methods check a polkit action, but `InitRunContext` did not, while it mutates shared system state as the daemon user: it resolves layers against the system repository, creates container cache bundles under `/var/lib/linglong/cache` and runs an init container (`/sbin/ldconfig`) as the daemon user. Any local user could invoke it repeatedly without any authentication.

## Changes

- Check a new `org.deepin.linglong.PackageManager1.init-run-context` action before queueing the work (delayed reply, same pattern as Install).
- Add the action to the polkit policy with `allow_active=yes`, so regular local application launches stay prompt-free while inactive or non-local callers must authenticate as admin.

## Test plan

- [x] `cmake --build` passes
- [x] Policy file remains valid XML
- [x] `clang-format --dry-run --Werror`