### PR TITLE
feat(cli): add doctor command to diagnose the local environment

### DIFF
--- a/apps/ll-cli/src/main.cpp
+++ b/apps/ll-cli/src/main.cpp
@@ -7,6 +7,7 @@
 #include "linglong/cli/cli.h"
 #include "linglong/cli/cli_printer.h"
 #include "linglong/cli/dbus_notifier.h"
+#include "linglong/cli/doctor.h"
 #include "linglong/cli/dummy_notifier.h"
 #include "linglong/cli/json_printer.h"
 #include "linglong/cli/terminal_notifier.h"
@@ -571,6 +572,37 @@ void addInspectCommand(CLI::App &commandParser,
 
 } // namespace
 
+int runDoctor(bool jsonOutput)
+{
+    const auto &checks = linglong::cli::runDoctorChecks();
+
+    if (jsonOutput) {
+        auto array = nlohmann::json::array();
+        for (const auto &check : checks) {
+            array.push_back(nlohmann::json{ { "name", check.name },
+                                            { "required", check.required },
+                                            { "ok", check.ok },
+                                            { "detail", check.detail } });
+        }
+        std::cout << array.dump() << std::endl;
+    } else {
+        for (const auto &check : checks) {
+            if (check.ok) {
+                std::cout << "[ ok ] " << check.name << ": " << check.detail << std::endl;
+            } else if (check.required) {
+                std::cout << "[FAIL] " << check.name << ": " << check.detail << std::endl;
+            } else {
+                std::cout << "[warn] " << check.name << ": " << check.detail << std::endl;
+            }
+        }
+    }
+
+    const auto failed = std::any_of(checks.cbegin(), checks.cend(), [](const auto &check) {
+        return check.required && !check.ok;
+    });
+    return failed ? 1 : 0;
+}
+
 int runCliApplication(int argc, char **mainArgv)
 {
     CLI::App commandParser{ _(
@@ -656,6 +688,11 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     addInfoCommand(commandParser, infoOptions, CliBuildInGroup);
     addContentCommand(commandParser, contentOptions, CliBuildInGroup);
     addPruneCommand(commandParser, CliAppManagingGroup);
+    auto *CliDiagnosticGroup = _("Diagnosing the environment");
+    auto *cliDoctor =
+      commandParser.add_subcommand("doctor", _("Check the local environment for common problems"))
+        ->group(CliDiagnosticGroup);
+    cliDoctor->usage(_("Usage: ll-cli doctor"));
     addInspectCommand(commandParser, inspectOptions, CliHiddenGroup);
 
     auto res = transformOldExec(argc, argv);
@@ -676,6 +713,18 @@ You can report bugs to the linyaps team under this project: https://github.com/O
     }
     if (globalOptions.verbose > 1) {
         ::setenv("LINYAPS_BACKTRACE", "1", 1);
+    }
+
+    // doctor runs before any runtime setup: its purpose is to report problems
+    // such as a missing OCI runtime or an unusable repository
+    {
+        const auto &commands = commandParser.get_subcommands();
+        auto parsedCommand = std::find_if(commands.begin(), commands.end(), [](CLI::App *app) {
+            return app->parsed();
+        });
+        if (parsedCommand != commands.end() && (*parsedCommand)->get_name() == "doctor") {
+            return runDoctor(jsonFlag->count() > 0);
+        }
     }
 
     // create printer

--- a/libs/linglong/CMakeLists.txt
+++ b/libs/linglong/CMakeLists.txt
@@ -22,6 +22,7 @@ pfl_add_library(
   src/linglong/builder/source_fetcher.cpp
   src/linglong/builder/source_fetcher.h
   src/linglong/cli/cli.cpp
+  src/linglong/cli/doctor.cpp
   src/linglong/cli/cli.h
   src/linglong/cli/cli_printer.cpp
   src/linglong/cli/cli_printer.h

--- a/libs/linglong/src/linglong/cli/doctor.cpp
+++ b/libs/linglong/src/linglong/cli/doctor.cpp
@@ -1,0 +1,236 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "linglong/cli/doctor.h"
+
+#include "configure.h"
+#include "linglong/common/dir.h"
+#include "linglong/repo/config.h"
+#include "linglong/runtime/overlayfs_driver.h"
+#include "linglong/utils/cmd.h"
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+#include <QStandardPaths>
+#include <QString>
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <filesystem>
+#include <fstream>
+
+namespace linglong::cli {
+
+namespace {
+
+std::optional<std::array<long long, 3>> parseVersionTuple(const std::string &version)
+{
+    // keep the numeric prefix, e.g. "1.15.0-dev+1fc6f59" -> 1.15.0
+    auto core = version.substr(0, version.find('-'));
+
+    std::array<long long, 3> numbers{ 0, 0, 0 };
+    std::size_t begin = 0;
+    for (std::size_t i = 0; i < numbers.size(); ++i) {
+        auto end = core.find('.', begin);
+        auto part = core.substr(begin, end == std::string::npos ? std::string::npos : end - begin);
+        if (part.empty()) {
+            return std::nullopt;
+        }
+        auto value = std::from_chars(part.data(), part.data() + part.size(), numbers[i]);
+        if (value.ec != std::errc{} || value.ptr != part.data() + part.size()) {
+            return std::nullopt;
+        }
+        if (end == std::string::npos) {
+            break;
+        }
+        begin = end + 1;
+    }
+    return numbers;
+}
+
+DoctorCheckResult checkOCIRuntime()
+{
+    DoctorCheckResult result{ .name = "oci-runtime", .required = true, .ok = false, .detail = "" };
+
+    auto ociRuntimeCLI = qgetenv("LINGLONG_OCI_RUNTIME");
+    if (ociRuntimeCLI.isEmpty()) {
+        ociRuntimeCLI = LINGLONG_DEFAULT_OCI_RUNTIME;
+    }
+
+    auto path = QStandardPaths::findExecutable(ociRuntimeCLI);
+    if (path.isEmpty()) {
+        result.detail = fmt::format("{} not found in PATH, sandbox operations will fail; install "
+                                    "it or point LINGLONG_OCI_RUNTIME to a usable runtime",
+                                    ociRuntimeCLI.toStdString());
+        return result;
+    }
+
+    result.ok = true;
+    result.detail = fmt::format("found {} at {}", ociRuntimeCLI.toStdString(), path.toStdString());
+    return result;
+}
+
+DoctorCheckResult checkRepository()
+{
+    DoctorCheckResult result{ .name = "repository", .required = true, .ok = false, .detail = "" };
+
+    const std::filesystem::path versionFile = std::filesystem::path(LINGLONG_ROOT) / ".version";
+    std::error_code ec;
+    if (!std::filesystem::exists(versionFile, ec)) {
+        result.detail =
+          fmt::format("{} not found, no repository has been initialized yet", versionFile.string());
+        // a missing repository is initialized on demand, not an error
+        result.ok = true;
+        result.required = false;
+        return result;
+    }
+
+    std::ifstream in(versionFile);
+    std::string repoVersion((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    while (!repoVersion.empty() && (repoVersion.back() == '\n' || repoVersion.back() == '\r')) {
+        repoVersion.pop_back();
+    }
+
+    auto cmp = compareVersions(repoVersion, LINGLONG_VERSION);
+    if (!cmp) {
+        result.detail = fmt::format("cannot parse repository version {} in {}",
+                                    repoVersion,
+                                    versionFile.string());
+        return result;
+    }
+    if (*cmp > 0) {
+        result.detail = fmt::format("repository version {} is newer than this tool ({}), "
+                                    "downgrading the repository is unsafe; upgrade linyaps",
+                                    repoVersion,
+                                    LINGLONG_VERSION);
+        return result;
+    }
+
+    result.ok = true;
+    result.detail = fmt::format("repository at {} is version {}", LINGLONG_ROOT, repoVersion);
+    return result;
+}
+
+DoctorCheckResult checkOverlaySupport()
+{
+    DoctorCheckResult result{ .name = "overlayfs", .required = true, .ok = false, .detail = "" };
+
+    auto mode = runtime::OverlayFSDriver::resolveOverlayMode(utils::OverlayMode::Auto);
+    if (!mode) {
+        result.detail = "neither kernel overlayfs nor a FUSE overlay backend (fuse-overlayfs and "
+                        "fusermount) is usable, containers cannot be prepared";
+        return result;
+    }
+
+    result.ok = true;
+    result.detail = fmt::format("using {} overlay backend",
+                                std::string(runtime::OverlayFSDriver::modeToString(*mode)));
+    return result;
+}
+
+DoctorCheckResult checkErofsTools()
+{
+    DoctorCheckResult result{ .name = "erofs-tools", .required = true, .ok = false, .detail = "" };
+
+    std::vector<std::string> missing;
+    for (const auto *tool : { "mkfs.erofs", "fsck.erofs" }) {
+        if (!utils::Cmd(tool).exists()) {
+            missing.emplace_back(tool);
+        }
+    }
+
+    if (!missing.empty()) {
+        result.detail = fmt::format("missing {}, required to build and install layer/uab packages",
+                                    fmt::join(missing, ", "));
+        return result;
+    }
+
+    result.ok = true;
+    result.detail = "mkfs.erofs and fsck.erofs are available";
+    return result;
+}
+
+DoctorCheckResult checkErofsFuse()
+{
+    DoctorCheckResult result{ .name = "erofsfuse", .required = false, .ok = true, .detail = "" };
+
+    if (utils::Cmd("erofsfuse").exists()) {
+        result.detail = "erofsfuse is available";
+        return result;
+    }
+
+    result.detail = "erofsfuse not found, uab layers are mounted through fsck.erofs instead";
+    return result;
+}
+
+DoctorCheckResult checkUserRuntimeDir()
+{
+    DoctorCheckResult result{ .name = "runtime-dir", .required = true, .ok = false, .detail = "" };
+
+    auto runtimeDir = common::dir::getRuntimeDir();
+    std::error_code ec;
+    if (!std::filesystem::exists(runtimeDir, ec)) {
+        result.detail =
+          fmt::format("{} does not exist, it is created on first use", runtimeDir.string());
+        // directories below the user runtime are created on demand
+        result.ok = true;
+        result.required = false;
+        return result;
+    }
+    if (!std::filesystem::is_directory(runtimeDir, ec)) {
+        result.detail = fmt::format("{} exists but is not a directory", runtimeDir.string());
+        return result;
+    }
+
+    auto probe = runtimeDir / ".linglong-doctor-probe";
+    if (!std::filesystem::exists(probe, ec)) {
+        std::ofstream touch(probe);
+        if (!touch.is_open()) {
+            result.detail =
+              fmt::format("{} is not writable by the current user", runtimeDir.string());
+            return result;
+        }
+        touch.close();
+    }
+    std::filesystem::remove(probe, ec);
+
+    result.ok = true;
+    result.detail = fmt::format("{} is writable", runtimeDir.string());
+    return result;
+}
+
+} // namespace
+
+std::optional<int> compareVersions(const std::string &lhs, const std::string &rhs)
+{
+    auto lhsTuple = parseVersionTuple(lhs);
+    auto rhsTuple = parseVersionTuple(rhs);
+    if (!lhsTuple || !rhsTuple) {
+        return std::nullopt;
+    }
+
+    for (std::size_t i = 0; i < lhsTuple->size(); ++i) {
+        if ((*lhsTuple)[i] != (*rhsTuple)[i]) {
+            return (*lhsTuple)[i] < (*rhsTuple)[i] ? -1 : 1;
+        }
+    }
+    return 0;
+}
+
+std::vector<DoctorCheckResult> runDoctorChecks()
+{
+    std::vector<DoctorCheckResult> results;
+    results.reserve(6);
+    results.push_back(checkOCIRuntime());
+    results.push_back(checkRepository());
+    results.push_back(checkOverlaySupport());
+    results.push_back(checkErofsTools());
+    results.push_back(checkErofsFuse());
+    results.push_back(checkUserRuntimeDir());
+    return results;
+}
+
+} // namespace linglong::cli

--- a/libs/linglong/src/linglong/cli/doctor.h
+++ b/libs/linglong/src/linglong/cli/doctor.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace linglong::cli {
+
+struct DoctorCheckResult
+{
+    std::string name;      // short identifier of the checked component
+    bool required{ true }; // failing a required check makes the environment unusable
+    bool ok{ false };
+    std::string detail; // finding or hint for the user
+};
+
+// Run every local environment check and return the results in a stable order.
+std::vector<DoctorCheckResult> runDoctorChecks();
+
+// Compare two "MAJOR.MINOR.PATCH" version strings, ignoring any suffix after '-'.
+// Returns a positive value when lhs is newer, a negative value when lhs is older,
+// zero when both are equal, and nullopt when either side cannot be parsed.
+std::optional<int> compareVersions(const std::string &lhs, const std::string &rhs);
+
+} // namespace linglong::cli

--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -20,6 +20,7 @@ pfl_add_executable(
   src/linglong/builder/source_fetcher_test.cpp
   src/linglong/cli/cli_printer_test.cpp
   src/linglong/cli/cli_test.cpp
+  src/linglong/cli/doctor_test.cpp
   src/linglong/common/gkeyfile_wrapper_test.cpp
   src/linglong/common/global/initialize_test.cpp
   src/linglong/common/cli/repo_test.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/cli/doctor_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/cli/doctor_test.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "linglong/cli/doctor.h"
+
+#include <algorithm>
+#include <set>
+#include <string>
+
+namespace linglong::cli {
+
+TEST(DoctorTest, compareVersions)
+{
+    EXPECT_EQ(compareVersions("1.15.0", "1.15.0"), 0);
+    EXPECT_GT(*compareVersions("2.0.0", "1.99.99"), 0);
+    EXPECT_LT(*compareVersions("1.14.0", "1.15.0"), 0);
+    EXPECT_GT(*compareVersions("1.15.1", "1.15.0"), 0);
+    EXPECT_LT(*compareVersions("1.9.0", "1.10.0"), 0);
+
+    // suffixes after '-' are ignored
+    EXPECT_EQ(compareVersions("1.15.0-dev+1fc6f59", "1.15.0"), 0);
+    EXPECT_GT(*compareVersions("1.15.0-dev", "1.14.0"), 0);
+
+    // missing components are treated as zero
+    EXPECT_EQ(compareVersions("1.15", "1.15.0"), 0);
+    EXPECT_GT(*compareVersions("1.15.1", "1.15"), 0);
+
+    // unparsable input
+    EXPECT_FALSE(compareVersions("banana", "1.0.0").has_value());
+    EXPECT_FALSE(compareVersions("1.0.0", "").has_value());
+    EXPECT_FALSE(compareVersions("1.x.0", "1.0.0").has_value());
+}
+
+TEST(DoctorTest, runDoctorChecksProducesWellFormedResults)
+{
+    auto checks = runDoctorChecks();
+    ASSERT_FALSE(checks.empty());
+
+    // every check reports itself with a unique name and a user-facing hint
+    std::set<std::string> names;
+    for (const auto &check : checks) {
+        EXPECT_FALSE(check.name.empty());
+        EXPECT_TRUE(names.insert(check.name).second) << "duplicate check name: " << check.name;
+        EXPECT_FALSE(check.detail.empty()) << "check without detail: " << check.name;
+    }
+
+    // the doctor always reports the components the sandbox depends on
+    const auto contains = [&checks](const std::string &name) {
+        return std::any_of(checks.cbegin(), checks.cend(), [&name](const auto &check) {
+            return check.name == name;
+        });
+    };
+    EXPECT_TRUE(contains("oci-runtime"));
+    EXPECT_TRUE(contains("repository"));
+    EXPECT_TRUE(contains("overlayfs"));
+    EXPECT_TRUE(contains("erofs-tools"));
+}
+
+TEST(DoctorTest, runDoctorChecksOptionalFindingsDoNotFail)
+{
+    auto checks = runDoctorChecks();
+
+    // a check that is not required never turns the environment unusable
+    for (const auto &check : checks) {
+        if (!check.required) {
+            EXPECT_TRUE(check.ok) << "optional check failed: " << check.name;
+        }
+    }
+}
+
+} // namespace linglong::cli


### PR DESCRIPTION
## Summary

Add `ll-cli doctor`, a single command that checks the local environment parts linyaps depends on and reports each with an actionable hint.

## Motivation

When one of the moving parts is missing or broken, the failure usually surfaces far away from its cause: sandbox commands fail with a generic error about the OCI runtime, uab installation silently falls back between erofsfuse and fsck.erofs, and a repository written by a newer linyaps version only produces confusing behavior later. Inspired by the doctor subcommands of other mature tools (brew doctor, npm doctor, podman system check).

## Changes

- New `linglong::cli::runDoctorChecks()` in `libs/linglong` (testable without a CLI process) with checks for: OCI runtime in PATH, repository version vs tool version, overlay backend (kernel or FUSE), erofs tools, erofsfuse (optional), and the user runtime directory.
- New `ll-cli doctor` subcommand, dispatched before runtime setup so it can report a missing OCI runtime itself; supports the global `--json` flag and exits non-zero when a required check fails.
- `DoctorTest` covers the version comparison (including the repository-newer-than-tool case) and the result contract.

## Example

```
$ ll-cli doctor
[ ok ] oci-runtime: found ll-box at /usr/bin/ll-box
[FAIL] repository: repository version 99.0.0 is newer than this tool (1.15.0), downgrading the repository is unsafe; upgrade linyaps
...
$ echo $?
1
```

## Test plan

- [x] `ctest -R Doctor`
- [x] Full `ctest` run (723/723)
- [x] Verified plain, `--json` and failure exit code with the real CLI
- [x] `clang-format --dry-run --Werror`