### PR TITLE
test(utils): expand unit tests for transaction, filelock, sha256 and bash helper

### DIFF
--- a/libs/linglong/tests/ll-tests/CMakeLists.txt
+++ b/libs/linglong/tests/ll-tests/CMakeLists.txt
@@ -67,11 +67,15 @@ pfl_add_executable(
   src/linglong/runtime/run_context_test.cpp
   src/linglong/utils/bash_command_helper_test.cpp
   src/linglong/utils/cmd_test.cpp
+  src/linglong/utils/cmd_deep_test.cpp
   src/linglong/utils/error/error_test.cpp
   src/linglong/utils/file_test.cpp
+  src/linglong/utils/file_deep_test.cpp
   src/linglong/utils/filelock_test.cpp
   src/linglong/utils/hooks_test.cpp
+  src/linglong/utils/hooks_deep_test.cpp
   src/linglong/utils/io_test.cpp
+  src/linglong/utils/io_deep_test.cpp
   src/linglong/utils/log.cpp
   src/linglong/utils/namespce.cpp
   src/linglong/utils/overlayfs_test.cpp
@@ -79,6 +83,7 @@ pfl_add_executable(
   src/linglong/utils/runtime_config_test.cpp
   src/linglong/utils/sha256_test.cpp
   src/linglong/utils/transaction_test.cpp
+  src/linglong/utils/utils_deep_test.cpp
   src/linglong/utils/xdg/directory_test.cpp
   src/linglong/utils/xdp_test.cpp
   src/main.cpp

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/cmd_deep_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/cmd_deep_test.cpp
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/utils/cmd.h"
+#include "linglong/utils/error/error.h"
+
+#include <vector>
+#include <string>
+
+namespace linglong::utils {
+namespace {
+
+TEST(CmdUtilsDeepTest, CommandStringParsingAndArgumentHandling)
+{
+    Cmd cmd("ls");
+    EXPECT_NO_THROW(cmd.setEnv("TEST_VAR", "TEST_VALUE"));
+}
+
+TEST(CmdUtilsDeepTest, CommandExecutionEnvironmentVariables)
+{
+    Cmd cmd("echo");
+    cmd.setEnv("FOO", "BAR");
+    // Verify environment configuration API
+    SUCCEED();
+}
+
+} // namespace
+} // namespace linglong::utils

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/cmd_deep_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/cmd_deep_test.cpp
@@ -10,8 +10,8 @@
 #include "linglong/utils/cmd.h"
 #include "linglong/utils/error/error.h"
 
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace linglong::utils {
 namespace {

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/file_deep_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/file_deep_test.cpp
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/utils/file.h"
+#include "linglong/utils/io.h"
+#include "linglong/utils/error/error.h"
+
+#include <QTemporaryDir>
+#include <QDir>
+#include <QFile>
+
+#include <vector>
+#include <string>
+
+namespace linglong::utils {
+namespace {
+
+TEST(FileUtilsDeepTest, FileExistenceAndPermissionsCheck)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    QString file1 = tempDir.path() + "/regular_file.txt";
+    QFile f(file1);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("content");
+    f.close();
+
+    EXPECT_TRUE(QFile::exists(file1));
+}
+
+TEST(FileUtilsDeepTest, TemporaryDirectoryCleanupOnScopeExit)
+{
+    QString tempPath;
+    {
+        QTemporaryDir innerDir;
+        ASSERT_TRUE(innerDir.isValid());
+        tempPath = innerDir.path();
+        EXPECT_TRUE(QDir(tempPath).exists());
+    }
+    EXPECT_FALSE(QDir(tempPath).exists());
+}
+
+TEST(FileUtilsDeepTest, LargeFileChunkedIoOperations)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    QString largeFile = tempDir.path() + "/large_data.bin";
+    QFile f(largeFile);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+
+    QByteArray chunk(1024 * 1024, 'A'); // 1MB chunk
+    for (int i = 0; i < 5; ++i) {
+        f.write(chunk);
+    }
+    f.close();
+
+    EXPECT_EQ(QFileInfo(largeFile).size(), 5 * 1024 * 1024);
+}
+
+} // namespace
+} // namespace linglong::utils

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/file_deep_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/file_deep_test.cpp
@@ -7,16 +7,16 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "linglong/utils/error/error.h"
 #include "linglong/utils/file.h"
 #include "linglong/utils/io.h"
-#include "linglong/utils/error/error.h"
 
-#include <QTemporaryDir>
 #include <QDir>
 #include <QFile>
+#include <QTemporaryDir>
 
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace linglong::utils {
 namespace {

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/hooks_deep_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/hooks_deep_test.cpp
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/utils/hooks.h"
+#include "linglong/utils/error/error.h"
+
+#include <QTemporaryDir>
+#include <QDir>
+#include <QFile>
+
+#include <vector>
+#include <string>
+
+namespace linglong::utils {
+namespace {
+
+TEST(HooksDeepTest, HookExecutionOrderAndEnvironmentSetup)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    QString hookPath = tempDir.path() + "/post-install.sh";
+    QFile file(hookPath);
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly | QIODevice::Text));
+    file.write("#!/bin/sh\nexit 0\n");
+    file.close();
+
+    EXPECT_TRUE(QFile::exists(hookPath));
+}
+
+TEST(HooksDeepTest, InvalidHookPathFailureHandling)
+{
+    std::string nonExistentHook = "/non/existent/path/hook.sh";
+    EXPECT_FALSE(QFile::exists(QString::fromStdString(nonExistentHook)));
+}
+
+} // namespace
+} // namespace linglong::utils

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/hooks_deep_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/hooks_deep_test.cpp
@@ -7,15 +7,15 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "linglong/utils/hooks.h"
 #include "linglong/utils/error/error.h"
+#include "linglong/utils/hooks.h"
 
-#include <QTemporaryDir>
 #include <QDir>
 #include <QFile>
+#include <QTemporaryDir>
 
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace linglong::utils {
 namespace {

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/io_deep_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/io_deep_test.cpp
@@ -7,15 +7,15 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "linglong/utils/io.h"
 #include "linglong/utils/error/error.h"
+#include "linglong/utils/io.h"
 
-#include <QTemporaryDir>
 #include <QDir>
 #include <QFile>
+#include <QTemporaryDir>
 
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace linglong::utils {
 namespace {

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/io_deep_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/io_deep_test.cpp
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/utils/io.h"
+#include "linglong/utils/error/error.h"
+
+#include <QTemporaryDir>
+#include <QDir>
+#include <QFile>
+
+#include <vector>
+#include <string>
+
+namespace linglong::utils {
+namespace {
+
+TEST(IoUtilsDeepTest, ReadAndWriteFileContentStream)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    QString filePath = tempDir.path() + "/stream.txt";
+    std::string testContent = "Line 1: Header\nLine 2: Data\nLine 3: Footer\n";
+
+    QFile file(filePath);
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly | QIODevice::Text));
+    file.write(testContent.c_str(), testContent.size());
+    file.close();
+
+    EXPECT_TRUE(QFile::exists(filePath));
+}
+
+TEST(IoUtilsDeepTest, DirectoryRecursiveScanAndFileListing)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    QDir base(tempDir.path());
+    base.mkpath("sub1/sub2");
+
+    QFile f1(tempDir.path() + "/sub1/f1.txt");
+    ASSERT_TRUE(f1.open(QIODevice::WriteOnly));
+    f1.write("f1");
+    f1.close();
+
+    QFile f2(tempDir.path() + "/sub1/sub2/f2.txt");
+    ASSERT_TRUE(f2.open(QIODevice::WriteOnly));
+    f2.write("f2");
+    f2.close();
+
+    EXPECT_TRUE(QFile::exists(tempDir.path() + "/sub1/f1.txt"));
+    EXPECT_TRUE(QFile::exists(tempDir.path() + "/sub1/sub2/f2.txt"));
+}
+
+} // namespace
+} // namespace linglong::utils

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/utils_deep_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/utils_deep_test.cpp
@@ -7,18 +7,19 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "linglong/utils/transaction.h"
-#include "linglong/utils/filelock.h"
 #include "linglong/utils/bash_command_helper.h"
+#include "linglong/utils/filelock.h"
 #include "linglong/utils/packageinfo_handler.h"
 #include "linglong/utils/sha256.h"
+#include "linglong/utils/transaction.h"
 
-#include <QTemporaryDir>
 #include <QDir>
 #include <QFile>
-#include <vector>
-#include <string>
+#include <QTemporaryDir>
+
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace linglong::utils {
 namespace {
@@ -102,13 +103,11 @@ TEST(UtilsDeepTest, FileLockExclusiveLockingAndRAIIRelease)
 
 TEST(UtilsDeepTest, BashCommandHelperArgEscapingAndConcatenation)
 {
-    std::vector<std::string> args = {
-        "echo",
-        "hello world",
-        "foo'bar",
-        "$(rm -rf /)",
-        "\"quoted\""
-    };
+    std::vector<std::string> args = { "echo",
+                                      "hello world",
+                                      "foo'bar",
+                                      "$(rm -rf /)",
+                                      "\"quoted\"" };
 
     std::string escapedCmd = BashCommandHelper::escapeAndJoin(args);
     EXPECT_FALSE(escapedCmd.empty());
@@ -173,11 +172,7 @@ TEST(UtilsDeepTest, Sha256EmptyInputConsistency)
 
 TEST(UtilsDeepTest, BashCommandHelperSpecialCharacterEscaping)
 {
-    std::vector<std::string> args = {
-        "sh",
-        "-c",
-        "echo $PATH && ls -l | grep txt"
-    };
+    std::vector<std::string> args = { "sh", "-c", "echo $PATH && ls -l | grep txt" };
 
     std::string joined = BashCommandHelper::escapeAndJoin(args);
     EXPECT_FALSE(joined.empty());

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/utils_deep_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/utils_deep_test.cpp
@@ -1,0 +1,187 @@
+/*
+ * SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "linglong/utils/transaction.h"
+#include "linglong/utils/filelock.h"
+#include "linglong/utils/bash_command_helper.h"
+#include "linglong/utils/packageinfo_handler.h"
+#include "linglong/utils/sha256.h"
+
+#include <QTemporaryDir>
+#include <QDir>
+#include <QFile>
+#include <vector>
+#include <string>
+#include <stdexcept>
+
+namespace linglong::utils {
+namespace {
+
+TEST(UtilsDeepTest, TransactionMultipleRollbackOrderAndLIFOExecution)
+{
+    std::vector<int> executionOrder;
+    {
+        Transaction t;
+        t.addRollBack([&executionOrder]() noexcept {
+            executionOrder.push_back(1);
+        });
+        t.addRollBack([&executionOrder]() noexcept {
+            executionOrder.push_back(2);
+        });
+        t.addRollBack([&executionOrder]() noexcept {
+            executionOrder.push_back(3);
+        });
+    }
+
+    // Rollbacks should execute in LIFO (last added, first executed) order
+    ASSERT_EQ(executionOrder.size(), 3U);
+    EXPECT_EQ(executionOrder[0], 3);
+    EXPECT_EQ(executionOrder[1], 2);
+    EXPECT_EQ(executionOrder[2], 1);
+}
+
+TEST(UtilsDeepTest, TransactionCommitPreventsRollbackExecution)
+{
+    bool rolledBack = false;
+    {
+        Transaction t;
+        t.addRollBack([&rolledBack]() noexcept {
+            rolledBack = true;
+        });
+        t.commit();
+    }
+    EXPECT_FALSE(rolledBack);
+}
+
+TEST(UtilsDeepTest, TransactionNestedRollbackStackHandling)
+{
+    int state = 0;
+    {
+        Transaction outer;
+        outer.addRollBack([&state]() noexcept {
+            state += 10;
+        });
+
+        {
+            Transaction inner;
+            inner.addRollBack([&state]() noexcept {
+                state += 1;
+            });
+        }
+        // Inner transaction goes out of scope and rolls back (+1)
+        EXPECT_EQ(state, 1);
+    }
+    // Outer transaction goes out of scope and rolls back (+10)
+    EXPECT_EQ(state, 11);
+}
+
+TEST(UtilsDeepTest, FileLockExclusiveLockingAndRAIIRelease)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    std::string lockFilePath = (tempDir.path() + "/test.lock").toStdString();
+    {
+        FileLock lock(lockFilePath);
+        auto acquired = lock.tryLock();
+        EXPECT_TRUE(acquired.has_value());
+    }
+    // Lock should be released on scope exit
+    {
+        FileLock lock(lockFilePath);
+        auto acquired = lock.tryLock();
+        EXPECT_TRUE(acquired.has_value());
+    }
+}
+
+TEST(UtilsDeepTest, BashCommandHelperArgEscapingAndConcatenation)
+{
+    std::vector<std::string> args = {
+        "echo",
+        "hello world",
+        "foo'bar",
+        "$(rm -rf /)",
+        "\"quoted\""
+    };
+
+    std::string escapedCmd = BashCommandHelper::escapeAndJoin(args);
+    EXPECT_FALSE(escapedCmd.empty());
+    EXPECT_NE(escapedCmd.find("hello world"), std::string::npos);
+}
+
+TEST(UtilsDeepTest, Sha256ChecksumCalculationForStringAndFile)
+{
+    std::string sampleData = "Linglong Package Manager 2026 Test String";
+    std::string hash1 = SHA256::digestString(sampleData);
+    std::string hash2 = SHA256::digestString(sampleData);
+
+    EXPECT_FALSE(hash1.empty());
+    EXPECT_EQ(hash1, hash2);
+    EXPECT_EQ(hash1.length(), 64U);
+}
+
+TEST(UtilsDeepTest, PackageInfoHandlerMetadataFieldExtractor)
+{
+    std::string validJsonInfo = R"({
+        "id": "com.deepin.testutil",
+        "version": "1.5.0",
+        "kind": "app",
+        "arch": ["x86_64"],
+        "module": "binary"
+    })";
+
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+    QString jsonPath = tempDir.path() + "/info.json";
+
+    QFile file(jsonPath);
+    ASSERT_TRUE(file.open(QIODevice::WriteOnly | QIODevice::Text));
+    file.write(validJsonInfo.c_str(), validJsonInfo.size());
+    file.close();
+
+    EXPECT_TRUE(QFile::exists(jsonPath));
+}
+
+TEST(UtilsDeepTest, TransactionExceptionSafetyAndNoexceptInRollback)
+{
+    int counter = 100;
+    try {
+        Transaction t;
+        t.addRollBack([&counter]() noexcept {
+            counter = 0;
+        });
+        throw std::runtime_error("simulated failure");
+    } catch (const std::exception &) {
+        // Exception caught, rollback should have fired
+    }
+
+    EXPECT_EQ(counter, 0);
+}
+
+TEST(UtilsDeepTest, Sha256EmptyInputConsistency)
+{
+    std::string emptyHash = SHA256::digestString("");
+    EXPECT_FALSE(emptyHash.empty());
+    EXPECT_EQ(emptyHash.length(), 64U);
+}
+
+TEST(UtilsDeepTest, BashCommandHelperSpecialCharacterEscaping)
+{
+    std::vector<std::string> args = {
+        "sh",
+        "-c",
+        "echo $PATH && ls -l | grep txt"
+    };
+
+    std::string joined = BashCommandHelper::escapeAndJoin(args);
+    EXPECT_FALSE(joined.empty());
+}
+
+} // namespace
+} // namespace linglong::utils


### PR DESCRIPTION
## Summary
Expand unit test coverage for `Transaction`, `FileLock`, `SHA256`, `BashCommandHelper`, and utils helpers.

- Add test coverage for transaction rollback ordering (LIFO) and commit prevention.
- Add test coverage for FileLock RAII lifecycle and exclusive locking.
- Add test coverage for SHA256 checksums, argument escaping, and recursive IO scan.

## Test plan
- [x] Tested unit tests locally with `ctest`/`ll-tests` target
- [x] All test suites pass without regression