### PR TITLE
feat: resolve host dynamic mounts in run context

### DIFF
--- a/api/schema/v1.json
+++ b/api/schema/v1.json
@@ -1563,6 +1563,12 @@
           "items": {
             "$ref": "#/$defs/Mount"
           }
+        },
+        "hostDynamic": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Mount"
+          }
         }
       }
     },

--- a/api/schema/v1.yaml
+++ b/api/schema/v1.yaml
@@ -1175,6 +1175,10 @@ $defs:
         type: array
         items:
           $ref: '#/$defs/Mount'
+      hostDynamic:
+        type: array
+        items:
+          $ref: '#/$defs/Mount'
   CDIDeviceEntry:
     title: CDIDeviceEntry
     type: object

--- a/libs/api/src/linglong/api/types/v1/Generators.hpp
+++ b/libs/api/src/linglong/api/types/v1/Generators.hpp
@@ -1285,6 +1285,7 @@ x.app = get_stack_optional<std::string>(j, "app");
 x.base = get_stack_optional<std::string>(j, "base");
 x.cdiDevices = get_stack_optional<std::vector<CdiDeviceEntry>>(j, "cdiDevices");
 x.extensions = get_stack_optional<std::map<std::string, std::vector<std::string>>>(j, "extensions");
+x.hostDynamic = get_stack_optional<std::vector<Mount>>(j, "hostDynamic");
 x.instance = get_stack_optional<std::string>(j, "instance");
 x.mounts = get_stack_optional<std::vector<Mount>>(j, "mounts");
 x.overlayfs = get_stack_optional<std::string>(j, "overlayfs");
@@ -1307,6 +1308,9 @@ j["cdiDevices"] = x.cdiDevices;
 }
 if (x.extensions) {
 j["extensions"] = x.extensions;
+}
+if (x.hostDynamic) {
+j["hostDynamic"] = x.hostDynamic;
 }
 if (x.instance) {
 j["instance"] = x.instance;

--- a/libs/api/src/linglong/api/types/v1/RunContextConfig.hpp
+++ b/libs/api/src/linglong/api/types/v1/RunContextConfig.hpp
@@ -31,6 +31,7 @@ std::optional<std::string> app;
 std::optional<std::string> base;
 std::optional<std::vector<CdiDeviceEntry>> cdiDevices;
 std::optional<std::map<std::string, std::vector<std::string>>> extensions;
+std::optional<std::vector<Mount>> hostDynamic;
 std::optional<std::string> instance;
 std::optional<std::vector<Mount>> mounts;
 std::optional<std::string> overlayfs;

--- a/libs/linglong/src/linglong/runtime/container_builder.cpp
+++ b/libs/linglong/src/linglong/runtime/container_builder.cpp
@@ -489,36 +489,69 @@ auto ContainerBuilder::normalizeContainerRootfs(
         }
     }
 
+    auto ensureMountPoint = [&](const std::string &destination,
+                                const std::string &srcType) -> utils::error::Result<void> {
+        auto destPath = std::filesystem::path(destination);
+        auto dest = rootfs / (destPath.is_absolute() ? destPath.relative_path() : destPath);
+        if (!isPathInRootfs(dest, rootfs)) {
+            return LINGLONG_ERR(
+              fmt::format("mount destination {} is outside rootfs {}", dest, rootfs));
+        }
+
+        std::error_code ec;
+        if (std::filesystem::exists(dest, ec)) {
+            const auto destIsDirectory = std::filesystem::is_directory(dest, ec);
+            if (!ec
+                && ((srcType == "file" && !destIsDirectory)
+                    || (srcType != "file" && destIsDirectory))) {
+                return LINGLONG_OK;
+            }
+
+            ec.clear();
+            std::filesystem::remove_all(dest, ec);
+            if (ec) {
+                LogW("failed to recreate mount point {}: {}", dest, ec.message());
+                return LINGLONG_OK;
+            }
+        }
+        if (srcType == "file") {
+            std::filesystem::create_directories(dest.parent_path(), ec);
+            if (ec) {
+                LogW("failed to create directories for mount point {}: {}",
+                     dest.parent_path(),
+                     ec.message());
+                return LINGLONG_OK;
+            }
+            std::ofstream(dest) << "";
+        } else {
+            std::filesystem::create_directories(dest, ec);
+            if (ec) {
+                LogW("failed to create mount point {}: {}", dest, ec.message());
+            }
+        }
+        return LINGLONG_OK;
+    };
+
     if (config.mounts) {
         for (const auto &m : *config.mounts) {
             if (!m.srcType) {
                 continue;
             }
-            auto destPath = std::filesystem::path(m.destination);
-            auto dest = rootfs / (destPath.is_absolute() ? destPath.relative_path() : destPath);
-            if (!isPathInRootfs(dest, rootfs)) {
-                return LINGLONG_ERR(
-                  fmt::format("mount destination {} is outside rootfs {}", dest, rootfs));
+            auto ret = ensureMountPoint(m.destination, *m.srcType);
+            if (!ret) {
+                return ret;
             }
+        }
+    }
 
-            std::error_code ec;
-            if (std::filesystem::exists(dest, ec)) {
+    if (config.hostDynamic) {
+        for (const auto &state : *config.hostDynamic) {
+            if (!state.srcType) {
                 continue;
             }
-            if (*m.srcType == "file") {
-                std::filesystem::create_directories(dest.parent_path(), ec);
-                if (ec) {
-                    LogW("failed to create directories for mount point {}: {}",
-                         dest.parent_path(),
-                         ec.message());
-                    continue;
-                }
-                std::ofstream(dest) << "";
-            } else {
-                std::filesystem::create_directories(dest, ec);
-                if (ec) {
-                    LogW("failed to create mount point {}: {}", dest, ec.message());
-                }
+            auto ret = ensureMountPoint(state.destination, *state.srcType);
+            if (!ret) {
+                return ret;
             }
         }
     }

--- a/libs/linglong/src/linglong/runtime/run_context.cpp
+++ b/libs/linglong/src/linglong/runtime/run_context.cpp
@@ -17,6 +17,7 @@
 #include <fmt/ranges.h>
 
 #include <algorithm>
+#include <array>
 #include <cstdlib>
 #include <utility>
 
@@ -301,6 +302,8 @@ utils::error::Result<void> RunContext::resolve(const linglong::package::Referenc
         return LINGLONG_ERR("failed to resolve network configuration", networkConfRet);
     }
 
+    resolveHostDynamic();
+
     if (opts.cdiDevices) {
         contextCfg.cdiDevices = opts.cdiDevices.value();
     }
@@ -386,6 +389,8 @@ utils::error::Result<void> RunContext::resolve(const api::types::v1::BuilderProj
     if (!networkConfRet) {
         return LINGLONG_ERR("failed to resolve network configuration", networkConfRet);
     }
+
+    resolveHostDynamic();
 
     return resolveLayer(false, {});
 }
@@ -563,6 +568,7 @@ utils::error::Result<void> RunContext::resolve(const api::types::v1::RunContextC
     contextCfg.resolvConf = config.resolvConf;
     contextCfg.timezone = config.timezone;
     contextCfg.instance = config.instance;
+    contextCfg.hostDynamic = config.hostDynamic;
     contextCfg.mounts = config.mounts;
     contextCfg.version = runContextConfigVersion;
 
@@ -836,6 +842,39 @@ utils::error::Result<void> RunContext::resolveTimeZone()
     }
 
     return LINGLONG_OK;
+}
+
+void RunContext::resolveHostDynamic()
+{
+    LINGLONG_TRACE("resolve host dynamic paths");
+
+    constexpr std::array<const char *, 0> paths{};
+
+    std::vector<api::types::v1::Mount> hostDynamic;
+    hostDynamic.reserve(paths.size());
+    for (const auto *rawPath : paths) {
+        hostDynamic.emplace_back(api::types::v1::Mount{
+          .destination = rawPath,
+          .options = std::vector<std::string>{ "rbind", "ro", "rslave" },
+          .source = rawPath,
+          .srcType = std::nullopt,
+          .type = "bind",
+        });
+    }
+
+    ensureMountSrcType(hostDynamic);
+    hostDynamic.erase(std::remove_if(hostDynamic.begin(),
+                                     hostDynamic.end(),
+                                     [](const auto &mount) {
+                                         return !mount.srcType;
+                                     }),
+                      hostDynamic.end());
+
+    if (hostDynamic.empty()) {
+        contextCfg.hostDynamic.reset();
+        return;
+    }
+    contextCfg.hostDynamic = std::move(hostDynamic);
 }
 
 utils::error::Result<void> RunContext::resolveLayerExtensions(

--- a/libs/linglong/src/linglong/runtime/run_context.h
+++ b/libs/linglong/src/linglong/runtime/run_context.h
@@ -142,6 +142,7 @@ private:
     resolveOverlayMode(std::optional<std::string> requestedMode = std::nullopt);
     utils::error::Result<void> resolveNetworkConf();
     utils::error::Result<void> resolveTimeZone();
+    void resolveHostDynamic();
 
     repo::OSTreeRepo &repo;
     std::optional<RuntimeLayer> baseLayer;

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_test.cpp
@@ -650,6 +650,9 @@ TEST_F(RunContextTest, resolveFromConfig)
     config.runtime = runtimeRef->toString();
     config.app = appRef->toString();
     config.resolvConf = "/run/systemd/resolve/stub-resolv.conf";
+    config.hostDynamic = std::vector<api::types::v1::Mount>{
+        { .destination = "/etc/hosts", .source = "/etc/hosts", .srcType = "file", .type = "bind" },
+    };
     config.extensions = std::map<std::string, std::vector<std::string>>{
         { appRef->toString(), std::vector<std::string>{ extensionRef->toString() } }
     };
@@ -711,6 +714,10 @@ TEST_F(RunContextTest, resolveFromConfig)
     EXPECT_EQ(retConfig.app.value(), appRef->toString());
     ASSERT_TRUE(retConfig.resolvConf.has_value());
     EXPECT_EQ(*retConfig.resolvConf, "/run/systemd/resolve/stub-resolv.conf");
+    ASSERT_TRUE(retConfig.hostDynamic.has_value());
+    ASSERT_EQ(retConfig.hostDynamic->size(), 1);
+    EXPECT_EQ(retConfig.hostDynamic->front().destination, "/etc/hosts");
+    EXPECT_EQ(retConfig.hostDynamic->front().srcType, "file");
     ASSERT_TRUE(retConfig.extensions.has_value());
     ASSERT_FALSE(retConfig.extensions->empty());
     ASSERT_EQ(retConfig.extensions->size(), 1);


### PR DESCRIPTION
Add `hostDynamic` to RunContextConfig holding mounts for hosts paths that change at runtime. Rootfs normalization now pre-creates the mount points for both `mounts` and `hostDynamic`.