### PR TITLE
test(runtime): expand unit tests for container builder options and security context

### DIFF
--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -63,8 +63,11 @@ pfl_add_executable(
   src/linglong/repo/ostree_repo_real_test.cpp
   src/linglong/repo/repo_cache_test.cpp
   src/linglong/runtime/container_builder_test.cpp
+  src/linglong/runtime/container_builder_deep_test.cpp
   src/linglong/runtime/overlayfs_driver_test.cpp
+  src/linglong/runtime/overlayfs_driver_deep_test.cpp
   src/linglong/runtime/run_context_test.cpp
+  src/linglong/runtime/run_context_deep_test.cpp
   src/linglong/utils/bash_command_helper_test.cpp
   src/linglong/utils/cmd_test.cpp
   src/linglong/utils/error/error_test.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/container_builder_deep_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/container_builder_deep_test.cpp
@@ -1,0 +1,228 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/cli/cli.h"
+#include "linglong/runtime/container_builder.h"
+#include "linglong/runtime/overlayfs_driver.h"
+#include "linglong/runtime/run_context.h"
+#include "linglong/utils/error/error.h"
+
+#include <QTemporaryDir>
+#include <QDir>
+#include <QFile>
+#include <vector>
+#include <string>
+#include <unordered_map>
+
+namespace linglong::runtime {
+
+using ::testing::_;
+using ::testing::Contains;
+
+class ContainerBuilderDeepTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_TRUE(tempDir.isValid());
+        rootPath = tempDir.path().toStdString();
+    }
+
+    QTemporaryDir tempDir;
+    std::string rootPath;
+};
+
+TEST_F(ContainerBuilderDeepTest, RunContainerOptionsMultipleEnvOverride)
+{
+    RunContainerOptions options;
+
+    cli::RunOptions cliOpts1;
+    cliOpts1.envs = { "KEY_A=valA", "KEY_B=valB", "COMMON=initial" };
+    auto res1 = options.applyCliRunOptions(cliOpts1);
+    ASSERT_TRUE(res1.has_value()) << res1.error().message();
+
+    cli::RunOptions cliOpts2;
+    cliOpts2.envs = { "COMMON=overridden", "KEY_C=valC" };
+    auto res2 = options.applyCliRunOptions(cliOpts2);
+    ASSERT_TRUE(res2.has_value()) << res2.error().message();
+
+    const auto &envs = options.getEnv();
+    EXPECT_EQ(envs.at("KEY_A"), "valA");
+    EXPECT_EQ(envs.at("KEY_B"), "valB");
+    EXPECT_EQ(envs.at("KEY_C"), "valC");
+    EXPECT_EQ(envs.at("COMMON"), "overridden");
+}
+
+TEST_F(ContainerBuilderDeepTest, RunContainerOptionsCapabilitiesDeduplication)
+{
+    RunContainerOptions options;
+
+    cli::RunOptions cliOpts;
+    cliOpts.capsAdd = { "CAP_SYS_PTRACE", "CAP_NET_ADMIN", "CAP_SYS_PTRACE", "CAP_DAC_OVERRIDE" };
+    auto res = options.applyCliRunOptions(cliOpts);
+    ASSERT_TRUE(res.has_value());
+
+    const auto &caps = options.getCapabilities();
+    EXPECT_GE(caps.size(), 3U);
+    EXPECT_THAT(caps, Contains("CAP_SYS_PTRACE"));
+    EXPECT_THAT(caps, Contains("CAP_NET_ADMIN"));
+    EXPECT_THAT(caps, Contains("CAP_DAC_OVERRIDE"));
+}
+
+TEST_F(ContainerBuilderDeepTest, SecurityContextToggleAndDuplicateHandling)
+{
+    RunContainerOptions options;
+    options.enableSecurityContext({ SecurityContextType::WAYLAND, SecurityContextType::PULSEAUDIO });
+    options.enableSecurityContext({ SecurityContextType::WAYLAND });
+
+    const auto &ctxs = options.getSecurityContexts();
+    EXPECT_EQ(ctxs.size(), 2U);
+}
+
+TEST_F(ContainerBuilderDeepTest, ContainerIDGenerationVarianceAndUniqueness)
+{
+    api::types::v1::RunContextConfig cfg1;
+    cfg1.version = "1.0";
+    cfg1.base = "stable:org.deepin.base/23/x86_64";
+    cfg1.runtime = "stable:org.deepin.runtime/23/x86_64";
+
+    api::types::v1::RunContextConfig cfg2 = cfg1;
+    cfg2.runtime = "stable:org.deepin.runtime/24/x86_64";
+
+    api::types::v1::RunContextConfig cfg3 = cfg1;
+    cfg3.version = "2.0";
+
+    std::string id1 = genContainerID(cfg1);
+    std::string id2 = genContainerID(cfg2);
+    std::string id3 = genContainerID(cfg3);
+
+    EXPECT_NE(id1, id2);
+    EXPECT_NE(id1, id3);
+    EXPECT_NE(id2, id3);
+}
+
+TEST_F(ContainerBuilderDeepTest, OverlayFSDriverMountOptionsConstruction)
+{
+    std::vector<std::string> lowerDirs = { rootPath + "/lower1", rootPath + "/lower2" };
+    std::string upperDir = rootPath + "/upper";
+    std::string workDir = rootPath + "/work";
+    std::string targetDir = rootPath + "/target";
+
+    for (const auto &dir : lowerDirs) {
+        QDir(QString::fromStdString(dir)).mkpath(".");
+    }
+    QDir(QString::fromStdString(upperDir)).mkpath(".");
+    QDir(QString::fromStdString(workDir)).mkpath(".");
+    QDir(QString::fromStdString(targetDir)).mkpath(".");
+
+    OverlayFSDriver driver;
+    SUCCEED();
+}
+
+TEST_F(ContainerBuilderDeepTest, SecurityContextTypeConversionRoundtrip)
+{
+    std::vector<SecurityContextType> types = {
+        SecurityContextType::WAYLAND,
+        SecurityContextType::PULSEAUDIO,
+        SecurityContextType::X11,
+        SecurityContextType::DBUS
+    };
+
+    for (auto t : types) {
+        std::string name = fromType(t);
+        EXPECT_NE(name, "unknown");
+        EXPECT_EQ(toType(name), t);
+    }
+}
+
+TEST_F(ContainerBuilderDeepTest, RunContainerOptionsInvalidEnvStringValidation)
+{
+    RunContainerOptions options;
+
+    cli::RunOptions cliOpts1;
+    cliOpts1.envs = { "=VALUE_WITHOUT_KEY" };
+    auto res1 = options.applyCliRunOptions(cliOpts1);
+    EXPECT_FALSE(res1.has_value());
+
+    cli::RunOptions cliOpts2;
+    cliOpts2.envs = { "   " };
+    auto res2 = options.applyCliRunOptions(cliOpts2);
+    EXPECT_FALSE(res2.has_value());
+}
+
+TEST_F(ContainerBuilderDeepTest, ContainerOptionsDeviceOptionParsing)
+{
+    RunContainerOptions options;
+    cli::RunOptions cliOpts;
+    cliOpts.deviceOptions = { api::types::v1::DeviceOption::Passthru };
+
+    auto res = options.applyCliRunOptions(cliOpts);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_TRUE(options.isDevicePassthruEnabled());
+}
+
+TEST_F(ContainerBuilderDeepTest, ContainerOptionsPrivilegedAndHostNetworkConfig)
+{
+    RunContainerOptions options;
+    cli::RunOptions cliOpts;
+    cliOpts.privileged = true;
+
+    auto res = options.applyCliRunOptions(cliOpts);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_TRUE(options.isPrivileged());
+}
+
+TEST_F(ContainerBuilderDeepTest, ComplexEnvVarSpecialCharactersAndEscaping)
+{
+    RunContainerOptions options;
+    cli::RunOptions cliOpts;
+    cliOpts.envs = {
+        "PATH=/usr/local/bin:/usr/bin:/bin",
+        "JSON_CFG={\"key\": \"val\", \"num\": 123}",
+        "URL=https://example.com/api?query=1&sort=asc"
+    };
+
+    auto res = options.applyCliRunOptions(cliOpts);
+    ASSERT_TRUE(res.has_value()) << res.error().message();
+
+    const auto &envs = options.getEnv();
+    EXPECT_EQ(envs.at("PATH"), "/usr/local/bin:/usr/bin:/bin");
+    EXPECT_EQ(envs.at("JSON_CFG"), "{\"key\": \"val\", \"num\": 123}");
+    EXPECT_EQ(envs.at("URL"), "https://example.com/api?query=1&sort=asc");
+}
+
+TEST_F(ContainerBuilderDeepTest, SecurityContextAllTypesEnumCheck)
+{
+    std::vector<SecurityContextType> allTypes = {
+        SecurityContextType::UNKNOWN,
+        SecurityContextType::WAYLAND,
+        SecurityContextType::X11,
+        SecurityContextType::PULSEAUDIO,
+        SecurityContextType::DBUS
+    };
+
+    for (const auto &t : allTypes) {
+        std::string s = fromType(t);
+        EXPECT_FALSE(s.empty());
+    }
+}
+
+TEST_F(ContainerBuilderDeepTest, RunContainerOptionsClearStateAndReset)
+{
+    RunContainerOptions options;
+    cli::RunOptions cliOpts;
+    cliOpts.envs = { "VAR1=VAL1", "VAR2=VAL2" };
+    cliOpts.privileged = true;
+
+    ASSERT_TRUE(options.applyCliRunOptions(cliOpts).has_value());
+    EXPECT_TRUE(options.isPrivileged());
+    EXPECT_EQ(options.getEnv().size(), 2U);
+}
+
+} // namespace linglong::runtime

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/container_builder_deep_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/container_builder_deep_test.cpp
@@ -13,12 +13,13 @@
 #include "linglong/runtime/run_context.h"
 #include "linglong/utils/error/error.h"
 
-#include <QTemporaryDir>
 #include <QDir>
 #include <QFile>
-#include <vector>
+#include <QTemporaryDir>
+
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace linglong::runtime {
 
@@ -78,7 +79,8 @@ TEST_F(ContainerBuilderDeepTest, RunContainerOptionsCapabilitiesDeduplication)
 TEST_F(ContainerBuilderDeepTest, SecurityContextToggleAndDuplicateHandling)
 {
     RunContainerOptions options;
-    options.enableSecurityContext({ SecurityContextType::WAYLAND, SecurityContextType::PULSEAUDIO });
+    options.enableSecurityContext(
+      { SecurityContextType::WAYLAND, SecurityContextType::PULSEAUDIO });
     options.enableSecurityContext({ SecurityContextType::WAYLAND });
 
     const auto &ctxs = options.getSecurityContexts();
@@ -127,12 +129,10 @@ TEST_F(ContainerBuilderDeepTest, OverlayFSDriverMountOptionsConstruction)
 
 TEST_F(ContainerBuilderDeepTest, SecurityContextTypeConversionRoundtrip)
 {
-    std::vector<SecurityContextType> types = {
-        SecurityContextType::WAYLAND,
-        SecurityContextType::PULSEAUDIO,
-        SecurityContextType::X11,
-        SecurityContextType::DBUS
-    };
+    std::vector<SecurityContextType> types = { SecurityContextType::WAYLAND,
+                                               SecurityContextType::PULSEAUDIO,
+                                               SecurityContextType::X11,
+                                               SecurityContextType::DBUS };
 
     for (auto t : types) {
         std::string name = fromType(t);
@@ -182,11 +182,9 @@ TEST_F(ContainerBuilderDeepTest, ComplexEnvVarSpecialCharactersAndEscaping)
 {
     RunContainerOptions options;
     cli::RunOptions cliOpts;
-    cliOpts.envs = {
-        "PATH=/usr/local/bin:/usr/bin:/bin",
-        "JSON_CFG={\"key\": \"val\", \"num\": 123}",
-        "URL=https://example.com/api?query=1&sort=asc"
-    };
+    cliOpts.envs = { "PATH=/usr/local/bin:/usr/bin:/bin",
+                     "JSON_CFG={\"key\": \"val\", \"num\": 123}",
+                     "URL=https://example.com/api?query=1&sort=asc" };
 
     auto res = options.applyCliRunOptions(cliOpts);
     ASSERT_TRUE(res.has_value()) << res.error().message();
@@ -199,13 +197,11 @@ TEST_F(ContainerBuilderDeepTest, ComplexEnvVarSpecialCharactersAndEscaping)
 
 TEST_F(ContainerBuilderDeepTest, SecurityContextAllTypesEnumCheck)
 {
-    std::vector<SecurityContextType> allTypes = {
-        SecurityContextType::UNKNOWN,
-        SecurityContextType::WAYLAND,
-        SecurityContextType::X11,
-        SecurityContextType::PULSEAUDIO,
-        SecurityContextType::DBUS
-    };
+    std::vector<SecurityContextType> allTypes = { SecurityContextType::UNKNOWN,
+                                                  SecurityContextType::WAYLAND,
+                                                  SecurityContextType::X11,
+                                                  SecurityContextType::PULSEAUDIO,
+                                                  SecurityContextType::DBUS };
 
     for (const auto &t : allTypes) {
         std::string s = fromType(t);

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/overlayfs_driver_deep_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/overlayfs_driver_deep_test.cpp
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/runtime/overlayfs_driver.h"
+#include "linglong/utils/error/error.h"
+
+#include <QTemporaryDir>
+#include <QDir>
+#include <QFile>
+
+#include <vector>
+#include <string>
+
+namespace linglong::runtime {
+
+class OverlayFSDriverDeepTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_TRUE(tempDir.isValid());
+        baseDir = tempDir.path().toStdString();
+        lower1 = baseDir + "/lower1";
+        lower2 = baseDir + "/lower2";
+        upper = baseDir + "/upper";
+        work = baseDir + "/work";
+        target = baseDir + "/target";
+
+        QDir(QString::fromStdString(lower1)).mkpath(".");
+        QDir(QString::fromStdString(lower2)).mkpath(".");
+        QDir(QString::fromStdString(upper)).mkpath(".");
+        QDir(QString::fromStdString(work)).mkpath(".");
+        QDir(QString::fromStdString(target)).mkpath(".");
+    }
+
+    QTemporaryDir tempDir;
+    std::string baseDir;
+    std::string lower1;
+    std::string lower2;
+    std::string upper;
+    std::string work;
+    std::string target;
+};
+
+TEST_F(OverlayFSDriverDeepTest, OverlayFSPathFormatValidation)
+{
+    std::vector<std::string> lowers = { lower1, lower2 };
+    EXPECT_FALSE(lowers.empty());
+    EXPECT_EQ(lowers.size(), 2U);
+}
+
+TEST_F(OverlayFSDriverDeepTest, OverlayFSMountDirectoryExistenceChecks)
+{
+    EXPECT_TRUE(QDir(QString::fromStdString(lower1)).exists());
+    EXPECT_TRUE(QDir(QString::fromStdString(lower2)).exists());
+    EXPECT_TRUE(QDir(QString::fromStdString(upper)).exists());
+    EXPECT_TRUE(QDir(QString::fromStdString(work)).exists());
+    EXPECT_TRUE(QDir(QString::fromStdString(target)).exists());
+}
+
+TEST_F(OverlayFSDriverDeepTest, MountOptionStringEscapingAndColonFormat)
+{
+    std::string combinedLower = lower1 + ":" + lower2;
+    std::string expectedOption = "lowerdir=" + combinedLower + ",upperdir=" + upper + ",workdir=" + work;
+    EXPECT_TRUE(expectedOption.find("lowerdir=") != std::string::npos);
+    EXPECT_TRUE(expectedOption.find("upperdir=") != std::string::npos);
+    EXPECT_TRUE(expectedOption.find("workdir=") != std::string::npos);
+}
+
+TEST_F(OverlayFSDriverDeepTest, EmptyLowerDirsHandling)
+{
+    std::vector<std::string> emptyLowers;
+    EXPECT_TRUE(emptyLowers.empty());
+}
+
+} // namespace linglong::runtime

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/overlayfs_driver_deep_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/overlayfs_driver_deep_test.cpp
@@ -10,12 +10,12 @@
 #include "linglong/runtime/overlayfs_driver.h"
 #include "linglong/utils/error/error.h"
 
-#include <QTemporaryDir>
 #include <QDir>
 #include <QFile>
+#include <QTemporaryDir>
 
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace linglong::runtime {
 
@@ -67,7 +67,8 @@ TEST_F(OverlayFSDriverDeepTest, OverlayFSMountDirectoryExistenceChecks)
 TEST_F(OverlayFSDriverDeepTest, MountOptionStringEscapingAndColonFormat)
 {
     std::string combinedLower = lower1 + ":" + lower2;
-    std::string expectedOption = "lowerdir=" + combinedLower + ",upperdir=" + upper + ",workdir=" + work;
+    std::string expectedOption =
+      "lowerdir=" + combinedLower + ",upperdir=" + upper + ",workdir=" + work;
     EXPECT_TRUE(expectedOption.find("lowerdir=") != std::string::npos);
     EXPECT_TRUE(expectedOption.find("upperdir=") != std::string::npos);
     EXPECT_TRUE(expectedOption.find("workdir=") != std::string::npos);

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_deep_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_deep_test.cpp
@@ -11,10 +11,11 @@
 #include "linglong/runtime/container_builder.h"
 #include "linglong/runtime/run_context.h"
 
-#include <QTemporaryDir>
 #include <QDir>
-#include <vector>
+#include <QTemporaryDir>
+
 #include <string>
+#include <vector>
 
 namespace linglong::runtime {
 

--- a/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_deep_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/runtime/run_context_deep_test.cpp
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/cli/cli.h"
+#include "linglong/runtime/container_builder.h"
+#include "linglong/runtime/run_context.h"
+
+#include <QTemporaryDir>
+#include <QDir>
+#include <vector>
+#include <string>
+
+namespace linglong::runtime {
+
+class RunContextDeepTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_TRUE(tempDir.isValid());
+        workDir = tempDir.path().toStdString();
+    }
+
+    QTemporaryDir tempDir;
+    std::string workDir;
+};
+
+TEST_F(RunContextDeepTest, RunContextConfigDefaultInitialization)
+{
+    api::types::v1::RunContextConfig cfg;
+    EXPECT_TRUE(cfg.version.empty());
+    EXPECT_TRUE(cfg.base.empty());
+    EXPECT_TRUE(cfg.runtime.empty());
+}
+
+TEST_F(RunContextDeepTest, ContainerIDHashingConsistency)
+{
+    api::types::v1::RunContextConfig cfg;
+    cfg.version = "1.0.0";
+    cfg.base = "org.deepin.base/23.0.0/x86_64";
+    cfg.runtime = "org.deepin.runtime/23.0.0/x86_64";
+
+    std::string id1 = genContainerID(cfg);
+    std::string id2 = genContainerID(cfg);
+
+    EXPECT_FALSE(id1.empty());
+    EXPECT_EQ(id1, id2);
+}
+
+TEST_F(RunContextDeepTest, RunContextConfigVersionComparison)
+{
+    api::types::v1::RunContextConfig cfgA;
+    cfgA.version = "1.0.0";
+    cfgA.base = "org.deepin.base/23.0.0/x86_64";
+
+    api::types::v1::RunContextConfig cfgB;
+    cfgB.version = "1.0.1";
+    cfgB.base = "org.deepin.base/23.0.0/x86_64";
+
+    EXPECT_NE(genContainerID(cfgA), genContainerID(cfgB));
+}
+
+TEST_F(RunContextDeepTest, RunContextConfigArchitectureVariations)
+{
+    api::types::v1::RunContextConfig cfgX86;
+    cfgX86.base = "org.deepin.base/23.0.0/x86_64";
+
+    api::types::v1::RunContextConfig cfgArm;
+    cfgArm.base = "org.deepin.base/23.0.0/aarch64";
+
+    EXPECT_NE(genContainerID(cfgX86), genContainerID(cfgArm));
+}
+
+TEST_F(RunContextDeepTest, MultiConfigHashCollisionResistance)
+{
+    std::vector<api::types::v1::RunContextConfig> configs;
+    for (int i = 0; i < 10; ++i) {
+        api::types::v1::RunContextConfig c;
+        c.version = "1.0." + std::to_string(i);
+        c.base = "org.deepin.base/23.0.0/x86_64";
+        c.runtime = "org.deepin.runtime/23.0.0/x86_64";
+        configs.push_back(c);
+    }
+
+    std::vector<std::string> hashes;
+    for (const auto &c : configs) {
+        hashes.push_back(genContainerID(c));
+    }
+
+    for (size_t i = 0; i < hashes.size(); ++i) {
+        for (size_t j = i + 1; j < hashes.size(); ++j) {
+            EXPECT_NE(hashes[i], hashes[j]);
+        }
+    }
+}
+
+} // namespace linglong::runtime


### PR DESCRIPTION
## Summary
Expand unit test coverage for `ContainerBuilder`, `RunContainerOptions`, `SecurityContext`, and `RunContext` in runtime.

- Add test coverage for multiple environment variable override behavior and complex characters.
- Add test coverage for Linux capability deduplication and security context roundtrip conversions.
- Add verification for Container ID generation uniqueness and collision resistance.

## Test plan
- [x] Tested unit tests locally with `ctest`/`ll-tests` target
- [x] All test suites pass without regression