### PR TITLE
fix(package-manager): reject layer metadata with empty architecture

### DIFF
--- a/libs/linglong/src/linglong/package_manager/package_manager.cpp
+++ b/libs/linglong/src/linglong/package_manager/package_manager.cpp
@@ -655,6 +655,11 @@ QVariantMap PackageManager::installFromLayer(const QDBusUnixFileDescriptor &fd,
 
     const auto &packageInfo = *packageInfoRet;
 
+    if (packageInfo.arch.empty()) {
+        return toDBusReply(utils::error::ErrorCode::Failed,
+                           "missing architecture in layer package info");
+    }
+
     auto architectureRet = package::Architecture::parse(packageInfo.arch[0]);
     if (!architectureRet) {
         return toDBusReply(architectureRet);

--- a/libs/linglong/src/linglong/package_manager/uab_installation.cpp
+++ b/libs/linglong/src/linglong/package_manager/uab_installation.cpp
@@ -71,6 +71,10 @@ utils::error::Result<void> UabInstallationAction::checkUABLayersConstrain(
 
     const auto &front = layers.front().info;
     for (const auto &layer : layers) {
+        if (layer.info.arch.empty()) {
+            return LINGLONG_ERR("missing architecture in uab layer info");
+        }
+
         auto arch = package::Architecture::parse(layer.info.arch[0]);
         if (!arch) {
             return LINGLONG_ERR(arch);

--- a/libs/linglong/tests/ll-tests/src/linglong/package_manager/uab_installation_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package_manager/uab_installation_test.cpp
@@ -81,6 +81,24 @@ TEST(CheckUABLayersConstrain, ArchMismatch)
     EXPECT_FALSE(result.has_value());
 }
 
+TEST(CheckUABLayersConstrain, EmptyArchitecture)
+{
+    TempDir tempDir;
+    MockOSTreeRepo mockRepo(tempDir.path());
+    repo::OSTreeRepo &repo = mockRepo;
+    std::vector<api::types::v1::UabLayer> layers;
+    api::types::v1::UabLayer layer;
+    // A layer whose meta info contains an empty architecture array
+    layer.minified = false;
+    layer.info.arch = {};
+    layers.push_back(layer);
+
+    auto result = UabInstallationAction::checkUABLayersConstrain(repo, layers);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_NE(result.error().message().find("missing architecture"), std::string::npos)
+      << result.error().message();
+}
+
 TEST(CheckUABLayersConstrain, DifferentIds)
 {
     TempDir tempDir;


### PR DESCRIPTION
## Problem / Evidence

Both install entry points that parse layer metadata index the architecture array without checking that it is non-empty:

- `UabInstallationAction::checkUABLayersConstrain` evaluates `layer.info.arch[0]` for every UAB layer (`libs/linglong/src/linglong/package_manager/uab_installation.cpp:74` before this change).
- `PackageManager::installFromLayer` evaluates `packageInfo.arch[0]` on the package info parsed from the layer file (`libs/linglong/src/linglong/package_manager/package_manager.cpp:658` before this change).

The UAB/layer `info.json` is file-supplied content, and the generated `from_json` for `PackageInfoV2` happily parses `"arch": []` into an empty vector (only a missing key throws). Installing such a UAB or layer therefore reaches an unguarded `std::vector::operator[]`.

Reproduced as a unit test against the existing `CheckUABLayersConstrain` harness: a layer with an empty `arch` array makes the test binary **segfault** before the fix (the debug build links UBSan, and the null dereference inside `Architecture::parse` still kills the process).

This is the same bug class that was already fixed for `Reference::fromPackageInfo` in c365ef47 (`fix(package): reject package info without architecture`); these two call sites were left unguarded and are reachable *before* that guard runs.

## Root cause / Fix

The architecture array coming from package metadata was assumed non-empty. Add an explicit emptiness check in both places and reject the file with a `missing architecture` diagnostic error, mirroring the wording already used in `Reference::fromPackageInfo`.

## Priority and scoring rationale

PRIORITY 72 = impact 30 (undefined behavior / crash of the package manager daemon during install of a crafted or corrupt package file) + blast radius 12 (UAB and layer install paths) + reproducibility 16 (deterministic, reproduced as a segfaulting unit test) + maintenance value 14 (completes an already-accepted fix pattern). FIX_CONFIDENCE 95.

## Tests

```
ctest -R "CheckUABLayersConstrain"   # 9/9 passed (8 existing + 1 new)
```

- New `CheckUABLayersConstrain.EmptyArchitecture` regression test: with the fix disabled the test segfaults; with the fix it fails cleanly and asserts the `missing architecture` error message.
- Full suite: `100% tests passed, 0 tests failed out of 723` on the branch base; the touched module was rerun after the change.
- `installFromLayer` has no unit-test harness (PackageManager requires a DBus environment), so that site is guarded by the same check but is not covered by an automated test; it is a three-line guard identical to the tested one.

## Risk

Low. Adds a rejection for previously-crashing input; no valid-package behavior changes since every real layer/UAB metadata carries at least one architecture.

Closes #1918