### PR TITLE
fix(builder): disconnect the cancel connection when the pull task ends

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -143,6 +143,7 @@ utils::error::Result<void> pullResolvedRef(const package::ReferenceWithRepo &ref
       2);
     QObject::connect(common::global::GlobalTaskControl::instance(),
                      &common::global::GlobalTaskControl::OnCancel,
+                     &tmpTask,
                      [&tmpTask]() {
                          tmpTask.Cancel();
                      });

--- a/libs/linglong/tests/ll-tests/src/linglong/builder/pull_dependency_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/builder/pull_dependency_test.cpp
@@ -16,6 +16,8 @@
 #include "linglong/utils/error/error.h"
 #include "ocppi/cli/crun/Crun.hpp"
 
+#include "linglong/common/global/initialize.h"
+
 #include <filesystem>
 #include <memory>
 #include <string>
@@ -395,6 +397,30 @@ TEST_F(PullDependencyTest, pullResolvedRef_not_cached_triggers_pull)
     auto result =
       builder::detail::pullResolvedRef(refWithRepo(std::move(*ref), "custom"), *m_repo, "binary");
     EXPECT_TRUE(result.has_value()) << result.error().message();
+}
+
+TEST_F(PullDependencyTest, pullResolvedRef_leaves_no_cancel_connection_behind)
+{
+    LINGLONG_TRACE("pullResolvedRef_leaves_no_cancel_connection_behind");
+
+    auto ref = package::Reference::parse("main:org.example.test/1.0.0.0/x86_64");
+    ASSERT_TRUE(ref.has_value()) << ref.error().message();
+
+    EXPECT_CALL(*m_repo, getLayerDir(_, _)).WillOnce(Return(LINGLONG_ERR("not found")));
+    EXPECT_CALL(*m_repo, pull(_, _, _)).WillOnce(Return(utils::error::Result<void>{}));
+
+    auto *taskControl = common::global::GlobalTaskControl::instance();
+    ASSERT_TRUE(taskControl);
+    // Drop connections registered by other tests so the check below only
+    // observes what pullResolvedRef leaves behind.
+    taskControl->disconnect(SIGNAL(OnCancel()));
+
+    auto result = builder::detail::pullResolvedRef(refWithRepo(std::move(*ref)), *m_repo, "binary");
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    // The connection to the process-wide cancel signal must not outlive the
+    // local task whose member it captures.
+    EXPECT_FALSE(taskControl->disconnect(SIGNAL(OnCancel())));
 }
 
 TEST_F(PullDependencyTest, buildStagePullDependency_continues_when_local_develop_pull_fails)

--- a/libs/linglong/tests/ll-tests/src/linglong/builder/pull_dependency_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/builder/pull_dependency_test.cpp
@@ -9,14 +9,13 @@
 #define private public
 #include "linglong/builder/linglong_builder.h"
 #undef private
+#include "linglong/common/global/initialize.h"
 #include "linglong/package/fuzzy_reference.h"
 #include "linglong/package/reference.h"
 #include "linglong/package_manager/package_task.h"
 #include "linglong/repo/ostree_repo.h"
 #include "linglong/utils/error/error.h"
 #include "ocppi/cli/crun/Crun.hpp"
-
-#include "linglong/common/global/initialize.h"
 
 #include <filesystem>
 #include <memory>


### PR DESCRIPTION
## Problem / Evidence

`builder::detail::pullResolvedRef` (libs/linglong/src/linglong/builder/linglong_builder.cpp) connects `GlobalTaskControl::OnCancel` to a lambda capturing the **local, stack-allocated** `service::PackageTask tmpTask`:

```cpp
QObject::connect(common::global::GlobalTaskControl::instance(),
                 &common::global::GlobalTaskControl::OnCancel,
                 [&tmpTask]() { tmpTask.Cancel(); });
```

The three-argument `QObject::connect(sender, signal, functor)` overload binds the connection lifetime to the **sender only**. `GlobalTaskControl::instance()` is a process-wide singleton, but `tmpTask` is destroyed when `pullResolvedRef` returns. So every call leaves one connection permanently registered on the singleton whose lambda references a destroyed object. The next `OnCancel` emission — `applicationInitialize()` emits it from the SIGINT/SIGTERM handler, i.e. whenever the user presses Ctrl+C while a build is past its dependency-pull stage — synchronously runs the lambda on the destroyed task, calling `PackageTask::Cancel()` on freed memory (use-after-free; `Cancel()` touches the already destroyed task state and its GCancellable).

A typical `ll-builder build` pulls base/runtime binary+develop layers through this function several times, and the build continues for minutes afterwards, so the dangling connections are present during the most likely window for the user to abort.

A sibling connection in the same function already uses the task as the implicit sender (`connect(&tmpTask, &PackageTask::PartChanged, partChanged)`), which is auto-disconnected on destruction — only the `OnCancel` connection is missing a context object.

## Root cause / Fix

Register the temporary task as the connection context object so Qt disconnects the connection automatically when the task is destroyed:

```cpp
QObject::connect(common::global::GlobalTaskControl::instance(),
                 &common::global::GlobalTaskControl::OnCancel,
                 &tmpTask,
                 [&tmpTask]() { tmpTask.Cancel(); });
```

No other behavior changes: while the task is alive the connection behaves exactly as before.

## Priority

PRIORITY = 77 / 100 (阈值 ≥70)：影响 32/40（长时间构建中按 Ctrl+C 触发 use-after-free 崩溃）+ 波及范围 14/20（ll-builder build/export 的所有依赖拉取路径）+ 可复现性 17/20（单元测试确定性复现连接残留）+ 维护价值 14/20（悬挂连接是隐蔽的进程级缺陷）。
FIX_CONFIDENCE = 90 / 100（阈值 ≥80）：receiver-context connect 是 Qt 标准做法，与同函数既有写法一致。

## Tests

新增回归测试 `PullDependencyTest.pullResolvedRef_leaves_no_cancel_connection_behind`（pull_dependency_test.cpp）：以 mock repo 调用 `pullResolvedRef`，随后断言 `GlobalTaskControl` 上不再有 `OnCancel` 连接（通过公开 API `disconnect(SIGNAL(OnCancel()))` 的返回值判定）。

- 修复前（临时还原修复后重建）：测试 **失败** —— `pullResolvedRef` 返回后 `OnCancel` 仍有一条连接残留：

```
35 - PullDependencyTest.pullResolvedRef_leaves_no_cancel_connection_behind (Failed)
0% tests passed, 1 tests failed out of 1
```

- 修复后：测试通过；全量测试套件无回归：

```
cd /workspace && ninja -C build ll-tests -j2 && cd build && ctest
100% tests passed, 0 tests failed out of 721
```

（161/162 DisplayTest 两例为基线即存在的 Skip，与本次改动无关。）

## Risk

低。改动仅添加连接的 context 对象；连接存活期间（任务未销毁时）取消行为与原先完全一致。