### PR TITLE
fix(utils): survive a child that exits without draining its stdin

### DIFF
--- a/libs/linglong/tests/ll-tests/src/linglong/utils/cmd_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/cmd_test.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 

--- a/libs/linglong/tests/ll-tests/src/linglong/utils/cmd_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/utils/cmd_test.cpp
@@ -76,4 +76,18 @@ TEST(command, toStdin)
       << "wc -c should report 1049600 bytes, got: " << *ret4;
 }
 
+TEST(command, toStdinChildExitsEarly_reportsExitCodeInsteadOfDying)
+{
+    // The child exits without draining its stdin while more than a pipe
+    // buffer of input is still pending. Writing to it must surface as an
+    // error result with the child's exit status, not terminate this process
+    // with SIGPIPE.
+    std::string large_data(1024 * 1024, 'x');
+    auto ret = linglong::utils::Cmd("sh").toStdin(large_data).exec({ "-c", "exit 3" });
+
+    EXPECT_FALSE(ret.has_value());
+    EXPECT_TRUE(ret.error().message().find("exit code 3") != std::string::npos)
+      << ret.error().message();
+}
+
 } // namespace

--- a/libs/utils/src/linglong/utils/cmd.cpp
+++ b/libs/utils/src/linglong/utils/cmd.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 
 #include <fcntl.h>
+#include <signal.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -188,6 +189,45 @@ utils::error::Result<std::string> Cmd::exec(const std::vector<std::string> &args
     stdoutPipe[1] = -1;
     close(stdinPipe[0]);
     stdinPipe[0] = -1;
+
+    // Block SIGPIPE while writing to the child's stdin: the child may exit
+    // without draining the pipe and the default disposition would terminate
+    // this process instead of surfacing EPIPE from the write in the polling
+    // loop below. Blocked only in the parent after fork so the child keeps
+    // the default disposition after exec.
+    sigset_t sigpipeBlocked, sigpipeOld;
+    sigemptyset(&sigpipeBlocked);
+    sigaddset(&sigpipeBlocked, SIGPIPE);
+    bool sigpipeBlockedHere = false;
+    if (!m_stdinContent.empty()) {
+        sigpipeBlockedHere = pthread_sigmask(SIG_BLOCK, &sigpipeBlocked, &sigpipeOld) == 0;
+        if (!sigpipeBlockedHere) {
+            return LINGLONG_ERR(fmt::format("failed to block SIGPIPE: {}",
+                                            common::error::errorString(errno)));
+        }
+    }
+    auto sigpipeRestorer = utils::finally::finally(
+      [&sigpipeBlocked, &sigpipeOld, sigpipeBlockedHere]() {
+          if (!sigpipeBlockedHere) {
+              return;
+          }
+          // Discard SIGPIPE raised by our own writes before unblocking it.
+          struct timespec timeout
+          {
+              0, 0
+          };
+          while (true) {
+              const auto raised = sigtimedwait(&sigpipeBlocked, nullptr, &timeout);
+              if (raised > 0) {
+                  continue;
+              }
+              if (raised == -1 && errno == EINTR) {
+                  continue;
+              }
+              break;
+          }
+          pthread_sigmask(SIG_SETMASK, &sigpipeOld, nullptr);
+      });
 
     auto setNonBlock = [](int fd) {
         int flags = fcntl(fd, F_GETFL, 0);

--- a/libs/utils/src/linglong/utils/cmd.cpp
+++ b/libs/utils/src/linglong/utils/cmd.cpp
@@ -202,20 +202,17 @@ utils::error::Result<std::string> Cmd::exec(const std::vector<std::string> &args
     if (!m_stdinContent.empty()) {
         sigpipeBlockedHere = pthread_sigmask(SIG_BLOCK, &sigpipeBlocked, &sigpipeOld) == 0;
         if (!sigpipeBlockedHere) {
-            return LINGLONG_ERR(fmt::format("failed to block SIGPIPE: {}",
-                                            common::error::errorString(errno)));
+            return LINGLONG_ERR(
+              fmt::format("failed to block SIGPIPE: {}", common::error::errorString(errno)));
         }
     }
-    auto sigpipeRestorer = utils::finally::finally(
-      [&sigpipeBlocked, &sigpipeOld, sigpipeBlockedHere]() {
+    auto sigpipeRestorer =
+      utils::finally::finally([&sigpipeBlocked, &sigpipeOld, sigpipeBlockedHere]() {
           if (!sigpipeBlockedHere) {
               return;
           }
           // Discard SIGPIPE raised by our own writes before unblocking it.
-          struct timespec timeout
-          {
-              0, 0
-          };
+          struct timespec timeout{ 0, 0 };
           while (true) {
               const auto raised = sigtimedwait(&sigpipeBlocked, nullptr, &timeout);
               if (raised > 0) {


### PR DESCRIPTION
Closes #1931

> 外部依据：[signal(7)](https://man7.org/linux/man-pages/man7/signal.7.html) — SIGPIPE 默认处置为终止进程（Term）；[write(2)](https://man7.org/linux/man-pages/man2/write.2.html) — 写入读端已关闭的管道时，write 以 EPIPE 失败，**且在此之前写进程会先收到 SIGPIPE**（除非该信号被阻塞或忽略）；[pthread_sigmask(3)](https://man7.org/linux/man-pages/man3/pthread_sigmask.3.html) — 检查/修改调用线程的信号掩码（线程级，不影响子进程与其他线程）。

## Problem / Evidence

`utils::Cmd::exec` (libs/utils/src/linglong/utils/cmd.cpp) feeds `m_stdinContent` to the child through a non-blocking pipe and multiplexes the writes through epoll. Nothing handles SIGPIPE: the process-wide disposition is the default one (the repository registers handlers for TERM/INT/QUIT/HUP/ABRT only), so when the child exits **without reading its stdin** — a crash, a failed validation, or a script that simply exits — the pipe read end closes, the next `write()` raises SIGPIPE, and the default action terminates the entire calling process **before** the `errno != EAGAIN` branch (which clearly anticipates an EPIPE write error) can run.

Concretely, `oci-cfg-generators` pipes the full OCI config JSON into a patch executable (`applyExecutablePatch` → `Cmd(patchFile).toStdin(std::move(inputJsonStr)).exec()`); with several mounts the JSON exceeds the 64 KiB pipe buffer, so any patch program that exits early kills `ll-cli run` (or the package-manager daemon when running install hooks) with signal 13 and no error message.

Deterministic reproduction with the new regression test (`sh` exits 3 without draining 1 MiB of pending stdin):

```
ctest -R "command.toStdinChildExitsEarly"   # 修复前
564 - command.toStdinChildExitsEarly_reportsExitCodeInsteadOfDying (SIGPIPE)
```

The gtest process itself dies from SIGPIPE — the bug kills the caller, not just the command result.

## Root cause / Fix

Block SIGPIPE in the parent process around the polling loop with `pthread_sigmask`, so the write fails with `EPIPE` and the existing error branch handles it; `exec()` then returns the child's real exit status as before.

Details that keep the change safe:

- the mask is set **after** `fork()`, so `exec`'d children keep the default SIGPIPE disposition;
- the mask is only set when there is stdin content to write;
- any pending SIGPIPE raised by our own writes is consumed with `sigtimedwait` before restoring the original mask, so it cannot fire later in unrelated code;
- `exec()` is `noexcept`, and on the (unlikely) `pthread_sigmask` failure the function now returns an error instead of risking process death.

## Priority

PRIORITY = 75 / 100 (阈值 ≥70)：影响 30/40（整个 CLI/守护进程被信号 13 静默杀死，用户看不到任何错误）+ 波及范围 12/20（所有 `Cmd::toStdin().exec()` 调用方，含 `ll-cli run` 的 executable patch 路径与安装 hook）+ 可复现性 19/20（单元测试确定性触发）+ 维护价值 14/20（"进程突然消失"类缺陷难排查）。
FIX_CONFIDENCE = 85 / 100 (阈值 ≥80)：线程级 `pthread_sigmask` + 丢弃挂起信号是 POSIX 标准模式，现有 EPIPE 分支已处理后续错误传播。

## Tests

新增 `command.toStdinChildExitsEarly_reportsExitCodeInsteadOfDying`（cmd_test.cpp）：

- 修复前：测试进程被 SIGPIPE 杀死（见上方原始输出）；
- 修复后：返回值携带子进程退出码：

```
ctest -R "command.toStdin"
1/2 Test #563: command.toStdin ... Passed
2/2 Test #564: command.toStdinChildExitsEarly_reportsExitCodeInsteadOfDying ... Passed
```

全量回归：`cd /workspace/build && ctest` → `100% tests passed, 0 tests failed out of 721`（DisplayTest 两例 Skip 为基线行为，与本次无关）。既有 `toStdin`/`setEnv`/`Exec` 用例验证正常 stdin 传输路径不受影响。

## Risk

低。仅父进程写循环期间在调用线程内屏蔽 SIGPIPE；子进程、其他线程的信号行为不变。`Cmd("fusermount").exec()` 等无 stdin 的调用路径完全不进入新分支。
