### PR TITLE
fix(ocppi): terminate the forked child when exec fails

### DIFF
--- a/libs/linglong/tests/ll-tests/src/ocppi/cli/common_cli_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/ocppi/cli/common_cli_test.cpp
@@ -57,3 +57,42 @@ TEST(CommonCLITest, ListForcesJsonOutput)
     };
     EXPECT_EQ(arguments, expectedArguments);
 }
+
+TEST(CommonCLITest, ListFailsWhenRuntimeIsNotExecutable)
+{
+    TempDir tempDir("ocppi-common-cli-");
+    ASSERT_TRUE(tempDir.isValid());
+
+    const auto runtimePath = tempDir.path() / "runtime";
+    {
+        std::ofstream runtime(runtimePath);
+        ASSERT_TRUE(runtime.is_open());
+        runtime << "#!/bin/sh\nprintf '[]\\n'\n";
+    }
+    // Deliberately leave the runtime without any executable permission bit so
+    // that execvp fails in the forked child. Crun::New only checks that the
+    // binary exists, so constructing the CLI must still succeed.
+    std::filesystem::permissions(runtimePath,
+                                 std::filesystem::perms::owner_read
+                                   | std::filesystem::perms::owner_write,
+                                 std::filesystem::perm_options::replace);
+
+    const auto duplicateMarker = tempDir.path() / "duplicate-process-marker";
+
+    auto cli = ocppi::cli::crun::Crun::New(runtimePath);
+    ASSERT_TRUE(cli.has_value());
+
+    ocppi::runtime::ListOption option{};
+    option.root = tempDir.path() / "root";
+    auto containers = cli.value()->list(option);
+    EXPECT_FALSE(containers.has_value());
+
+    // A failed exec must terminate the forked child. If the child instead
+    // unwound into the caller, it would keep running this test body as a
+    // duplicate of the test process and create the marker before this
+    // (parent) process gets a chance to write it below.
+    EXPECT_FALSE(std::filesystem::exists(duplicateMarker));
+
+    std::ofstream marker(duplicateMarker);
+    ASSERT_TRUE(marker.is_open());
+}

--- a/libs/ocppi/src/ocppi/cli/Process.cpp
+++ b/libs/ocppi/src/ocppi/cli/Process.cpp
@@ -43,7 +43,8 @@ int runProcess(const std::string &binaryPath,
                 ::dup2(pipes[1], 1);
 
                 ret = execvp(binaryPath.data(), (char **)(cArgs.get()));
-                std::cerr << "execvp failed: " << std::strerror(errno) << std::endl;
+                std::cerr << "execvp failed: " << std::strerror(errno)
+                          << std::endl;
                 // Exceptions cannot cross fork(): unwinding here would run the
                 // caller's cleanup code and continue as a duplicate of the
                 // parent process, so the child must terminate immediately.
@@ -112,7 +113,8 @@ int runProcess(const std::string &binaryPath,
         int ret{ 0 };
         if (childId == 0) {
                 ret = execvp(binaryPath.data(), (char **)(cArgs.get()));
-                std::cerr << "execvp failed: " << std::strerror(errno) << std::endl;
+                std::cerr << "execvp failed: " << std::strerror(errno)
+                          << std::endl;
                 // Exceptions cannot cross fork(): unwinding here would run the
                 // caller's cleanup code and continue as a duplicate of the
                 // parent process, so the child must terminate immediately.

--- a/libs/ocppi/src/ocppi/cli/Process.cpp
+++ b/libs/ocppi/src/ocppi/cli/Process.cpp
@@ -6,6 +6,9 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <system_error>
@@ -40,8 +43,11 @@ int runProcess(const std::string &binaryPath,
                 ::dup2(pipes[1], 1);
 
                 ret = execvp(binaryPath.data(), (char **)(cArgs.get()));
-                throw std::system_error(errno, std::generic_category(),
-                                        "execvp");
+                std::cerr << "execvp failed: " << std::strerror(errno) << std::endl;
+                // Exceptions cannot cross fork(): unwinding here would run the
+                // caller's cleanup code and continue as a duplicate of the
+                // parent process, so the child must terminate immediately.
+                ::_exit(EXIT_FAILURE);
         }
 
         ::close(pipes[1]);
@@ -106,8 +112,11 @@ int runProcess(const std::string &binaryPath,
         int ret{ 0 };
         if (childId == 0) {
                 ret = execvp(binaryPath.data(), (char **)(cArgs.get()));
-                throw std::system_error(errno, std::generic_category(),
-                                        "execvp");
+                std::cerr << "execvp failed: " << std::strerror(errno) << std::endl;
+                // Exceptions cannot cross fork(): unwinding here would run the
+                // caller's cleanup code and continue as a duplicate of the
+                // parent process, so the child must terminate immediately.
+                ::_exit(EXIT_FAILURE);
         }
 
         int interruptTimes = 0;


### PR DESCRIPTION
## Problem / Evidence

Both `runProcess` overloads in `libs/ocppi/src/ocppi/cli/Process.cpp` handle a failed `execvp` in the forked child by executing `throw std::system_error(...)`. C++ exceptions cannot meaningfully cross `fork()`: the unwinding runs *inside the child*, up through the `catch (...) { return tl::unexpected(std::current_exception()); }` handlers in `CommonCLI` — so the child catches the exception, returns from the ocppi call, and **keeps executing the caller's code as a duplicate of the parent process**.

Concretely, when crun/runc is missing or being replaced during an upgrade (ENOENT/ETXTBSY/EACCES on exec):

- in `ll-package-manager`, every container operation forks a second copy of the daemon that continues the install/uninstall task with full side effects (repo writes, DBus replies, hooks);
- in the output-capturing variant, the duplicate keeps the pipe write end open (fd 1 is `dup2`ed to the pipe and never closed), so the parent can block in `read()` indefinitely while the duplicate lives on.

Reproduced with a new unit test on the existing `CommonCLITest` harness: a runtime binary without executable permission bits makes the pre-fix child continue running the test body — detected via a marker file that only a duplicate process executing the test body could create. The test fails on the unfixed code and passes after the fix.

## Root cause / Fix

After `execvp` fails, the child now reports the failure on stderr and terminates immediately with `::_exit(EXIT_FAILURE)`, so the parent observes a failed exit status and returns `CommandFailedError` as intended. This matches the fork/exec error handling already used in `libs/utils/src/linglong/utils/cmd.cpp` (`_exit(EXIT_FAILURE)` after a failed `execvpe`).

## Priority and scoring rationale

PRIORITY 83 = impact 34 (a duplicated daemon/CLI process silently repeats operations and mutates user-visible state, or the operation hangs forever on the unclosed pipe) + blast radius 17 (every ocppi container operation in both the daemon and the CLI) + reproducibility 15 (deterministic whenever exec fails; reproduced as a failing unit test) + maintenance value 17 (canonical fork/exec fix aligned with existing in-repo practice). FIX_CONFIDENCE 95.

## Tests

```
ctest -R "CommonCLITest"   # 2/2 passed
ctest -j4                  # 721/721 passed
```

- New `CommonCLITest.ListFailsWhenRuntimeIsNotExecutable`: fails on the unfixed code (duplicate-process marker detected), passes after the fix.
- Full suite: `100% tests passed, 0 tests failed out of 721`.

## Risk

Low. The only behavior change is on the exec-failure path, which previously produced the duplicate-process bug; every successful exec path is untouched. The exit status decoding (`::wait` vs `waitpid(childId)` and raw wait-status values) is intentionally left as is — that is a separate issue already tracked in #1846.