### PR TITLE
fix: set proper home and shell for linglong user

### DIFF
--- a/misc/lib/sysusers.d/linglong.conf
+++ b/misc/lib/sysusers.d/linglong.conf
@@ -6,4 +6,4 @@
 # at boot on systemd-based systems that ship with an unpopulated /etc/.
 # See sysuser.d(5) for details.
 
-u @LINGLONG_USERNAME@ - "linglong Package Manager"
+u @LINGLONG_USERNAME@ - "linglong Package Manager" /nonexistent -


### PR DESCRIPTION
1. Update the sysusers.d configuration to explicitly set /nonexistent as the home directory and an empty shell for the linglong user
2. Prevent systemd-sysusers from creating an unnecessary home directory for the service account
3. Restrict interactive login access for the package manager system user
4. Align the service account definition with common system user best practices

Influence:
1. Verify the linglong user is created with the home directory set to / nonexistent
2. Confirm no home directory is created for the user during sysusers processing
3. Test that the service user cannot log in interactively due to the empty shell
4. Confirm the linglong package manager daemon still functions correctly under the modified account