### PR TITLE
fix(package-manager): fail uninstall when module removal fails

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -1396,12 +1396,19 @@ utils::error::Result<void> PackageManager::uninstallRef(
          ref.toString(),
          common::strings::join(modules.value(), ','));
 
+    std::optional<utils::error::Error> firstError;
     for (const auto &module : modules.value()) {
         auto res = uninstallRefModule(ref, module);
         if (!res) {
             LogW(fmt::format("failed to uninstall {}/{}: {}", ref.toString(), module, res.error()));
+            if (!firstError) {
+                firstError = std::move(res).error();
+            }
             continue;
         }
+    }
+    if (firstError) {
+        return LINGLONG_ERR(std::move(*firstError));
     }
 
     return LINGLONG_OK;

--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -1397,10 +1397,13 @@ utils::error::Result<void> PackageManager::uninstallRef(
          common::strings::join(modules.value(), ','));
 
     std::optional<utils::error::Error> firstError;
+    std::vector<std::string> failures;
     for (const auto &module : modules.value()) {
         auto res = uninstallRefModule(ref, module);
         if (!res) {
-            LogW(fmt::format("failed to uninstall {}/{}: {}", ref.toString(), module, res.error()));
+            auto message = res.error().message();
+            LogW(fmt::format("failed to uninstall {}/{}: {}", ref.toString(), module, message));
+            failures.emplace_back(fmt::format("{}: {}", module, message));
             if (!firstError) {
                 firstError = std::move(res).error();
             }
@@ -1408,7 +1411,17 @@ utils::error::Result<void> PackageManager::uninstallRef(
         }
     }
     if (firstError) {
-        return LINGLONG_ERR(std::move(*firstError));
+        auto merged = repo->mergeModules();
+        if (!merged) {
+            LogW("failed to merge modules after uninstalling {}: {}",
+                 ref.toString(),
+                 merged.error());
+        }
+
+        return LINGLONG_ERR(fmt::format("failed to uninstall {} modules: {}",
+                                        ref.toString(),
+                                        common::strings::join(failures, '\n')),
+                            std::move(*firstError));
     }
 
     return LINGLONG_OK;

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/action_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/action_test.cpp
@@ -46,6 +46,8 @@ public:
                 getLayerItem,
                 (const package::Reference &ref, std::string module),
                 (override, const, noexcept));
+
+    MOCK_METHOD(utils::error::Result<void>, mergeModules, (), (override, const, noexcept));
 };
 
 class MockAction : public service::Action
@@ -129,18 +131,26 @@ TEST_F(ActionTest, InstallNewApp)
     EXPECT_EQ(result->newRef->reference.toString(), "main:id1/1.0.0/x86_64");
 }
 
-TEST_F(ActionTest, UninstallRefPropagatesModuleRemovalFailure)
+TEST_F(ActionTest, UninstallRefPropagatesAllModuleRemovalFailures)
 {
-    LINGLONG_TRACE("UninstallRefPropagatesModuleRemovalFailure");
+    LINGLONG_TRACE("UninstallRefPropagatesAllModuleRemovalFailures");
 
     auto ref = package::Reference::parse("main:id1/1.0.0/x86_64").value();
     EXPECT_CALL(*repo, getLayerItem(ref, "develop"))
-      .WillOnce(Return(LINGLONG_ERR("remove failed")));
+      .WillOnce(
+        Return(LINGLONG_ERR("remove develop failed", utils::error::ErrorCode::PermissionDenied)));
+    EXPECT_CALL(*repo, getLayerItem(ref, "debug"))
+      .WillOnce(
+        Return(LINGLONG_ERR("remove debug failed", utils::error::ErrorCode::AppUninstallFailed)));
+    EXPECT_CALL(*repo, mergeModules()).WillOnce(Return(LINGLONG_ERR("merge failed")));
 
-    auto result = pm->uninstallRef(ref, std::vector<std::string>{ "develop" });
+    auto result = pm->uninstallRef(ref, std::vector<std::string>{ "develop", "debug" });
 
     ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error().message(), "remove failed");
+    EXPECT_EQ(result.error().code(), static_cast<int>(utils::error::ErrorCode::PermissionDenied));
+    EXPECT_EQ(result.error().message(),
+              "failed to uninstall main:id1/1.0.0/x86_64 modules: develop: remove develop failed\n"
+              "debug: remove debug failed");
 }
 
 TEST_F(ActionTest, OverwriteApp)

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/action_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/action_test.cpp
@@ -41,6 +41,11 @@ public:
                 listLocalBy,
                 (const repo::repoCacheQuery &query),
                 (override, const, noexcept));
+
+    MOCK_METHOD(utils::error::Result<api::types::v1::RepositoryCacheLayersItem>,
+                getLayerItem,
+                (const package::Reference &ref, std::string module),
+                (override, const, noexcept));
 };
 
 class MockAction : public service::Action
@@ -122,6 +127,20 @@ TEST_F(ActionTest, InstallNewApp)
     EXPECT_EQ(result->kind, "app");
     EXPECT_EQ(result->oldRef, std::nullopt);
     EXPECT_EQ(result->newRef->reference.toString(), "main:id1/1.0.0/x86_64");
+}
+
+TEST_F(ActionTest, UninstallRefPropagatesModuleRemovalFailure)
+{
+    LINGLONG_TRACE("UninstallRefPropagatesModuleRemovalFailure");
+
+    auto ref = package::Reference::parse("main:id1/1.0.0/x86_64").value();
+    EXPECT_CALL(*repo, getLayerItem(ref, "develop"))
+      .WillOnce(Return(LINGLONG_ERR("remove failed")));
+
+    auto result = pm->uninstallRef(ref, std::vector<std::string>{ "develop" });
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().message(), "remove failed");
 }
 
 TEST_F(ActionTest, OverwriteApp)


### PR DESCRIPTION
## 问题背景

卸载多个模块时，`PackageManager::uninstallRef` 只记录模块删除错误，最终仍可能返回成功，导致任务和命令行误报卸载完成，实际模块仍然存在。

连续卸载时，后续模块也可能失败；如果只返回第一条错误，调用方无法获知完整失败范围。部分模块删除成功后，合并仓库状态也需要及时刷新。

## 修改内容

- 保留逐模块卸载，单个模块失败后继续处理剩余模块。
- 汇总所有失败模块及错误信息，同时保留第一条错误码作为主因。
- 出现部分删除时，返回错误前刷新合并模块状态。
- 合并失败只记录日志，不覆盖原始卸载错误。
- 增加多模块失败及错误优先级的回归测试。

## 验证

- `cmake --build build-ci --parallel 4` 通过。
- 相关文件 `clang-format --dry-run --Werror` 通过。
- `ActionTest.UninstallRefPropagatesAllModuleRemovalFailures`：1/1 通过。
- `*Install*:*Uninstall*`：32/32 通过。
- 完整 `ll-tests`：712 通过、8 跳过；1 项因容器缺少 FUSE 设备失败，同一失败已在未包含本修改的 worktree 上复现。