### PR TITLE
fix: harden package manager systemd sandboxing

### DIFF
--- a/misc/lib/systemd/system/org.deepin.linglong.PackageManager.service
+++ b/misc/lib/systemd/system/org.deepin.linglong.PackageManager.service
@@ -11,3 +11,7 @@ User=@LINGLONG_USERNAME@
 Group=@LINGLONG_USERNAME@
 BusName=org.deepin.linglong.PackageManager1
 ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/linglong/ll-package-manager
+
+# 安全隔离配置
+PrivateTmp=yes
+ProtectHome=yes


### PR DESCRIPTION
1. Add PrivateTmp=yes to the org.deepin.linglong.PackageManager systemd service unit
2. Add ProtectHome=yes to the same unit
3. Isolate the package manager daemon's temporary file namespace so it cannot see or tamper with other processes' files in /tmp
4. Restrict the daemon from accessing /home, /root and /run/user, reducing the attack surface if the privileged service is compromised
5. The service runs as a privileged daemon, so limiting its filesystem visibility follows the principle of least privilege commonly recommended by systemd-analyze security

Influence:
1. Verify the ll-package-manager service starts, stays active and does not enter a failed state after the new directives are applied
2. Test core package operations (install, uninstall, update, upgrade, query) to confirm sandboxing does not break normal workflows
3. Confirm the daemon does not depend on shared /tmp state or files located under /home or /root
4. Check that temporary files created during package operations are cleaned up automatically with the private tmp namespace
5. Run systemd-analyze security on the unit to confirm the exposure score improves
6. Review journal logs for any denied path access or permission errors introduced by ProtectHome