### PR TITLE
fix(package-manager): prevent app removal after extra module failure

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -1348,7 +1348,8 @@ utils::error::Result<void> PackageManager::installRef(Task &task,
     return LINGLONG_OK;
 }
 
-utils::error::Result<bool> PackageManager::tryUninstallRef(const package::Reference &ref) noexcept
+utils::error::Result<bool> PackageManager::tryUninstallRef(
+  const package::Reference &ref, std::optional<std::vector<std::string>> modules) noexcept
 {
     LINGLONG_TRACE(fmt::format("try uninstall ref {}", ref.toString()));
 
@@ -1359,8 +1360,10 @@ utils::error::Result<bool> PackageManager::tryUninstallRef(const package::Refere
     }
 
     if (*busy) {
-        auto modules = repo->getModuleList(ref);
-        for (const auto &module : modules) {
+        if (!modules) {
+            modules = repo->getModuleList(ref);
+        }
+        for (const auto &module : *modules) {
             auto res = repo->markDeleted(ref, true, module);
             if (res) {
                 transaction.addRollBack([this, &ref, module]() noexcept {
@@ -1374,7 +1377,7 @@ utils::error::Result<bool> PackageManager::tryUninstallRef(const package::Refere
             }
         }
     } else {
-        auto res = uninstallRef(ref);
+        auto res = uninstallRef(ref, std::move(modules));
         if (!res) {
             return LINGLONG_ERR(res.error());
         }

--- a/libs/linglong/src/linglong/package_manager/package_manager.h
+++ b/libs/linglong/src/linglong/package_manager/package_manager.h
@@ -110,7 +110,9 @@ public
                                          const package::Reference &ref,
                                          const std::string &module,
                                          bool noAutoPrune = false) noexcept;
-    virtual utils::error::Result<bool> tryUninstallRef(const package::Reference &ref) noexcept;
+    virtual utils::error::Result<bool>
+    tryUninstallRef(const package::Reference &ref,
+                    std::optional<std::vector<std::string>> modules = std::nullopt) noexcept;
     utils::error::Result<void>
     uninstallRef(const package::Reference &ref,
                  std::optional<std::vector<std::string>> modules = std::nullopt) noexcept;

--- a/libs/linglong/src/linglong/package_manager/ref_installation.cpp
+++ b/libs/linglong/src/linglong/package_manager/ref_installation.cpp
@@ -343,15 +343,17 @@ utils::error::Result<void> RefInstallationAction::install(Task &task)
     LogD("install total size {}, need download size {}", taskTotalSize, taskNeededSize);
 
     utils::Transaction transaction;
-    // uninstall target ref if failed
-    transaction.addRollBack([this]() noexcept {
-        auto res = pm.tryUninstallRef(operation.newRef->reference);
-        if (!res) {
-            LogW("failed to roll back installed {}: {}",
-                 operation.newRef->reference.toString(),
-                 res.error());
-        }
-    });
+    if (!installingExtraModulesOnly) {
+        // uninstall target ref if failed
+        transaction.addRollBack([this]() noexcept {
+            auto res = pm.tryUninstallRef(operation.newRef->reference);
+            if (!res) {
+                LogW("failed to roll back installed {}: {}",
+                     operation.newRef->reference.toString(),
+                     res.error());
+            }
+        });
+    }
     for (const auto &item : refsToInstall) {
         const auto &[refRepo, module, meta] = item;
 
@@ -361,6 +363,17 @@ utils::error::Result<void> RefInstallationAction::install(Task &task)
         auto res = pm.installRefModule(task, refRepo, module);
         if (!res) {
             return LINGLONG_ERR(res);
+        }
+        if (installingExtraModulesOnly) {
+            transaction.addRollBack([this, ref = refRepo.reference, module]() noexcept {
+                auto res = pm.tryUninstallRef(ref, std::vector<std::string>{ module });
+                if (!res) {
+                    LogW("failed to roll back installed {}/{}: {}",
+                         ref.toString(),
+                         module,
+                         res.error());
+                }
+            });
         }
     }
 

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/ref_installation_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/ref_installation_test.cpp
@@ -63,6 +63,11 @@ public:
 
     MOCK_METHOD(utils::error::Result<void>, pruneUnused, (), (override, noexcept));
 
+    MOCK_METHOD(utils::error::Result<bool>,
+                tryUninstallRef,
+                (const package::Reference &ref, std::optional<std::vector<std::string>> modules),
+                (override, noexcept));
+
     MOCK_METHOD(utils::error::Result<void>,
                 executePostInstallHooks,
                 (const package::Reference &ref),
@@ -314,6 +319,69 @@ TEST_F(RefInstallationTest, InstallExtraOnly)
     service::PackageTask task({});
     ASSERT_TRUE(action->prepare());
     ASSERT_TRUE(action->doAction(task));
+}
+
+TEST_F(RefInstallationTest, InstallExtraOnlyFailureKeepsExistingModules)
+{
+    LINGLONG_TRACE("InstallExtraOnlyFailureKeepsExistingModules");
+
+    auto fuzzy = package::FuzzyReference::parse("main:id/1.0.0/x86_64").value();
+    std::vector<std::string> modules{ "develop", "debug" };
+    api::types::v1::CommonOptions opts{ .force = false, .skipInteraction = true };
+    auto action =
+      service::RefInstallationAction::create(fuzzy, modules, *pm, *repo, opts, std::nullopt);
+
+    auto localRef = package::Reference::parse("main:id/1.0.0/x86_64").value();
+    EXPECT_CALL(*repo, latestLocalReference(_)).WillOnce(Return(localRef));
+    EXPECT_CALL(*repo, getLayerItem(localRef, "develop"))
+      .WillOnce(Return(LINGLONG_ERR("not found")));
+    EXPECT_CALL(*repo, getLayerItem(localRef, "debug")).WillOnce(Return(LINGLONG_ERR("not found")));
+
+    api::types::v1::PackageInfoV2 infoDevelop{
+        .arch = { "x86_64" },
+        .base = "base",
+        .channel = "main",
+        .id = "id",
+        .kind = "app",
+        .packageInfoV2Module = "develop",
+        .runtime = "runtime",
+        .version = "1.0.0",
+    };
+    auto infoDebug = infoDevelop;
+    infoDebug.packageInfoV2Module = "debug";
+
+    repo::RemotePackages remote;
+    remote.addPackages(api::types::v1::Repo{ .name = "repo" },
+                       std::vector<api::types::v1::PackageInfoV2>{ infoDevelop, infoDebug });
+    EXPECT_CALL(*repo, matchRemoteByPriority(_, _)).WillOnce(Return(std::move(remote)));
+
+    EXPECT_CALL(*repo, fetchRefMetaData(_, "develop", true))
+      .WillOnce(Return(repo::RefMetaData{ "rev123", nlohmann::json(infoDevelop).dump() }));
+    EXPECT_CALL(*repo, fetchRefMetaData(_, "debug", false))
+      .WillOnce(Return(repo::RefMetaData{ "rev124", nlohmann::json(infoDebug).dump() }));
+    EXPECT_CALL(*repo, getRefStatistics(_)).WillRepeatedly([](const repo::RefMetaData &) {
+        return utils::error::Result<repo::RefStatistics>{
+            repo::RefStatistics{ .archived = 1000, .needed_archived = 500 }
+        };
+    });
+
+    EXPECT_CALL(*pm, needToInstall("base", _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*pm, needToInstall("runtime", _)).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*pm, installRefModule(_, _, "develop"))
+      .WillOnce(Return(utils::error::Result<void>{}));
+    EXPECT_CALL(*pm, installRefModule(_, _, "debug")).WillOnce(Return(LINGLONG_ERR("pull failed")));
+    EXPECT_CALL(*pm, tryUninstallRef(localRef, _))
+      .WillOnce([&](const package::Reference &,
+                    const std::optional<std::vector<std::string>> &rollbackModules) {
+          EXPECT_EQ(rollbackModules, std::vector<std::string>{ "develop" });
+          return utils::error::Result<bool>{ true };
+      });
+    EXPECT_CALL(*repo, mergeModules()).Times(0);
+    EXPECT_CALL(*pm, applyApp(_, _)).Times(0);
+
+    service::PackageTask task({});
+    ASSERT_TRUE(action->prepare());
+    ASSERT_FALSE(action->doAction(task));
 }
 
 TEST_F(RefInstallationTest, InstallMultipleModules)


### PR DESCRIPTION
## 问题

为已安装应用追加多个模块时，安装流程会预先注册整个应用引用的回滚操作。如果后续模块安装失败，回滚可能删除或标记删除应用的全部模块，包括原有的 binary 模块，导致已经安装的应用不可用。

## 修改

- 普通安装仍保持原有的整包回滚逻辑。
- 追加模块时，仅在模块安装成功后登记回滚。
- 回滚范围限定为本次成功安装的模块，不影响应用原有模块。
- 增加回归测试，覆盖前一个模块安装成功、后一个模块安装失败的场景。

## 验证

- Ubuntu 24.04 + Qt 6 完整编译通过。
- `RefInstallationTest.InstallExtraOnlyFailureKeepsExistingModules` 通过。
- 安装和卸载相关测试 20/20 通过。