### PR TITLE
chore: update shell completions

### DIFF
--- a/misc/share/bash-completion/completions/ll-builder
+++ b/misc/share/bash-completion/completions/ll-builder
@@ -7,7 +7,7 @@
 # linglong builder completion
 
 __ll_builder_get_layer_list() {
-    ls *.layer 2>/dev/null | tr '\n' ' '
+    find . -maxdepth 1 -name '*.layer' -printf '%f\n' 2>/dev/null | tr '\n' ' '
 }
 
 __ll_builder_get_repo_name_list() {
@@ -41,7 +41,7 @@ _ll_builder_complete() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD - 1]}"
 
-    local subcommands="create build run export push import import-dir extract repo list remove"
+    local subcommands="create build run export push import extract clean repo list remove"
     local version_options="--version"
     local common_options="-h --help --help-all"
 
@@ -58,12 +58,12 @@ _ll_builder_complete() {
         ;;
     build)
         local build_options="-f --file --offline --isolate-network"
-        build_options+=" --full-develop-module --skip-fetch-source --skip-pull-depend"
+        build_options+=" --skip-fetch-source --skip-pull-depend"
         build_options+=" --skip-run-container --skip-commit-output --skip-output-check --skip-strip-symbols"
         output_options="${common_options} ${build_options}"
         ;;
     run)
-        local run_options="-f --file --modules --debug --extensions"
+        local run_options="-f --file --modules --workdir --debug --extensions"
         output_options="${common_options} ${run_options}"
 
         if [[ ${prev} == "--extensions" ]]; then
@@ -71,7 +71,7 @@ _ll_builder_complete() {
         fi
         ;;
     export)
-        local export_options="-f --file -z --compressor --icon --layer --loader --no-develop -o --output --ref --modules"
+        local export_options="-f --file -z --compressor --icon --layer --uabx --loader --no-develop -o --output --ref --modules"
         output_options="${common_options} ${export_options}"
 
         case ${prev} in
@@ -83,6 +83,9 @@ _ll_builder_complete() {
             ;;
         esac
         ;;
+    clean)
+        output_options="-f --file ${common_options}"
+        ;;
     remove)
         local remove_options="--no-clean-objects"
         output_options="${common_options} ${remove_options} $(__ll_builder_get_commited_list)"
@@ -91,22 +94,26 @@ _ll_builder_complete() {
         local push_options="-f --file --repo-url --repo-name --module"
         output_options="${common_options} ${push_options}"
         ;;
-    import | import-dir)
-        if [[ ${COMP_CWORD} -eq 2 ]]; then
+    import)
+        output_options="${common_options}"
+        if [[ ${COMP_CWORD} -eq 2 && "$cur" != -* ]]; then
             COMPREPLY=($(compgen -f -- "${cur}"))
             return 0
         fi
         ;;
     extract)
-        if [[ ${COMP_CWORD} -eq 2 ]]; then
-            output_options="$(__ll_builder_get_layer_list)"
+        output_options="${common_options}"
+        if [[ ${COMP_CWORD} -eq 2 && "$cur" != -* ]]; then
+            output_options="$(__ll_builder_get_layer_list) ${common_options}"
         fi
         ;;
     repo)
-        local repo_subcommands="add remove update set-default show enable-mirror disable-mirror"
+        local repo_subcommands="add remove update set-default show set-priority enable-mirror disable-mirror"
         if [[ ${prev} == "repo" ]]; then
             output_options="${common_options} ${repo_subcommands}"
-        elif [[ " remove update set-default enable-mirror disable-mirror " =~ " ${prev} " ]]; then
+        elif [[ " ${COMP_WORDS[*]} " =~ " enable-mirror " ]]; then
+            output_options="--region ${common_options}"
+        elif [[ " remove update set-default set-priority enable-mirror disable-mirror " =~ " ${prev} " ]]; then
             output_options="$(__ll_builder_get_repo_name_list)"
         else
             output_options="${common_options}"

--- a/misc/share/bash-completion/completions/ll-cli
+++ b/misc/share/bash-completion/completions/ll-cli
@@ -1,6 +1,6 @@
 #!/bin/env bash
 
-# SPDX-FileCopyrightText: 2023 - 2025 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -54,7 +54,7 @@ _ll_cli_completion() {
         cword=$COMP_CWORD
     }
 
-    local subcommands="run ps enter kill install uninstall upgrade search list repo info content prune"
+    local subcommands="run ps enter kill install uninstall upgrade search list analyze repo info content prune"
     local global_opts="--help --help-all --json --verbose -v --no-progress"
 
     COMPREPLY=()
@@ -81,29 +81,36 @@ _ll_cli_completion() {
     local opts=""
     case "$subcmd" in
     run)
-        if [[ "$prev" == "run" ]]; then
+        if [[ "$prev" == "run" && "$cur" != -* ]]; then
             opts="$(__ll_cli_get_installed_app_list)"
         else
-            opts="--file --url --env --base --runtime --extensions"
+            opts="--file --url --env --base --runtime --extensions --workdir"
+            opts+=" --enable-xdp --disable-xdp --enable-pipewire --enable-atspi"
+            opts+=" --cdi-spec-dir --device --device-mode --instance"
+            opts+=" --debug --debug-listen --debug-debuginfod --debug-symbol-dir"
         fi
         ;;
+    ps)
+        opts="--no-truncated"
+        ;;
     enter)
-        if [[ "$prev" == "enter" ]]; then
+        if [[ "$prev" == "enter" && "$cur" != -* ]]; then
             opts="$(__ll_cli_get_container_list)"
         else
             opts="--working-directory"
         fi
         ;;
     kill)
-        if [[ "$prev" == "kill" || "$prev" == "-s" || "$prev" == "--signal" ]]; then
-            [[ "$prev" == "kill" ]] && opts="$(__ll_cli_get_container_list)"
-            [[ "$prev" != "kill" ]] && opts="SIGTERM SIGKILL SIGINT SIGHUP"
+        if [[ "$prev" == "-s" || "$prev" == "--signal" ]]; then
+            opts="SIGTERM SIGKILL SIGINT SIGHUP"
+        elif [[ "$prev" == "kill" && "$cur" != -* ]]; then
+            opts="$(__ll_cli_get_container_list)"
         else
             opts="--signal -s"
         fi
         ;;
     install)
-        opts="--module --repo --force -y"
+        opts="--module --repo --force -y --no-auto-prune"
 
         if [[ "$cur" != -* ]]; then
             _filedir '@(layer|uab)'
@@ -116,13 +123,28 @@ _ll_cli_completion() {
         fi
         ;;
     upgrade)
-        opts="$(__ll_cli_get_installed_app_list)"
+        if [[ "$cur" == -* ]]; then
+            opts="--deps-only --no-auto-prune"
+        else
+            opts="$(__ll_cli_get_installed_app_list)"
+        fi
         ;;
     uninstall)
-        if [[ "$prev" == "uninstall" ]]; then
+        if [[ "$prev" == "uninstall" && "$cur" != -* ]]; then
             opts="$(__ll_cli_get_installed_app_list)"
         else
-            opts="--module --force"
+            opts="--module --force --no-auto-prune"
+        fi
+        ;;
+    analyze)
+        local analyze_subs="size depends"
+        if [[ "$prev" == "analyze" ]]; then
+            opts="$analyze_subs"
+        elif [[ "$prev" == "size" || "$prev" == "--sort" ]]; then
+            [[ "$prev" == "size" ]] && opts="--sort --asc"
+            [[ "$prev" == "--sort" ]] && opts="actual logical exclusive shared id"
+        elif [[ "$prev" == "depends" ]]; then
+            opts="$(__ll_cli_get_installed_list)"
         fi
         ;;
     search | list)
@@ -137,6 +159,8 @@ _ll_cli_completion() {
         local repo_subs="add remove update set-default show set-priority enable-mirror disable-mirror"
         if [[ "$prev" == "repo" ]]; then
             opts="$repo_subs"
+        elif [[ " ${words[*]} " =~ " enable-mirror " ]]; then
+            opts="--region"
         elif [[ " remove update set-default set-priority enable-mirror disable-mirror " =~ " $prev " ]]; then
             opts="$(__ll_cli_get_repo_alias_list)"
         elif [[ " ${words[*]} " =~ " add " ]]; then

--- a/misc/share/fish/vendor_completions.d/ll-builder.fish
+++ b/misc/share/fish/vendor_completions.d/ll-builder.fish
@@ -9,25 +9,29 @@ function __ll_builder_get_refs
     ll-builder list 2>/dev/null
 end
 
+function __ll_builder_get_layer_files
+    find . -maxdepth 1 -name '*.layer' -printf '%f\n' 2>/dev/null
+end
+
 complete -c ll-builder -n "__fish_use_subcommand" -l version
 
 complete -c ll-builder -s h -l help
 complete -c ll-builder -l help-all
 
 # 3. Subcommands
-set -l cmds create build run export push import import-dir extract repo remove list
+set -l cmds create build run export push import extract clean repo remove list
 complete -c ll-builder -f -n "__fish_use_subcommand" -a "$cmds"
 
 # 4. Build options
 complete -c ll-builder -f -n "__fish_seen_subcommand_from build" -s f -l file -l offline -l isolate-network
-complete -c ll-builder -f -n "__fish_seen_subcommand_from build" -l full-develop-module -l skip-fetch-source -l skip-pull-depend -l skip-run-container -l skip-commit-output -l skip-output-check -l skip-strip-symbols
+complete -c ll-builder -f -n "__fish_seen_subcommand_from build" -l skip-fetch-source -l skip-pull-depend -l skip-run-container -l skip-commit-output -l skip-output-check -l skip-strip-symbols
 
 # 5. Run options
-complete -c ll-builder -f -n "__fish_seen_subcommand_from run" -s f -l file -l modules -l debug
+complete -c ll-builder -f -n "__fish_seen_subcommand_from run" -s f -l file -l modules -l workdir -l debug
 complete -c ll-builder -f -n "__fish_seen_subcommand_from run" -l extensions -a "(__ll_builder_get_refs)"
 
 # 6. Export options
-complete -c ll-builder -f -n "__fish_seen_subcommand_from export" -s f -l file -l icon -l layer -l loader -l no-develop -s o -l output -l modules
+complete -c ll-builder -f -n "__fish_seen_subcommand_from export" -s f -l file -l icon -l layer -l uabx -l loader -l no-develop -s o -l output -l modules
 complete -c ll-builder -f -n "__fish_seen_subcommand_from export" -s z -l compressor -a "lz4 lzma zstd"
 complete -c ll-builder -f -n "__fish_seen_subcommand_from export" -l ref -a "(__ll_builder_get_refs)"
 
@@ -35,13 +39,17 @@ complete -c ll-builder -f -n "__fish_seen_subcommand_from export" -l ref -a "(__
 complete -c ll-builder -f -n "__fish_seen_subcommand_from remove" -l no-clean-objects
 complete -c ll-builder -f -n "__fish_seen_subcommand_from remove" -a "(__ll_builder_get_refs)"
 
+# clean
+complete -c ll-builder -f -n "__fish_seen_subcommand_from clean" -s f -l file
+
 # 8. Push options
 complete -c ll-builder -f -n "__fish_seen_subcommand_from push" -s f -l file -l repo-url -l repo-name -l module
 
 # 9. Repo subcommands and arguments
-complete -c ll-builder -f -n "__fish_seen_subcommand_from repo" -a "add remove update set-default show enable-mirror disable-mirror"
-set -l repo_sub_needs_name remove update set-default enable-mirror disable-mirror
+complete -c ll-builder -f -n "__fish_seen_subcommand_from repo" -a "add remove update set-default show set-priority enable-mirror disable-mirror"
+set -l repo_sub_needs_name remove update set-default set-priority enable-mirror disable-mirror
 complete -c ll-builder -f -n "__fish_seen_subcommand_from repo; and __fish_seen_subcommand_from $repo_sub_needs_name" -a "(__ll_builder_get_repos)"
+complete -c ll-builder -f -n "__fish_seen_subcommand_from repo; and __fish_seen_subcommand_from enable-mirror" -l region
 
 # 10. File completions for specific commands
-complete -c ll-builder -f -n "__fish_seen_subcommand_from import extract" -a "(ls *.layer 2>/dev/null)"
+complete -c ll-builder -f -n "__fish_seen_subcommand_from import extract" -a "(__ll_builder_get_layer_files)"

--- a/misc/share/fish/vendor_completions.d/ll-cli.fish
+++ b/misc/share/fish/vendor_completions.d/ll-cli.fish
@@ -34,23 +34,27 @@ for opt in $global_short_opts
 end
 
 # --- 一级子命令定义 ---
-set -l subcommands run ps enter kill install uninstall upgrade search list repo info content prune
+set -l subcommands run ps enter kill install uninstall upgrade search list analyze repo info content prune
 complete -c ll-cli -n "__fish_use_subcommand" -a "$subcommands"
 
 # --- 子命令参数补全逻辑 ---
 
 # run, enter, kill
 complete -c ll-cli -n "__fish_seen_subcommand_from run" -l file -l url -l env -l base -l runtime -l extensions
+complete -c ll-cli -n "__fish_seen_subcommand_from run" -l workdir -l enable-xdp -l disable-xdp -l enable-pipewire -l enable-atspi -l cdi-spec-dir -l device -l device-mode -l instance -l debug -l debug-listen -l debug-debuginfod -l debug-symbol-dir
+complete -c ll-cli -n "__fish_seen_subcommand_from run; and __fish_contains_opt device-mode" -xa "passthru"
+complete -c ll-cli -n "__fish_seen_subcommand_from ps" -l no-truncated
 complete -c ll-cli -n "__fish_seen_subcommand_from run" -a "(__fish_ll_cli_get_installed_apps)"
 complete -c ll-cli -n "__fish_seen_subcommand_from enter" -l working-directory
 complete -c ll-cli -n "__fish_seen_subcommand_from kill" -s s -l signal -xa "SIGTERM SIGKILL SIGINT SIGHUP"
 complete -c ll-cli -n "__fish_seen_subcommand_from enter kill" -a "(__fish_ll_cli_get_containers)"
 
 # install / uninstall / upgrade
-complete -c ll-cli -n "__fish_seen_subcommand_from install" -l module -l repo -l force -s y
+complete -c ll-cli -n "__fish_seen_subcommand_from install" -l module -l repo -l force -s y -l no-auto-prune
 complete -c ll-cli -n "__fish_seen_subcommand_from install" -k -a "(__fish_complete_suffix .layer .uab)"
-complete -c ll-cli -n "__fish_seen_subcommand_from uninstall" -l module -l force
+complete -c ll-cli -n "__fish_seen_subcommand_from uninstall" -l module -l force -l no-auto-prune
 complete -c ll-cli -n "__fish_seen_subcommand_from uninstall upgrade" -a "(__fish_ll_cli_get_installed_apps)"
+complete -c ll-cli -n "__fish_seen_subcommand_from upgrade" -l deps-only -l no-auto-prune
 
 # search / list
 complete -c ll-cli -n "__fish_seen_subcommand_from search list" -l type -xa "runtime base app all"
@@ -62,6 +66,13 @@ set -l repo_subs add remove update set-default show set-priority enable-mirror d
 complete -c ll-cli -n "__fish_seen_subcommand_from repo; and not __fish_seen_subcommand_from $repo_subs" -a "$repo_subs"
 complete -c ll-cli -n "__fish_seen_subcommand_from repo; and __fish_seen_subcommand_from add" -l alias
 complete -c ll-cli -n "__fish_seen_subcommand_from repo; and __fish_seen_subcommand_from remove update set-default set-priority enable-mirror disable-mirror" -a "(__fish_ll_cli_get_repo_aliases)"
+complete -c ll-cli -n "__fish_seen_subcommand_from repo; and __fish_seen_subcommand_from enable-mirror" -l region
+
+# analyze
+complete -c ll-cli -n "__fish_seen_subcommand_from analyze; and not __fish_seen_subcommand_from size depends" -a "size depends"
+complete -c ll-cli -n "__fish_seen_subcommand_from analyze; and __fish_seen_subcommand_from size" -l sort -l asc
+complete -c ll-cli -n "__fish_seen_subcommand_from analyze; and __fish_seen_subcommand_from size; and __fish_contains_opt sort" -a "actual logical exclusive shared id"
+complete -c ll-cli -n "__fish_seen_subcommand_from analyze; and __fish_seen_subcommand_from depends" -a "(__fish_ll_cli_get_installed_all)"
 
 # info 和 content 支持已安装的 app/runtime
 complete -c ll-cli -n "__fish_seen_subcommand_from info content" -a "(__fish_ll_cli_get_installed_all)"

--- a/misc/share/zsh/vendor-completions/_ll-builder
+++ b/misc/share/zsh/vendor-completions/_ll-builder
@@ -14,7 +14,7 @@ _ll_builder_get_repo_name_list() {
 
 _ll-builder() {
     local -a subcommands
-    subcommands=(create build run export push import import-dir extract repo list remove)
+    subcommands=(create build run export push import extract clean repo list remove)
 
     _arguments -C \
         '--version' \
@@ -32,7 +32,7 @@ _ll-builder() {
                     _arguments '(-h --help --help-all)'{-h,--help,--help-all}
                     ;;
                 build)
-                    _values '' -f --file --offline --isolate-network --full-develop-module \
+                    _values '' -f --file --offline --isolate-network \
                         --skip-fetch-source --skip-pull-depend --skip-run-container \
                         --skip-commit-output --skip-output-check --skip-strip-symbols \
                         -h --help --help-all
@@ -40,13 +40,13 @@ _ll-builder() {
                 run)
                     _arguments \
                         '(-f --file)'{-f,--file} \
-                        '--modules' '--debug' \
+                        '--modules' '--workdir' '--debug' \
                         '--extensions: :($( _ll_builder_get_commited_list ))' \
                         '(-h --help --help-all)'{-h,--help,--help-all}
                     ;;
                 export)
                     _arguments \
-                        '(-f --file)'{-f,--file} '--icon' '--layer' '--loader' '--no-develop' \
+                        '(-f --file)'{-f,--file} '--icon' '--layer' '--uabx' '--loader' '--no-develop' \
                         '(-o --output)'{-o,--output} '--modules' \
                         '(-z --compressor)'{-z,--compressor}': :(lz4 lzma zstd)' \
                         '--ref: :($( _ll_builder_get_commited_list ))' \
@@ -58,10 +58,15 @@ _ll-builder() {
                         '*: :($( _ll_builder_get_commited_list ))' \
                         '(-h --help --help-all)'{-h,--help,--help-all}
                     ;;
+                clean)
+                    _arguments \
+                        '(-f --file)'{-f,--file} \
+                        '(-h --help --help-all)'{-h,--help,--help-all}
+                    ;;
                 push)
                     _values '' -f --file --repo-url --repo-name --module -h --help --help-all
                     ;;
-                import|import-dir)
+                import)
                     _arguments '1: :_files' '(-h --help --help-all)'{-h,--help,--help-all}
                     ;;
                 extract)
@@ -69,11 +74,14 @@ _ll-builder() {
                     ;;
                 repo)
                     if (( CURRENT == 2 )); then
-                        compadd add remove update set-default show enable-mirror disable-mirror
+                        compadd add remove update set-default show set-priority enable-mirror disable-mirror
                     else
                         case $words[2] in
-                            remove|update|set-default|enable-mirror|disable-mirror)
+                            remove|update|set-default|set-priority|disable-mirror)
                                 compadd $(_ll_builder_get_repo_name_list)
+                                ;;
+                            enable-mirror)
+                                _arguments '--region:region:' '*: :($(_ll_builder_get_repo_name_list))'
                                 ;;
                         esac
                     fi

--- a/misc/share/zsh/vendor-completions/_ll-cli
+++ b/misc/share/zsh/vendor-completions/_ll-cli
@@ -47,7 +47,7 @@ _ll_cli() {
             local -a subcmds
             subcmds=(
                 'run' 'ps' 'enter' 'kill' 'install' 'uninstall'
-                'upgrade' 'search' 'list' 'repo' 'info' 'content' 'prune'
+                'upgrade' 'search' 'list' 'analyze' 'repo' 'info' 'content' 'prune'
             )
             _values 'subcommand' $subcmds
             ;;
@@ -56,15 +56,22 @@ _ll_cli() {
                 run)
                     _arguments -S -s $global_opts \
                         '--file' '--url' '--env' '--base' '--runtime' '--extensions' \
+                        '--workdir' '--enable-xdp' '--disable-xdp' '--enable-pipewire' \
+                        '--enable-atspi' '--cdi-spec-dir' '--device' \
+                        '--device-mode:mode:(passthru)' '--instance' '--debug' \
+                        '--debug-listen' '--debug-debuginfod' '--debug-symbol-dir' \
                         '1: :__ll_cli_get_installed_apps'
+                    ;;
+                ps)
+                    _arguments -S -s $global_opts '--no-truncated'
                     ;;
                 install)
                     _arguments -S -s $global_opts \
-                        '--module' '--repo' '--force' '-y' \
+                        '--module' '--repo' '--force' '-y' '--no-auto-prune' \
                         '*:file:_files -g "*.uab *.layer"'
                     ;;
                 uninstall)
-                    _arguments -S -s $global_opts '--module' '--force' '1: :__ll_cli_get_installed_apps'
+                    _arguments -S -s $global_opts '--module' '--force' '--no-auto-prune' '1: :__ll_cli_get_installed_apps'
                     ;;
                 repo)
                     if ((CURRENT == 2)); then
@@ -78,8 +85,11 @@ _ll_cli() {
                                     '--alias:alias: ' \
                                     '*:repository name/URL:'
                                 ;;
-                            remove | set-default | set-priority | enable-mirror | disable-mirror | update)
+                            remove | set-default | set-priority | disable-mirror | update)
                                 _arguments -S -s $global_opts "*: :__ll_cli_get_repo_aliases"
+                                ;;
+                            enable-mirror)
+                                _arguments -S -s $global_opts '--region' "*: :__ll_cli_get_repo_aliases"
                                 ;;
                         esac
                     fi
@@ -100,7 +110,31 @@ _ll_cli() {
                         '--upgradable'
                     ;;
                 upgrade)
-                    _arguments -S -s $global_opts '1: :__ll_cli_get_installed_apps'
+                    _arguments -S -s $global_opts '--deps-only' '--no-auto-prune' '1: :__ll_cli_get_installed_apps'
+                    ;;
+                analyze)
+                    if ((CURRENT == 2)); then
+                        local -a analyze_subs
+                        analyze_subs=('size' 'depends')
+                        _values 'analyze subcommand' $analyze_subs
+                    else
+                        case $words[2] in
+                            size)
+                                if [[ $words[CURRENT-1] == "--sort" ]]; then
+                                    compadd -- actual logical exclusive shared id
+                                else
+                                    compadd -- --sort --asc \
+                                        --help --help-all --json --verbose -v --no-progress
+                                fi
+                                ;;
+                            depends)
+                                local -a all_items
+                                all_items=(${(f)"$(ll-cli list 2>/dev/null | awk 'NR>1 {print $1}')"})
+                                compadd -- --help --help-all --json --verbose -v --no-progress
+                                compadd -- $all_items
+                                ;;
+                        esac
+                    fi
                     ;;
                 info)
                     _arguments -s -S $global_opts \


### PR DESCRIPTION
1. Update ll-builder and ll-cli completions for bash, fish, and zsh to align with current CLI behavior
2. Remove obsolete ll-builder `import-dir` subcommand and `--full- develop-module` build option
3. Add ll-builder `clean` subcommand completion and optional layer file listing
4. Add ll-cli `analyze` subcommand with `size` and `depends` completions
5. Add new run options: `--workdir`, `--enable-xdp`, `--disable-xdp`, `--enable-pipewire`, `--enable-atspi`, `--cdi-spec-dir`, `--device`, `--device-mode`, `--instance`, and debug flags
6. Add `--no-auto-prune` to ll-cli install/uninstall and `--deps-only` to upgrade completions
7. Add `ps --no-truncated`, `repo enable-mirror --region`, and `repo set-priority` completions
8. Fix completion logic to distinguish options from positional arguments where needed

Influence:
1. Verify ll-builder completions include new `clean` subcommand and `--uabx` export option
2. Verify ll-builder no longer suggests `import-dir` or `--full-develop- module`
3. Verify ll-cli `analyze size` and `analyze depends` completions work correctly with available options
4. Verify ll-cli `run` now suggests `--workdir`, device, and debug- related flags
5. Verify ll-cli `install` and `uninstall` suggest `--no-auto-prune`, and `upgrade` suggests `--deps-only`
6. Verify `repo enable-mirror` suggests `--region` and existing repo aliases
7. Verify `import`/`extract` completions still offer layer files and options properly
8. Verify no regression in bash, fish, or zsh completion behavior for existing commands