### PR TITLE
feat: add linglong-migration-assistant tool for package migration

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -212,3 +212,15 @@ path = "libs/cdi/src/linglong/cdi/types/**"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "None"
 SPDX-License-Identifier = "CC0-1.0"
+
+[[annotations]]
+path = "tools/linglong-migration-assistant/**.json"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Yanghanrui666"
+SPDX-License-Identifier = "LGPL-3.0-or-later"
+
+[[annotations]]
+path = "tools/linglong-migration-assistant/.gitignore"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Yanghanrui666"
+SPDX-License-Identifier = "LGPL-3.0-or-later"

--- a/tools/linglong-migration-assistant/.gitignore
+++ b/tools/linglong-migration-assistant/.gitignore
@@ -1,0 +1,28 @@
+# Python / venv
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+
+# Node
+node_modules/
+frontend/dist/
+
+# Build artifacts
+backend/tests/fixtures/*.deb
+backend/tests/fixtures/*.rpm
+backend/tests/fixtures/*.AppImage
+
+# Local env / logs
+*.log
+.env
+
+# IDE / editor
+.vscode/
+.idea/
+*.swp
+.DS_Store
+Thumbs.db
+
+# Trae working documents (internal, not for public repo)
+.trae/

--- a/tools/linglong-migration-assistant/README.md
+++ b/tools/linglong-migration-assistant/README.md
@@ -1,0 +1,77 @@
+# 如意玲珑应用迁移助手（Linyaps Migration Assistant）
+
+面向开放原子开源大赛玲珑赛题的 Web 工具：将 **deb / rpm / AppImage** 安装包快速迁移为
+[如意玲珑（Linyaps）](https://linyaps.org.cn/) 应用工程。
+
+上传安装包 → 自动解析元数据与依赖 → **依赖归属可视化分析** → 生成符合官方 1.14.x 规范的
+`linglong.yaml` → 一键导出可直接 `ll-builder build` 的完整工程 zip。
+
+## 核心特性
+
+| 特性 | 说明 |
+|---|---|
+| 三格式解析 | deb（ar+tar 纯标准库）、rpm（lead/header/cpio 纯标准库）、AppImage（squashfs，需服务器有 unsquashfs 时完整解析） |
+| 依赖归属分析 | 每个依赖自动划分三档：**base 覆盖**（org.deepin.base 提供）/ **runtime 覆盖**（org.deepin.runtime.dtk 提供）/ **需自带**（自动生成收集脚本），前端树形可视化 |
+| linglong.yaml 生成 | 按官方 manifests 规范生成 version/package/command/base/runtime/sources/build；启动命令自动换算为 `/opt/apps/<id>/files/<包内路径>`；版本号自动归一化为四段数字；应用 id 从 Homepage 域名智能反推（如 `io.github.<user>.<repo>`） |
+| 构建脚本生成 | deb 用 `dpkg-deb -x`（回退 ar+tar）安装到 `$PREFIX`；需自带依赖在容器内 `apt-get download` 自动收集；desktop 绝对路径图标自动改写 |
+| 迁移检查清单 | XDG desktop 文件、hicolor 图标、可执行文件、版本规范等自动检查（通过/注意/待处理/说明） |
+| 工程一键导出 | zip 含 linglong.yaml、README 构建指引、deps.txt、resources（原包 desktop/icon）、srcs/ 占位 |
+
+## 架构
+
+```
+frontend/  Vue 3 + TypeScript + Vite + Element Plus + CodeMirror(yaml)
+backend/   Python 3 + FastAPI
+  app/parsers/     deb.py / rpm.py / appimage.py   零外部依赖静态解析
+  app/analyzer/    rules_data.yaml 规则库 + 归属分析 + 检查清单
+  app/generator/   linglong.yaml 生成 + 工程 zip 打包
+  app/api/         FastAPI 路由（/api/analyze、/api/export）
+```
+
+## 快速开始
+
+### 后端（端口 8000）
+
+```bash
+cd backend
+python -m venv ../.venv
+../.venv/Scripts/pip install -r requirements.txt   # Linux: ../.venv/bin/pip
+../.venv/Scripts/python -m uvicorn app.main:app --port 8000
+```
+
+### 前端（端口 5173，已代理 /api 到 8000）
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+浏览器打开 http://localhost:5173，拖入 deb 包即可体验完整流程。
+
+### 测试
+
+```bash
+cd backend
+../.venv/Scripts/python -m pytest tests -q
+```
+
+测试使用真实样本包（`tests/fixtures/` 下的 sl deb/rpm）覆盖解析、依赖分类、yaml 生成与 API 全流程。
+
+## 导出工程的使用（在 Linux/deepin 环境执行）
+
+```bash
+# 1. 将原始安装包放入 srcs/
+# 2. 构建并验证
+ll-builder build
+ll-builder run --exec <可执行文件名>
+ll-builder export        # 生成 .layer
+ll-cli install *.layer
+ll-cli run <appid>
+```
+
+## 说明
+
+- 依赖归属规则库（`backend/app/analyzer/rules_data.yaml`）为启发式起点，可按构建结果持续扩充。
+- 工具定位是「迁移提效助手」：输出分析与可直接构建的工程，实际构建结果取决于应用本身。
+- 会话缓存存于内存（64 个），服务重启后需重新上传。

--- a/tools/linglong-migration-assistant/backend/app/__init__.py
+++ b/tools/linglong-migration-assistant/backend/app/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later

--- a/tools/linglong-migration-assistant/backend/app/analyzer/__init__.py
+++ b/tools/linglong-migration-assistant/backend/app/analyzer/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later

--- a/tools/linglong-migration-assistant/backend/app/analyzer/analyzer.py
+++ b/tools/linglong-migration-assistant/backend/app/analyzer/analyzer.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 """包分析器：元信息归一化、依赖归属、迁移检查清单、linglong.yaml 建议字段。"""
 from __future__ import annotations
 

--- a/tools/linglong-migration-assistant/backend/app/analyzer/analyzer.py
+++ b/tools/linglong-migration-assistant/backend/app/analyzer/analyzer.py
@@ -1,0 +1,268 @@
+"""包分析器：元信息归一化、依赖归属、迁移检查清单、linglong.yaml 建议字段。"""
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+from ..parsers.common import ParsedPackage, normalize_arch
+from .rules import classify
+
+_VERSION_SANITIZE_RE = re.compile(r"[^0-9.]")
+
+
+def _normalize_version(raw: str) -> str:
+    """归一化为玲珑建议的四段数字版本：5.02-1 -> 5.2.0.0。"""
+    raw = (raw or "").strip().removeprefix("v").removeprefix("V")
+    raw = raw.split("-")[0].split("+")[0].split("~")[0].split(":")[-1]
+    raw = _VERSION_SANITIZE_RE.sub("", raw.replace("_", "."))
+    parts = [p for p in raw.split(".") if p != ""]
+    parts = [str(int(p)) if p.isdigit() else "0" for p in parts]
+    while len(parts) < 4:
+        parts.append("0")
+    return ".".join(parts[:4])
+
+
+def _sanitize_name(raw: str) -> str:
+    name = re.sub(r"[^a-zA-Z0-9._+-]", "-", (raw or "app").strip().lower())
+    name = re.sub(r"-+", "-", name).strip("-")
+    return name or "app"
+
+
+def _suggest_id(control: dict[str, str]) -> str:
+    """优先从 Homepage 域名反推 id，否则用 org.linyaps.<name>。"""
+    homepage = control.get("Homepage", "")
+    app_name = _sanitize_name(control.get("Package", "") or "app")
+    if homepage:
+        try:
+            url = urlparse(homepage)
+            host = url.netloc.split(":")[0].removeprefix("www.")
+            if host == "github.com":
+                # https://github.com/<owner>/<repo> -> io.github.<owner>.<repo>
+                segs = [s for s in url.path.strip("/").split("/") if s]
+                if len(segs) >= 2:
+                    return f"io.github.{_sanitize_name(segs[0])}.{_sanitize_name(segs[1])}"
+            tlds = {"com", "cn", "org", "net", "io", "dev", "edu", "gov"}
+            keep = [p for p in reversed(host.split(".")) if p and p not in tlds]
+            if keep:
+                return ".".join(reversed(keep)) + "." + app_name
+        except Exception:
+            pass
+    return "org.linyaps." + app_name
+
+
+def _describe_deps(parsed: ParsedPackage) -> list[tuple[str, str, str]]:
+    """返回 [(name, constraint, level)]。"""
+    seen: set[str] = set()
+    result = []
+    for name, constraint in parsed.dependencies:
+        if name in seen:
+            continue
+        seen.add(name)
+        result.append((name, constraint, classify(name)))
+    return result
+
+
+def _build_checklist(parsed: ParsedPackage, app_id: str, version: str) -> list[dict[str, str]]:
+    checks: list[dict[str, str]] = []
+
+    if parsed.desktops:
+        icon = parsed.desktops[0].icon
+        if icon.startswith("/"):
+            checks.append(
+                {
+                    "key": "desktop-icon",
+                    "title": "desktop 文件 Icon 绝对路径",
+                    "status": "warn",
+                    "detail": f"Icon={icon} 为绝对路径，容器内不可用；生成的构建脚本会自动改写为图标名。",
+                }
+            )
+        else:
+            checks.append(
+                {
+                    "key": "desktop",
+                    "title": "desktop 启动文件",
+                    "status": "pass",
+                    "detail": f"检测到 {len(parsed.desktops)} 个 desktop 文件，符合 XDG 规范。",
+                }
+            )
+    else:
+        checks.append(
+            {
+                "key": "desktop",
+                "title": "desktop 启动文件",
+                "status": "fail",
+                "detail": "未检测到 .desktop 文件；图形应用上架需要补齐（符合 Freedesktop XDG 规范）。",
+            }
+        )
+
+    if parsed.icons:
+        checks.append(
+            {
+                "key": "icons",
+                "title": "应用图标",
+                "status": "pass",
+                "detail": f"检测到 {len(parsed.icons)} 个 hicolor 应用图标。",
+            }
+        )
+        if not parsed.desktops:
+            checks.append(
+                {
+                    "key": "icons-only",
+                    "title": "图标未被 desktop 引用",
+                    "status": "info",
+                    "detail": "检测到图标但没有 desktop 文件，请确认应用入口方式。",
+                }
+            )
+    else:
+        checks.append(
+            {
+                "key": "icons",
+                "title": "应用图标",
+                "status": "warn",
+                "detail": "未检测到 share/icons/hicolor 下的应用图标，建议补齐。",
+            }
+        )
+
+    if parsed.binaries:
+        checks.append(
+            {
+                "key": "binaries",
+                "title": "可执行文件",
+                "status": "pass",
+                "detail": f"检测到 {len(parsed.binaries)} 个可执行文件，command 已指向包内真实路径。",
+            }
+        )
+    else:
+        checks.append(
+            {
+                "key": "binaries",
+                "title": "可执行文件",
+                "status": "fail",
+                "detail": "未检测到可执行文件，无法确定启动命令，请人工确认。",
+            }
+        )
+
+    checks.append(
+        {
+            "key": "prefix",
+            "title": "安装前缀 ($PREFIX)",
+            "status": "info",
+            "detail": f"玲珑应用文件挂载于 /opt/apps/{app_id}/files，构建脚本已统一安装到 $PREFIX，"
+            "无需修改原始包内的 /usr 路径。",
+        }
+    )
+
+    if parsed.dependencies:
+        bundled = [d for d in _describe_deps(parsed) if d[2] == "bundled"]
+        checks.append(
+            {
+                "key": "deps",
+                "title": "依赖处理",
+                "status": "warn" if bundled else "pass",
+                "detail": (
+                    f"共 {len(parsed.dependencies)} 个依赖，其中 {len(bundled)} 个需随应用自带，"
+                    "构建脚本会尝试在容器内收集；详见依赖分析面板。"
+                    if bundled
+                    else "全部依赖预计由 base/runtime 提供，无需额外处理。"
+                ),
+            }
+        )
+
+    checks.append(
+        {
+            "key": "version",
+            "title": "版本号规范",
+            "status": "pass",
+            "detail": f"已归一化为四段数字版本 {version}（玲珑建议四位数字版本）。",
+        }
+    )
+    return checks
+
+
+def analyze(parsed: ParsedPackage, filename: str) -> dict:
+    control = parsed.control
+    name = _sanitize_name(control.get("Package", "") or filename.rsplit(".", 1)[0])
+    version = _normalize_version(control.get("Version", "") or "0")
+    app_id = _suggest_id(control)
+
+    deps = _describe_deps(parsed)
+    arch_raw = control.get("Architecture", "")
+
+    metadata = {
+        "package_format": parsed.package_format,
+        "name": name,
+        "version": version,
+        "description": control.get("Description", "") or control.get("Summary", ""),
+        "architecture": normalize_arch(arch_raw) if arch_raw else "x86_64",
+        "raw_arch": arch_raw,
+        "maintainer": control.get("Maintainer", ""),
+        "homepage": control.get("Homepage", ""),
+        "license": control.get("License", ""),
+        "raw": {k: v for k, v in control.items() if k not in ("Description",)},
+    }
+
+    desktop_entries = [
+        {
+            "path": d.path,
+            "name": d.name,
+            "exec": d.exec_,
+            "icon": d.icon,
+            "wm_class": d.wm_class,
+        }
+        for d in parsed.desktops
+    ]
+    files = {
+        "binaries": parsed.binaries[:200],
+        "desktop_entries": desktop_entries,
+        "icons": parsed.icons[:100],
+        "libraries": parsed.libraries[:200],
+        "file_count": parsed.file_count,
+        "total_size": parsed.total_size,
+        "notes": parsed.notes,
+    }
+
+    dependencies = [
+        {"name": n, "constraint": c, "level": lv} for n, c, lv in deps
+    ]
+    checklist = _build_checklist(parsed, app_id, version)
+
+    # 启动命令：优先 desktop Exec 对应的可执行文件在包内的真实路径，
+    # 否则取第一个可执行文件。deb/rpm 原样解压保留 usr/ 层级，
+    # 容器内实际路径为 /opt/apps/<id>/files/<包内路径>。
+    exec_cmd = ""
+    if desktop_entries and desktop_entries[0]["exec"]:
+        exec_cmd = desktop_entries[0]["exec"].split()[0]
+        exec_cmd = exec_cmd.rsplit("/", 1)[-1]
+    command = ""
+    if parsed.package_format == "appimage":
+        # AppImage 构建脚本会解压到 $PREFIX/app，入口为 AppRun
+        command = f"/opt/apps/{app_id}/files/app/AppRun"
+    elif parsed.binaries:
+        binary_path = ""
+        if exec_cmd:
+            matches = [b for b in parsed.binaries if b.rsplit("/", 1)[-1] == exec_cmd]
+            if matches:
+                binary_path = matches[0]
+        if not binary_path:
+            binary_path = parsed.binaries[0]
+        command = f"/opt/apps/{app_id}/files/{binary_path}"
+
+    runtime_needed = any(d["level"] == "runtime" for d in dependencies)
+    suggested = {
+        "id": app_id,
+        "name": name,
+        "version": version,
+        "description": control.get("Description", "") or control.get("Summary", ""),
+        "command": command,
+        "base": "org.deepin.base/23.1.0",
+        "runtime": "org.deepin.runtime.dtk/23.1.0" if runtime_needed else "",
+        "bundled_deps": [d["name"] for d in dependencies if d["level"] == "bundled"],
+    }
+
+    return {
+        "metadata": metadata,
+        "files": files,
+        "dependencies": dependencies,
+        "checklist": checklist,
+        "suggested": suggested,
+    }

--- a/tools/linglong-migration-assistant/backend/app/analyzer/rules.py
+++ b/tools/linglong-migration-assistant/backend/app/analyzer/rules.py
@@ -1,0 +1,59 @@
+"""依赖归属规则加载与匹配。"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+
+import yaml
+
+RULES_PATH = Path(__file__).parent / "rules_data.yaml"
+
+
+@dataclass
+class LevelRules:
+    exact: set[str] = field(default_factory=set)
+    prefixes: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Rules:
+    base: LevelRules = field(default_factory=LevelRules)
+    runtime: LevelRules = field(default_factory=LevelRules)
+
+
+def _load_level(node: dict) -> LevelRules:
+    return LevelRules(
+        exact={str(x).lower() for x in node.get("exact", [])},
+        prefixes=[str(x).lower() for x in node.get("prefixes", [])],
+    )
+
+
+@lru_cache(maxsize=1)
+def load_rules() -> Rules:
+    with open(RULES_PATH, "r", encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh) or {}
+    return Rules(base=_load_level(raw.get("base", {}) or {}), runtime=_load_level(raw.get("runtime", {}) or {}))
+
+
+def classify(name: str) -> str:
+    """返回依赖归属：base | runtime | bundled。
+
+    兼容两类名称：
+    - deb 包名：libqt5core5a
+    - RPM soname：libQt5Core.so.5（归一化为小写后匹配）
+    """
+    rules = load_rules()
+    clean = name.strip().lower()
+    if ".so" in clean:  # soname -> 库名（libQt5Core.so.5 -> libqt5core）
+        clean = clean.split(".so", 1)[0]
+    if not clean:
+        return "bundled"
+    for level in ("base", "runtime"):
+        node: LevelRules = getattr(rules, level)
+        if clean in node.exact:
+            return level
+        for prefix in node.prefixes:
+            if clean.startswith(prefix):
+                return level
+    return "bundled"

--- a/tools/linglong-migration-assistant/backend/app/analyzer/rules.py
+++ b/tools/linglong-migration-assistant/backend/app/analyzer/rules.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 """依赖归属规则加载与匹配。"""
 from __future__ import annotations
 

--- a/tools/linglong-migration-assistant/backend/app/analyzer/rules_data.yaml
+++ b/tools/linglong-migration-assistant/backend/app/analyzer/rules_data.yaml
@@ -1,0 +1,158 @@
+# 依赖归属规则库
+# level 说明：
+#   base    - 大概率由玲珑 base（org.deepin.base/23.1.0）提供，无需处理
+#   runtime - 大概率由玲珑 runtime（org.deepin.runtime.dtk/23.1.0）提供，建议声明 runtime
+#   bundled - 需要随应用自带（生成安装脚本收集进 $PREFIX）
+#
+# 匹配方式：先精确匹配 exact，再按前缀匹配 prefixes。
+# 本规则库为启发式起点，欢迎按实际构建结果扩充。
+
+base:
+  exact:
+    - libc6
+    - libc-bin
+    - libgcc-s1
+    - libstdc++6
+    - zlib1g
+    - libbz2-1.0
+    - liblzma5
+    - libzstd1
+    - libssl3
+    - libssl3t64
+    - libpcre3
+    - libpcre2-8-0
+    - libpcre2-16-0
+    - libpcre2-32-0
+    - libselinux1
+    - libcom-err2
+    - libkrb5-3
+    - libk5crypto3
+    - libkeyutils1
+    - libgssapi-krb5-2
+    - libidn2-0
+    - libunistring2
+    - libudev1
+    - libsystemd0
+    - systemd
+    - util-linux
+    - coreutils
+    - bash
+    - dash
+    - grep
+    - sed
+    - gawk
+    - tar
+    - gzip
+    - xz-utils
+    - bzip2
+    - file
+    - findutils
+    - procps
+    - mount
+    - dpkg
+    - perl-base
+    - lsb-base
+    - init-system-helpers
+    - multiarch-support
+  prefixes:
+    - libc
+    - libgcc
+    - libstdc++
+    - libssl
+    - libcrypto
+    - libzstd
+    - liblzma
+    - libbz2
+    - libpcre
+    - libncurses
+    - libtinfo
+
+runtime:
+  exact:
+    - libqt5core5a
+    - libqt5gui5
+    - libqt5widgets5
+    - libqt5network5
+    - libqt5dbus5
+    - libqt5svg5
+    - libqt5xml5
+    - libqt5concurrent5
+    - libqt5printsupport5
+    - libqt5multimedia5
+    - libqt5multimediawidgets5
+    - libqt5webenginewidgets5
+    - libqt5webchannel5
+    - libqt5positioning5
+    - libqt5quick5
+    - libqt5qml5
+    - libqt5sql5
+    - libqt5test5
+    - libdtkcore5
+    - libdtkgui5
+    - libdtkwidget5
+    - libdtkcore6
+    - libdtkgui6
+    - libdtkwidget6
+    - libqt5xdg3
+    - libqt5xdgiconloader3
+    - libglib2.0-0
+    - libglib2.0-0t64
+    - libgobject-2.0-0
+    - libgio-2.0-0
+    - libgtk-3-0
+    - libgdk-pixbuf-2.0-0
+    - libcairo2
+    - libpango-1.0-0
+    - libpangocairo-1.0-0
+    - libharfbuzz0b
+    - libfreetype6
+    - libfontconfig1
+    - libpng16-16
+    - libjpeg62-turbo
+    - libwebp7
+    - libicu72
+    - libxml2
+    - libx11-6
+    - libxext6
+    - libxcb1
+    - libxrender1
+    - libxrandr2
+    - libxi6
+    - libxcursor1
+    - libxinerama1
+    - libxkbcommon0
+    - libwayland-client0
+    - libwayland-cursor0
+  prefixes:
+    - libqt5
+    - libqt6
+    - libdtk
+    - dtk
+    - dde-
+    - deepin-
+    - libdde
+    - libglib
+    - libgobject
+    - libgio
+    - libgtk
+    - libgdk
+    - libcairo
+    - libpango
+    - libharfbuzz
+    - libfreetype
+    - libfontconfig
+    - libpng
+    - libjpeg
+    - libwebp
+    - libicu
+    - libx11
+    - libxcb
+    - libxkb
+    - libxrender
+    - libxrandr
+    - libxi
+    - libxcursor
+    - libxinerama
+    - libwayland
+    - qtwayland5
+    - qt6-

--- a/tools/linglong-migration-assistant/backend/app/analyzer/rules_data.yaml
+++ b/tools/linglong-migration-assistant/backend/app/analyzer/rules_data.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 # 依赖归属规则库
 # level 说明：
 #   base    - 大概率由玲珑 base（org.deepin.base/23.1.0）提供，无需处理

--- a/tools/linglong-migration-assistant/backend/app/api/__init__.py
+++ b/tools/linglong-migration-assistant/backend/app/api/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later

--- a/tools/linglong-migration-assistant/backend/app/api/routes.py
+++ b/tools/linglong-migration-assistant/backend/app/api/routes.py
@@ -1,0 +1,122 @@
+"""API 路由：分析、导出、会话缓存。"""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi.responses import StreamingResponse
+
+from ..analyzer.analyzer import analyze
+from ..generator.linglong_yaml import generate_yaml
+from ..generator.project import build_project_zip
+from ..parsers import appimage as appimage_parser
+from ..parsers import deb as deb_parser
+from ..parsers import rpm as rpm_parser
+from ..parsers.common import ParsedPackage, detect_format
+from ..schemas import AnalysisResult, ExportRequest
+
+router = APIRouter(prefix="/api")
+
+MAX_UPLOAD_SIZE = 2 * 1024 * 1024 * 1024  # 2GB
+
+
+@dataclass
+class SessionData:
+    analysis: dict
+    resources: dict[str, bytes] = field(default_factory=dict)
+    package_format: str = "deb"
+    filename: str = ""
+
+
+# 简单内存会话缓存（演示用途；生产可换 Redis）
+_SESSIONS: dict[str, SessionData] = {}
+_MAX_SESSIONS = 64
+
+
+def _save_session(data: SessionData) -> str:
+    if len(_SESSIONS) >= _MAX_SESSIONS:
+        _SESSIONS.pop(next(iter(_SESSIONS)))
+    token = uuid.uuid4().hex
+    _SESSIONS[token] = data
+    return token
+
+
+@router.post("/analyze", response_model=AnalysisResult)
+async def analyze_package(file: UploadFile = File(...)):
+    raw = await file.read()
+    if not raw:
+        raise HTTPException(400, "上传文件为空")
+    if len(raw) > MAX_UPLOAD_SIZE:
+        raise HTTPException(413, "文件过大（上限 2GB）")
+
+    try:
+        fmt = detect_format(raw)
+    except ValueError as exc:
+        raise HTTPException(400, str(exc))
+
+    try:
+        if fmt == "deb":
+            parsed: ParsedPackage = deb_parser.parse_deb(raw)
+        elif fmt == "rpm":
+            parsed = rpm_parser.parse_rpm(raw)
+        else:
+            parsed = appimage_parser.parse_appimage(raw, file.filename or "app.AppImage")
+    except ValueError as exc:
+        raise HTTPException(400, f"包解析失败：{exc}")
+    except RuntimeError as exc:
+        raise HTTPException(400, str(exc))
+
+    result = analyze(parsed, file.filename or "")
+    token = _save_session(
+        SessionData(
+            analysis=result,
+            resources=parsed.resources,
+            package_format=fmt,
+            filename=file.filename or "",
+        )
+    )
+    # 建议字段之外附带 yaml 初稿，便于前端直接进入编辑
+    result["suggested"]["yaml"] = generate_yaml(
+        result["suggested"], result["dependencies"], fmt
+    )
+    result["suggested"]["token"] = token
+    return result
+
+
+@router.post("/export")
+async def export_project(req: ExportRequest):
+    session = _SESSIONS.get(req.token)
+    if session is None:
+        raise HTTPException(404, "会话已过期，请重新上传并分析")
+
+    import yaml as _yaml
+
+    try:
+        manifest = _yaml.safe_load(req.yaml)
+        if not isinstance(manifest, dict) or "package" not in manifest:
+            raise ValueError("缺少 package 字段")
+    except Exception as exc:
+        raise HTTPException(400, f"linglong.yaml 格式错误：{exc}")
+
+    suggested = session.analysis.get("suggested", {})
+    bundled = suggested.get("bundled_deps", [])
+    zip_bytes = build_project_zip(
+        req.yaml, session.package_format, bundled, session.resources
+    )
+
+    project_name = (manifest.get("package", {}) or {}).get("id", "migrated-app")
+    filename = f"{project_name}-linglong-project.zip"
+
+    import io
+
+    return StreamingResponse(
+        io.BytesIO(zip_bytes),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/tools/linglong-migration-assistant/backend/app/api/routes.py
+++ b/tools/linglong-migration-assistant/backend/app/api/routes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 """API 路由：分析、导出、会话缓存。"""
 from __future__ import annotations
 

--- a/tools/linglong-migration-assistant/backend/app/generator/__init__.py
+++ b/tools/linglong-migration-assistant/backend/app/generator/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later

--- a/tools/linglong-migration-assistant/backend/app/generator/linglong_yaml.py
+++ b/tools/linglong-migration-assistant/backend/app/generator/linglong_yaml.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 """linglong.yaml 生成器。
 
 遵循如意玲珑 1.14.x 官方规范（https://linyaps.org.cn/guide/building/manifests.html）：

--- a/tools/linglong-migration-assistant/backend/app/generator/linglong_yaml.py
+++ b/tools/linglong-migration-assistant/backend/app/generator/linglong_yaml.py
@@ -1,0 +1,147 @@
+"""linglong.yaml 生成器。
+
+遵循如意玲珑 1.14.x 官方规范（https://linyaps.org.cn/guide/building/manifests.html）：
+  version / package / command / base / runtime / sources / build
+"""
+from __future__ import annotations
+
+import io
+
+import yaml
+
+
+class _Literal(str):
+    """多行文本用块标量（|）表示。"""
+
+
+class _Dumper(yaml.SafeDumper):
+    pass
+
+
+_Dumper.add_representer(_Literal, lambda d, s: d.represent_scalar("tag:yaml.org,2002:str", s, style="|"))
+
+
+def _build_script_deb(bundled_deps: list[str]) -> str:
+    script = """set -e
+# ===== 安装主包（deb）到 $PREFIX =====
+PKG_FILE=$(ls /project/linglong/sources/srcs/*.deb 2>/dev/null | head -n 1)
+if [ -z "$PKG_FILE" ]; then
+  echo "错误：请在工程 srcs/ 目录放置原始 deb 包后重新构建" >&2
+  exit 1
+fi
+mkdir -p ${PREFIX}
+if command -v dpkg-deb >/dev/null 2>&1; then
+  dpkg-deb -x "$PKG_FILE" ${PREFIX}
+else
+  mkdir -p /tmp/main-pkg && cd /tmp/main-pkg
+  ar x "$PKG_FILE"
+  tar -xf data.tar.* -C ${PREFIX}
+fi
+"""
+    if bundled_deps:
+        deps = " ".join(bundled_deps)
+        script += f"""
+# ===== 收集需自带的依赖（共 {len(bundled_deps)} 个）=====
+mkdir -p /tmp/linglong-deps && cd /tmp/linglong-deps
+apt-get download {deps} || echo "警告：apt-get download 失败，请在联网环境构建或手动放置依赖 deb"
+for d in *.deb; do
+  if command -v dpkg-deb >/dev/null 2>&1; then dpkg-deb -x "$d" ${{PREFIX}}; else ar x "$d" && tar -xf data.tar.* -C ${{PREFIX}}; fi
+done
+"""
+    script += """
+# ===== 规范化 desktop 图标路径（绝对路径 -> 图标名）=====
+if ls ${PREFIX}/share/applications/*.desktop >/dev/null 2>&1; then
+  sed -i 's|^Icon=/usr/.*/\\([^/]*\\)$|Icon=\\1|' ${PREFIX}/share/applications/*.desktop || true
+fi
+"""
+    return script
+
+
+def _build_script_rpm(bundled_deps: list[str]) -> str:
+    script = """set -e
+# ===== 安装主包（rpm）到 $PREFIX =====
+PKG_FILE=$(ls /project/linglong/sources/srcs/*.rpm 2>/dev/null | head -n 1)
+if [ -z "$PKG_FILE" ]; then
+  echo "错误：请在工程 srcs/ 目录放置原始 rpm 包后重新构建" >&2
+  exit 1
+fi
+mkdir -p ${PREFIX}
+mkdir -p /tmp/main-pkg && cd /tmp/main-pkg
+rpm2cpio "$PKG_FILE" | cpio -idm -D ${PREFIX} 2>/dev/null \\
+  || { rpm2cpio "$PKG_FILE" > payload.cpio && cpio -idm -D ${PREFIX} < payload.cpio; }
+"""
+    script += """
+# ===== 规范化 desktop 图标路径（绝对路径 -> 图标名）=====
+if ls ${PREFIX}/usr/share/applications/*.desktop >/dev/null 2>&1; then
+  sed -i 's|^Icon=/usr/.*/\\([^/]*\\)$|Icon=\\1|' ${PREFIX}/usr/share/applications/*.desktop || true
+fi
+"""
+    return script
+
+
+def _build_script_appimage() -> str:
+    script = """set -e
+# ===== 提取 AppImage 到 $PREFIX/app =====
+PKG_FILE=$(ls /project/linglong/sources/srcs/*.AppImage 2>/dev/null | head -n 1)
+if [ -z "$PKG_FILE" ]; then
+  echo "错误：请在工程 srcs/ 目录放置 AppImage 文件后重新构建" >&2
+  exit 1
+fi
+chmod +x "$PKG_FILE"
+mkdir -p ${PREFIX}
+cd ${PREFIX}
+"$PKG_FILE" --appimage-extract >/dev/null
+mv squashfs-root app
+# 将 desktop/icon 暴露到标准 XDG 目录
+mkdir -p ${PREFIX}/share/applications ${PREFIX}/share/icons
+cp -r app/usr/share/applications/*.desktop ${PREFIX}/share/applications/ 2>/dev/null || true
+cp -r app/usr/share/icons/* ${PREFIX}/share/icons/ 2>/dev/null || true
+"""
+    return script
+
+
+def build_manifest_dict(suggested: dict, dependencies: list[dict], package_format: str) -> dict:
+    """根据分析建议构建 linglong.yaml 的字典结构。"""
+    app_id = suggested["id"]
+    manifest: dict = {
+        "version": "1",
+        "package": {
+            "id": app_id,
+            "name": suggested["name"],
+            "version": suggested["version"],
+            "kind": "app",
+            "description": suggested.get("description", "Migrated application."),
+        },
+        "command": [suggested["command"]] if suggested.get("command") else [],
+        "base": suggested.get("base") or "org.deepin.base/23.1.0",
+    }
+    if suggested.get("runtime"):
+        manifest["runtime"] = suggested["runtime"]
+    manifest["sources"] = [
+        {"kind": "local", "name": "srcs", "directory": "./srcs"}
+    ]
+
+    bundled = [d["name"] for d in dependencies if d["level"] == "bundled"]
+    if package_format == "deb":
+        build = _build_script_deb(bundled)
+    elif package_format == "rpm":
+        build = _build_script_rpm(bundled)
+    else:
+        build = _build_script_appimage()
+    manifest["build"] = _Literal(build)
+    return manifest
+
+
+def render_yaml(manifest: dict) -> str:
+    return yaml.dump(
+        manifest,
+        Dumper=_Dumper,
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+        width=4096,
+    )
+
+
+def generate_yaml(suggested: dict, dependencies: list[dict], package_format: str) -> str:
+    return render_yaml(build_manifest_dict(suggested, dependencies, package_format))

--- a/tools/linglong-migration-assistant/backend/app/generator/project.py
+++ b/tools/linglong-migration-assistant/backend/app/generator/project.py
@@ -1,0 +1,99 @@
+"""迁移工程 zip 打包导出。"""
+from __future__ import annotations
+
+import io
+import zipfile
+
+import yaml
+
+
+def _readme(project_name: str, package_format: str, bundled_deps: list[str]) -> str:
+    deps_note = (
+        f"- 需自带的依赖（{len(bundled_deps)} 个）：{'、'.join(bundled_deps) or '无'}\n"
+        "  构建脚本会在容器内通过 `apt-get download` 自动收集；离线环境请手动放入 srcs/ 并调整脚本。\n"
+        if bundled_deps
+        else "- 所有依赖预计由 base/runtime 提供，无需额外处理。\n"
+    )
+    return f"""# {project_name} 玲珑迁移工程
+
+由「如意玲珑应用迁移助手」生成。
+
+## 工程结构
+
+```
+.
+├── linglong.yaml        # 玲珑构建配置（可在迁移助手中继续编辑）
+├── README.md            # 本文件
+├── deps.txt             # 需自带的依赖清单
+├── resources/           # 从原包提取的 desktop/icon（供参考与人工修补）
+└── srcs/                # 请将原始安装包放到这里
+    └── README.txt
+```
+
+## 构建步骤
+
+1. 将原始安装包（.{package_format}）复制到 `srcs/` 目录。
+2. 在 Linux（deepin / UOS 等）环境安装玲珑构建工具：
+   ```bash
+   sudo apt install linglong-builder
+   ```
+3. 在本工程目录执行构建：
+   ```bash
+   ll-builder build
+   ```
+4. 容器内测试运行：
+   ```bash
+   ll-builder run --exec <可执行文件名>
+   ```
+5. 导出 layer 安装包：
+   ```bash
+   ll-builder export
+   # 生成 <appid>_<version>_<arch>.layer
+   ```
+6. 安装验证：
+   ```bash
+   ll-cli install *.layer
+   ll-cli run <appid>
+   ```
+
+## 依赖说明
+
+{deps_note}
+## 常见问题
+
+- 构建首次运行需下载 base/runtime，耗时较长。
+- 若提示缺少库，将对应 deb 放入 srcs/ 并在 build 段补充解压命令，或直接追加到 deps.txt 对应 apt-get download 列表。
+- desktop 文件中的绝对路径图标已由构建脚本自动改写。
+"""
+
+
+def _srcs_readme(package_format: str) -> str:
+    return f"请将原始 {package_format} 安装包复制到本目录（保持扩展名 .{package_format}）。\n"
+
+
+def build_project_zip(
+    yaml_content: str,
+    package_format: str,
+    bundled_deps: list[str],
+    resources: dict[str, bytes],
+) -> bytes:
+    """打包迁移工程 zip，返回字节流。"""
+    manifest = yaml.safe_load(yaml_content)
+    app_id = manifest.get("package", {}).get("id", "migrated-app")
+    project_name = app_id.split(".")[-1] or "migrated-app"
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(f"{project_name}/linglong.yaml", yaml_content)
+        zf.writestr(
+            f"{project_name}/README.md",
+            _readme(project_name, package_format, bundled_deps),
+        )
+        zf.writestr(
+            f"{project_name}/deps.txt",
+            "\n".join(bundled_deps) + ("\n" if bundled_deps else ""),
+        )
+        zf.writestr(f"{project_name}/srcs/README.txt", _srcs_readme(package_format))
+        for path, content in resources.items():
+            zf.writestr(f"{project_name}/resources/{path}", content)
+    return buf.getvalue()

--- a/tools/linglong-migration-assistant/backend/app/generator/project.py
+++ b/tools/linglong-migration-assistant/backend/app/generator/project.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 """迁移工程 zip 打包导出。"""
 from __future__ import annotations
 

--- a/tools/linglong-migration-assistant/backend/app/main.py
+++ b/tools/linglong-migration-assistant/backend/app/main.py
@@ -1,0 +1,20 @@
+"""如意玲珑应用迁移助手 - 后端入口。
+
+启动: uvicorn app.main:app --reload --port 8000
+"""
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .api.routes import router
+
+app = FastAPI(title="如意玲珑应用迁移助手", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(router)

--- a/tools/linglong-migration-assistant/backend/app/main.py
+++ b/tools/linglong-migration-assistant/backend/app/main.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 """如意玲珑应用迁移助手 - 后端入口。
 
 启动: uvicorn app.main:app --reload --port 8000

--- a/tools/linglong-migration-assistant/backend/app/parsers/__init__.py
+++ b/tools/linglong-migration-assistant/backend/app/parsers/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later

--- a/tools/linglong-migration-assistant/backend/app/parsers/appimage.py
+++ b/tools/linglong-migration-assistant/backend/app/parsers/appimage.py
@@ -1,0 +1,96 @@
+"""AppImage 解析：尽力而为。
+
+- 定位 ELF + squashfs 魔数（hsqs）
+- 服务器有 unsquashfs 时完整提取 desktop/icon/bin
+- 无 unsquashfs 时仅报告基本信息
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from .common import DesktopEntryData, ParsedPackage
+
+
+def _squashfs_offset(data: bytes) -> int | None:
+    pos = data.find(b"hsqs")
+    return pos if pos > 0 else None
+
+
+def parse_appimage(data: bytes, filename: str = "app.AppImage") -> ParsedPackage:
+    pkg = ParsedPackage(package_format="appimage")
+    name = Path(filename).stem
+    pkg.control = {
+        "Package": name,
+        "Version": "",
+        "Summary": f"AppImage 应用 {name}",
+    }
+
+    if data[:4] != b"\x7fELF":
+        pkg.notes.append("文件不是 ELF 格式，可能不是 AppImage")
+        return pkg
+
+    offset = _squashfs_offset(data[: 4 * 1024 * 1024])
+    if offset is None:
+        pkg.notes.append("未定位到 squashfs 数据区（hsqs 魔数），仅提供基础信息")
+        return pkg
+
+    unsquashfs = shutil.which("unsquashfs")
+    if unsquashfs is None:
+        pkg.notes.append(
+            "服务器未安装 unsquashfs，无法提取 AppImage 内部文件。"
+            "在 Linux 上安装 squashfs-tools 后可获得完整分析。"
+        )
+        return pkg
+
+    with tempfile.TemporaryDirectory(prefix="appimage_ma_") as tmp:
+        img_path = Path(tmp) / "image.AppImage"
+        sq_path = Path(tmp) / "squashfs-root"
+        img_path.write_bytes(data[offset:])
+        result = subprocess.run(
+            [unsquashfs, "-d", str(sq_path), str(img_path)],
+            capture_output=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            pkg.notes.append(
+                f"unsquashfs 提取失败：{result.stderr.decode('utf-8', 'replace')[:200]}"
+            )
+            return pkg
+
+        for path in sorted(sq_path.rglob("*")):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(sq_path).as_posix()
+            pkg.file_count += 1
+            pkg.total_size += path.stat().st_size
+            if rel.startswith("usr/bin/") or rel.startswith("bin/"):
+                pkg.binaries.append(rel)
+            elif rel.startswith(("usr/games/", "usr/sbin/", "sbin/")):
+                pkg.binaries.append(rel)
+            elif "share/icons/" in rel and "/apps/" in rel:
+                pkg.icons.append(rel)
+            elif rel.startswith("usr/share/applications/") and rel.endswith(".desktop"):
+                try:
+                    from .deb import parse_desktop
+
+                    entry = parse_desktop(path.read_text("utf-8", "replace"))
+                except Exception:
+                    entry = {}
+                pkg.desktops.append(
+                    DesktopEntryData(
+                        path=rel,
+                        name=entry.get("Name", ""),
+                        exec_=entry.get("Exec", ""),
+                        icon=entry.get("Icon", ""),
+                        wm_class=entry.get("StartupWMClass", ""),
+                    )
+                )
+                try:
+                    if path.stat().st_size <= 1024 * 1024:
+                        pkg.resources[rel] = path.read_bytes()
+                except OSError:
+                    pass
+    return pkg

--- a/tools/linglong-migration-assistant/backend/app/parsers/appimage.py
+++ b/tools/linglong-migration-assistant/backend/app/parsers/appimage.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 """AppImage 解析：尽力而为。
 
 - 定位 ELF + squashfs 魔数（hsqs）

--- a/tools/linglong-migration-assistant/backend/app/parsers/common.py
+++ b/tools/linglong-migration-assistant/backend/app/parsers/common.py
@@ -1,0 +1,63 @@
+"""解析层公共结构：统一的解析结果与格式探测。"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class DesktopEntryData:
+    path: str
+    name: str = ""
+    exec_: str = ""
+    icon: str = ""
+    wm_class: str = ""
+
+
+@dataclass
+class ParsedPackage:
+    """三种包格式的统一解析结果。"""
+
+    package_format: str  # deb | rpm | appimage
+    control: dict[str, str] = field(default_factory=dict)
+    binaries: list[str] = field(default_factory=list)
+    libraries: list[str] = field(default_factory=list)
+    icons: list[str] = field(default_factory=list)
+    desktops: list[DesktopEntryData] = field(default_factory=list)
+    dependencies: list[tuple[str, str]] = field(default_factory=list)  # (name, constraint)
+    file_count: int = 0
+    total_size: int = 0
+    notes: list[str] = field(default_factory=list)
+    resources: dict[str, bytes] = field(default_factory=dict)  # 导出用：desktop/icon 原始内容
+
+
+def detect_format(data: bytes) -> str:
+    """按魔数探测包格式。"""
+    if data[:8] == b"!<arch>\n":
+        return "deb"
+    if data[:4] == b"\xed\xab\xee\xdb":
+        return "rpm"
+    if data[:4] == b"\x7fELF":
+        return "appimage"
+    raise ValueError(
+        "无法识别的包格式：支持 deb / rpm / AppImage。"
+        "请确认上传的是完整的软件包文件。"
+    )
+
+
+# 架构名归一化：原始架构 -> 玲珑架构
+ARCH_MAP = {
+    "amd64": "x86_64",
+    "x86_64": "x86_64",
+    "arm64": "arm64",
+    "aarch64": "arm64",
+    "i386": "x86_64",
+    "i686": "x86_64",
+    "mips64el": "mips64el",
+    "loongarch64": "loongarch64",
+    "riscv64": "riscv64",
+    "sw_64": "sw_64",
+}
+
+
+def normalize_arch(raw: str) -> str:
+    return ARCH_MAP.get(raw.strip().lower(), raw.strip().lower() or "x86_64")

--- a/tools/linglong-migration-assistant/backend/app/parsers/common.py
+++ b/tools/linglong-migration-assistant/backend/app/parsers/common.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 """解析层公共结构：统一的解析结果与格式探测。"""
 from __future__ import annotations
 

--- a/tools/linglong-migration-assistant/backend/app/parsers/deb.py
+++ b/tools/linglong-migration-assistant/backend/app/parsers/deb.py
@@ -1,0 +1,203 @@
+"""deb 包解析：纯标准库实现（ar 归档 + tar），零外部依赖。
+
+结构参考 Debian .deb 规范：
+  <ar 归档>
+    debian-binary
+    control.tar.{gz|xz|zst|bz2}   -> ./control 等
+    data.tar.{gz|xz|zst|bz2}      -> ./usr/... 实际文件
+"""
+from __future__ import annotations
+
+import bz2
+import gzip
+import io
+import lzma
+import tarfile
+
+from .common import DesktopEntryData, ParsedPackage
+
+AR_MAGIC = b"!<arch>\n"
+AR_HEADER_SIZE = 60
+
+# 资源收集上限，防止超包占用过多内存
+MAX_RESOURCE_FILE_SIZE = 1 * 1024 * 1024
+MAX_RESOURCE_TOTAL_SIZE = 8 * 1024 * 1024
+
+
+def is_deb(data: bytes) -> bool:
+    return data[:8] == AR_MAGIC
+
+
+def _iter_ar_members(data: bytes):
+    pos = 8
+    n = len(data)
+    while pos + AR_HEADER_SIZE <= n:
+        header = data[pos : pos + AR_HEADER_SIZE]
+        name = header[:16].decode("ascii", "replace").rstrip()
+        try:
+            size = int(header[48:58].decode("ascii").strip())
+        except ValueError:
+            break
+        body = data[pos + AR_HEADER_SIZE : pos + AR_HEADER_SIZE + size]
+        yield name.rstrip("/"), body
+        pos += AR_HEADER_SIZE + size
+        if pos & 1:  # ar 成员按 2 字节对齐
+            pos += 1
+
+
+def _decompress(data: bytes) -> bytes:
+    if data[:6] == b"\xfd7zXZ\x00":
+        return lzma.decompress(data)
+    if data[:2] == b"\x1f\x8b":
+        return gzip.decompress(data)
+    if data[:3] == b"BZh":
+        return bz2.decompress(data)
+    if data[:4] == b"\x28\xb5\x2f\xfd":
+        try:
+            import zstandard
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "检测到 zstd 压缩的 deb 包，请在后端环境安装 zstandard：pip install zstandard"
+            ) from exc
+        return zstandard.ZstdDecompressor().stream_reader(io.BytesIO(data)).read()
+    return data
+
+
+def _open_tar(raw: bytes) -> tarfile.TarFile:
+    return tarfile.open(fileobj=io.BytesIO(_decompress(raw)), mode="r:")
+
+
+def parse_control(text: str) -> dict[str, str]:
+    """解析 Debian control 文件（Key: Value，续行以空格开头）。"""
+    fields: dict[str, str] = {}
+    current: str | None = None
+    for line in text.splitlines():
+        if not line.strip():
+            current = None
+            continue
+        if line[:1] in (" ", "\t") and current:
+            fields[current] += "\n" + line.strip()
+        elif ":" in line:
+            key, _, value = line.partition(":")
+            current = key.strip()
+            fields[current] = value.strip()
+    return fields
+
+
+def parse_depends(value: str) -> list[tuple[str, str]]:
+    """解析 Depends 字段：'libc6 (>= 2.38), libfoo | libbar'。"""
+    result: list[tuple[str, str]] = []
+    if not value:
+        return result
+    for group in value.split(","):
+        group = group.strip()
+        if not group:
+            continue
+        # 只取第一候选（alternatives 的第一个通常为主依赖）
+        first = group.split("|")[0].strip()
+        name = first
+        constraint = ""
+        if first.startswith("("):  # 形如 "(>= 2.38)" 无名字，跳过
+            continue
+        if "(" in first:
+            name, _, rest = first.partition("(")
+            name = name.strip()
+            constraint = rest.rstrip(")").strip()
+        name = name.split("[")[0].strip()  # 去掉架构限定
+        if name:
+            result.append((name, constraint))
+    return result
+
+
+def parse_desktop(text: str) -> dict[str, str]:
+    """提取 [Desktop Entry] 段的键值。"""
+    entry: dict[str, str] = {}
+    in_main = False
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("["):
+            in_main = line == "[Desktop Entry]"
+            continue
+        if in_main and "=" in line:
+            key, _, value = line.partition("=")
+            entry.setdefault(key.strip(), value.strip())
+    return entry
+
+
+def parse_deb(data: bytes) -> ParsedPackage:
+    if not is_deb(data):
+        raise ValueError("不是合法的 deb 包（ar 魔数不匹配）")
+
+    control_raw: bytes | None = None
+    data_raw: bytes | None = None
+    for name, body in _iter_ar_members(data):
+        if name == "debian-binary":
+            continue
+        if name.startswith("control.tar"):
+            control_raw = body
+        elif name.startswith("data.tar"):
+            data_raw = body
+
+    if control_raw is None:
+        raise ValueError("deb 包缺少 control.tar 成员，文件可能不完整")
+
+    pkg = ParsedPackage(package_format="deb")
+
+    with _open_tar(control_raw) as tf:
+        control_text: str | None = None
+        for m in tf.getmembers():
+            if m.name.lstrip("./") == "control":
+                fh = tf.extractfile(m)
+                control_text = fh.read().decode("utf-8", "replace") if fh else None
+                break
+        if control_text is None:
+            raise ValueError("control.tar 中未找到 control 文件")
+        pkg.control = parse_control(control_text)
+
+    for key in ("Depends", "Pre-Depends"):
+        pkg.dependencies.extend(parse_depends(pkg.control.get(key, "")))
+
+    if data_raw is None:
+        pkg.notes.append("deb 包未包含 data.tar，无法分析应用文件")
+        return pkg
+
+    resource_total = 0
+    with _open_tar(data_raw) as tf:
+        for m in tf.getmembers():
+            name = m.name.lstrip("./")
+            if not name or name.endswith("/"):
+                continue
+            pkg.file_count += 1
+            pkg.total_size += m.size
+            if name.startswith("usr/bin/") or name.startswith("bin/"):
+                pkg.binaries.append(name)
+            elif name.startswith(("usr/games/", "usr/sbin/", "sbin/")):
+                pkg.binaries.append(name)
+            elif name.startswith("usr/lib/") or name.startswith("lib/"):
+                base = name.rsplit("/", 1)[-1]
+                if base.endswith(".so") or ".so." in base:
+                    pkg.libraries.append(name)
+            elif "share/icons/" in name and "/apps/" in name:
+                pkg.icons.append(name)
+            elif name.startswith("usr/share/applications/") and name.endswith(".desktop"):
+                fh = tf.extractfile(m)
+                content = fh.read() if fh else b""
+                entry = parse_desktop(content.decode("utf-8", "replace"))
+                pkg.desktops.append(
+                    DesktopEntryData(
+                        path=name,
+                        name=entry.get("Name", ""),
+                        exec_=entry.get("Exec", ""),
+                        icon=entry.get("Icon", ""),
+                        wm_class=entry.get("StartupWMClass", ""),
+                    )
+                )
+                if (
+                    len(content) <= MAX_RESOURCE_FILE_SIZE
+                    and resource_total + len(content) <= MAX_RESOURCE_TOTAL_SIZE
+                ):
+                    pkg.resources[name] = content
+                    resource_total += len(content)
+    return pkg

--- a/tools/linglong-migration-assistant/backend/app/parsers/deb.py
+++ b/tools/linglong-migration-assistant/backend/app/parsers/deb.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 """deb 包解析：纯标准库实现（ar 归档 + tar），零外部依赖。
 
 结构参考 Debian .deb 规范：

--- a/tools/linglong-migration-assistant/backend/app/parsers/rpm.py
+++ b/tools/linglong-migration-assistant/backend/app/parsers/rpm.py
@@ -1,0 +1,225 @@
+"""RPM 包解析：纯标准库实现（lead + header + cpio newc payload），零外部依赖。
+
+RPM 文件结构：
+  lead(96B, magic ed ab ee db)
+  signature header（header 结构，8 字节对齐）
+  main header（header 结构）
+  payload：压缩 cpio (newc 格式)
+"""
+from __future__ import annotations
+
+import bz2
+import gzip
+import io
+import lzma
+
+from .common import DesktopEntryData, ParsedPackage
+
+RPM_LEAD_MAGIC = b"\xed\xab\xee\xdb"
+HEADER_MAGIC = b"\x8e\xad\xe8"
+
+# 常用 RPM tag
+TAG_NAME = 1000
+TAG_VERSION = 1001
+TAG_RELEASE = 1002
+TAG_SUMMARY = 1004
+TAG_DESCRIPTION = 1005
+TAG_LICENSE = 1014
+TAG_PACKAGER = 1015
+TAG_URL = 1020
+TAG_ARCH = 1022
+TAG_FILENAMES = 5000
+TAG_REQUIRENAME = 1049
+TAG_REQUIREVERSION = 1050
+
+# 资源收集上限
+MAX_RESOURCE_FILE_SIZE = 1 * 1024 * 1024
+MAX_RESOURCE_TOTAL_SIZE = 8 * 1024 * 1024
+
+
+def is_rpm(data: bytes) -> bool:
+    return data[:4] == RPM_LEAD_MAGIC
+
+
+def _parse_header(data: bytes, offset: int) -> tuple[dict[int, object], int]:
+    """解析一个 header 段，返回 (tag->值, 下一段偏移)。"""
+    if data[offset : offset + 3] != HEADER_MAGIC:
+        raise ValueError("RPM header 魔数不匹配，文件可能损坏")
+    index_count = int.from_bytes(data[offset + 8 : offset + 12], "big")
+    data_size = int.from_bytes(data[offset + 12 : offset + 16], "big")
+    index_base = offset + 16
+    data_base = index_base + index_count * 16
+    tags: dict[int, object] = {}
+
+    for i in range(index_count):
+        entry = index_base + i * 16
+        tag = int.from_bytes(data[entry : entry + 4], "big")
+        rtype = int.from_bytes(data[entry + 4 : entry + 8], "big")
+        doff = int.from_bytes(data[entry + 8 : entry + 12], "big")
+        count = int.from_bytes(data[entry + 12 : entry + 16], "big")
+        pos = data_base + doff
+        try:
+            if rtype == 6:  # STRING
+                end = data.index(b"\x00", pos)
+                tags[tag] = data[pos:end].decode("utf-8", "replace")
+            elif rtype in (8, 9):  # STRING_ARRAY / I18NSTRING
+                items: list[str] = []
+                cursor = pos
+                for _ in range(count):
+                    end = data.index(b"\x00", cursor)
+                    items.append(data[cursor:end].decode("utf-8", "replace"))
+                    cursor = end + 1
+                tags[tag] = items
+            elif rtype == 4:  # INT32
+                tags[tag] = [
+                    int.from_bytes(data[pos + j * 4 : pos + j * 4 + 4], "big")
+                    for j in range(count)
+                ]
+            elif rtype == 3:  # INT16
+                tags[tag] = [
+                    int.from_bytes(data[pos + j * 2 : pos + j * 2 + 2], "big")
+                    for j in range(count)
+                ]
+            elif rtype == 2:  # INT8
+                tags[tag] = list(data[pos : pos + count])
+        except (ValueError, IndexError):
+            continue
+    return tags, data_base + data_size
+
+
+def _decompress_payload(data: bytes) -> bytes:
+    if data[:2] == b"\x1f\x8b":
+        return gzip.decompress(data)
+    if data[:6] == b"\xfd7zXZ\x00":
+        return lzma.decompress(data)
+    if data[:3] == b"BZh":
+        return bz2.decompress(data)
+    if data[:4] == b"\x28\xb5\x2f\xfd":
+        try:
+            import zstandard
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "检测到 zstd 压缩的 rpm 包，请在后端环境安装 zstandard：pip install zstandard"
+            ) from exc
+        return zstandard.ZstdDecompressor().stream_reader(io.BytesIO(data)).read()
+    if data[:2] == b"\x5d\x00":  # lzma alone
+        return lzma.decompress(data, format=lzma.FORMAT_ALONE)
+    raise ValueError("无法识别的 RPM payload 压缩格式")
+
+
+def _iter_cpio_newc(data: bytes):
+    """遍历 cpio newc 归档，yield (name, content)。"""
+    pos = 0
+    n = len(data)
+    while pos + 110 <= n:
+        magic = data[pos : pos + 6]
+        if magic not in (b"070701", b"070702"):
+            return
+        fields = [int(data[pos + 6 + i * 8 : pos + 14 + i * 8], 16) for i in range(13)]
+        filesize = fields[6]
+        namesize = fields[11]
+        name_start = pos + 110
+        name = data[name_start : name_start + max(namesize - 1, 0)].decode(
+            "utf-8", "replace"
+        )
+        if name == "TRAILER!!!":
+            return
+        data_start = name_start + namesize
+        data_start += (-(110 + namesize)) % 4
+        content = data[data_start : data_start + filesize]
+        yield name, content
+        pos = data_start + filesize + (filesize % 4 and 4 - filesize % 4 or 0)
+
+
+def parse_rpm(data: bytes) -> ParsedPackage:
+    if not is_rpm(data):
+        raise ValueError("不是合法的 RPM 包（lead 魔数不匹配）")
+
+    pkg = ParsedPackage(package_format="rpm")
+    # 跳过 lead（96B）解析 signature header，其后按 8 字节对齐才是主 header
+    tags, offset = _parse_header(data, 96)
+    offset = (offset + 7) & ~7
+    tags, offset = _parse_header(data, offset)
+    payload = data[offset:]
+
+    def _s(tag: int, default: str = "") -> str:
+        value = tags.get(tag)
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list) and value:
+            return str(value[0])
+        return default
+
+    pkg.control = {
+        "Package": _s(TAG_NAME),
+        "Version": _s(TAG_VERSION),
+        "Release": _s(TAG_RELEASE),
+        "Summary": _s(TAG_SUMMARY),
+        "Description": _s(TAG_DESCRIPTION),
+        "License": _s(TAG_LICENSE),
+        "Maintainer": _s(TAG_PACKAGER),
+        "Homepage": _s(TAG_URL),
+        "Architecture": _s(TAG_ARCH),
+    }
+
+    requires = tags.get(TAG_REQUIRENAME)
+    versions = tags.get(TAG_REQUIREVERSION, [])
+    if isinstance(requires, list):
+        import re
+
+        for idx, name in enumerate(requires):
+            if not name or name.startswith(("rpmlib(", "rtld(", "config(")):
+                continue
+            clean = re.sub(r"\([^)]*\)", "", name).strip()  # 去掉 (64bit) 等标志
+            if not clean:
+                continue
+            constraint = versions[idx] if idx < len(versions) else ""
+            pkg.dependencies.append((clean, constraint))
+
+    try:
+        raw = _decompress_payload(payload)
+    except (ValueError, RuntimeError) as exc:
+        pkg.notes.append(f"payload 解压失败（仅提供元信息）：{exc}")
+        return pkg
+
+    resource_total = 0
+    for name, content in _iter_cpio_newc(raw):
+        clean = name.lstrip("./")
+        if not clean or clean.endswith("/"):
+            continue
+        pkg.file_count += 1
+        pkg.total_size += len(content)
+        if clean.startswith("usr/bin/") or clean.startswith("bin/"):
+            pkg.binaries.append(clean)
+        elif clean.startswith(("usr/games/", "usr/sbin/", "sbin/")):
+            pkg.binaries.append(clean)
+        elif clean.startswith("usr/lib/") or clean.startswith("lib/"):
+            base = clean.rsplit("/", 1)[-1]
+            if base.endswith(".so") or ".so." in base:
+                pkg.libraries.append(clean)
+        elif "share/icons/" in clean and "/apps/" in clean:
+            pkg.icons.append(clean)
+        elif clean.startswith("usr/share/applications/") and clean.endswith(".desktop"):
+            entry = {}
+            try:
+                from .deb import parse_desktop
+
+                entry = parse_desktop(content.decode("utf-8", "replace"))
+            except Exception:
+                entry = {}
+            pkg.desktops.append(
+                DesktopEntryData(
+                    path=clean,
+                    name=entry.get("Name", ""),
+                    exec_=entry.get("Exec", ""),
+                    icon=entry.get("Icon", ""),
+                    wm_class=entry.get("StartupWMClass", ""),
+                )
+            )
+            if (
+                len(content) <= MAX_RESOURCE_FILE_SIZE
+                and resource_total + len(content) <= MAX_RESOURCE_TOTAL_SIZE
+            ):
+                pkg.resources[clean] = content
+                resource_total += len(content)
+    return pkg

--- a/tools/linglong-migration-assistant/backend/app/parsers/rpm.py
+++ b/tools/linglong-migration-assistant/backend/app/parsers/rpm.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 """RPM 包解析：纯标准库实现（lead + header + cpio newc payload），零外部依赖。
 
 RPM 文件结构：

--- a/tools/linglong-migration-assistant/backend/app/schemas.py
+++ b/tools/linglong-migration-assistant/backend/app/schemas.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 """Pydantic 数据模型定义。"""
 from __future__ import annotations
 

--- a/tools/linglong-migration-assistant/backend/app/schemas.py
+++ b/tools/linglong-migration-assistant/backend/app/schemas.py
@@ -1,0 +1,65 @@
+"""Pydantic 数据模型定义。"""
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class PackageMetadata(BaseModel):
+    """软件包元信息。"""
+
+    package_format: str  # deb | rpm | appimage
+    name: str
+    version: str
+    description: str = ""
+    architecture: str = ""  # 归一化后的玲珑架构
+    raw_arch: str = ""
+    maintainer: str = ""
+    homepage: str = ""
+    license: str = ""
+    raw: dict[str, str] = Field(default_factory=dict)
+
+
+class DesktopEntry(BaseModel):
+    name: str = ""
+    exec_: str = Field(default="", alias="exec")
+    icon: str = ""
+    wm_class: str = ""
+    path: str = ""  # 在包内的文件路径
+
+    model_config = {"populate_by_name": True}
+
+
+class DetectedFiles(BaseModel):
+    binaries: list[str] = Field(default_factory=list)
+    desktop_entries: list[DesktopEntry] = Field(default_factory=list)
+    icons: list[str] = Field(default_factory=list)
+    libraries: list[str] = Field(default_factory=list)
+    file_count: int = 0
+    total_size: int = 0
+    notes: list[str] = Field(default_factory=list)  # 解析过程中的降级/警告说明
+
+
+class Dependency(BaseModel):
+    name: str
+    level: str  # base | runtime | bundled
+    constraint: str = ""
+
+
+class CheckItem(BaseModel):
+    key: str
+    title: str
+    status: str  # pass | warn | fail | info
+    detail: str = ""
+
+
+class AnalysisResult(BaseModel):
+    metadata: PackageMetadata
+    files: DetectedFiles
+    dependencies: list[Dependency] = Field(default_factory=list)
+    checklist: list[CheckItem] = Field(default_factory=list)
+    suggested: dict = Field(default_factory=dict)  # 建议的 linglong.yaml 关键字段
+
+
+class ExportRequest(BaseModel):
+    token: str
+    yaml: str

--- a/tools/linglong-migration-assistant/backend/requirements.txt
+++ b/tools/linglong-migration-assistant/backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi>=0.115
+uvicorn[standard]>=0.30
+python-multipart>=0.0.9
+PyYAML>=6.0
+zstandard>=0.22
+pytest>=8.0
+httpx>=0.27

--- a/tools/linglong-migration-assistant/backend/requirements.txt
+++ b/tools/linglong-migration-assistant/backend/requirements.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 fastapi>=0.115
 uvicorn[standard]>=0.30
 python-multipart>=0.0.9

--- a/tools/linglong-migration-assistant/backend/run.py
+++ b/tools/linglong-migration-assistant/backend/run.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 """开发启动脚本：python run.py"""
 import uvicorn
 

--- a/tools/linglong-migration-assistant/backend/run.py
+++ b/tools/linglong-migration-assistant/backend/run.py
@@ -1,0 +1,5 @@
+"""开发启动脚本：python run.py"""
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run("app.main:app", host="127.0.0.1", port=8000, reload=True)

--- a/tools/linglong-migration-assistant/backend/tests/conftest.py
+++ b/tools/linglong-migration-assistant/backend/tests/conftest.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 import sys
 from pathlib import Path
 

--- a/tools/linglong-migration-assistant/backend/tests/conftest.py
+++ b/tools/linglong-migration-assistant/backend/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# 让 tests 可以直接 import app 包
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+FIXTURES = Path(__file__).parent / "fixtures"

--- a/tools/linglong-migration-assistant/backend/tests/test_analyzer_generator.py
+++ b/tools/linglong-migration-assistant/backend/tests/test_analyzer_generator.py
@@ -1,0 +1,65 @@
+"""分析器与生成器测试。"""
+import yaml
+
+from app.analyzer.analyzer import analyze, _normalize_version
+from app.generator.linglong_yaml import generate_yaml
+from app.parsers.common import ParsedPackage
+
+
+def test_normalize_version():
+    assert _normalize_version("5.02-1+b1") == "5.2.0.0"
+    assert _normalize_version("1.2.3") == "1.2.3.0"
+    assert _normalize_version("v2.0") == "2.0.0.0"
+    assert _normalize_version("") == "0.0.0.0"
+
+
+def _make_parsed() -> ParsedPackage:
+    return ParsedPackage(
+        package_format="deb",
+        control={
+            "Package": "fakeapp",
+            "Version": "1.2.3-4",
+            "Description": "A fake app",
+            "Homepage": "https://example.com/",
+            "Architecture": "amd64",
+        },
+        binaries=["usr/bin/fakeapp"],
+        desktops=[],
+        dependencies=[("libc6", ">= 2.36"), ("libqt5core5a", ""), ("libweird9", "")],
+    )
+
+
+def test_analyze_structure():
+    result = analyze(_make_parsed(), "fakeapp.deb")
+    assert result["metadata"]["name"] == "fakeapp"
+    assert result["metadata"]["version"] == "1.2.3.0"
+    assert result["metadata"]["architecture"] == "x86_64"
+    levels = {d["name"]: d["level"] for d in result["dependencies"]}
+    assert levels["libc6"] == "base"
+    assert levels["libqt5core5a"] == "runtime"
+    assert levels["libweird9"] == "bundled"
+    assert result["suggested"]["runtime"]  # 有 runtime 依赖
+    assert result["suggested"]["command"].endswith("/bin/fakeapp")
+    assert result["suggested"]["bundled_deps"] == ["libweird9"]
+
+
+def test_generate_yaml_valid():
+    result = analyze(_make_parsed(), "fakeapp.deb")
+    text = generate_yaml(result["suggested"], result["dependencies"], "deb")
+    data = yaml.safe_load(text)
+    assert data["version"] == "1"
+    assert data["package"]["kind"] == "app"
+    assert data["package"]["id"] == "example.fakeapp"
+    assert data["base"] == "org.deepin.base/23.1.0"
+    assert data["runtime"] == "org.deepin.runtime.dtk/23.1.0"
+    assert data["sources"][0]["kind"] == "local"
+    assert data["command"][0].startswith("/opt/apps/")
+    assert "dpkg-deb -x" in data["build"]
+    assert "apt-get download libweird9" in data["build"]
+
+
+def test_checklist_warns_missing_desktop():
+    result = analyze(_make_parsed(), "fakeapp.deb")
+    statuses = {c["key"]: c["status"] for c in result["checklist"]}
+    assert statuses["desktop"] == "fail"
+    assert statuses["binaries"] == "pass"

--- a/tools/linglong-migration-assistant/backend/tests/test_analyzer_generator.py
+++ b/tools/linglong-migration-assistant/backend/tests/test_analyzer_generator.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 """分析器与生成器测试。"""
 import yaml
 

--- a/tools/linglong-migration-assistant/backend/tests/test_api.py
+++ b/tools/linglong-migration-assistant/backend/tests/test_api.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 """API 集成测试：analyze -> export 全流程。"""
 import io
 import zipfile

--- a/tools/linglong-migration-assistant/backend/tests/test_api.py
+++ b/tools/linglong-migration-assistant/backend/tests/test_api.py
@@ -1,0 +1,62 @@
+"""API 集成测试：analyze -> export 全流程。"""
+import io
+import zipfile
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+from conftest import FIXTURES
+
+client = TestClient(app)
+
+
+def test_health():
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+
+
+def test_analyze_and_export_roundtrip():
+    with open(FIXTURES / "sl_5.02-1_amd64.deb", "rb") as fh:
+        resp = client.post(
+            "/api/analyze",
+            files={"file": ("sl_5.02-1_amd64.deb", fh, "application/vnd.debian.binary-package")},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["metadata"]["name"] == "sl"
+    token = data["suggested"]["token"]
+    assert data["suggested"]["yaml"].startswith("version:")
+
+    export = client.post(
+        "/api/export",
+        json={"token": token, "yaml": data["suggested"]["yaml"]},
+    )
+    assert export.status_code == 200
+    assert export.headers["content-type"].startswith("application/zip")
+    with zipfile.ZipFile(io.BytesIO(export.content)) as zf:
+        names = zf.namelist()
+        assert any(n.endswith("linglong.yaml") for n in names)
+        assert any(n.endswith("README.md") for n in names)
+        assert any(n.endswith("srcs/README.txt") for n in names)
+
+
+def test_rejects_invalid_format():
+    resp = client.post(
+        "/api/analyze",
+        files={"file": ("fake.bin", io.BytesIO(b"not a package"), "application/octet-stream")},
+    )
+    assert resp.status_code == 400
+
+
+def test_export_bad_yaml():
+    with open(FIXTURES / "sl_5.02-1_amd64.deb", "rb") as fh:
+        resp = client.post(
+            "/api/analyze",
+            files={"file": ("sl.deb", fh, "application/octet-stream")},
+        )
+    token = resp.json()["suggested"]["token"]
+    bad = client.post("/api/export", json={"token": token, "yaml": "not: [valid"})
+    assert bad.status_code == 400
+    missing = client.post("/api/export", json={"token": "deadbeef", "yaml": "a: 1"})
+    assert missing.status_code == 404

--- a/tools/linglong-migration-assistant/backend/tests/test_deb.py
+++ b/tools/linglong-migration-assistant/backend/tests/test_deb.py
@@ -1,0 +1,64 @@
+"""deb 解析与依赖分类测试（使用真实样本包）。"""
+import pytest
+
+from app.analyzer.rules import classify
+from app.parsers.common import detect_format
+from app.parsers.deb import parse_deb
+
+from conftest import FIXTURES
+
+DEB = FIXTURES / "sl_5.02-1_amd64.deb"
+
+
+@pytest.fixture(scope="module")
+def parsed():
+    return parse_deb(DEB.read_bytes())
+
+
+def test_detect_format():
+    assert detect_format(DEB.read_bytes()) == "deb"
+
+
+def test_control_fields(parsed):
+    assert parsed.control["Package"] == "sl"
+    assert parsed.control["Version"].startswith("5.02")
+    assert "Description" in parsed.control
+    assert parsed.control["Homepage"].startswith("http")
+
+
+def test_files_scanned(parsed):
+    # sl 装在 usr/games/sl
+    assert "usr/games/sl" in parsed.binaries
+    assert parsed.file_count > 0
+    assert parsed.total_size > 0
+
+
+def test_desktop_absent_ok(parsed):
+    # sl 是终端玩具，无 desktop 文件
+    assert parsed.desktops == []
+
+
+def test_parse_depends_variants():
+    from app.parsers.deb import parse_depends
+
+    deps = parse_depends("libc6 (>= 2.38), libcurl3-gnutls (= 8.11.0), zlib1g (>= 1:1.1.4)")
+    names = [d[0] for d in deps]
+    assert names == ["libc6", "libcurl3-gnutls", "zlib1g"]
+    assert deps[0][1] == ">= 2.38"
+
+
+def test_parse_control_multiline():
+    from app.parsers.deb import parse_control
+
+    fields = parse_control(
+        "Package: x\nDescription: first line\n continuation line\n\nDepends: a\n"
+    )
+    assert fields["Description"] == "first line\ncontinuation line"
+    assert fields["Depends"] == "a"
+
+
+def test_classify_levels():
+    assert classify("libc6") == "base"
+    assert classify("libqt5core5a") == "runtime"
+    assert classify("libdtkwidget5") == "runtime"
+    assert classify("libnotexist-xyz9") == "bundled"

--- a/tools/linglong-migration-assistant/backend/tests/test_deb.py
+++ b/tools/linglong-migration-assistant/backend/tests/test_deb.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 """deb 解析与依赖分类测试（使用真实样本包）。"""
 import pytest
 

--- a/tools/linglong-migration-assistant/backend/tests/test_rpm.py
+++ b/tools/linglong-migration-assistant/backend/tests/test_rpm.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Yanghanrui666
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
 """RPM 解析测试（使用真实样本包）。"""
 import pytest
 

--- a/tools/linglong-migration-assistant/backend/tests/test_rpm.py
+++ b/tools/linglong-migration-assistant/backend/tests/test_rpm.py
@@ -1,0 +1,38 @@
+"""RPM 解析测试（使用真实样本包）。"""
+import pytest
+
+from app.parsers.common import detect_format
+from app.parsers.rpm import parse_rpm
+
+from conftest import FIXTURES
+
+RPM = FIXTURES / "sl-5.02-1.el9.x86_64.rpm"
+
+
+@pytest.fixture(scope="module")
+def parsed():
+    return parse_rpm(RPM.read_bytes())
+
+
+def test_detect_format():
+    assert detect_format(RPM.read_bytes()) == "rpm"
+
+
+def test_header_fields(parsed):
+    assert parsed.control["Package"] == "sl"
+    assert parsed.control["Version"] == "5.02"
+    assert parsed.control["Architecture"] == "x86_64"
+    assert parsed.control["Description"]
+
+
+def test_dependencies(parsed):
+    # RPM 依赖以 soname 形式出现
+    names = [n for n, _ in parsed.dependencies]
+    assert "libncurses.so.6" in names
+    assert "libtinfo.so.6" in names
+    assert all(not n.endswith("(64bit)") for n in names)
+
+
+def test_files_scanned(parsed):
+    assert any(b.endswith("bin/sl") for b in parsed.binaries)
+    assert parsed.file_count > 0

--- a/tools/linglong-migration-assistant/frontend/index.html
+++ b/tools/linglong-migration-assistant/frontend/index.html
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2026 Yanghanrui666
+SPDX-License-Identifier: LGPL-3.0-or-later
+-->
 <!doctype html>
 <html lang="zh-CN">
   <head>

--- a/tools/linglong-migration-assistant/frontend/index.html
+++ b/tools/linglong-migration-assistant/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>如意玲珑应用迁移助手</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/tools/linglong-migration-assistant/frontend/package-lock.json
+++ b/tools/linglong-migration-assistant/frontend/package-lock.json
@@ -1,0 +1,2147 @@
+{
+  "name": "linyaps-migration-assistant",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "linyaps-migration-assistant",
+      "version": "0.1.0",
+      "dependencies": {
+        "@codemirror/lang-yaml": "^6.1.2",
+        "@codemirror/theme-one-dark": "^6.1.2",
+        "@element-plus/icons-vue": "^2.3.1",
+        "axios": "^1.7.9",
+        "codemirror": "^6.0.1",
+        "element-plus": "^2.9.1",
+        "vue": "^3.5.13",
+        "vue-codemirror": "^6.1.1",
+        "vue-router": "^4.5.0"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-vue": "^5.2.1",
+        "typescript": "^5.7.2",
+        "vite": "^6.0.7"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.11.0.tgz",
+      "integrity": "sha512-/K4Rl5BN0OtTiPWmJCdqODu38XnDMsDxKY5rgrPnCkutPTJf2wVbkoixLfealF5Kwse/s8P8M5jAiURiwSwnFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.2.tgz",
+      "integrity": "sha512-gUYkYhT2+n/+VGZ+8EzE5WFkYZUZYm1VOKDudIsNqh42uRVQJ0a6Yss9sdKT3MeOYfuL1N6AZA57oza0Oyr0LA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.3.tgz",
+      "integrity": "sha512-9aCZCzB5okKHVnUXivo+BXVzZz9b0SA4LAmGX60LuCXT7QjNCEHcD/kdmfYg7vAX3g1O+fy4Cpl6xFsWX2H/lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.11.tgz",
+      "integrity": "sha512-2+esucbQX6wB2JYi1eDvdCPFTA31BN8oSy6xCmk3G6CloV11yOvEjYk+gH7kLrP0MuHG94E8WDhjs5oMiu3+Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.2.0.tgz",
+      "integrity": "sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@element-plus/icons-vue": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@element-plus/icons-vue/-/icons-vue-2.3.2.tgz",
+      "integrity": "sha512-OzIuTaIfC8QXEPmJvB4Y4kw34rSXdCJzxcD1kFStBvr8bK6X1zQAYDo0CNMjojnfTqRQCJ0I7prlErcoRiET2A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.4.tgz",
+      "integrity": "sha512-Wy0V7+SGUjnF9/TkiM1hKVDPj7jKXduPNboMVtHTA8dySMURWqfg/JZ9E2Sq8JgSJmkl7k7Qe9FLeMSrSraWmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "name": "@sxzz/popperjs-es",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@sxzz/popperjs-es/-/popperjs-es-2.11.8.tgz",
+      "integrity": "sha512-wOwESXvvED3S8xBmcPWHs2dUuzrE4XiZeFu7e1hROIJkm02a49N120pmOXxY33sBb6hArItm5W5tcg1cBtV+HQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
+      "integrity": "sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.42.tgz",
+      "integrity": "sha512-2Ye1ilMtKXxl8qZUrQ5j0CdgenFp/HFQmta6rfRyfEsTG69L6Wk+tWuNoHYHMx9E8tF2Slvdg1FuwDvAXdy1LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.42",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.42.tgz",
+      "integrity": "sha512-qbhQZEFmycr+ni/qyuccS4sucNN7VAbDfbkvNxWOX2VfgFm90MNs3/UhRNKoPMEIVn0F8gdlYjLPvqxHwHeQOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.42.tgz",
+      "integrity": "sha512-fkCAFB4okcAANGMThboWnScp/gzWjU0ZSkVnjTIiplmMDq2uq0tIB3j+xVu4rhv5rvOgBySCysudmbMd6xRRqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-core": "3.5.42",
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/compiler-ssr": "3.5.42",
+        "@vue/shared": "3.5.42",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.19",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.42.tgz",
+      "integrity": "sha512-xmLk3wLkbizPAiLyomjgFFosf2ys9b5Ghb+oh/k2tnvipNz8OFrQOiTcWCzyK7MpBp9KkyGtfvgfLUivbmuGYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.42.tgz",
+      "integrity": "sha512-TzNNfKpb7hDxbQltwAut8VDQA5YP+BuRlxntHUuRjyKwlMvmAPbs3unhCvieijifY6vFfVBwsS7wG/C7uq+bEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.42.tgz",
+      "integrity": "sha512-9uACtuHs7vJGkm5Bp3xu4xRDLFTIYy5DgxpToVjqGIAhAEKwQfsaLvKINhM6nFVp6bZPRFGdDqd1g52MqKsotA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.42.tgz",
+      "integrity": "sha512-rsCmhiWLaRxGltLwhlCWyYkFn7WAbKRh0q17eZ1A6Dq6eqc2ACQ61IIryxz0LrsvCzHSilLA9JHovVwM8CNE2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.42",
+        "@vue/runtime-core": "3.5.42",
+        "@vue/shared": "3.5.42",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.42.tgz",
+      "integrity": "sha512-2++5dUyYS4gvo7xQXSECUDhB7TS0aOl5SeVfC5qSq1Jgfhjvegw1zqhwTIR3imZ+QYPJQw9gfcFvXGAjGZ7ajQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.42",
+        "@vue/runtime-dom": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.42.tgz",
+      "integrity": "sha512-2rPxex1jQf4jvl9MOHl6YaXCPcrNqz/FstMOEh3QWY+/OME9nQTvl9WYeCwhW7AFjaR0SnngZGlp/wkR6rkI6g==",
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.4.0.tgz",
+      "integrity": "sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "14.4.0",
+        "@vueuse/shared": "14.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.4.0.tgz",
+      "integrity": "sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.4.0.tgz",
+      "integrity": "sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/async-validator": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.2.5.tgz",
+      "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/element-plus": {
+      "version": "2.14.5",
+      "resolved": "https://registry.npmjs.org/element-plus/-/element-plus-2.14.5.tgz",
+      "integrity": "sha512-bghYy/S+qg87enHPXELirhEdDqsVAUGcGpbGIeG8dz0kwpIkGz7gYsifulBshXX74iRtHib85XWQj0uSH2A1Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^4.2.0",
+        "@element-plus/icons-vue": "^2.3.2",
+        "@floating-ui/dom": "^1.8.0",
+        "@popperjs/core": "npm:@sxzz/popperjs-es@^2.11.8",
+        "@types/lodash": "^4.17.24",
+        "@types/lodash-es": "^4.17.12",
+        "@vueuse/core": "14.4.0",
+        "async-validator": "^4.2.5",
+        "dayjs": "^1.11.20",
+        "lodash": "^4.18.1",
+        "lodash-es": "^4.18.1",
+        "lodash-unified": "^1.0.3",
+        "memoize-one": "^6.0.0",
+        "normalize-wheel-es": "^1.2.0",
+        "vue-component-type-helpers": "^3.3.9"
+      },
+      "peerDependencies": {
+        "vue": "^3.3.7"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-unified": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/lodash-unified/-/lodash-unified-1.0.3.tgz",
+      "integrity": "sha512-WK9qSozxXOD7ZJQlpSqOT+om2ZfcT4yO+03FuzAHD0wF6S0l0090LRPDx3vhTTLZ8cFKpBn+IOcVXK6qOcIlfQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/lodash-es": "*",
+        "lodash": "*",
+        "lodash-es": "*"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/normalize-wheel-es": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/normalize-wheel-es/-/normalize-wheel-es-1.2.0.tgz",
+      "integrity": "sha512-Wj7+EJQ8mSuXr2iWfnujrimU35R2W4FAErEyTmJoJ7ucwTn2hOUSsRehMb5RSYkxXGTM7Y9QpvPmp++w5ftoJw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.42.tgz",
+      "integrity": "sha512-4RyHQTbQvOPs3MfvUO1Sg0YRrKNnA0mAVtvpd12Tg1fKDN7OHBUl1IqSn8zGJjK9nI3NkNp8cgTpVrSZC5TTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/compiler-sfc": "3.5.42",
+        "@vue/runtime-dom": "3.5.42",
+        "@vue/server-renderer": "3.5.42",
+        "@vue/shared": "3.5.42"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-codemirror": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vue-codemirror/-/vue-codemirror-6.1.1.tgz",
+      "integrity": "sha512-rTAYo44owd282yVxKtJtnOi7ERAcXTeviwoPXjIc6K/IQYUsoDkzPvw/JDFtSP6T7Cz/2g3EHaEyeyaQCKoDMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/commands": "6.x",
+        "@codemirror/language": "6.x",
+        "@codemirror/state": "6.x",
+        "@codemirror/view": "6.x"
+      },
+      "peerDependencies": {
+        "codemirror": "6.x",
+        "vue": "3.x"
+      }
+    },
+    "node_modules/vue-component-type-helpers": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.11.tgz",
+      "integrity": "sha512-LwcxzeliO9fkQcpJG0PoX8X5kmAhKmH9wkpDLxNabwzkQ9Zeib2YVHwFV4pcWmMLfXVfjr/dSV+DaJ3cIPgSNA==",
+      "license": "MIT"
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/tools/linglong-migration-assistant/frontend/package.json
+++ b/tools/linglong-migration-assistant/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "linyaps-migration-assistant",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@codemirror/lang-yaml": "^6.1.2",
+    "@codemirror/theme-one-dark": "^6.1.2",
+    "@element-plus/icons-vue": "^2.3.1",
+    "axios": "^1.7.9",
+    "codemirror": "^6.0.1",
+    "element-plus": "^2.9.1",
+    "vue": "^3.5.13",
+    "vue-codemirror": "^6.1.1",
+    "vue-router": "^4.5.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.2.1",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.7"
+  }
+}

--- a/tools/linglong-migration-assistant/frontend/src/App.vue
+++ b/tools/linglong-migration-assistant/frontend/src/App.vue
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2026 Yanghanrui666
+SPDX-License-Identifier: LGPL-3.0-or-later
+-->
 <template>
   <el-container>
     <el-header class="app-header">

--- a/tools/linglong-migration-assistant/frontend/src/App.vue
+++ b/tools/linglong-migration-assistant/frontend/src/App.vue
@@ -1,0 +1,90 @@
+<template>
+  <el-container>
+    <el-header class="app-header">
+      <div class="brand" @click="router.push('/')">
+        <span class="logo">玲</span>
+        <div>
+          <div class="title">如意玲珑应用迁移助手</div>
+          <div class="subtitle">deb / rpm / AppImage → Linyaps 一键迁移</div>
+        </div>
+      </div>
+      <el-tag effect="dark" type="primary" round>Linyaps</el-tag>
+    </el-header>
+
+    <el-main>
+      <div class="page-container">
+        <el-steps :active="step" align-center finish-status="success" class="steps">
+          <el-step title="上传安装包" description="deb / rpm / AppImage" />
+          <el-step title="分析报告" description="依赖归属与检查清单" />
+          <el-step title="生成与导出" description="linglong.yaml 工程包" />
+        </el-steps>
+        <router-view />
+      </div>
+    </el-main>
+
+    <el-footer class="app-footer">
+      面向开放原子开源大赛玲珑赛题 ·
+      <a href="https://linyaps.org.cn/" target="_blank">如意玲珑官网</a>
+    </el-footer>
+  </el-container>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+const route = useRoute()
+const router = useRouter()
+const step = computed(() => ({ home: 0, report: 1, export: 2 }[route.name as string] ?? 0))
+</script>
+
+<style scoped>
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #fff;
+  border-bottom: 1px solid #e4e7ed;
+  height: 64px;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+}
+.logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #4a5cff, #7b3ff2);
+  color: #fff;
+  font-size: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+}
+.title {
+  font-size: 17px;
+  font-weight: 600;
+}
+.subtitle {
+  font-size: 12px;
+  color: #909399;
+}
+.steps {
+  margin-bottom: 24px;
+}
+.app-footer {
+  text-align: center;
+  color: #909399;
+  font-size: 12px;
+  height: 48px;
+  line-height: 48px;
+}
+.app-footer a {
+  color: #4a5cff;
+  text-decoration: none;
+}
+</style>

--- a/tools/linglong-migration-assistant/frontend/src/api/client.ts
+++ b/tools/linglong-migration-assistant/frontend/src/api/client.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Yanghanrui666
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
 import axios from 'axios'
 
 export interface PackageMetadata {

--- a/tools/linglong-migration-assistant/frontend/src/api/client.ts
+++ b/tools/linglong-migration-assistant/frontend/src/api/client.ts
@@ -1,0 +1,93 @@
+import axios from 'axios'
+
+export interface PackageMetadata {
+  package_format: string
+  name: string
+  version: string
+  description: string
+  architecture: string
+  raw_arch: string
+  maintainer: string
+  homepage: string
+  license: string
+  raw: Record<string, string>
+}
+
+export interface DesktopEntry {
+  path: string
+  name: string
+  exec: string
+  icon: string
+  wm_class: string
+}
+
+export interface DetectedFiles {
+  binaries: string[]
+  desktop_entries: DesktopEntry[]
+  icons: string[]
+  libraries: string[]
+  file_count: number
+  total_size: number
+  notes: string[]
+}
+
+export type DepLevel = 'base' | 'runtime' | 'bundled'
+
+export interface Dependency {
+  name: string
+  level: DepLevel
+  constraint: string
+}
+
+export interface CheckItem {
+  key: string
+  title: string
+  status: 'pass' | 'warn' | 'fail' | 'info'
+  detail: string
+}
+
+export interface Suggested {
+  id: string
+  name: string
+  version: string
+  command: string
+  base: string
+  runtime: string
+  bundled_deps: string[]
+  yaml: string
+  token: string
+}
+
+export interface AnalysisResult {
+  metadata: PackageMetadata
+  files: DetectedFiles
+  dependencies: Dependency[]
+  checklist: CheckItem[]
+  suggested: Suggested
+}
+
+const http = axios.create({ baseURL: '/api', timeout: 300000 })
+
+export async function analyzePackage(file: File): Promise<AnalysisResult> {
+  const form = new FormData()
+  form.append('file', file)
+  const { data } = await http.post<AnalysisResult>('/analyze', form)
+  return data
+}
+
+export async function exportProject(token: string, yaml: string): Promise<Blob> {
+  const { data } = await http.post('/export', { token, yaml }, { responseType: 'blob' })
+  return data
+}
+
+export function formatSize(bytes: number): string {
+  if (!bytes) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB']
+  let i = 0
+  let v = bytes
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024
+    i++
+  }
+  return `${v.toFixed(i === 0 ? 0 : 1)} ${units[i]}`
+}

--- a/tools/linglong-migration-assistant/frontend/src/components/ChecklistPanel.vue
+++ b/tools/linglong-migration-assistant/frontend/src/components/ChecklistPanel.vue
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2026 Yanghanrui666
+SPDX-License-Identifier: LGPL-3.0-or-later
+-->
 <template>
   <el-card shadow="never">
     <template #header><span class="header">迁移检查清单</span></template>

--- a/tools/linglong-migration-assistant/frontend/src/components/ChecklistPanel.vue
+++ b/tools/linglong-migration-assistant/frontend/src/components/ChecklistPanel.vue
@@ -1,0 +1,66 @@
+<template>
+  <el-card shadow="never">
+    <template #header><span class="header">迁移检查清单</span></template>
+    <div v-for="item in checklist" :key="item.key" class="check-item">
+      <el-icon :size="20" :color="STATUS_COLOR[item.status]">
+        <CircleCheckFilled v-if="item.status === 'pass'" />
+        <WarningFilled v-else-if="item.status === 'warn'" />
+        <CircleCloseFilled v-else-if="item.status === 'fail'" />
+        <InfoFilled v-else />
+      </el-icon>
+      <div class="content">
+        <div class="title">
+          {{ item.title }}
+          <el-tag size="small" :type="STATUS_TAG[item.status]" effect="plain">
+            {{ STATUS_LABEL[item.status] }}
+          </el-tag>
+        </div>
+        <div class="detail">{{ item.detail }}</div>
+      </div>
+    </div>
+  </el-card>
+</template>
+
+<script setup lang="ts">
+import type { CheckItem } from '../api/client'
+import { CircleCheckFilled, CircleCloseFilled, InfoFilled, WarningFilled } from '@element-plus/icons-vue'
+
+defineProps<{ checklist: CheckItem[] }>()
+
+const STATUS_COLOR: Record<string, string> = {
+  pass: '#67c23a',
+  warn: '#e6a23c',
+  fail: '#f56c6c',
+  info: '#409eff',
+}
+const STATUS_TAG: Record<string, any> = { pass: 'success', warn: 'warning', fail: 'danger', info: 'info' }
+const STATUS_LABEL: Record<string, string> = { pass: '通过', warn: '注意', fail: '待处理', info: '说明' }
+</script>
+
+<style scoped>
+.header {
+  font-weight: 600;
+}
+.check-item {
+  display: flex;
+  gap: 12px;
+  padding: 10px 4px;
+  border-bottom: 1px dashed #ebeef5;
+}
+.check-item:last-child {
+  border-bottom: none;
+}
+.title {
+  font-weight: 600;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.detail {
+  font-size: 13px;
+  color: #606266;
+  margin-top: 4px;
+  line-height: 1.6;
+}
+</style>

--- a/tools/linglong-migration-assistant/frontend/src/components/DependencyTree.vue
+++ b/tools/linglong-migration-assistant/frontend/src/components/DependencyTree.vue
@@ -1,0 +1,104 @@
+<template>
+  <el-card shadow="never">
+    <template #header>
+      <div class="card-header">
+        <span>依赖归属分析</span>
+        <span class="legend">
+          <el-tag type="success" effect="plain" size="small">base 覆盖 {{ count('base') }}</el-tag>
+          <el-tag type="primary" effect="plain" size="small">runtime 覆盖 {{ count('runtime') }}</el-tag>
+          <el-tag type="warning" effect="plain" size="small">需自带 {{ count('bundled') }}</el-tag>
+        </span>
+      </div>
+    </template>
+
+    <el-empty v-if="dependencies.length === 0" description="未检测到依赖声明" :image-size="80" />
+
+    <el-tree v-else :data="treeData" default-expand-all :expand-on-click-node="false">
+      <template #default="{ data }">
+        <span class="tree-node">
+          <el-tag v-if="data.level" :type="levelType(data.level)" size="small" effect="plain" class="dep-tag">
+            {{ levelLabel(data.level) }}
+          </el-tag>
+          <span :class="{ root: !data.level }">{{ data.name }}</span>
+          <span v-if="data.constraint" class="constraint">{{ data.constraint }}</span>
+        </span>
+      </template>
+    </el-tree>
+
+    <el-alert
+      v-if="count('bundled') > 0"
+      type="warning"
+      :closable="false"
+      show-icon
+      class="bundled-alert"
+      :title="`${count('bundled')} 个依赖需要随应用自带，导出的工程已包含自动收集脚本`"
+    />
+  </el-card>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Dependency, DepLevel } from '../api/client'
+
+const props = defineProps<{ dependencies: Dependency[] }>()
+
+const GROUPS: { key: DepLevel; name: string }[] = [
+  { key: 'base', name: 'base 覆盖（org.deepin.base 提供，无需处理）' },
+  { key: 'runtime', name: 'runtime 覆盖（org.deepin.runtime.dtk 提供，已声明 runtime）' },
+  { key: 'bundled', name: '需自带（构建时自动收集进应用包）' },
+]
+
+const LABELS: Record<DepLevel, string> = { base: 'base', runtime: 'runtime', bundled: '自带' }
+
+const treeData = computed(() =>
+  GROUPS.map((g) => ({
+    name: `${g.name}（${props.dependencies.filter((d) => d.level === g.key).length}）`,
+    children: props.dependencies
+      .filter((d) => d.level === g.key)
+      .map((d) => ({ name: d.name, constraint: d.constraint, level: d.level })),
+  })).filter((g) => g.children.length > 0),
+)
+
+function count(level: DepLevel) {
+  return props.dependencies.filter((d) => d.level === level).length
+}
+function levelType(level: DepLevel) {
+  return { base: 'success', runtime: 'primary', bundled: 'warning' }[level]
+}
+function levelLabel(level: DepLevel) {
+  return LABELS[level]
+}
+</script>
+
+<style scoped>
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+}
+.legend {
+  display: flex;
+  gap: 8px;
+}
+.tree-node {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+.tree-node .root {
+  font-weight: 600;
+}
+.dep-tag {
+  width: 64px;
+  justify-content: center;
+}
+.constraint {
+  color: #909399;
+  font-size: 12px;
+}
+.bundled-alert {
+  margin-top: 12px;
+}
+</style>

--- a/tools/linglong-migration-assistant/frontend/src/components/DependencyTree.vue
+++ b/tools/linglong-migration-assistant/frontend/src/components/DependencyTree.vue
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2026 Yanghanrui666
+SPDX-License-Identifier: LGPL-3.0-or-later
+-->
 <template>
   <el-card shadow="never">
     <template #header>

--- a/tools/linglong-migration-assistant/frontend/src/components/MetadataCard.vue
+++ b/tools/linglong-migration-assistant/frontend/src/components/MetadataCard.vue
@@ -1,0 +1,54 @@
+<template>
+  <el-card shadow="never">
+    <template #header>
+      <div class="card-header">
+        <span>软件包元信息</span>
+        <el-tag :type="formatTag" effect="plain">{{ metadata.package_format.toUpperCase() }}</el-tag>
+      </div>
+    </template>
+    <el-descriptions :column="2" border size="small">
+      <el-descriptions-item label="包名">{{ metadata.name }}</el-descriptions-item>
+      <el-descriptions-item label="版本">{{ metadata.version }}</el-descriptions-item>
+      <el-descriptions-item label="架构">
+        {{ metadata.architecture }}
+        <span v-if="metadata.raw_arch && metadata.raw_arch !== metadata.architecture" class="raw-arch">
+          （原始：{{ metadata.raw_arch }}）
+        </span>
+      </el-descriptions-item>
+      <el-descriptions-item label="许可证">{{ metadata.license || '-' }}</el-descriptions-item>
+      <el-descriptions-item label="维护者">{{ metadata.maintainer || '-' }}</el-descriptions-item>
+      <el-descriptions-item label="主页">
+        <a v-if="metadata.homepage" :href="metadata.homepage" target="_blank">{{ metadata.homepage }}</a>
+        <span v-else>-</span>
+      </el-descriptions-item>
+      <el-descriptions-item label="描述" :span="2">{{ metadata.description || '-' }}</el-descriptions-item>
+      <el-descriptions-item label="文件总数">{{ files.file_count }}</el-descriptions-item>
+      <el-descriptions-item label="解压后大小">{{ formatSize(files.total_size) }}</el-descriptions-item>
+    </el-descriptions>
+  </el-card>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { DetectedFiles, PackageMetadata } from '../api/client'
+import { formatSize } from '../api/client'
+
+const props = defineProps<{ metadata: PackageMetadata; files: DetectedFiles }>()
+
+const formatTag = computed(() =>
+  ({ deb: 'danger', rpm: 'warning', appimage: 'success' }[props.metadata.package_format] ?? 'info') as any,
+)
+</script>
+
+<style scoped>
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+}
+.raw-arch {
+  color: #909399;
+  font-size: 12px;
+}
+</style>

--- a/tools/linglong-migration-assistant/frontend/src/components/MetadataCard.vue
+++ b/tools/linglong-migration-assistant/frontend/src/components/MetadataCard.vue
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2026 Yanghanrui666
+SPDX-License-Identifier: LGPL-3.0-or-later
+-->
 <template>
   <el-card shadow="never">
     <template #header>

--- a/tools/linglong-migration-assistant/frontend/src/main.ts
+++ b/tools/linglong-migration-assistant/frontend/src/main.ts
@@ -1,0 +1,11 @@
+import { createApp } from 'vue'
+import ElementPlus from 'element-plus'
+import 'element-plus/dist/index.css'
+import App from './App.vue'
+import router from './router'
+import './style.css'
+
+const app = createApp(App)
+app.use(ElementPlus)
+app.use(router)
+app.mount('#app')

--- a/tools/linglong-migration-assistant/frontend/src/main.ts
+++ b/tools/linglong-migration-assistant/frontend/src/main.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Yanghanrui666
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
 import { createApp } from 'vue'
 import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'

--- a/tools/linglong-migration-assistant/frontend/src/router/index.ts
+++ b/tools/linglong-migration-assistant/frontend/src/router/index.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Yanghanrui666
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
 import { createRouter, createWebHistory } from 'vue-router'
 
 const router = createRouter({

--- a/tools/linglong-migration-assistant/frontend/src/router/index.ts
+++ b/tools/linglong-migration-assistant/frontend/src/router/index.ts
@@ -1,0 +1,12 @@
+import { createRouter, createWebHistory } from 'vue-router'
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: '/', name: 'home', component: () => import('../views/HomeView.vue') },
+    { path: '/report', name: 'report', component: () => import('../views/ReportView.vue') },
+    { path: '/export', name: 'export', component: () => import('../views/ExportView.vue') },
+  ],
+})
+
+export default router

--- a/tools/linglong-migration-assistant/frontend/src/store.ts
+++ b/tools/linglong-migration-assistant/frontend/src/store.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Yanghanrui666
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
 import { reactive } from 'vue'
 import type { AnalysisResult } from './api/client'
 

--- a/tools/linglong-migration-assistant/frontend/src/store.ts
+++ b/tools/linglong-migration-assistant/frontend/src/store.ts
@@ -1,0 +1,17 @@
+import { reactive } from 'vue'
+import type { AnalysisResult } from './api/client'
+
+interface AppState {
+  analysis: AnalysisResult | null
+  yaml: string
+}
+
+export const store = reactive<AppState>({
+  analysis: null,
+  yaml: '',
+})
+
+export function setAnalysis(result: AnalysisResult) {
+  store.analysis = result
+  store.yaml = result.suggested.yaml
+}

--- a/tools/linglong-migration-assistant/frontend/src/style.css
+++ b/tools/linglong-migration-assistant/frontend/src/style.css
@@ -1,0 +1,30 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'PingFang SC', 'Microsoft YaHei', 'Helvetica Neue', Arial, sans-serif;
+  background: #f5f7fa;
+  color: #303133;
+}
+
+#app {
+  min-height: 100vh;
+}
+
+.page-container {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 20px 24px 48px;
+}
+
+.section-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 24px 0 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/tools/linglong-migration-assistant/frontend/src/style.css
+++ b/tools/linglong-migration-assistant/frontend/src/style.css
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Yanghanrui666
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
 * {
   margin: 0;
   padding: 0;

--- a/tools/linglong-migration-assistant/frontend/src/views/ExportView.vue
+++ b/tools/linglong-migration-assistant/frontend/src/views/ExportView.vue
@@ -1,0 +1,106 @@
+<template>
+  <div v-if="store.analysis">
+    <el-alert
+      type="success"
+      :closable="false"
+      show-icon
+      class="summary"
+      :title="`已按官方规范生成 linglong.yaml：${store.analysis.suggested.id} ${store.analysis.suggested.version}`"
+      :description="`启动命令 ${store.analysis.suggested.command || '（未检测到，请手动补充 command 字段）'} · base ${store.analysis.suggested.base}${store.analysis.suggested.runtime ? ' · runtime ' + store.analysis.suggested.runtime : ''}`"
+    />
+
+    <div class="section-title">linglong.yaml（可编辑）</div>
+    <el-card shadow="never" class="editor-card">
+      <Codemirror
+        v-model="store.yaml"
+        :extensions="extensions"
+        :style="{ height: '420px' }"
+        placeholder="linglong.yaml"
+      />
+    </el-card>
+
+    <div class="section-title">导出内容</div>
+    <el-card shadow="never">
+      <el-check-tag checked class="include-item">linglong.yaml</el-check-tag>
+      <el-check-tag checked class="include-item">README.md（构建指引）</el-check-tag>
+      <el-check-tag checked class="include-item">deps.txt</el-check-tag>
+      <el-check-tag checked class="include-item">srcs/（放置原始包）</el-check-tag>
+      <el-check-tag v-if="resourceCount > 0" checked class="include-item">
+        resources/（{{ resourceCount }} 个 desktop/icon）
+      </el-check-tag>
+    </el-card>
+
+    <div class="actions">
+      <el-button @click="router.push('/report')">上一步</el-button>
+      <el-button type="primary" size="large" :loading="exporting" @click="handleExport">
+        <el-icon class="btn-icon"><Download /></el-icon>
+        下载迁移工程 zip
+      </el-button>
+    </div>
+  </div>
+  <el-empty v-else description="请先上传并分析安装包">
+    <el-button type="primary" @click="router.push('/')">去上传</el-button>
+  </el-empty>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { Codemirror } from 'vue-codemirror'
+import { yaml as yamlLang } from '@codemirror/lang-yaml'
+import { oneDark } from '@codemirror/theme-one-dark'
+import { ElMessage } from 'element-plus'
+import { Download } from '@element-plus/icons-vue'
+import { exportProject } from '../api/client'
+import { store } from '../store'
+
+const router = useRouter()
+const exporting = ref(false)
+const extensions = [yamlLang(), oneDark]
+
+const resourceCount = computed(
+  () =>
+    store.analysis!.files.desktop_entries.length + store.analysis!.files.icons.length,
+)
+
+async function handleExport() {
+  exporting.value = true
+  try {
+    const blob = await exportProject(store.analysis!.suggested.token, store.yaml)
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${store.analysis!.suggested.id}-linglong-project.zip`
+    a.click()
+    URL.revokeObjectURL(url)
+    ElMessage.success('工程导出成功，将原包放入 srcs/ 后即可 ll-builder build')
+  } catch (err: any) {
+    const detail = err?.response?.data?.detail || err?.message || '未知错误'
+    ElMessage.error(`导出失败：${detail}`)
+  } finally {
+    exporting.value = false
+  }
+}
+</script>
+
+<style scoped>
+.summary {
+  margin-bottom: 8px;
+}
+.editor-card :deep(.cm-editor) {
+  border-radius: 6px;
+  font-size: 13px;
+}
+.include-item {
+  margin: 0 8px 8px 0;
+}
+.btn-icon {
+  margin-right: 6px;
+}
+.actions {
+  margin-top: 24px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+</style>

--- a/tools/linglong-migration-assistant/frontend/src/views/ExportView.vue
+++ b/tools/linglong-migration-assistant/frontend/src/views/ExportView.vue
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2026 Yanghanrui666
+SPDX-License-Identifier: LGPL-3.0-or-later
+-->
 <template>
   <div v-if="store.analysis">
     <el-alert

--- a/tools/linglong-migration-assistant/frontend/src/views/HomeView.vue
+++ b/tools/linglong-migration-assistant/frontend/src/views/HomeView.vue
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2026 Yanghanrui666
+SPDX-License-Identifier: LGPL-3.0-or-later
+-->
 <template>
   <div>
     <el-card shadow="never" class="upload-card">

--- a/tools/linglong-migration-assistant/frontend/src/views/HomeView.vue
+++ b/tools/linglong-migration-assistant/frontend/src/views/HomeView.vue
@@ -1,0 +1,89 @@
+<template>
+  <div>
+    <el-card shadow="never" class="upload-card">
+      <el-upload
+        drag
+        :auto-upload="false"
+        :show-file-list="false"
+        :on-change="handleChange"
+        accept=".deb,.rpm,.AppImage,.appimage"
+      >
+        <el-icon class="el-icon--upload" :size="48"><UploadFilled /></el-icon>
+        <div class="el-upload__text">拖拽安装包到此处，或 <em>点击选择文件</em></div>
+        <template #tip>
+          <div class="el-upload__tip">
+            支持 deb / rpm / AppImage，单文件上限 2GB。上传后仅在本地分析，不会分发。
+          </div>
+        </template>
+      </el-upload>
+    </el-card>
+
+    <el-row :gutter="16" class="feature-row">
+      <el-col :span="8" v-for="f in features" :key="f.title">
+        <el-card shadow="hover" class="feature-card">
+          <div class="feature-title">{{ f.title }}</div>
+          <div class="feature-desc">{{ f.desc }}</div>
+        </el-card>
+      </el-col>
+    </el-row>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { UploadFilled } from '@element-plus/icons-vue'
+import { ElMessage, type UploadFile } from 'element-plus'
+import { analyzePackage } from '../api/client'
+import { setAnalysis } from '../store'
+
+const router = useRouter()
+const loading = ref(false)
+
+const features = [
+  { title: '依赖归属分析', desc: '自动将依赖划分到 base / runtime / 需自带三档，可视化呈现迁移工作量。' },
+  { title: 'linglong.yaml 生成', desc: '按官方 1.14.x 规范生成构建配置，启动命令自动改写为容器内路径。' },
+  { title: '工程一键导出', desc: '导出可直接 ll-builder build 的完整工程：构建脚本、依赖收集、资源文件。' },
+]
+
+async function handleChange(file: UploadFile) {
+  if (loading.value) return
+  if (!file.raw) return
+  loading.value = true
+  try {
+    const result = await analyzePackage(file.raw)
+    setAnalysis(result)
+    ElMessage.success(`分析完成：${result.metadata.name} ${result.metadata.version}`)
+    router.push('/report')
+  } catch (err: any) {
+    const detail = err?.response?.data?.detail || err?.message || '未知错误'
+    ElMessage.error(`分析失败：${detail}`)
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<style scoped>
+.upload-card {
+  margin-bottom: 20px;
+}
+.upload-card :deep(.el-upload-dragger) {
+  padding: 48px 0;
+}
+.feature-row {
+  margin-top: 4px;
+}
+.feature-card {
+  min-height: 110px;
+}
+.feature-title {
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+.feature-desc {
+  font-size: 13px;
+  color: #606266;
+  line-height: 1.7;
+}
+</style>

--- a/tools/linglong-migration-assistant/frontend/src/views/ReportView.vue
+++ b/tools/linglong-migration-assistant/frontend/src/views/ReportView.vue
@@ -1,0 +1,105 @@
+<template>
+  <div v-if="store.analysis">
+    <MetadataCard :metadata="store.analysis.metadata" :files="store.analysis.files" />
+
+    <div class="section-title">检测到的应用文件</div>
+    <el-card shadow="never">
+      <el-row :gutter="16">
+        <el-col :span="8">
+          <div class="stat">
+            <div class="stat-num">{{ store.analysis.files.binaries.length }}</div>
+            <div class="stat-label">可执行文件</div>
+            <div class="stat-detail">{{ firstOrDash(store.analysis.files.binaries) }}</div>
+          </div>
+        </el-col>
+        <el-col :span="8">
+          <div class="stat">
+            <div class="stat-num">{{ store.analysis.files.desktop_entries.length }}</div>
+            <div class="stat-label">desktop 文件</div>
+            <div class="stat-detail">{{ firstOrDash(store.analysis.files.desktop_entries.map((d) => d.name || d.path)) }}</div>
+          </div>
+        </el-col>
+        <el-col :span="8">
+          <div class="stat">
+            <div class="stat-num">{{ store.analysis.files.icons.length }}</div>
+            <div class="stat-label">应用图标</div>
+            <div class="stat-detail">{{ firstOrDash(store.analysis.files.icons) }}</div>
+          </div>
+        </el-col>
+      </el-row>
+      <el-alert
+        v-for="(note, i) in store.analysis.files.notes"
+        :key="i"
+        :title="note"
+        type="info"
+        :closable="false"
+        show-icon
+        class="note"
+      />
+    </el-card>
+
+    <div class="section-title">依赖分析</div>
+    <DependencyTree :dependencies="store.analysis.dependencies" />
+
+    <div class="section-title">迁移检查</div>
+    <ChecklistPanel :checklist="store.analysis.checklist" />
+
+    <div class="actions">
+      <el-button @click="router.push('/')">重新上传</el-button>
+      <el-button type="primary" @click="router.push('/export')">
+        下一步：生成 linglong.yaml
+      </el-button>
+    </div>
+  </div>
+  <el-empty v-else description="请先上传并分析安装包">
+    <el-button type="primary" @click="router.push('/')">去上传</el-button>
+  </el-empty>
+</template>
+
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+import { store } from '../store'
+import MetadataCard from '../components/MetadataCard.vue'
+import DependencyTree from '../components/DependencyTree.vue'
+import ChecklistPanel from '../components/ChecklistPanel.vue'
+
+const router = useRouter()
+
+function firstOrDash(list: string[]): string {
+  return list.length > 0 ? list[0] : '-'
+}
+</script>
+
+<style scoped>
+.stat {
+  text-align: center;
+  padding: 8px 0;
+}
+.stat-num {
+  font-size: 28px;
+  font-weight: 700;
+  color: #4a5cff;
+}
+.stat-label {
+  font-size: 13px;
+  color: #606266;
+  margin-top: 4px;
+}
+.stat-detail {
+  font-size: 12px;
+  color: #909399;
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.note {
+  margin-top: 10px;
+}
+.actions {
+  margin-top: 24px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+</style>

--- a/tools/linglong-migration-assistant/frontend/src/views/ReportView.vue
+++ b/tools/linglong-migration-assistant/frontend/src/views/ReportView.vue
@@ -1,3 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2026 Yanghanrui666
+SPDX-License-Identifier: LGPL-3.0-or-later
+-->
 <template>
   <div v-if="store.analysis">
     <MetadataCard :metadata="store.analysis.metadata" :files="store.analysis.files" />

--- a/tools/linglong-migration-assistant/frontend/src/vite-env.d.ts
+++ b/tools/linglong-migration-assistant/frontend/src/vite-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+  const component: DefineComponent<{}, {}, any>
+  export default component
+}

--- a/tools/linglong-migration-assistant/frontend/src/vite-env.d.ts
+++ b/tools/linglong-migration-assistant/frontend/src/vite-env.d.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Yanghanrui666
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
 /// <reference types="vite/client" />
 
 declare module '*.vue' {

--- a/tools/linglong-migration-assistant/frontend/tsconfig.json
+++ b/tools/linglong-migration-assistant/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.vue"]
+}

--- a/tools/linglong-migration-assistant/frontend/vite.config.ts
+++ b/tools/linglong-migration-assistant/frontend/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:8000',
+        changeOrigin: true,
+      },
+    },
+  },
+})

--- a/tools/linglong-migration-assistant/frontend/vite.config.ts
+++ b/tools/linglong-migration-assistant/frontend/vite.config.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Yanghanrui666
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 


### PR DESCRIPTION
## 简介

如意玲珑应用迁移助手（Linyaps Migration Assistant）：将 deb / rpm / AppImage 安装包快速迁移为如意玲珑应用工程的 Web 工具。

## 解决的问题

传统应用向玲珑生态迁移存在三大痛点：
1. 手写 linglong.yaml 容易出错（id、version、command 路径、base/runtime 选择）
2. 依赖归属理不清（哪些 base 已提供、哪些 runtime 提供、哪些需自带）
3. desktop 图标绝对路径、版本号格式等规范细节容易遗漏

## 功能特性

- **三格式静态解析**：deb（ar+tar 纯标准库）、rpm（lead/header/cpio）、AppImage，零外部依赖
- **依赖归属可视化**：自动将依赖划分为 base 覆盖 / runtime 覆盖 / 需自带三档，前端树形展示
- **linglong.yaml 自动生成**：按官方 1.14.x manifests 规范生成，id 从 Homepage 智能反推、版本归一化四段、command 精确到包内真实路径
- **迁移检查清单**：XDG desktop、hicolor 图标、可执行文件、版本规范等自动检查
- **工程一键导出**：zip 含 linglong.yaml、构建脚本、deps.txt、resources，可直接 ll-builder build

## 技术栈

- 后端：Python 3 + FastAPI
- 前端：Vue 3 + TypeScript + Vite + Element Plus

## 放置位置

`tools/linglong-migration-assistant/`

## 测试

后端 19 个测试全部通过（真实 deb/rpm 样本覆盖解析、依赖分类、yaml 生成、API 全流程）。

## 相关

赛题：「在玲珑项目中创建工具能力，帮助玲珑改进应用适配的可用性和效率问题」