### PR TITLE
fix(repo): reject repo config with missing default repository

### DIFF
--- a/libs/linglong/src/linglong/repo/config.cpp
+++ b/libs/linglong/src/linglong/repo/config.cpp
@@ -40,6 +40,19 @@ loadConfig(const std::filesystem::path &file) noexcept
 
             // 将旧版本配置转换为新版本
             config = convertToV2(*configV1);
+            if (!config) {
+                return LINGLONG_ERR(config);
+            }
+        }
+
+        if (std::find_if(config->repos.begin(),
+                         config->repos.end(),
+                         [&config](const auto &repo) {
+                             return repo.alias.value_or(repo.name) == config->defaultRepo;
+                         })
+            == config->repos.end()) {
+            return LINGLONG_ERR(
+              fmt::format("default repository {} not found in repos", config->defaultRepo));
         }
 
         return config;
@@ -136,17 +149,24 @@ getPriorityGroupedRepos(api::types::v1::RepoConfigV2 cfg) noexcept
     return groupedRepos;
 }
 
-api::types::v1::RepoConfigV2 convertToV2(const api::types::v1::RepoConfig &cfg) noexcept
+utils::error::Result<api::types::v1::RepoConfigV2>
+convertToV2(const api::types::v1::RepoConfig &cfg) noexcept
 {
+    LINGLONG_TRACE("convert repo config to v2");
+
+    const auto defaultRepo =
+      std::find_if(cfg.repos.begin(), cfg.repos.end(), [&cfg](const auto &repo) {
+          return repo.first == cfg.defaultRepo;
+      });
+    if (defaultRepo == cfg.repos.end()) {
+        return LINGLONG_ERR(
+          fmt::format("default repository {} not found in repos", cfg.defaultRepo));
+    }
+
     api::types::v1::RepoConfigV2 configV2;
     configV2.version = 2;
     configV2.defaultRepo = cfg.defaultRepo;
     int64_t priority = 0;
-
-    const auto &defaultRepo =
-      std::find_if(cfg.repos.begin(), cfg.repos.end(), [&cfg](const auto &repo) {
-          return repo.first == cfg.defaultRepo;
-      });
 
     api::types::v1::Repo repoV2{
         .name = defaultRepo->first,

--- a/libs/linglong/src/linglong/repo/config.h
+++ b/libs/linglong/src/linglong/repo/config.h
@@ -28,6 +28,7 @@ std::vector<api::types::v1::Repo> getPrioritySortedRepos(api::types::v1::RepoCon
 std::vector<std::vector<api::types::v1::Repo>>
 getPriorityGroupedRepos(api::types::v1::RepoConfigV2 cfg) noexcept;
 
-api::types::v1::RepoConfigV2 convertToV2(const api::types::v1::RepoConfig &cfg) noexcept;
+utils::error::Result<api::types::v1::RepoConfigV2>
+convertToV2(const api::types::v1::RepoConfig &cfg) noexcept;
 
 } // namespace linglong::repo

--- a/libs/linglong/tests/ll-tests/src/linglong/repo/config_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/repo/config_test.cpp
@@ -74,26 +74,40 @@ TEST(Repo, ConventToV2)
     cfg.repos = { { "repo1", "http://example.com/repo1" } };
 
     auto configV2 = convertToV2(cfg);
+    ASSERT_TRUE(configV2.has_value()) << configV2.error().message();
 
-    EXPECT_EQ(configV2.defaultRepo, "repo1");
-    EXPECT_EQ(configV2.repos.size(), 1);
-    EXPECT_EQ(configV2.repos[0].name, "repo1");
-    EXPECT_EQ(configV2.repos[0].url, "http://example.com/repo1");
-    EXPECT_EQ(configV2.repos[0].priority, 0);
+    EXPECT_EQ(configV2->defaultRepo, "repo1");
+    EXPECT_EQ(configV2->repos.size(), 1);
+    EXPECT_EQ(configV2->repos[0].name, "repo1");
+    EXPECT_EQ(configV2->repos[0].url, "http://example.com/repo1");
+    EXPECT_EQ(configV2->repos[0].priority, 0);
 
     cfg.defaultRepo = "repo2";
     cfg.repos = { { "repo1", "http://example.com/repo1" },
                   { "repo2", "http://example.com/repo2" } };
     configV2 = convertToV2(cfg);
+    ASSERT_TRUE(configV2.has_value()) << configV2.error().message();
 
-    EXPECT_EQ(configV2.defaultRepo, "repo2");
-    EXPECT_EQ(configV2.repos.size(), 2);
-    EXPECT_EQ(configV2.repos[0].name, "repo2");
-    EXPECT_EQ(configV2.repos[0].url, "http://example.com/repo2");
-    EXPECT_EQ(configV2.repos[0].priority, 0);
-    EXPECT_EQ(configV2.repos[1].name, "repo1");
-    EXPECT_EQ(configV2.repos[1].url, "http://example.com/repo1");
-    EXPECT_EQ(configV2.repos[1].priority, -100);
+    EXPECT_EQ(configV2->defaultRepo, "repo2");
+    EXPECT_EQ(configV2->repos.size(), 2);
+    EXPECT_EQ(configV2->repos[0].name, "repo2");
+    EXPECT_EQ(configV2->repos[0].url, "http://example.com/repo2");
+    EXPECT_EQ(configV2->repos[0].priority, 0);
+    EXPECT_EQ(configV2->repos[1].name, "repo1");
+    EXPECT_EQ(configV2->repos[1].url, "http://example.com/repo1");
+    EXPECT_EQ(configV2->repos[1].priority, -100);
+}
+
+TEST(Repo, ConventToV2MissingDefaultRepoFails)
+{
+    RepoConfig cfg;
+    cfg.defaultRepo = "missing";
+    cfg.repos = { { "repo1", "http://example.com/repo1" } };
+
+    auto configV2 = convertToV2(cfg);
+    EXPECT_FALSE(configV2.has_value());
+    EXPECT_NE(configV2.error().message().find("not found in repos"), std::string::npos)
+      << configV2.error().message();
 }
 
 TEST(Repo, GetPrioritySortedRepos)
@@ -168,6 +182,42 @@ TEST(Repo, LoadConfigMissingFileFails)
     TempDir dir;
     auto cfg = loadConfig(dir.path() / "nope.yaml");
     EXPECT_FALSE(cfg.has_value());
+}
+
+TEST(Repo, LoadConfigV2YamlMissingDefaultRepoFails)
+{
+    TempDir dir;
+    auto file = dir.path() / "config.yaml";
+    std::ofstream(file) << R"(
+defaultRepo: missing
+repos:
+  - name: stable
+    priority: 0
+    url: https://example.com/repo
+version: 2
+)";
+
+    auto cfg = loadConfig(file);
+    ASSERT_FALSE(cfg.has_value());
+    EXPECT_NE(cfg.error().message().find("not found in repos"), std::string::npos)
+      << cfg.error().message();
+}
+
+TEST(Repo, LoadConfigV1YamlMissingDefaultRepoFails)
+{
+    TempDir dir;
+    auto file = dir.path() / "config.yaml";
+    std::ofstream(file) << R"(
+defaultRepo: missing
+repos:
+  stable: https://example.com/repo
+version: 1
+)";
+
+    auto cfg = loadConfig(file);
+    ASSERT_FALSE(cfg.has_value());
+    EXPECT_NE(cfg.error().message().find("not found in repos"), std::string::npos)
+      << cfg.error().message();
 }
 
 TEST(Repo, LoadConfigFromVectorTriesUntilSuccess)


### PR DESCRIPTION
## Problem / Evidence

`loadConfig` accepted repository configs whose `defaultRepo` does not match any entry in `repos`, and `convertToV2` unconditionally dereferenced the result of `std::find_if` without comparing it against `end()`:

- V1 conversion path: `convertToV2` looks up `cfg.defaultRepo` in the `repos` map and reads `defaultRepo->first` / `defaultRepo->second` unconditionally (`libs/linglong/src/linglong/repo/config.cpp`, before this change). With a V1 config such as

  ```yaml
  version: 1
  defaultRepo: missing
  repos:
    stable: https://example.com/repo
  ```

  the lookup fails, the `end()` iterator is dereferenced and the resulting `Repo` name/url are read from unrelated memory — undefined behavior on every subsequent config load.
- V2 path: a V2 config file with a dangling `defaultRepo` parsed successfully and was returned to callers, where `getDefaultRepo()` performs the same unchecked lookup (`OSTreeRepo::push`, `tryMigrate`), so the UB simply moved downstream.

This was reported in #1823.

## Root cause / Fix

The config was never validated at load time; `saveConfig` enforces the same invariant on write, but nothing enforced it on read.

- `loadConfig` now rejects both formats with a `default repository <name> not found in repos` diagnostic error after parsing/conversion.
- `convertToV2` is now fallible (`utils::error::Result<RepoConfigV2>`) and returns an error instead of dereferencing the failed lookup; `loadConfig` propagates the error.

## Priority and scoring rationale

PRIORITY 74 = impact 25 (UB / memory-unsafe read on a core load path, deterministic crash or garbage config for affected files) + blast radius 18 (every command and the daemon load the repo config) + reproducibility 16 (deterministic given the file) + maintenance value 15 (clear correctness fix matching the existing `saveConfig` invariant). FIX_CONFIDENCE 95.

## Tests

```
ctest -R "Repo.Config|Repo.Convent|Repo.LoadConfig|Repo.SaveConfig"   # 11/11 passed
ctest -j4                                                              # 723/723 passed
```

- `Repo.ConventToV2MissingDefaultRepoFails`, `Repo.LoadConfigV2YamlMissingDefaultRepoFails`, `Repo.LoadConfigV1YamlMissingDefaultRepoFails` are new regression tests; they fail/crash on the unfixed code (verified by rebuilding with the load-time validation disabled: the V2 case was silently accepted).
- Full suite: `100% tests passed, 0 tests failed out of 723` (2 pre-existing environment skips for X11 display tests).

## Risk

Low. Configs written by `saveConfig` always satisfy the invariant; only configs that previously triggered undefined behavior (or produced a broken in-memory config) are now rejected with a clear error. `getDefaultRepo()` itself keeps its current contract and remains safe for every config produced by the now-validated load path.

Closes #1823