### PR TITLE
fix(runtime): validate caller-supplied fields in config-based resolve

### DIFF
--- a/libs/linglong/src/linglong/runtime/run_context.cpp
+++ b/libs/linglong/src/linglong/runtime/run_context.cpp
@@ -44,6 +44,14 @@ void ensureMountSrcType(std::vector<api::types::v1::Mount> &mounts)
     }
 }
 
+std::filesystem::path zoneinfoDir()
+{
+    auto *tzdirEnv = std::getenv("TZDIR");
+    return (tzdirEnv != nullptr && tzdirEnv[0] != '\0')
+      ? std::filesystem::path(tzdirEnv)
+      : std::filesystem::path("/usr/share/zoneinfo");
+}
+
 std::optional<std::string> timezoneFromPath(const std::filesystem::path &path,
                                             const std::filesystem::path &zoneinfoRoot)
 {
@@ -559,11 +567,41 @@ utils::error::Result<void> RunContext::resolve(const api::types::v1::RunContextC
         contextCfg.cdiDevices = config.cdiDevices.value();
     }
 
-    contextCfg.overlayfs = config.overlayfs;
-    contextCfg.resolvConf = config.resolvConf;
-    contextCfg.timezone = config.timezone;
+    // the config can come from an untrusted caller, so apply the same validation
+    // the runnable-based resolve path applies to these fields
+    auto overlayRet = resolveOverlayMode(config.overlayfs);
+    if (!overlayRet) {
+        return LINGLONG_ERR("failed to resolve overlayfs mode", overlayRet);
+    }
+
+    if (config.resolvConf) {
+        if (!config.resolvConf->empty()
+            && !std::filesystem::path{ *config.resolvConf }.is_absolute()) {
+            return LINGLONG_ERR(
+              fmt::format("resolv.conf path {} is not an absolute path", *config.resolvConf));
+        }
+        contextCfg.resolvConf = config.resolvConf;
+    }
+
+    if (config.timezone) {
+        if (!config.timezone->empty()) {
+            auto zoneinfoRoot = zoneinfoDir();
+            auto timezone = timezoneFromPath(zoneinfoRoot / *config.timezone, zoneinfoRoot);
+            if (!timezone || *timezone != *config.timezone) {
+                return LINGLONG_ERR(fmt::format("timezone {} is not a zone below the zoneinfo root",
+                                                *config.timezone));
+            }
+            contextCfg.timezone = config.timezone;
+        } else {
+            contextCfg.timezone = config.timezone;
+        }
+    }
+
     contextCfg.instance = config.instance;
-    contextCfg.mounts = config.mounts;
+    if (config.mounts) {
+        contextCfg.mounts = *config.mounts;
+        ensureMountSrcType(*contextCfg.mounts);
+    }
     contextCfg.version = runContextConfigVersion;
 
     return resolveLayer(false, {});
@@ -787,10 +825,7 @@ utils::error::Result<void> RunContext::resolveTimeZone()
 {
     LINGLONG_TRACE("resolve timezone");
 
-    auto *tzdirEnv = std::getenv("TZDIR");
-    auto zoneinfoRoot = (tzdirEnv != nullptr && tzdirEnv[0] != '\0')
-      ? std::filesystem::path(tzdirEnv)
-      : std::filesystem::path("/usr/share/zoneinfo");
+    auto zoneinfoRoot = zoneinfoDir();
 
     auto localtimePath = std::filesystem::path("/etc/localtime");
     std::error_code ec;

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_test.cpp
@@ -511,6 +511,126 @@ TEST_F(RunContextTest, resolveRunnableWithBase)
     EXPECT_EQ(*context.getConfig().overlayfs, "fuse");
 }
 
+TEST_F(RunContextTest, resolveConfigRejectsTimezoneOutsideZoneinfo)
+{
+    auto baseRef = package::Reference::parse("stable:org.deepin.base/23.0.0/x86_64");
+    ASSERT_TRUE(baseRef.has_value());
+
+    api::types::v1::RepositoryCacheLayersItem baseItem;
+    baseItem.info.id = "org.deepin.base";
+    baseItem.info.version = "23.0.0";
+    baseItem.info.kind = "base";
+    baseItem.info.channel = "stable";
+    baseItem.info.arch = { std::string{ "x86_64" } };
+    EXPECT_CALL(*repo, getLayerItem(*baseRef, testing::_)).WillOnce(Return(baseItem));
+
+    api::types::v1::RunContextConfig config;
+    config.version = "1";
+    config.base = "stable:org.deepin.base/23.0.0/x86_64";
+    config.timezone = "../../etc";
+
+    RunContext context(*this->repo);
+    auto result = context.resolve(config);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error().message(), ::testing::HasSubstr("timezone"));
+}
+
+TEST_F(RunContextTest, resolveConfigRejectsRelativeResolvConf)
+{
+    auto baseRef = package::Reference::parse("stable:org.deepin.base/23.0.0/x86_64");
+    ASSERT_TRUE(baseRef.has_value());
+
+    api::types::v1::RepositoryCacheLayersItem baseItem;
+    baseItem.info.id = "org.deepin.base";
+    baseItem.info.version = "23.0.0";
+    baseItem.info.kind = "base";
+    baseItem.info.channel = "stable";
+    baseItem.info.arch = { std::string{ "x86_64" } };
+    EXPECT_CALL(*repo, getLayerItem(*baseRef, testing::_)).WillOnce(Return(baseItem));
+
+    api::types::v1::RunContextConfig config;
+    config.version = "1";
+    config.base = "stable:org.deepin.base/23.0.0/x86_64";
+    config.resolvConf = "etc/resolv.conf";
+
+    RunContext context(*this->repo);
+    auto result = context.resolve(config);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_THAT(result.error().message(), ::testing::HasSubstr("resolv.conf"));
+}
+
+TEST_F(RunContextTest, resolveConfigRejectsUnknownOverlayMode)
+{
+    auto baseRef = package::Reference::parse("stable:org.deepin.base/23.0.0/x86_64");
+    ASSERT_TRUE(baseRef.has_value());
+
+    api::types::v1::RepositoryCacheLayersItem baseItem;
+    baseItem.info.id = "org.deepin.base";
+    baseItem.info.version = "23.0.0";
+    baseItem.info.kind = "base";
+    baseItem.info.channel = "stable";
+    baseItem.info.arch = { std::string{ "x86_64" } };
+    EXPECT_CALL(*repo, getLayerItem(*baseRef, testing::_)).WillOnce(Return(baseItem));
+
+    api::types::v1::RunContextConfig config;
+    config.version = "1";
+    config.base = "stable:org.deepin.base/23.0.0/x86_64";
+    config.overlayfs = "bogus";
+
+    RunContext context(*this->repo);
+    auto result = context.resolve(config);
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST_F(RunContextTest, resolveConfigValidatesCallerFields)
+{
+    if (!std::filesystem::exists("/usr/share/zoneinfo/UTC")
+        || !std::filesystem::exists("/etc/resolv.conf")) {
+        GTEST_SKIP() << "required host files are not available";
+    }
+
+    auto baseRef = package::Reference::parse("stable:org.deepin.base/23.0.0/x86_64");
+    ASSERT_TRUE(baseRef.has_value());
+
+    api::types::v1::RepositoryCacheLayersItem baseItem;
+    baseItem.info.id = "org.deepin.base";
+    baseItem.info.version = "23.0.0";
+    baseItem.info.kind = "base";
+    baseItem.info.channel = "stable";
+    baseItem.info.arch = { std::string{ "x86_64" } };
+    EXPECT_CALL(*repo, getLayerItem(*baseRef, testing::_)).WillOnce(Return(baseItem));
+
+    package::LayerDir mockLayerDir(tempDir->path() / "merged");
+    EXPECT_CALL(*repo, getMergedModuleDir(*baseRef, testing::_))
+      .WillOnce(Return(utils::error::Result<package::LayerDir>(mockLayerDir)));
+
+    api::types::v1::RunContextConfig config;
+    config.version = "1";
+    config.base = "stable:org.deepin.base/23.0.0/x86_64";
+    config.timezone = "UTC";
+    config.resolvConf = "/etc/resolv.conf";
+    config.mounts =
+      std::vector<api::types::v1::Mount>{ api::types::v1::Mount{ .destination = "/mnt/host-data",
+                                                                 .source = tempDir->path(),
+                                                                 .type = "bind" } };
+
+    RunContext context(*this->repo);
+    auto result = context.resolve(config);
+    ASSERT_TRUE(result.has_value()) << "Failed to resolve config: " << result.error().message();
+
+    const auto &resolved = context.getConfig();
+    ASSERT_TRUE(resolved.timezone.has_value());
+    EXPECT_EQ(*resolved.timezone, "UTC");
+    ASSERT_TRUE(resolved.resolvConf.has_value());
+    EXPECT_EQ(*resolved.resolvConf, "/etc/resolv.conf");
+    ASSERT_TRUE(resolved.overlayfs.has_value());
+    EXPECT_EQ(*resolved.overlayfs, "fuse");
+    ASSERT_TRUE(resolved.mounts.has_value());
+    ASSERT_EQ(resolved.mounts->size(), 1);
+    ASSERT_TRUE(resolved.mounts->front().srcType.has_value());
+    EXPECT_EQ(*resolved.mounts->front().srcType, "dir");
+}
+
 TEST_F(RunContextTest, resolveRunnableWithInvalidKind)
 {
     LINGLONG_TRACE("resolveRunnableWithInvalidKind");


### PR DESCRIPTION
## Summary

Apply the same field validation to `RunContext::resolve(RunContextConfig)` that the runnable-based resolve path already applies.

## Root cause

The runnable path resolves and validates `overlayfs`, `resolvConf`, `timezone` and `mounts` (mode parsing, host-derived resolv.conf, timezone containment via `timezoneFromPath`, mount srcType). The config path copied all of them verbatim, and it is reachable with caller-supplied JSON through the `PackageManager1.InitRunContext` DBus method. Unvalidated values ended up in the generated container configuration, for example an arbitrary timezone string written into the bundle's `/etc/localtime` symlink without the zoneinfo containment check.

## Changes

- Parse the overlayfs mode instead of copying it.
- Require a non-empty `resolvConf` to be an absolute path.
- Require a non-empty `timezone` to name a zone below the zoneinfo root.
- Run `ensureMountSrcType` over caller-supplied mounts.
- Config generated by `ll-cli` already contains the validated values, so regular flows are unaffected.

## Test plan

- [x] New `RunContextTest` cases: out-of-zoneinfo timezone, relative resolv.conf, unknown overlayfs mode, and valid fields resolving with srcType filled in
- [x] Full `ctest` run (724/724)
- [x] `clang-format --dry-run --Werror`