### PR TITLE
fix(builder): disconnect the cancel connection when the pull task ends

### DIFF
--- a/libs/linglong/src/linglong/builder/linglong_builder.cpp
+++ b/libs/linglong/src/linglong/builder/linglong_builder.cpp
@@ -143,6 +143,7 @@ utils::error::Result<void> pullResolvedRef(const package::ReferenceWithRepo &ref
       2);
     QObject::connect(common::global::GlobalTaskControl::instance(),
                      &common::global::GlobalTaskControl::OnCancel,
+                     &tmpTask,
                      [&tmpTask]() {
                          tmpTask.Cancel();
                      });

--- a/libs/linglong/tests/ll-tests/src/linglong/builder/pull_dependency_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/builder/pull_dependency_test.cpp
@@ -422,6 +422,29 @@ TEST_F(PullDependencyTest, pullResolvedRef_leaves_no_cancel_connection_behind)
     EXPECT_FALSE(taskControl->disconnect(SIGNAL(OnCancel())));
 }
 
+TEST_F(PullDependencyTest, pullResolvedRef_cancel_during_pull_reaches_the_task)
+{
+    LINGLONG_TRACE("pullResolvedRef_cancel_during_pull_reaches_the_task");
+
+    auto ref = package::Reference::parse("main:org.example.test/1.0.0.0/x86_64");
+    ASSERT_TRUE(ref.has_value()) << ref.error().message();
+
+    EXPECT_CALL(*m_repo, getLayerDir(_, _)).WillOnce(Return(LINGLONG_ERR("not found")));
+    EXPECT_CALL(*m_repo, pull(_, _, _))
+      .WillOnce([](service::Task &taskContext,
+                   const package::ReferenceWithRepo &,
+                   const std::string &) -> utils::error::Result<void> {
+          // Emits OnCancel synchronously. The task must stay reachable
+          // through the cancel connection while it is alive.
+          common::global::GlobalTaskControl::cancel();
+          EXPECT_TRUE(taskContext.isTaskDone());
+          return {};
+      });
+
+    auto result = builder::detail::pullResolvedRef(refWithRepo(std::move(*ref)), *m_repo, "binary");
+    EXPECT_TRUE(result.has_value()) << result.error().message();
+}
+
 TEST_F(PullDependencyTest, buildStagePullDependency_continues_when_local_develop_pull_fails)
 {
     LINGLONG_TRACE("buildStagePullDependency_continues_when_local_develop_pull_fails");

--- a/libs/linglong/tests/ll-tests/src/linglong/builder/pull_dependency_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/builder/pull_dependency_test.cpp
@@ -16,6 +16,8 @@
 #include "linglong/utils/error/error.h"
 #include "ocppi/cli/crun/Crun.hpp"
 
+#include "linglong/common/global/initialize.h"
+
 #include <filesystem>
 #include <memory>
 #include <string>
@@ -395,6 +397,30 @@ TEST_F(PullDependencyTest, pullResolvedRef_not_cached_triggers_pull)
     auto result =
       builder::detail::pullResolvedRef(refWithRepo(std::move(*ref), "custom"), *m_repo, "binary");
     EXPECT_TRUE(result.has_value()) << result.error().message();
+}
+
+TEST_F(PullDependencyTest, pullResolvedRef_leaves_no_cancel_connection_behind)
+{
+    LINGLONG_TRACE("pullResolvedRef_leaves_no_cancel_connection_behind");
+
+    auto ref = package::Reference::parse("main:org.example.test/1.0.0.0/x86_64");
+    ASSERT_TRUE(ref.has_value()) << ref.error().message();
+
+    EXPECT_CALL(*m_repo, getLayerDir(_, _)).WillOnce(Return(LINGLONG_ERR("not found")));
+    EXPECT_CALL(*m_repo, pull(_, _, _)).WillOnce(Return(utils::error::Result<void>{}));
+
+    auto *taskControl = common::global::GlobalTaskControl::instance();
+    ASSERT_TRUE(taskControl);
+    // Drop connections registered by other tests so the check below only
+    // observes what pullResolvedRef leaves behind.
+    taskControl->disconnect(SIGNAL(OnCancel()));
+
+    auto result = builder::detail::pullResolvedRef(refWithRepo(std::move(*ref)), *m_repo, "binary");
+    ASSERT_TRUE(result.has_value()) << result.error().message();
+
+    // The connection to the process-wide cancel signal must not outlive the
+    // local task whose member it captures.
+    EXPECT_FALSE(taskControl->disconnect(SIGNAL(OnCancel())));
 }
 
 TEST_F(PullDependencyTest, buildStagePullDependency_continues_when_local_develop_pull_fails)

--- a/libs/linglong/tests/ll-tests/src/linglong/builder/pull_dependency_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/builder/pull_dependency_test.cpp
@@ -434,9 +434,15 @@ TEST_F(PullDependencyTest, pullResolvedRef_cancel_during_pull_reaches_the_task)
       .WillOnce([](service::Task &taskContext,
                    const package::ReferenceWithRepo &,
                    const std::string &) -> utils::error::Result<void> {
-          // Emits OnCancel synchronously. The task must stay reachable
-          // through the cancel connection while it is alive.
-          common::global::GlobalTaskControl::cancel();
+          // Emit the process-wide cancel signal directly: calling
+          // GlobalTaskControl::cancel() would permanently flip the singleton's
+          // canceled flag and break other tests running in the same binary
+          // (GlobalTaskControl.InstanceIsAvailableAndNotInitiallyCanceled).
+          auto *control = const_cast<common::global::GlobalTaskControl *>(
+            common::global::GlobalTaskControl::instance());
+          Q_EMIT control->OnCancel();
+          // The task must stay reachable through the cancel connection while
+          // it is alive.
           EXPECT_TRUE(taskContext.isTaskDone());
           return {};
       });

--- a/libs/linglong/tests/ll-tests/src/linglong/builder/pull_dependency_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/builder/pull_dependency_test.cpp
@@ -9,14 +9,13 @@
 #define private public
 #include "linglong/builder/linglong_builder.h"
 #undef private
+#include "linglong/common/global/initialize.h"
 #include "linglong/package/fuzzy_reference.h"
 #include "linglong/package/reference.h"
 #include "linglong/package_manager/package_task.h"
 #include "linglong/repo/ostree_repo.h"
 #include "linglong/utils/error/error.h"
 #include "ocppi/cli/crun/Crun.hpp"
-
-#include "linglong/common/global/initialize.h"
 
 #include <filesystem>
 #include <memory>


### PR DESCRIPTION
Closes #1930

> Supersedes #1925 (rebuilt so every commit satisfies commitlint's body requirement; code and tests unchanged).

## Problem / Evidence

`builder::detail::pullResolvedRef` (libs/linglong/src/linglong/builder/linglong_builder.cpp) connects `GlobalTaskControl::OnCancel` to a lambda capturing the **local, stack-allocated** `service::PackageTask tmpTask`:

```cpp
QObject::connect(common::global::GlobalTaskControl::instance(),
                 &common::global::GlobalTaskControl::OnCancel,
                 [&tmpTask]() { tmpTask.Cancel(); });
```

The three-argument `QObject::connect(sender, signal, functor)` overload binds the connection lifetime to the **sender only** ([Qt documentation](https://doc.qt.io/qt-6/qobject.html#connect): the functor overload without a context object keeps the connection alive until the *sender* is destroyed; only the overload with a context/receiver object disconnects automatically "when the receiver is destroyed"). `GlobalTaskControl::instance()` is a process-wide singleton (libs/linglong/src/linglong/common/global/initialize.cpp), but `tmpTask` is destroyed when `pullResolvedRef` returns. So every call leaves one connection permanently registered on the singleton whose lambda references a destroyed object. The next `OnCancel` emission — `applicationInitialize()` emits it from the SIGINT/SIGTERM handler (initialize.cpp:34), i.e. whenever the user presses Ctrl+C while a build is past its dependency-pull stage — synchronously runs the lambda on the destroyed task, calling `PackageTask::Cancel()` on freed memory (use-after-free; `Cancel()` calls `taskID()`/`updateState()` and dereferences the already-unref'd `m_cancelFlag` GCancellable).

A typical `ll-builder build` pulls base/runtime binary+develop layers through this function several times, and the build continues for minutes afterwards, so the dangling connections are present during the most likely window for the user to abort.

A sibling connection in the same function already uses the task as the implicit sender (`connect(&tmpTask, &PackageTask::PartChanged, partChanged)`), which is auto-disconnected on destruction — only the `OnCancel` connection is missing a context object.

## Root cause / Fix

Register the temporary task as the connection context object so Qt disconnects the connection automatically when the task is destroyed:

```cpp
QObject::connect(common::global::GlobalTaskControl::instance(),
                 &common::global::GlobalTaskControl::OnCancel,
                 &tmpTask,
                 [&tmpTask]() { tmpTask.Cancel(); });
```

No other behavior changes: while the task is alive the connection behaves exactly as before.

## Priority

PRIORITY = 77 / 100 (阈值 ≥70)：影响 32/40（长时间构建中按 Ctrl+C 触发 use-after-free 崩溃）+ 波及范围 14/20（ll-builder build/export 的所有依赖拉取路径）+ 可复现性 17/20（单元测试确定性复现连接残留）+ 维护价值 14/20（悬挂连接是隐蔽的进程级缺陷）。
FIX_CONFIDENCE = 90 / 100 (阈值 ≥80)：receiver-context connect 是 Qt 标准做法，与同函数既有写法一致。

## Tests

两个互补的回归测试（pull_dependency_test.cpp）：

1. `pullResolvedRef_leaves_no_cancel_connection_behind` — 以 mock repo 调用 `pullResolvedRef`，随后断言 `GlobalTaskControl` 上不再有 `OnCancel` 连接（通过公开 API `disconnect(SIGNAL(OnCancel()))` 的返回值判定）。

   - 修复前（临时还原修复、`touch` 强制重建后运行）：测试 **失败** —— `pullResolvedRef` 返回后 `OnCancel` 仍有一条连接残留：

```
$ ctest -R "pullResolvedRef_leaves_no_cancel_connection_behind" --output-on-failure
[4/4] Linking CXX executable libs/linglong/tests/ll-tests/ll-tests
 1 FAILED TEST

0% tests passed, 1 tests failed out of 1

The following tests FAILED:
	35 - PullDependencyTest.pullResolvedRef_leaves_no_cancel_connection_behind (Failed)
Errors while running CTest
```

2. `pullResolvedRef_cancel_during_pull_reaches_the_task` — 在 mock pull 内同步 emit `OnCancel`，断言任务真正进入 Canceled 终态。该测试证明修复保留了连接的正向功能（防止"修复"退化成"不建立连接"），修复前后均通过。

   - 修复后与两个断开残留测试一起运行：

```
$ ctest -R "PullDependencyTest.pullResolvedRef" --output-on-failure
2/4 Test #34: PullDependencyTest.pullResolvedRef_not_cached_triggers_pull ..............   Passed    0.03 sec
3/4 Test #35: PullDependencyTest.pullResolvedRef_leaves_no_cancel_connection_behind ....   Passed    0.03 sec
4/4 Test #36: PullDependencyTest.pullResolvedRef_cancel_during_pull_reaches_the_task ...   Passed    0.02 sec

100% tests passed, 0 tests failed out of 4
```

全量回归：

```
$ ctest
100% tests passed, 0 tests failed out of 722
```

（DisplayTest 两例为基线即存在的 Skip，需要真实 X11 socket，与本次改动无关。）

## Risk

低。改动仅添加连接的 context 对象；连接存活期间（任务未销毁时）取消行为与原先完全一致（由测试 2 验证）。
