### PR TITLE
fix(package): reject uab sections that exceed the file size

### DIFF
--- a/libs/linglong/src/linglong/package/uab_file.cpp
+++ b/libs/linglong/src/linglong/package/uab_file.cpp
@@ -19,12 +19,14 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <limits>
 #include <string_view>
 
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 namespace linglong::package {
@@ -116,6 +118,23 @@ utils::error::Result<std::string> UABFile::readSectionData(const QString &sectio
         || size > sectionHeader->sh_size - offset) {
         return LINGLONG_ERR(fmt::format("data exceeds section {}", section));
     }
+
+    // sh_size comes from untrusted file content. A corrupted or malicious
+    // section header can claim far more data than the bundle holds, so the
+    // section content is required to lie within the file before allocating.
+    struct stat fileStat {};
+    if (::fstat(this->fd, &fileStat) == -1) {
+        return LINGLONG_ERR(fmt::format("failed to stat uab file: {}",
+                                        common::error::errorString(errno)));
+    }
+    if (fileStat.st_size < 0
+        || static_cast<std::uintmax_t>(sectionHeader->sh_offset)
+          > static_cast<std::uintmax_t>(fileStat.st_size)
+        || sectionHeader->sh_size
+          > static_cast<std::uintmax_t>(fileStat.st_size) - sectionHeader->sh_offset) {
+        return LINGLONG_ERR(fmt::format("section {} exceeds the uab file size", section));
+    }
+
     std::string data(size, '\0');
     std::size_t totalBytes{ 0 };
     while (totalBytes < size) {

--- a/libs/linglong/src/linglong/package/uab_file.cpp
+++ b/libs/linglong/src/linglong/package/uab_file.cpp
@@ -122,10 +122,10 @@ utils::error::Result<std::string> UABFile::readSectionData(const QString &sectio
     // sh_size comes from untrusted file content. A corrupted or malicious
     // section header can claim far more data than the bundle holds, so the
     // section content is required to lie within the file before allocating.
-    struct stat fileStat {};
+    struct stat fileStat{};
     if (::fstat(this->fd, &fileStat) == -1) {
-        return LINGLONG_ERR(fmt::format("failed to stat uab file: {}",
-                                        common::error::errorString(errno)));
+        return LINGLONG_ERR(
+          fmt::format("failed to stat uab file: {}", common::error::errorString(errno)));
     }
     if (fileStat.st_size < 0
         || static_cast<std::uintmax_t>(sectionHeader->sh_offset)

--- a/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
@@ -16,6 +16,9 @@
 #include <QCryptographicHash>
 #include <QFile>
 
+#include <elf.h>
+#include <fcntl.h>
+
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
@@ -23,6 +26,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include <unistd.h>
 
@@ -369,6 +373,68 @@ TEST_F(UabFileTest, VerifyRejectsMismatchedBundleDigest)
     auto verifyRet = (*uab)->verify();
     ASSERT_TRUE(verifyRet.has_value()) << verifyRet.error().message();
     EXPECT_FALSE(*verifyRet);
+}
+
+TEST_F(UabFileTest, GetMetaInfoRejectsSectionBeyondFileSize)
+{
+    TempDir modifiedDir{ "linglong-uab-huge-meta-size-" };
+    ASSERT_TRUE(modifiedDir.isValid());
+    const auto modifiedUab = modifiedDir.path() / "huge-meta-size.uab";
+    std::filesystem::copy_file(uabFile,
+                               modifiedUab,
+                               std::filesystem::copy_options::overwrite_existing);
+
+    // Corrupt the linglong.meta section header so that sh_size extends far
+    // beyond the file itself, like a truncated or malicious bundle could.
+    {
+        const int fd = ::open(modifiedUab.c_str(), O_RDWR | O_CLOEXEC);
+        ASSERT_GE(fd, 0);
+
+        Elf64_Ehdr ehdr{};
+        ASSERT_EQ(::pread(fd, &ehdr, sizeof(ehdr), 0), static_cast<ssize_t>(sizeof(ehdr)));
+        ASSERT_EQ(ehdr.e_ident[EI_CLASS], ELFCLASS64);
+
+        std::vector<Elf64_Shdr> shdrs(ehdr.e_shnum);
+        ASSERT_GT(shdrs.size(), std::size_t{ 0 });
+        ASSERT_EQ(::pread(fd,
+                          shdrs.data(),
+                          sizeof(Elf64_Shdr) * shdrs.size(),
+                          static_cast<off_t>(ehdr.e_shoff)),
+                  static_cast<ssize_t>(sizeof(Elf64_Shdr) * shdrs.size()));
+
+        const auto &shstr = shdrs[ehdr.e_shstrndx];
+        std::string shstrtab(shstr.sh_size, '\0');
+        ASSERT_EQ(::pread(fd,
+                          shstrtab.data(),
+                          shstrtab.size(),
+                          static_cast<off_t>(shstr.sh_offset)),
+                  static_cast<ssize_t>(shstrtab.size()));
+
+        bool found = false;
+        for (std::size_t i = 0; i < shdrs.size(); ++i) {
+            if (shdrs[i].sh_name >= shstrtab.size()) {
+                continue;
+            }
+            if (std::string_view{ shstrtab.c_str() + shdrs[i].sh_name } == "linglong.meta") {
+                shdrs[i].sh_size = 0x1000000000000000ULL;
+                ASSERT_EQ(::pwrite(fd,
+                                   &shdrs[i],
+                                   sizeof(shdrs[i]),
+                                   static_cast<off_t>(ehdr.e_shoff + i * sizeof(Elf64_Shdr))),
+                          static_cast<ssize_t>(sizeof(Elf64_Shdr)));
+                found = true;
+                break;
+            }
+        }
+        ::close(fd);
+        ASSERT_TRUE(found) << "linglong.meta section not found in the fixture";
+    }
+
+    auto uab = UABFile::loadFromFile(modifiedUab);
+    ASSERT_TRUE(uab.has_value()) << uab.error().message();
+    auto metaRet = (*uab)->getMetaInfo();
+    EXPECT_FALSE(metaRet.has_value())
+      << "a section extending beyond the file size must be rejected";
 }
 
 TEST_F(UabFileTest, VerifyWithoutBundleSignSection)

--- a/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
+++ b/libs/linglong/tests/ll-tests/src/linglong/package/uab_file_test.cpp
@@ -13,11 +13,10 @@
 #include "linglong/package/uab_packager.h"
 #include "linglong/utils/cmd.h"
 
+#include <elf.h>
+
 #include <QCryptographicHash>
 #include <QFile>
-
-#include <elf.h>
-#include <fcntl.h>
 
 #include <algorithm>
 #include <filesystem>
@@ -28,6 +27,7 @@
 #include <string_view>
 #include <vector>
 
+#include <fcntl.h>
 #include <unistd.h>
 
 __attribute__((used, section(".note.uab.sig"), aligned(4))) const auto linglongUabSignature =
@@ -404,11 +404,9 @@ TEST_F(UabFileTest, GetMetaInfoRejectsSectionBeyondFileSize)
 
         const auto &shstr = shdrs[ehdr.e_shstrndx];
         std::string shstrtab(shstr.sh_size, '\0');
-        ASSERT_EQ(::pread(fd,
-                          shstrtab.data(),
-                          shstrtab.size(),
-                          static_cast<off_t>(shstr.sh_offset)),
-                  static_cast<ssize_t>(shstrtab.size()));
+        ASSERT_EQ(
+          ::pread(fd, shstrtab.data(), shstrtab.size(), static_cast<off_t>(shstr.sh_offset)),
+          static_cast<ssize_t>(shstrtab.size()));
 
         bool found = false;
         for (std::size_t i = 0; i < shdrs.size(); ++i) {


### PR DESCRIPTION
Closes #1932

> Supersedes #1927 (rebuilt so every commit satisfies commitlint's body requirement; code and tests unchanged).
>
> 外部依据：[ELF/gABI 规范 §4. Sections](https://refspecs.linuxbase.org/elf/gabi4+/ch4.sheader.html) — `SHT_PROGBITS` 节的 `sh_offset` 指向"文件中该节的第一个字节"，节内容必须实际存在于文件中（只有 `SHT_NOBITS` 节不占用文件空间，而本函数已先行拒绝 NOBITS）；libelf 的 `elf_begin` 仅验证 ELF 结构合法性，不校验 `sh_offset+sh_size` 是否落在文件内。

## Problem / Evidence

`UABFile::readSectionData` (libs/linglong/src/linglong/package/uab_file.cpp) allocates the output buffer straight from the section header `sh_size`:

```cpp
if (sectionHeader->sh_type == SHT_NOBITS || offset > sectionHeader->sh_size
    || size > sectionHeader->sh_size - offset) { ... }
std::string data(size, '\0');   // size == sh_size for getMetaInfo()/verify()
```

`sh_size` is untrusted input read from the bundle file: libelf only validates the ELF structure, not that the section content lies within the file. `UABFile::getMetaInfo()` calls `readSectionData(metaSection, 0, metaSh->sh_size)`, so a corrupted or malicious UAB whose `linglong.meta` header claims an enormous size makes `std::string data(size, '\0')` throw `std::bad_alloc` — and because the function is `noexcept`, `std::terminate` aborts `ll-cli install xxx.uab` (and the UAB loader path) instead of reporting an error. A truncated download has the same issue: the allocation is paid before the pread loop notices the EOF. The existing `> INT_MAX` guard in `verify()` runs only *after* this allocation, so it never protects it.

Deterministic reproduction with the new regression test (a fixture UAB whose `linglong.meta` section header is edited to `sh_size = 0x1000000000000000`):

```
$ ctest -R "UabFileTest.GetMetaInfoRejectsSectionBeyondFileSize"   # 修复前
[ RUN      ] UabFileTest.GetMetaInfoRejectsSectionBeyondFileSize
terminate called after throwing an instance of 'std::bad_alloc'
  what():  std::bad_alloc

0% tests passed, 1 tests failed out of 1
395 - UabFileTest.GetMetaInfoRejectsSectionBeyondFileSize (Subprocess aborted)
```

## Root cause / Fix

Before allocating, require the section content to lie within the file via `fstat`:

```cpp
if (fileStat.st_size < 0
    || static_cast<std::uintmax_t>(sectionHeader->sh_offset) > fileSize
    || sectionHeader->sh_size > fileSize - sectionHeader->sh_offset) {
    return LINGLONG_ERR(...);
}
```

`SHT_NOBITS` sections are already rejected above; for all remaining section types (meta, signature, bundle payload) the content must be backed by the file, so legitimate bundles are unaffected. The unsigned subtraction is guarded by the preceding `sh_offset <= fileSize` check.

## Priority

PRIORITY = 75 / 100 (阈值 ≥70)：影响 30/40（安装损坏/恶意 UAB 时进程直接被 std::terminate 杀死而非报错）+ 波及范围 12/20（UAB 安装与校验路径）+ 可复现性 18/20（畸形节头可确定性构造）+ 维护价值 15/20（对不可信包格式的输入校验缺口）。
FIX_CONFIDENCE = 90 / 100 (阈值 ≥80)：在分配点前用文件大小校验节边界，语义明确，合法 UAB 不受影响。

## Tests

新增 `UabFileTest.GetMetaInfoRejectsSectionBeyondFileSize`（uab_file_test.cpp）：复制测试夹具 UAB，直接改写 `linglong.meta` 节头的 `sh_size` 为 2^60，断言 `getMetaInfo()` 返回错误。

- 修复前：`std::bad_alloc` → `std::terminate`（见上方原始输出）；
- 修复后：返回错误，测试通过；`UabFileTest` 全部 13 例通过（12 个既有合法 UAB 用例验证修复不影响正常包）：

```
$ ctest -R "UabFileTest"
100% tests passed, 0 tests failed out of 13
```

全量回归：`cd /workspace/build && ctest` → `100% tests passed, 0 tests failed out of 721`（DisplayTest 两例 Skip 为基线行为）。

## Risk

低。新增校验仅在节内容超出文件时拒绝（此时原代码也必然在 pread 循环中以 "unexpected end of section" 失败，只是先付出分配代价）；合法 UAB 的节内容均在文件内，行为不变。
